### PR TITLE
restore: incr_slot init and clear

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -231,7 +231,7 @@ snapshot_path_gui_publish( fd_snapct_tile_t *  ctx,
 static void
 predict_incremental( fd_snapct_tile_t * ctx ) {
   if( FD_UNLIKELY( !ctx->config.incremental_snapshots ) ) return;
-  if( FD_UNLIKELY( ctx->predicted_incremental.full_slot==ULONG_MAX ) ) return;
+  if( FD_UNLIKELY( ctx->predicted_incremental.full_slot==FD_SSPEER_SLOT_UNKNOWN ) ) return;
 
   fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 1, ctx->predicted_incremental.full_slot );
 
@@ -296,11 +296,11 @@ on_snapshot_hash( fd_snapct_tile_t *                 ctx,
                   fd_ip4_port_t                      addr,
                   fd_gossip_update_message_t const * msg ) {
   ulong         full_slot = msg->snapshot_hashes->full_slot;
-  ulong         incr_slot = 0UL;
+  ulong         incr_slot = FD_SSPEER_SLOT_UNKNOWN;
   uchar const * incr_hash = NULL;
 
   for( ulong i=0UL; i<msg->snapshot_hashes->incremental_len; i++ ) {
-    if( FD_LIKELY( msg->snapshot_hashes->incremental[ i ].slot>incr_slot ) ) {
+    if( FD_LIKELY( !incr_hash || msg->snapshot_hashes->incremental[ i ].slot>incr_slot ) ) {
       incr_slot = msg->snapshot_hashes->incremental[ i ].slot;
       incr_hash = msg->snapshot_hashes->incremental[ i ].hash;
     }
@@ -313,7 +313,13 @@ on_snapshot_hash( fd_snapct_tile_t *                 ctx,
     fd_sspeer_selector_remove( ctx->selector, key );
     return;
   }
-  fd_sspeer_selector_add( ctx->selector, key, addr, ULONG_MAX, full_slot, incr_slot, msg->snapshot_hashes->full_hash, incr_hash );
+  /* The add may fail due to capacity/pool exhaustion, but the cluster
+     slot should still be updated since the gossip observation is valid
+     cluster-level intelligence regardless of whether this particular
+     peer can be tracked. */
+  fd_sspeer_selector_add( ctx->selector, key, addr, FD_SSPEER_LATENCY_UNKNOWN,
+                          full_slot, incr_slot,
+                          msg->snapshot_hashes->full_hash, incr_hash );
   fd_sspeer_selector_process_cluster_slot( ctx->selector, full_slot, incr_slot );
   predict_incremental( ctx );
 }
@@ -596,7 +602,7 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_WAITING_FOR_PEERS: {
       if( FD_UNLIKELY( now>ctx->deadline_nanos ) ) FD_LOG_ERR(( "timed out waiting for peers." ));
 
-      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, ULONG_MAX );
+      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, FD_SSPEER_SLOT_UNKNOWN );
       if( FD_LIKELY( best.addr.l ) ) {
         ctx->state = FD_SNAPCT_STATE_COLLECTING_PEERS;
         ctx->deadline_nanos = now+FD_SNAPCT_COLLECTING_PEERS_TIMEOUT;
@@ -608,7 +614,7 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL: {
       if( FD_UNLIKELY( now>ctx->deadline_nanos ) ) FD_LOG_ERR(( "timed out waiting for incremental snapshot peers." ));
 
-      FD_TEST( ctx->predicted_incremental.full_slot!=ULONG_MAX );
+      FD_TEST( ctx->predicted_incremental.full_slot!=FD_SSPEER_SLOT_UNKNOWN );
       fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 1, ctx->predicted_incremental.full_slot );
       if( FD_LIKELY( best.addr.l ) ) {
         ctx->state = FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL;
@@ -621,7 +627,7 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_COLLECTING_PEERS: {
       if( FD_UNLIKELY( !ctx->gossip.saturated && now<ctx->deadline_nanos ) ) break;
 
-      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, ULONG_MAX );
+      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, FD_SSPEER_SLOT_UNKNOWN );
       if( FD_UNLIKELY( !best.addr.l ) ) {
         if( !ctx->gossip_enabled ) {
           FD_LOG_ERR(( "no peers are available and discovery of new peers via gossip is disabled. aborting." ));
@@ -632,9 +638,9 @@ after_credit( fd_snapct_tile_t *  ctx,
       }
 
       fd_sscluster_slot_t cluster = fd_sspeer_selector_cluster_slot( ctx->selector );
-      if( FD_UNLIKELY( cluster.incremental==ULONG_MAX && ctx->config.incremental_snapshots ) ) {
+      if( FD_UNLIKELY( cluster.incremental==FD_SSPEER_SLOT_UNKNOWN && ctx->config.incremental_snapshots ) ) {
         /* We must have a cluster full slot to be in this state. */
-        FD_TEST( cluster.full!=ULONG_MAX );
+        FD_TEST( cluster.full!=FD_SSPEER_SLOT_UNKNOWN );
         /* fall back to full snapshot only if the highest cluster slot
            is a full snapshot only */
         FD_LOG_WARNING(( "incremental snapshots were enabled via [snapshots.incremental_snapshots], but no incremental snapshot is available in the cluster. "
@@ -1170,20 +1176,23 @@ gossip_frag( fd_snapct_tile_t *  ctx,
       new_addr.port = msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].port;
 
       if( FD_UNLIKELY( new_addr.l!=cur_addr.l ) ) {
-        entry->rpc_addr = new_addr;
-        if( FD_LIKELY( !!cur_addr.l ) ) {
-          fd_ssping_remove( ctx->ssping, cur_addr );
-        }
         fd_sspeer_key_t entry_key = {0};
         *entry_key.pubkey = entry->pubkey;
         entry_key.is_url  = 0;
         if( FD_LIKELY( !!new_addr.l ) ) {
+          if( FD_UNLIKELY( FD_SSPEER_SCORE_INVALID==fd_sspeer_selector_add( ctx->selector, &entry_key, new_addr,
+                                                                            FD_SSPEER_LATENCY_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
+                                                                            FD_SSPEER_SLOT_UNKNOWN, NULL, NULL ) ) ) {
+            break;
+          }
           fd_ssping_add( ctx->ssping, new_addr );
-          /* update address */
-          fd_sspeer_selector_add( ctx->selector, &entry_key, new_addr, ULONG_MAX, ULONG_MAX, ULONG_MAX, NULL, NULL );
         } else {
           fd_sspeer_selector_remove( ctx->selector, &entry_key );
         }
+        if( FD_LIKELY( !!cur_addr.l ) ) {
+          fd_ssping_remove( ctx->ssping, cur_addr );
+        }
+        entry->rpc_addr = new_addr;
         if( !ctx->config.sources.gossip.allow_any ) {
           FD_BASE58_ENCODE_32_BYTES( pubkey->uc, pubkey_b58 );
           if( FD_LIKELY( !!new_addr.l ) ) {
@@ -1657,8 +1666,8 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( has_snapld_dc && has_ack_loopback );
   FD_TEST( ctx->gossip_enabled==(ctx->gossip_in_mem!=NULL) );
 
-  ctx->predicted_incremental.full_slot = ULONG_MAX;
-  ctx->predicted_incremental.slot      = ULONG_MAX;
+  ctx->predicted_incremental.full_slot = FD_SSPEER_SLOT_UNKNOWN;
+  ctx->predicted_incremental.slot      = FD_SSPEER_SLOT_UNKNOWN;
   ctx->predicted_incremental.pending   = 0;
 
   fd_memset( &ctx->metrics, 0, sizeof(ctx->metrics) );

--- a/src/discof/restore/utils/fd_http_resolver.c
+++ b/src/discof/restore/utils/fd_http_resolver.c
@@ -70,6 +70,14 @@ typedef struct fd_ssresolve_peer fd_ssresolve_peer_t;
 #define DLIST_NEXT  deadline.next
 #include "../../../util/tmpl/fd_dlist.c"
 
+static inline void
+clear_peer_snapshot_data( fd_ssresolve_peer_t * peer ) {
+  peer->full_slot = FD_SSPEER_SLOT_UNKNOWN;
+  peer->incr_slot = FD_SSPEER_SLOT_UNKNOWN;
+  fd_memset( peer->full_hash, 0, FD_HASH_FOOTPRINT );
+  fd_memset( peer->incr_hash, 0, FD_HASH_FOOTPRINT );
+}
+
 struct fd_http_resolver_private {
   fd_ssresolve_peer_t *            pool;
   deadline_list_t *                unresolved;
@@ -232,21 +240,24 @@ fd_http_resolver_add( fd_http_resolver_t *   resolver,
   } else {
     peer->key.url.hostname[ 0 ] = '\0';
   }
-  peer->key.url.resolved_addr        = addr;
-  peer->key.is_url                   = 1;
-  peer->state                        = PEER_STATE_UNRESOLVED;
-  peer->addr                         = addr;
-  peer->is_https                     = is_https;
-  peer->fd.idx                       = ULONG_MAX;
-  peer->full_slot                    = ULONG_MAX;
-  peer->incr_slot                    = ULONG_MAX;
+  peer->key.url.resolved_addr = addr;
+  peer->key.is_url            = 1;
+  peer->state                 = PEER_STATE_UNRESOLVED;
+  peer->addr                  = addr;
+  peer->is_https              = is_https;
+  peer->fd.idx                = ULONG_MAX;
+  peer->full_slot             = FD_SSPEER_SLOT_UNKNOWN;
+  peer->incr_slot             = FD_SSPEER_SLOT_UNKNOWN;
+  fd_memset( peer->full_hash, 0, FD_HASH_FOOTPRINT );
+  fd_memset( peer->incr_hash, 0, FD_HASH_FOOTPRINT );
 
   /* The peer needs to be added to the selector, in order to guarantee
      that any subsequent update on the selector is able to find it.
      At this time, latency, full/incr slot, as well as full/incr hash
      are unknown. */
-  ulong score = fd_sspeer_selector_add( selector, &peer->key, addr, ULONG_MAX, ULONG_MAX, ULONG_MAX, NULL, NULL );
-  if( FD_UNLIKELY( score==ULONG_MAX ) ) {
+  ulong score = fd_sspeer_selector_add( selector, &peer->key, addr, FD_SSPEER_LATENCY_UNKNOWN,
+                                        FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, NULL, NULL );
+  if( FD_UNLIKELY( score==FD_SSPEER_SCORE_INVALID ) ) {
     /* If unable to add, then release the element back to the pool. */
     FD_LOG_WARNING(( "failed to add peer to selector (hostname \"%s\" addr=" FD_IP4_ADDR_FMT ":%hu score=%lu)",
                      peer->key.url.hostname[ 0 ] ? peer->key.url.hostname : "(none)",
@@ -465,7 +476,8 @@ poll_advance( fd_http_resolver_t * resolver,
       deadline_list_ele_push_tail( resolver->valid, peer, resolver->pool );
       remove_peer( resolver, peer->fd.idx );
 
-      resolver->on_resolve_cb( resolver->cb_arg, &peer->key, peer->full_slot, peer->incr_slot, peer->full_hash, peer->incr_hash );
+      resolver->on_resolve_cb( resolver->cb_arg, &peer->key, peer->full_slot, peer->incr_slot, peer->full_hash,
+                               peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN ? peer->incr_hash : NULL );
     }
   }
 }
@@ -478,6 +490,17 @@ fd_http_resolver_advance( fd_http_resolver_t *   resolver,
     fd_ssresolve_peer_t * peer = deadline_list_ele_pop_head( resolver->unresolved, resolver->pool );
 
     FD_LOG_INFO(( "resolving " FD_IP4_ADDR_FMT ":%hu", FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ), fd_ushort_bswap( peer->addr.port ) ));
+    /* Clear stale snapshot data so the new resolve cycle starts clean.
+       Without this, a previously-valid peer could carry stale
+       incr_slot/incr_hash through the invalid->unresolved cycle. */
+    clear_peer_snapshot_data( peer );
+    /* Re-add the peer to the selector with unknown data.  The peer may
+       have been removed from the selector during a previous timeout or
+       failed re-resolve.  The add call may fail if the selector is
+       full, which is fine — the peer will still attempt to resolve and
+       the next cycle will try again. */
+    fd_sspeer_selector_add( selector, &peer->key, peer->addr, FD_SSPEER_LATENCY_UNKNOWN,
+                            FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, NULL, NULL );
     int result = peer_connect( resolver, peer );
     if( FD_UNLIKELY( -1==result ) ) {
       peer->state          = PEER_STATE_INVALID;
@@ -520,6 +543,9 @@ fd_http_resolver_advance( fd_http_resolver_t *   resolver,
 
     deadline_list_ele_pop_head( resolver->valid, resolver->pool );
 
+    /* Clear stale snapshot data before re-resolving so the peer
+       does not carry data from the previous resolve cycle. */
+    clear_peer_snapshot_data( peer );
     int result = peer_connect( resolver, peer );
     if( FD_UNLIKELY( -1==result ) ) {
       peer->state = PEER_STATE_INVALID;

--- a/src/discof/restore/utils/fd_sspeer_selector.c
+++ b/src/discof/restore/utils/fd_sspeer_selector.c
@@ -1,4 +1,5 @@
 #include "fd_sspeer_selector.h"
+#include "../../../util/bits/fd_sat.h"
 #include "../../../util/log/fd_log.h"
 
 static int
@@ -109,8 +110,14 @@ typedef struct fd_sspeer_private fd_sspeer_private_t;
 #define TREAP_PRIO      score_treap.prio
 #include "../../../util/tmpl/fd_treap.c"
 
-#define DEFAULT_SLOTS_BEHIND   (1000UL*1000UL)        /* 1,000,000 slots behind */
-#define DEFAULT_PEER_LATENCY   (100L*1000L*1000L)     /* 100ms */
+#define DEFAULT_SLOTS_BEHIND         (1000UL*1000UL) /* 1,000,000 slots behind */
+/* Assumed latency (in nanos) for peers that have not been pinged yet.
+   Pings are sent immediately on peer discovery, so this default is
+   short-lived.  100ms is a neutral middle-ground: high enough that
+   any peer with a measured latency is preferred, low enough that slot
+   distance still meaningfully differentiates unpinged peers. */
+#define DEFAULT_PEER_LATENCY         (100UL*1000UL*1000UL)  /* 100ms */
+#define DEFAULT_SLOTS_BEHIND_PENALTY (1000UL)
 
 #define FD_SSPEER_SELECTOR_DEBUG 0
 
@@ -179,6 +186,8 @@ fd_sspeer_selector_new( void * shmem,
   void * _peer_idx_list           = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),           max_peers * sizeof(ulong) );
 
   selector->pool               = peer_pool_join( peer_pool_new( _pool, 2UL*max_peers ) );
+  /* Seed treap priorities so the treap is balanced. */
+  score_treap_seed( selector->pool, 2UL*max_peers, seed );
   selector->map_by_key         = peer_map_by_key_join( peer_map_by_key_new( _map, peer_map_by_key_chain_cnt_est( 2UL*max_peers ), seed ) );
   selector->map_by_addr        = peer_map_by_addr_join( peer_map_by_addr_new( _multimap_by_addr, peer_map_by_addr_chain_cnt_est( 2UL*max_peers ), seed ) );
   selector->score_treap        = score_treap_join( score_treap_new( _score_treap, max_peers ) );
@@ -187,7 +196,7 @@ fd_sspeer_selector_new( void * shmem,
   selector->max_peers          = max_peers;
 
   selector->cluster_slot.full          = 0UL;
-  selector->cluster_slot.incremental   = 0UL;
+  selector->cluster_slot.incremental   = FD_SSPEER_SLOT_UNKNOWN;
   selector->incremental_snapshot_fetch = incremental_snapshot_fetch;
 
   FD_COMPILER_MFENCE();
@@ -279,33 +288,71 @@ fd_sspeer_selector_delete( void * shselector ) {
 
 /* Calculates a score for a peer given its latency and its resolved
    full and incremental slots */
-ulong
-fd_sspeer_selector_score( fd_sspeer_selector_t * selector,
-                          ulong                  peer_latency,
-                          ulong                  full_slot,
-                          ulong                  incr_slot ) {
-  static const ulong slots_behind_penalty = 1000UL;
-  ulong slot                              = ULONG_MAX;
-  ulong slots_behind                      = DEFAULT_SLOTS_BEHIND;
-  peer_latency = peer_latency!=ULONG_MAX ? peer_latency : DEFAULT_PEER_LATENCY;
+static ulong
+fd_sspeer_selector_score( fd_sspeer_selector_t const * selector,
+                          ulong                        peer_latency,
+                          ulong                        full_slot,
+                          ulong                        incr_slot ) {
+  peer_latency = peer_latency!=FD_SSPEER_LATENCY_UNKNOWN ? peer_latency : DEFAULT_PEER_LATENCY;
 
-  if( FD_LIKELY( full_slot!=ULONG_MAX ) ) {
-    if( FD_UNLIKELY( incr_slot==ULONG_MAX ) ) {
-      slot         = full_slot;
-      slots_behind = selector->cluster_slot.full>slot ? selector->cluster_slot.full - slot : 0UL;
+  ulong slots_behind = DEFAULT_SLOTS_BEHIND;
+
+  if( FD_LIKELY( full_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+    if( FD_LIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN &&
+                   selector->cluster_slot.incremental!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+      slots_behind = selector->cluster_slot.incremental>incr_slot ? selector->cluster_slot.incremental - incr_slot : 0UL;
     } else {
-      slot         = incr_slot;
-      slots_behind = selector->cluster_slot.incremental>slot ? selector->cluster_slot.incremental - slot : 0UL;
+      /* Either the peer has no incremental or the cluster has no
+         incremental reference yet.  Fall back to comparing full_slot
+         against the cluster full slot. */
+      slots_behind = selector->cluster_slot.full>full_slot ? selector->cluster_slot.full - full_slot : 0UL;
     }
   }
 
-  /* TODO: come up with a better/more dynamic score function */
-  return peer_latency + slots_behind_penalty*slots_behind;
+  /* Using saturating arithmetic to avoid overflow and cap at
+     FD_SSPEER_SCORE_MAX. */
+  ulong penalty = fd_ulong_sat_mul( DEFAULT_SLOTS_BEHIND_PENALTY, slots_behind );
+  ulong score   = fd_ulong_sat_add( peer_latency, penalty );
+  return fd_ulong_min( score, FD_SSPEER_SCORE_MAX );
+}
+
+/* Validates slot arguments for both new and existing peers.  Returns
+   0 on success, -1 on failure due to incr_slot<full_slot, and -2 on
+   failure due to full_slot==UNKNOWN with incr_slot!=UNKNOWN.  The
+   caller passes in the effective (already-resolved) full_slot and
+   incr_slot values.  No log on failure (the caller is responsible
+   for logging whenever needed).
+
+   Two invariants are enforced:
+   1. When both slots are known, incr_slot must be >= full_slot.
+   2. An incremental slot requires a known full slot. */
+static int
+fd_sspeer_validate_slot_args( ulong full_slot,
+                              ulong incr_slot ) {
+  if( FD_UNLIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN &&
+                   full_slot!=FD_SSPEER_SLOT_UNKNOWN &&
+                   incr_slot<full_slot ) ) {
+    return -1;
+  }
+
+  if( FD_UNLIKELY( full_slot==FD_SSPEER_SLOT_UNKNOWN &&
+                   incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+    return -2;
+  }
+
+  return 0;
 }
 
 /* Updates a peer's score with new values for latency and/or resolved
-   full/incremental slots */
-static void
+   full/incremental slots.  Returns FD_SSPEER_UPDATE_SUCCESS on
+   success, or the specific fd_sspeer_validate_slot_args error code
+   on failure without modifying the peer or any data structure.
+
+   Slot-based incremental clearing: when the caller provides
+   incr_slot==UNKNOWN and full_slot!=UNKNOWN, the peer's existing
+   incremental data is cleared if it is stale (peer->incr_slot <
+   full_slot).  Otherwise, the existing incremental data is preserved. */
+static int
 fd_sspeer_selector_update( fd_sspeer_selector_t * selector,
                            fd_sspeer_private_t *  peer,
                            ulong                  latency,
@@ -313,21 +360,45 @@ fd_sspeer_selector_update( fd_sspeer_selector_t * selector,
                            ulong                  incr_slot,
                            uchar const            full_hash[ FD_HASH_FOOTPRINT ],
                            uchar const            incr_hash[ FD_HASH_FOOTPRINT ] ) {
-  score_treap_ele_remove( selector->score_treap, peer, selector->pool );
+  ulong peer_latency   = latency!=FD_SSPEER_LATENCY_UNKNOWN ? latency : peer->latency;
+  ulong peer_full_slot = full_slot!=FD_SSPEER_SLOT_UNKNOWN ? full_slot : peer->full_slot;
 
-  ulong peer_latency   = latency!=ULONG_MAX ? latency : peer->latency;
-  ulong peer_full_slot = full_slot!=ULONG_MAX ? full_slot : peer->full_slot;
-  ulong peer_incr_slot = incr_slot!=ULONG_MAX ? incr_slot : peer->incr_slot;
+  ulong peer_incr_slot;
+  int   clear_incr = 0;
+  if( incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) {
+    peer_incr_slot = incr_slot;
+  } else if( full_slot!=FD_SSPEER_SLOT_UNKNOWN &&
+             peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN &&
+             peer->incr_slot<full_slot ) {
+    /* The caller is providing a new full_slot that has advanced past
+       the peer's existing incremental — the incremental is stale. */
+    peer_incr_slot = FD_SSPEER_SLOT_UNKNOWN;
+    clear_incr     = 1;
+  } else {
+    peer_incr_slot = peer->incr_slot;
+  }
+
+  int validate_err = fd_sspeer_validate_slot_args( peer_full_slot, peer_incr_slot );
+  if( FD_UNLIKELY( validate_err ) ) return validate_err;
+
+  score_treap_ele_remove( selector->score_treap, peer, selector->pool );
 
   peer->score = fd_sspeer_selector_score( selector, peer_latency, peer_full_slot, peer_incr_slot );
 
   peer->latency   = peer_latency;
   peer->full_slot = peer_full_slot;
   peer->incr_slot = peer_incr_slot;
-  if( FD_LIKELY( full_hash ) ) fd_memcpy( peer->full_hash, full_hash, FD_HASH_FOOTPRINT );
-  if( FD_LIKELY( incr_hash ) ) fd_memcpy( peer->incr_hash, incr_hash, FD_HASH_FOOTPRINT );
+  if( FD_LIKELY( full_hash ) ) {
+    fd_memcpy( peer->full_hash, full_hash, FD_HASH_FOOTPRINT );
+  }
+  if( FD_UNLIKELY( clear_incr ) ) {
+    fd_memset( peer->incr_hash, 0, FD_HASH_FOOTPRINT );
+  } else if( FD_LIKELY( incr_hash ) ) {
+    fd_memcpy( peer->incr_hash, incr_hash, FD_HASH_FOOTPRINT );
+  }
 
   score_treap_ele_insert( selector->score_treap, peer, selector->pool );
+  return FD_SSPEER_UPDATE_SUCCESS;
 }
 
 int
@@ -337,12 +408,13 @@ fd_sspeer_selector_update_on_resolve( fd_sspeer_selector_t *  selector,
                                       ulong                   incr_slot,
                                       uchar const             full_hash[ FD_HASH_FOOTPRINT ],
                                       uchar const             incr_hash[ FD_HASH_FOOTPRINT ] ) {
-  if( FD_UNLIKELY( key==NULL ) ) return -1;
+  if( FD_UNLIKELY( key==NULL ) ) return FD_SSPEER_UPDATE_ERR_NULL_KEY;
   fd_sspeer_private_t * peer = peer_map_by_key_ele_query( selector->map_by_key, key, NULL, selector->pool );
-  if( FD_UNLIKELY( peer==NULL ) ) return -2;
-  fd_sspeer_selector_update( selector, peer, ULONG_MAX, full_slot, incr_slot, full_hash, incr_hash );
-  peer->valid = peer->full_slot!=ULONG_MAX;
-  return 0;
+  if( FD_UNLIKELY( peer==NULL ) ) return FD_SSPEER_UPDATE_ERR_NOT_FOUND;
+  int update_status = fd_sspeer_selector_update( selector, peer, FD_SSPEER_LATENCY_UNKNOWN, full_slot, incr_slot, full_hash, incr_hash );
+  if( FD_UNLIKELY( update_status!=FD_SSPEER_UPDATE_SUCCESS ) ) return FD_SSPEER_UPDATE_ERR_INVALID_ARG;
+  peer->valid = peer->full_slot!=FD_SSPEER_SLOT_UNKNOWN;
+  return FD_SSPEER_UPDATE_SUCCESS;
 }
 
 ulong
@@ -354,7 +426,27 @@ fd_sspeer_selector_update_on_ping( fd_sspeer_selector_t * selector,
   for(;;) {
     if( FD_UNLIKELY( ele_idx==ULONG_MAX ) ) break;
     fd_sspeer_private_t * peer = selector->pool + ele_idx;
-    fd_sspeer_selector_update( selector, peer, latency, ULONG_MAX, ULONG_MAX, NULL, NULL );
+    /* Update cannot fail here: slots are FD_SSPEER_SLOT_UNKNOWN and
+       hashes are NULL, so fd_sspeer_validate_slot_args always
+       returns FD_SSPEER_UPDATE_SUCCESS (no clear_incr trigger,
+       no incr<full violation). */
+    int update_status = fd_sspeer_selector_update( selector, peer, latency,
+                                                   FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
+                                                   NULL, NULL );
+    if( FD_UNLIKELY( update_status!=FD_SSPEER_UPDATE_SUCCESS ) ) {
+      /* A warning is a tradeoff between crashing with FD_LOG_CRIT and
+         potentially missing the log altogether with FD_LOG_DEBUG. */
+      if( peer->key.is_url ) {
+        FD_LOG_WARNING(( "unexpected selector update returned %d for peer %s " FD_IP4_ADDR_FMT ":%hu",
+                         update_status, peer->key.url.hostname,
+                         FD_IP4_ADDR_FMT_ARGS( peer->key.url.resolved_addr.addr ), fd_ushort_bswap( peer->key.url.resolved_addr.port ) ));
+      } else {
+        FD_BASE58_ENCODE_32_BYTES( peer->key.pubkey->uc, peer_pubkey_b58 );
+        FD_LOG_WARNING(( "unexpected selector update returned %d for peer %s " FD_IP4_ADDR_FMT ":%hu",
+                         update_status, peer_pubkey_b58,
+                         FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ), fd_ushort_bswap( peer->addr.port ) ));
+      }
+    }
     ele_idx = peer_map_by_addr_idx_next_const( ele_idx, ULONG_MAX, selector->pool );
     cnt++;
   }
@@ -370,28 +462,35 @@ fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
                         ulong                  incr_slot,
                         uchar const            full_hash[ FD_HASH_FOOTPRINT ],
                         uchar const            incr_hash[ FD_HASH_FOOTPRINT ] ) {
-  if( FD_UNLIKELY( key==NULL ) ) return ULONG_MAX;
+  if( FD_UNLIKELY( key==NULL ) ) return FD_SSPEER_SCORE_INVALID;
   /* A peer without a valid address cannot be added to the selector.
      For an existing peer changing from a valid address to 0, it is
      the caller's responsibility to remove them. */
-  if( FD_UNLIKELY( !addr.l ) ) return ULONG_MAX;
+  if( FD_UNLIKELY( !addr.l ) ) return FD_SSPEER_SCORE_INVALID;
 
   fd_sspeer_private_t * peer = peer_map_by_key_ele_query( selector->map_by_key, key, NULL, selector->pool );
   if( FD_LIKELY( peer ) ) {
+    int update_status = fd_sspeer_selector_update( selector, peer, latency, full_slot, incr_slot, full_hash, incr_hash );
+    if( FD_UNLIKELY( update_status!=FD_SSPEER_UPDATE_SUCCESS ) ) return FD_SSPEER_SCORE_INVALID;
+    /* Update the addr map after the selector update so that the peer
+       is not mutated when the update fails. */
     if( FD_UNLIKELY( peer->addr.l!=addr.l ) ) {
       peer_map_by_addr_ele_remove_fast( selector->map_by_addr, peer, selector->pool );
       peer->addr = addr;
       peer_map_by_addr_ele_insert( selector->map_by_addr, peer, selector->pool );
     }
-    fd_sspeer_selector_update( selector, peer, latency, full_slot, incr_slot, full_hash, incr_hash );
   } else {
     if( FD_UNLIKELY( !peer_pool_free( selector->pool ) ) ) {
       FD_LOG_WARNING(( "peer selector pool exhausted" ));
-      return ULONG_MAX;
+      return FD_SSPEER_SCORE_INVALID;
     }
     if( FD_UNLIKELY( score_treap_ele_cnt(selector->score_treap)>=selector->max_peers ) ) {
       FD_LOG_WARNING(( "peer selector at max capacity" ));
-      return ULONG_MAX;
+      return FD_SSPEER_SCORE_INVALID;
+    }
+
+    if( FD_UNLIKELY( fd_sspeer_validate_slot_args( full_slot, incr_slot ) ) ) {
+      return FD_SSPEER_SCORE_INVALID;
     }
 
     peer = peer_pool_ele_acquire( selector->pool );
@@ -403,13 +502,14 @@ fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
     peer->incr_slot = incr_slot;
     if( FD_LIKELY( full_hash ) ) fd_memcpy( peer->full_hash, full_hash, FD_HASH_FOOTPRINT );
     else                         fd_memset( peer->full_hash, 0, FD_HASH_FOOTPRINT );
+    /* full_hash and incr_hash are treated independently here. */
     if( FD_LIKELY( incr_hash ) ) fd_memcpy( peer->incr_hash, incr_hash, FD_HASH_FOOTPRINT );
     else                         fd_memset( peer->incr_hash, 0, FD_HASH_FOOTPRINT );
     peer_map_by_key_ele_insert( selector->map_by_key, peer, selector->pool );
     peer_map_by_addr_ele_insert( selector->map_by_addr, peer, selector->pool );
     score_treap_ele_insert( selector->score_treap, peer, selector->pool );
   }
-  peer->valid = peer->full_slot!=ULONG_MAX;
+  peer->valid = peer->full_slot!=FD_SSPEER_SLOT_UNKNOWN;
   return peer->score;
 }
 
@@ -441,17 +541,28 @@ fd_sspeer_t
 fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
                          int                    incremental,
                          ulong                  base_slot ) {
-  if( FD_UNLIKELY( incremental ) ) {
-    FD_TEST( base_slot!=ULONG_MAX );
+  if( FD_UNLIKELY( incremental && base_slot==FD_SSPEER_SLOT_UNKNOWN ) ) {
+    FD_LOG_WARNING(( "incremental selection requires a valid base_slot" ));
+    return (fd_sspeer_t){
+      .addr      = { .l=0UL },
+      .full_slot = FD_SSPEER_SLOT_UNKNOWN,
+      .incr_slot = FD_SSPEER_SLOT_UNKNOWN,
+      .score     = FD_SSPEER_SCORE_INVALID,
+      .full_hash = {0},
+      .incr_hash = {0},
+    };
   }
 
   for( score_treap_fwd_iter_t iter = score_treap_fwd_iter_init( selector->score_treap, selector->pool );
        !score_treap_fwd_iter_done( iter );
        iter = score_treap_fwd_iter_next( iter, selector->pool ) ) {
     fd_sspeer_private_t const * peer = score_treap_fwd_iter_ele_const( iter, selector->pool );
+    /* For full selection (!incremental), any valid peer is eligible.
+       For incremental selection, the peer must serve the same base full
+       snapshot and must actually offer an incremental snapshot. */
     if( FD_LIKELY( peer->valid &&
                    (!incremental ||
-                   (incremental && peer->full_slot==base_slot) ) ) ) {
+                   (peer->full_slot==base_slot && peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN) ) ) ) {
       fd_sspeer_t best = {
         .addr      = peer->addr,
         .full_slot = peer->full_slot,
@@ -466,9 +577,9 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
 
   return (fd_sspeer_t){
     .addr      = { .l=0UL },
-    .full_slot = ULONG_MAX,
-    .incr_slot = ULONG_MAX,
-    .score     = ULONG_MAX,
+    .full_slot = FD_SSPEER_SLOT_UNKNOWN,
+    .incr_slot = FD_SSPEER_SLOT_UNKNOWN,
+    .score     = FD_SSPEER_SCORE_INVALID,
     .full_hash = {0},
     .incr_hash = {0},
   };
@@ -478,22 +589,50 @@ void
 fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector,
                                          ulong                  full_slot,
                                          ulong                  incr_slot ) {
-  if( full_slot==ULONG_MAX && incr_slot==ULONG_MAX ) return;
+  if( FD_UNLIKELY( full_slot==FD_SSPEER_SLOT_UNKNOWN ) ) return;
 
-  FD_TEST( full_slot!=ULONG_MAX );
+  /* Reject cluster slot updates where the incremental slot is before
+     the full slot.  Both must be known for the check to apply.  Genesis
+     (full_slot=0, incr_slot=0) is supported. */
+  if( FD_UNLIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN && incr_slot<full_slot ) ) return;
+
   if( FD_LIKELY( selector->incremental_snapshot_fetch ) ) {
-    /* incremental slot is less than or equal to cluster incremental slot */
-    if( FD_UNLIKELY( incr_slot!=ULONG_MAX && selector->cluster_slot.incremental!=ULONG_MAX && incr_slot<=selector->cluster_slot.incremental ) ) return;
-    /* incremental slot is less than or equal to cluster full slot when cluster incremental slot does not exist */
-    else if( FD_UNLIKELY( incr_slot!=ULONG_MAX && selector->cluster_slot.incremental==ULONG_MAX && incr_slot<=selector->cluster_slot.full ) )   return;
-    /* full slot is less than cluster full slot when incremental slot does not exist */
-    else if( FD_UNLIKELY( incr_slot==ULONG_MAX && full_slot<=selector->cluster_slot.full ) )                                                           return;
+    /* The full slot must never regress, regardless of incr_slot. */
+    if( FD_UNLIKELY( full_slot<selector->cluster_slot.full ) ) return;
+
+    /* Reject updates that do not advance the cluster slot.
+       incr_slot     | stored incr   | reject when
+       --------------|---------------|--------------------------------
+       valid         | valid         | incr_slot < stored.incremental
+                     |               |   OR (incr_slot == stored.incremental
+                     |               |       AND full_slot <= stored.full)
+       valid         | _SLOT_UNKNOWN | incr_slot <  stored.full
+                     |               |   (strict: genesis accepted)
+       _SLOT_UNKNOWN | valid         | full_slot <= stored.full
+       _SLOT_UNKNOWN | _SLOT_UNKNOWN | full_slot <= stored.full  */
+    if( FD_UNLIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+      if( FD_UNLIKELY( selector->cluster_slot.incremental!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+        if( FD_UNLIKELY( ( incr_slot<selector->cluster_slot.incremental ||
+                         ( incr_slot==selector->cluster_slot.incremental &&
+                           full_slot<=selector->cluster_slot.full ) ) ) ) return;
+      } else {
+        if( FD_UNLIKELY( incr_slot<selector->cluster_slot.full ) ) return;
+      }
+    } else if( FD_UNLIKELY( full_slot<=selector->cluster_slot.full ) ) return;
+
   } else {
     if( FD_UNLIKELY( full_slot<=selector->cluster_slot.full ) ) return;
   }
 
-  selector->cluster_slot.full        = full_slot;
-  selector->cluster_slot.incremental = incr_slot;
+  selector->cluster_slot.full = full_slot;
+  if( FD_LIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
+    selector->cluster_slot.incremental = incr_slot;
+  } else if( FD_UNLIKELY( selector->cluster_slot.incremental!=FD_SSPEER_SLOT_UNKNOWN &&
+                           selector->cluster_slot.incremental<full_slot ) ) {
+    /* The full slot advanced past the incremental slot, so the
+       incremental reference is stale and must be invalidated. */
+    selector->cluster_slot.incremental = FD_SSPEER_SLOT_UNKNOWN;
+  }
 
   if( FD_UNLIKELY( score_treap_ele_cnt( selector->score_treap )==0UL ) ) return;
 

--- a/src/discof/restore/utils/fd_sspeer_selector.h
+++ b/src/discof/restore/utils/fd_sspeer_selector.h
@@ -13,6 +13,27 @@
 
 #define FD_SSPEER_SELECTOR_MAGIC (0xF17EDA2CE5593350) /* FIREDANCE SSPING V0 */
 
+/* Sentinel score returned by fd_sspeer_selector_best when no peer was
+   found and by fd_sspeer_selector_add on failure. */
+#define FD_SSPEER_SCORE_INVALID   (ULONG_MAX)
+
+/* Maximum score a valid peer can have.  FD_SSPEER_SCORE_MAX ensures a
+   valid peer's score is never confused with FD_SSPEER_SCORE_INVALID. */
+#define FD_SSPEER_SCORE_MAX       (ULONG_MAX-1UL)
+
+/* Sentinel value indicating that a snapshot slot (full or incremental)
+   is unknown or absent. */
+#define FD_SSPEER_SLOT_UNKNOWN    (ULONG_MAX)
+
+/* Sentinel value indicating that peer latency has not been measured. */
+#define FD_SSPEER_LATENCY_UNKNOWN (ULONG_MAX)
+
+/* Return codes for fd_sspeer_selector_update_on_resolve. */
+#define FD_SSPEER_UPDATE_SUCCESS         ( 0)
+#define FD_SSPEER_UPDATE_ERR_NULL_KEY    (-1)
+#define FD_SSPEER_UPDATE_ERR_NOT_FOUND   (-2)
+#define FD_SSPEER_UPDATE_ERR_INVALID_ARG (-3)
+
 /* fd_sscluster_slot stores the highest full and incremental slot pair
    seen in the cluster. */
 struct fd_sscluster_slot {
@@ -64,8 +85,17 @@ fd_sspeer_selector_delete( void * shselector );
 
 /* Update the selector when an http server is resolved.  The peer is
    identified by key.  The values that can be updated are slot and
-   hash, for both full and incremental snapshots.  On success it
-   returns 0, -1 if key==NULL, and -2 if the key was not found. */
+   hash, for both full and incremental snapshots.  Returns
+   FD_SSPEER_UPDATE_SUCCESS on success, FD_SSPEER_UPDATE_ERR_NULL_KEY
+   if key==NULL, FD_SSPEER_UPDATE_ERR_NOT_FOUND if the key was not
+   found, and FD_SSPEER_UPDATE_ERR_INVALID_ARG if the update failed
+   due to invalid arguments (e.g. incr_slot < full_slot).
+
+   Slot-based incremental clearing: when the caller provides
+   incr_slot==FD_SSPEER_SLOT_UNKNOWN and full_slot!=FD_SSPEER_SLOT_UNKNOWN,
+   the peer's existing incremental data is cleared if it is stale
+   (peer->incr_slot < full_slot).  Otherwise, existing incremental
+   data is preserved. */
 int
 fd_sspeer_selector_update_on_resolve( fd_sspeer_selector_t *  selector,
                                       fd_sspeer_key_t const * key,
@@ -86,7 +116,15 @@ fd_sspeer_selector_update_on_ping( fd_sspeer_selector_t * selector,
 
 /* Add a peer to the selector.  If the peer already exists,
    fd_sspeer_selector_add updates the existing peer's score using the
-   given peer latency and snapshot info.  Returns the updated score. */
+   given peer latency and snapshot info.  Returns the updated score.
+
+   Slot-based incremental clearing: for an existing peer, when
+   incr_slot==FD_SSPEER_SLOT_UNKNOWN and full_slot!=FD_SSPEER_SLOT_UNKNOWN,
+   the peer's incremental data is cleared if it is stale
+   (peer->incr_slot < full_slot).  For a new peer, full_hash and
+   incr_hash are handled independently.
+
+   Returns the updated score, or FD_SSPEER_SCORE_INVALID on failure. */
 ulong
 fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
                         fd_sspeer_key_t const * key,
@@ -111,7 +149,10 @@ fd_sspeer_selector_remove_by_addr( fd_sspeer_selector_t * selector,
 
 /* Select the best peer to download a snapshot from.  incremental
    indicates to select a peer to download an incremental snapshot.  If
-   incremental is set, base_slot must be a valid full snapshot slot. */
+   incremental is set, base_slot must be a valid full snapshot slot.
+   Peers that do not offer an incremental snapshot
+   (incr_slot==FD_SSPEER_SLOT_UNKNOWN) are excluded from incremental
+   selection. */
 fd_sspeer_t
 fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
                          int                    incremental,

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -64,6 +64,54 @@ generate_rand_sspeer_key( fd_sspeer_key_t * key,
   return ret;
 }
 
+
+struct test_wksp_struct {
+   fd_sspeer_selector_t * selector;
+   void *                 shmem;
+   ulong                  max_peers;
+   int                    incr_snap_fetch;
+   ulong                  seed;
+};
+typedef struct test_wksp_struct test_wksp_t;
+
+static void
+test_wksp_init( fd_wksp_t *   wksp,
+                test_wksp_t * t_wksp,
+                ulong         max_peers,
+                int           incr_snap_fetch,
+                ulong         seed ) {
+  FD_TEST( t_wksp->selector==NULL );
+  FD_TEST( t_wksp->shmem==NULL );
+  t_wksp->shmem    = fd_wksp_alloc_laddr( wksp, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( max_peers ), 1UL );
+  t_wksp->selector = fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, max_peers, incr_snap_fetch, seed ) );
+  FD_TEST( t_wksp->selector );
+  t_wksp->max_peers       = max_peers;
+  t_wksp->incr_snap_fetch = incr_snap_fetch;
+  t_wksp->seed            = seed;
+}
+
+static void
+test_wksp_reinit( test_wksp_t * t_wksp ) {
+  FD_TEST( t_wksp->selector!=NULL );
+  FD_TEST( fd_sspeer_selector_delete( fd_sspeer_selector_leave( t_wksp->selector ) )==t_wksp->shmem );
+  FD_TEST( fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, t_wksp->max_peers, t_wksp->incr_snap_fetch, t_wksp->seed ) )==t_wksp->selector );
+}
+
+static void
+test_wksp_fini( test_wksp_t * t_wksp ) {
+  FD_TEST( t_wksp->selector!=NULL );
+  fd_wksp_free_laddr( fd_sspeer_selector_delete( fd_sspeer_selector_leave( t_wksp->selector ) ) );
+  t_wksp->shmem    = NULL;
+  t_wksp->selector = NULL;
+}
+
+static void
+verify_initial_cluster_slot( fd_sspeer_selector_t * selector ) {
+  fd_sscluster_slot_t cluster_slot_0 = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cluster_slot_0.full==0UL );
+  FD_TEST( cluster_slot_0.incremental==FD_SSPEER_SLOT_UNKNOWN );
+}
+
 static void
 test_basic_peer_selection( fd_sspeer_selector_t * selector,
                            fd_rng_t *             rng ) {
@@ -79,12 +127,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   /* Add a peer and it should be the best peer */
   fd_sspeer_key_t key[1]; FD_TEST( generate_rand_sspeer_key( key, rng, fd_rng_int( rng )&0x1/*is_url*/) );
   fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 35, 123, 172, 227 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key, addr, 1000UL, 1500UL, 5L*1000L*1000L )==5UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key, addr, 1000UL, 1500UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1500UL );
-  FD_TEST( best.score==5L*1000L*1000L );
+  FD_TEST( best.score==5UL*1000UL*1000UL );
 
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -93,12 +141,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
      the best peer */
   fd_sspeer_key_t key2[1]; FD_TEST( generate_rand_sspeer_key( key2, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr2 = { .addr = FD_IP4_ADDR( 35, 123, 172, 228 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key2, addr2, 1000UL, 1500UL, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key2, addr2, 1000UL, 1500UL, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1500UL );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -106,12 +154,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   /* Add a peer with the same latency but lagging slots behind */
   fd_sspeer_key_t key3[1]; FD_TEST( generate_rand_sspeer_key( key3, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr3 = { .addr = FD_IP4_ADDR( 35, 123, 172, 229 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key3, addr3, 1000UL, 1400UL, 3L*1000L*1000L )==3UL*1000UL*1000UL + 100UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key3, addr3, 1000UL, 1400UL, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL + 100UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1500UL );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   FD_TEST( 3UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 3UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -122,12 +170,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   /* Add a peer that is slightly slower but caught up in slots */
   fd_sspeer_key_t key4[1]; FD_TEST( generate_rand_sspeer_key( key4, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr4 = { .addr = FD_IP4_ADDR( 35, 123, 172, 230 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key4, addr4, 1000UL, 1600UL, 3L*1000L*1000L + 75L*1000L )==3UL*1000UL*1000UL + 75UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX );
+  FD_TEST( add_peer( selector, key4, addr4, 1000UL, 1600UL, 3UL*1000UL*1000UL + 75UL*1000UL )==3UL*1000UL*1000UL + 75UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr4.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3L*1000L*1000L + 75L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
 
   FD_TEST( 4UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 4UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -135,12 +183,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   /* Add a fast peer that doesn't have resolved slots */
   fd_sspeer_key_t key5[1]; FD_TEST( generate_rand_sspeer_key( key5, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr5 = { .addr = FD_IP4_ADDR( 35, 123, 172, 231 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key5, addr5, ULONG_MAX, ULONG_MAX, 2L*1000L*1000L )==2UL*1000UL*1000UL + 1000UL*1000UL*1000UL);
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX );
+  FD_TEST( add_peer( selector, key5, addr5, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 1000UL*1000UL*1000UL);
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr4.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3L*1000L*1000L + 75L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
 
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -150,21 +198,21 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   FD_TEST( best.addr.l==addr4.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3L*1000L*1000L + 75L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
 
   cluster_incr_slot = 1700UL;
   fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   /* Add a peer that is fast and at the highest slot but not building
-     off full slot, which makes it invalid an incremental peer */
+     off full slot, which makes it an invalid incremental peer */
   fd_sspeer_key_t key6[1]; FD_TEST( generate_rand_sspeer_key( key6, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr6 = { .addr = FD_IP4_ADDR( 35, 123, 172, 232 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key6, addr6, 900UL, 1700UL, 2L*1000L*1000L )==2UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key6, addr6, 900UL, 1700UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 1, 1000UL );
   FD_TEST( best.addr.l==addr4.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3L*1000L*1000L + 75L*1000L + 100UL*1000UL );
+  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL + 100UL*1000UL );
 
   FD_TEST( 6UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 6UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -172,12 +220,12 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   /* Add a fast incremental peer that is caught up to the cluster slot */
   fd_sspeer_key_t key7[1]; FD_TEST( generate_rand_sspeer_key( key7, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr7 = { .addr = FD_IP4_ADDR( 35, 123, 172, 233 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key7, addr7, 1000UL, 1700UL, 2L*1000L*1000L )==2UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key7, addr7, 1000UL, 1700UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 1, 1000UL );
   FD_TEST( best.addr.l==addr7.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1700UL );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   FD_TEST( 7UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 7UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -211,49 +259,49 @@ test_duplicate_peers( fd_sspeer_selector_t * selector,
   fd_sspeer_key_t key_url_B[1]; FD_TEST( generate_rand_sspeer_key( key_url_B, rng, 1 ) );
   fd_ip4_port_t addr0; FD_TEST( generate_rand_addr_non_zero( &addr0, rng ) );
   /* This is a test, but in reality resolved_addr should match addr0. */
-  fd_sspeer_key_t key_url_C[1]; *key_url_C = *key_url_A; key_url_C->url.resolved_addr.l = ~key_url_A->url.resolved_addr.l;
+  fd_sspeer_key_t key_url_C[1]; *key_url_C = *key_url_A; key_url_C->url.resolved_addr.l = (key_url_A->url.resolved_addr.l ^ 2UL) | 1UL;
 
   /* Add peers with same addr, same full_slot and incr_slot. */
 
   /* ... pubkey peer, latency 2us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_pub_A, addr0, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_pub_A, addr0, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr0.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... pubkey peer, latency 3us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_pub_B, addr0, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_pub_B, addr0, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr0.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... url peer, latency 4us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_url_A, addr0, cluster_full_slot, cluster_incr_slot, 4L*1000L*1000L )==4UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_url_A, addr0, cluster_full_slot, cluster_incr_slot, 4UL*1000UL*1000UL )==4UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr0.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... url peer, latency 5us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_url_B, addr0, cluster_full_slot, cluster_incr_slot, 5L*1000L*1000L )==5UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_url_B, addr0, cluster_full_slot, cluster_incr_slot, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr0.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... url peer, latency 1us, expected best score 1e6. */
-  FD_TEST( add_peer( selector, key_url_C, addr0, cluster_full_slot, cluster_incr_slot, 1L*1000L*1000L )==1UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_url_C, addr0, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL )==1UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr0.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==1L*1000L*1000L );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
 
   /* Cleanup */
   fd_sspeer_selector_remove_by_addr( selector, addr0 );
@@ -281,28 +329,28 @@ test_peer_addr_change( fd_sspeer_selector_t * selector,
   /* Add 2 peers change the addr of one of them. */
 
   /* ... peer A, latency 2us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... peer B, latency 3us, expected best score 2e6. */
-  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... peer A, new addr, latency 4us, expected best score 3e6 */
-  FD_TEST( add_peer( selector, key_A, addr_A1, cluster_full_slot, cluster_incr_slot, 4L*1000L*1000L )==4UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_A, addr_A1, cluster_full_slot, cluster_incr_slot, 4UL*1000UL*1000UL )==4UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   /* Cleanup */
   fd_sspeer_selector_remove( selector, key_A );
@@ -330,79 +378,111 @@ test_update_on_ping( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_AB; FD_TEST( generate_rand_addr_non_zero( &addr_AB, rng ) );
   fd_ip4_port_t addr_CD; FD_TEST( generate_rand_addr_non_zero( &addr_CD, rng ) );
   fd_ip4_port_t addr_E;  FD_TEST( generate_rand_addr_non_zero( &addr_E,  rng ) );
+  fd_ip4_port_t addr_X;  FD_TEST( generate_rand_addr_non_zero( &addr_X,  rng ) );
 
   /* Add 5 peers: pairs AB, CD and single E. */
 
   /* ... peers A and B, latency 2us, expected best score 2e6 (pair AB). */
-  FD_TEST( add_peer( selector, key_A, addr_AB, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_A, addr_AB, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
-  FD_TEST( add_peer( selector, key_B, addr_AB, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_B, addr_AB, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... peers C and D, latency 3us, expected best score 2e6 (pair AB). */
-  FD_TEST( add_peer( selector, key_C, addr_CD, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_C, addr_CD, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
-  FD_TEST( add_peer( selector, key_D, addr_CD, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_D, addr_CD, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... peers E, latency 4us, expected best score 2e6 (pair AB). */
-  FD_TEST( add_peer( selector, key_E, addr_E, cluster_full_slot, cluster_incr_slot, 4L*1000L*1000L )==4UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_E, addr_E, cluster_full_slot, cluster_incr_slot, 4UL*1000UL*1000UL )==4UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* ... update addr_AB to 5us, expected best score 3e6 (pair CD). */
-  FD_TEST( 2UL==fd_sspeer_selector_update_on_ping( selector, addr_AB, 5L*1000L*1000L ) );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( 2UL==fd_sspeer_selector_update_on_ping( selector, addr_AB, 5UL*1000UL*1000UL ) );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_CD.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   /* ... update addr_CD to 6us, expected best score 4e6 (single E). */
-  FD_TEST( 2UL==fd_sspeer_selector_update_on_ping( selector, addr_CD, 6L*1000L*1000L ) );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( 2UL==fd_sspeer_selector_update_on_ping( selector, addr_CD, 6UL*1000UL*1000UL ) );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_E.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==4L*1000L*1000L );
+  FD_TEST( best.score==4UL*1000UL*1000UL );
 
   /* ... update addr_E to 7us, expected best score 5e6 (pair AB). */
-  FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_E, 7L*1000L*1000L ) );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_E, 7UL*1000UL*1000UL ) );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_AB.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==5L*1000L*1000L );
+  FD_TEST( best.score==5UL*1000UL*1000UL );
+
+  /* ... update unknown addr returns 0 (no peers updated). */
+  FD_TEST( 0UL==fd_sspeer_selector_update_on_ping( selector, addr_X, 1UL*1000UL*1000UL ) );
 
   /* Verify how many peers were added to selector. */
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* Cleanup */
+  /* Verify hashes are preserved after update_on_ping.  Add a peer with
+     explicit hashes, update latency via ping, and confirm hashes are
+     unchanged. */
   fd_sspeer_selector_remove_by_addr( selector, addr_AB );
   fd_sspeer_selector_remove_by_addr( selector, addr_CD );
   fd_sspeer_selector_remove_by_addr( selector, addr_E  );
+
+  uchar test_full_hash[ FD_HASH_FOOTPRINT ];
+  uchar test_incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( test_full_hash, fd_rng_uchar( rng ), FD_HASH_FOOTPRINT );
+  fd_memset( test_incr_hash, fd_rng_uchar( rng ), FD_HASH_FOOTPRINT );
+
+  fd_sspeer_key_t key_F[1]; FD_TEST( generate_rand_sspeer_key( key_F, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t   addr_F;   FD_TEST( generate_rand_addr_non_zero( &addr_F, rng ) );
+
+  fd_sspeer_selector_add( selector, key_F, addr_F, 2UL*1000UL*1000UL,
+                          cluster_full_slot, cluster_incr_slot,
+                          test_full_hash, test_incr_hash );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( fd_memeq( best.full_hash, test_full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.incr_hash, test_incr_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Update latency via ping, hashes should be preserved. */
+  FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_F, 3UL*1000UL*1000UL ) );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_F.l );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
+  FD_TEST( fd_memeq( best.full_hash, test_full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.incr_hash, test_incr_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Cleanup. */
+  fd_sspeer_selector_remove( selector, key_F );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
@@ -425,53 +505,57 @@ test_update_on_resolve( fd_sspeer_selector_t * selector,
 
   /* Add 2 peers and update gradually. */
 
-  /* ... peer A latency 3us, expected best score 3e6 (the expected score must not match the default one). */
-  FD_TEST( add_peer( selector, key_A, addr_A, ULONG_MAX, ULONG_MAX, 3L*1000L*1000L )!=3UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  /* ... peer A latency 3us, expected best score 3e6 (the expected
+     score must not match the default one). */
+  FD_TEST( add_peer( selector, key_A, addr_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )!=3UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
-  FD_TEST( best.full_slot==ULONG_MAX );
-  FD_TEST( best.incr_slot==ULONG_MAX );
-  FD_TEST( best.score==ULONG_MAX );
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, NULL,  cluster_full_slot, cluster_incr_slot, NULL, NULL )==-1 );
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==-2 );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_A, ULONG_MAX, ULONG_MAX, NULL, NULL )==0  );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, NULL,  cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NULL_KEY );
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
-  FD_TEST( best.full_slot==ULONG_MAX );
-  FD_TEST( best.incr_slot==ULONG_MAX );
-  FD_TEST( best.score==ULONG_MAX );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_A, ULONG_MAX, cluster_incr_slot, NULL, NULL )==0  );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is now rejected
+     (an incremental slot requires a known full slot). */
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_INVALID_ARG  );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
-  FD_TEST( best.full_slot==ULONG_MAX );
-  FD_TEST( best.incr_slot==ULONG_MAX );
-  FD_TEST( best.score==ULONG_MAX );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==0  );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
-  /* ... peer B latency 2us, expected best score 2e6 (the expected score must not match the default one). */
-  FD_TEST( add_peer( selector, key_B, addr_B, ULONG_MAX, ULONG_MAX, 2L*1000L*1000L )!=2UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  /* ... peer B latency 2us, expected best score 2e6 (the expected
+     score must not match the default one). */
+  FD_TEST( add_peer( selector, key_B, addr_B, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=2UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==0  );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( best.score==3UL*1000UL*1000UL );
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* Cleanup and verification. */
   fd_sspeer_selector_remove( selector, key_A );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==-2 );
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
   fd_sspeer_selector_remove( selector, key_B );
-  FD_TEST (fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==-2 );
+  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
@@ -494,37 +578,37 @@ test_address_zero( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_0 = { .addr = 0U, .port = 0U };
 
   /* Try to add both peers with addr_0. */
-  FD_TEST( add_peer( selector, key_A, addr_0, cluster_full_slot, cluster_incr_slot, 1L*1000L*1000L )==ULONG_MAX );
-  FD_TEST( add_peer( selector, key_B, addr_0, cluster_full_slot, cluster_incr_slot, 1L*1000L*1000L )==ULONG_MAX );
+  FD_TEST( add_peer( selector, key_A, addr_0, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_0, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   /* Add both peers with valid addresses. */
-  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
-  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   /* Try to add both peers with addr_0. Selector state must not change. */
-  FD_TEST( add_peer( selector, key_A, addr_0, cluster_full_slot, cluster_incr_slot, 1L*1000L*1000L )==ULONG_MAX );
-  FD_TEST( add_peer( selector, key_B, addr_0, cluster_full_slot, cluster_incr_slot, 1L*1000L*1000L )==ULONG_MAX );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_A, addr_0, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_0, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -551,24 +635,24 @@ test_duplicate_hostnames( fd_sspeer_selector_t * selector,
 
   /* Two HTTP servers with same hostname but different resolved_addr. */
   fd_sspeer_key_t key_url_A[1]; FD_TEST( generate_rand_sspeer_key( key_url_A, rng, 1 ) );
-  fd_sspeer_key_t key_url_B[1]; *key_url_B = *key_url_A; key_url_B->url.resolved_addr.l = key_url_A->url.resolved_addr.l ^ 1UL;
+  fd_sspeer_key_t key_url_B[1]; *key_url_B = *key_url_A; key_url_B->url.resolved_addr.l = (key_url_A->url.resolved_addr.l ^ 2UL) | 1UL;
   fd_ip4_port_t addr_A = key_url_A->url.resolved_addr;
   fd_ip4_port_t addr_B = key_url_B->url.resolved_addr;
 
   /* Add both peers with valid addresses. */
-  FD_TEST( add_peer( selector, key_url_A, addr_A, cluster_full_slot, cluster_incr_slot, 3L*1000L*1000L )==3UL*1000UL*1000UL );
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_url_A, addr_A, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3L*1000L*1000L );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
-  FD_TEST( add_peer( selector, key_url_B, addr_B, cluster_full_slot, cluster_incr_slot, 2L*1000L*1000L )==2UL*1000UL*1000UL );
-  best = fd_sspeer_selector_best( selector, 0, ULONG_MAX);
+  FD_TEST( add_peer( selector, key_url_B, addr_B, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2L*1000L*1000L );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -580,6 +664,1418 @@ test_duplicate_hostnames( fd_sspeer_selector_t * selector,
   fd_sspeer_selector_remove( selector, key_url_B );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_add_clears_incremental( fd_sspeer_selector_t * selector,
+                             fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing add clears incremental" ));
+
+  ulong cluster_full_slot = 8000UL;
+  ulong cluster_incr_slot = 8500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_N; FD_TEST( generate_rand_addr_non_zero( &addr_N, rng ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  /* Add peer A with valid incremental. */
+  FD_TEST( add_peer( selector, key_A, addr_N, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_N.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* Peer A should be a valid incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_N.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* Re-add same peer with FD_SSPEER_SLOT_UNKNOWN for incr_slot (it
+     simulates a gossip contact-info update that only carries address,
+     no slot info).  The existing incr_slot should be preserved. */
+  FD_TEST( add_peer( selector, key_A, addr_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_LATENCY_UNKNOWN )==2UL*1000UL*1000UL );
+
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* New gossip message for peer A arrives without an incremental but
+     with the SAME full_slot.  The peer's existing incr_slot (8500) is
+     >= full_slot (8000), so the incremental is not stale and should
+     be preserved (slot-based clearing only clears when incr_slot <
+     full_slot). */
+  uchar temp_full_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( temp_full_hash, fd_rng_uchar( rng ), FD_HASH_FOOTPRINT );
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   temp_full_hash, NULL )==2UL*1000UL*1000UL );
+
+  /* Peer A should STILL be a valid incremental candidate (not stale). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* full_hash should be updated even though incremental was preserved. */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Clear incremental by advancing full_slot past the peer's incr_slot.
+     Peer has incr_slot=8500, new full_slot=8501 > 8500, so the
+     incremental is genuinely stale and should be cleared. */
+  ulong new_full_slot = cluster_incr_slot + 1UL;
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   temp_full_hash, NULL )==2UL*1000UL*1000UL );
+
+  /* Peer A should no longer be an incremental candidate (cleared). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+  best = fd_sspeer_selector_best( selector, 1, new_full_slot );
+  FD_TEST( !best.addr.l );
+
+  /* Full selection should return peer A with updated full_slot. */
+  uchar zeroed_hash[ FD_HASH_FOOTPRINT ] = {0};
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==new_full_slot );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* Restore peer A with a valid incremental for subsequent tests. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, cluster_incr_slot,
+                                   temp_full_hash, temp_full_hash )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Same full_slot again (idempotent): incr_slot (8500) >= full_slot
+     (8000) means the incremental is not stale, so it is preserved. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   temp_full_hash, NULL )==2UL*1000UL*1000UL );
+
+  /* Peer A should still be an incremental candidate (not stale). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+
+  /* full_slot exactly at incr_slot: incr_slot (8500) >= full_slot
+     (8500) so the incremental is not stale and is preserved. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_incr_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   temp_full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
+  best = fd_sspeer_selector_best( selector, 1, cluster_incr_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* Now clear with full_slot one past incr_slot: incr_slot (8500) <
+     full_slot (8501), genuinely stale. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_incr_slot + 1UL, FD_SSPEER_SLOT_UNKNOWN,
+                                   temp_full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
+  best = fd_sspeer_selector_best( selector, 1, cluster_incr_slot + 1UL );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Add peer B without incremental (new peer). */
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Peer A is still best for full (lower latency). */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+
+  /* Neither peer should be an incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Re-add peer A with a valid incremental slot.  This verifies the
+     full transition cycle: has-incremental -> clear -> has-incremental. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, cluster_incr_slot,
+                                   temp_full_hash, temp_full_hash )==2UL*1000UL*1000UL );
+
+  /* Peer A should once again be a valid incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+  FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.incr_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+
+  /* add() with full_hash==NULL, incr_hash!=NULL: the full_hash should
+     be preserved (not overwritten) and the incr_hash should be updated.
+     No slot-based clearing because full_slot==UNKNOWN. */
+  uchar new_incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( new_incr_hash, 0xEE, FD_HASH_FOOTPRINT );
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
+                                   NULL, new_incr_hash )!=FD_SSPEER_SCORE_INVALID );
+
+  /* The peer's existing full_hash should be preserved (full_hash was
+     NULL so no overwrite), and incr_hash should be updated. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.incr_hash, new_incr_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_on_resolve_clears_incremental( fd_sspeer_selector_t * selector,
+                                    fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing on_resolve clears incremental" ));
+
+  ulong cluster_full_slot = 8700UL;
+  ulong cluster_incr_slot = 8800UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+
+  /* Add peer A with valid full+incremental and explicit hashes. */
+  uchar rand_uchar = fd_rng_uchar( rng );
+  uchar full_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( full_hash,  rand_uchar, FD_HASH_FOOTPRINT );
+  uchar incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( incr_hash, ~rand_uchar, FD_HASH_FOOTPRINT );
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, 2UL*1000UL*1000UL,
+                                   cluster_full_slot, cluster_incr_slot,
+                                   full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Peer A should be a valid incremental candidate. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* Call update_on_resolve with full_hash non-NULL and incr_hash NULL,
+     using the SAME full_slot.  Because the peer's incr_slot (8800) >=
+     full_slot (8700), the incremental is not stale and is preserved. */
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+
+  /* Peer A should STILL be a valid incremental candidate (not stale). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* Now advance full_slot past the peer's incr_slot so the slot-based
+     clear fires.  new_full_slot (8801) > incr_slot (8800). */
+  ulong new_full_slot = cluster_incr_slot + 1UL;
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+
+  /* Peer A should no longer be an incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Peer A should still be valid for full selection with cleared
+     incremental (incr_slot==FD_SSPEER_SLOT_UNKNOWN, incr_hash zeroed). */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==new_full_slot );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  uchar zeroed_hash[ FD_HASH_FOOTPRINT ] = {0};
+  FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cluster_slot_incremental( fd_sspeer_selector_t * selector,
+                               fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing cluster slot incremental" ));
+
+  ulong cluster_full_slot = 9000UL;
+  ulong cluster_incr_slot = 9500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  /* Add two peers with valid incrementals at the cluster slot. */
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+
+  /* Peer A is the best incremental candidate. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* A newer full_slot arrives with no incremental.  The cluster full
+     slot advances but incremental is preserved (not reset). */
+  fd_sspeer_selector_process_cluster_slot( selector, 9001UL, FD_SSPEER_SLOT_UNKNOWN );
+
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==9001UL );
+  FD_TEST( cs.incremental==cluster_incr_slot );
+
+  /* Peers still have incr_slot==9500 so they are still valid
+     incremental candidates for base_slot 9000.  Cluster incremental
+     is preserved at 9500, so slots_behind==0 and score==latency. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* A subsequent observation with a higher incremental advances it. */
+  fd_sspeer_selector_process_cluster_slot( selector, 9001UL, 9600UL );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==9001UL );
+  FD_TEST( cs.incremental==9600UL );
+
+  /* Now peers are 100 slots behind (9600-9500). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 100UL*1000UL );
+
+  /* Advance full past incremental (9600) to 10000 with no new
+     incremental.  The cluster incremental is invalidated (set to
+     FD_SSPEER_SLOT_UNKNOWN).  All peers must be rescored: peers with
+     valid incr_slot now fall back to comparing full_slot against the
+     cluster full slot.  Peers have full_slot=9000, so
+     slots_behind = 10000-9000 = 1000. */
+  fd_sspeer_selector_process_cluster_slot( selector, 10000UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==10000UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Peers still have incr_slot==9500 so they are still incremental
+     candidates for base_slot 9000.  Score: latency + 1000*1000. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL*1000UL );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  /* Full selection falls back to full_slot comparison when
+     cluster.incremental == FD_SSPEER_SLOT_UNKNOWN.
+     Same score as incremental. */
+  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL*1000UL );
+
+  /* Re-establish cluster incremental.  Peers should be rescored back
+     to using incremental slot difference. */
+  fd_sspeer_selector_process_cluster_slot( selector, 10000UL, 10000UL );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==10000UL );
+  FD_TEST( cs.incremental==10000UL );
+
+  /* Peers are now 500 slots behind (10000-9500).
+     Score = 2_000_000 + 500*1000 = 2_500_000. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 500UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_slot_zero( fd_sspeer_selector_t * selector,
+                fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing slot zero" ));
+
+  /* full_slot==0 and incr_slot==0 are valid slot values (e.g. genesis).
+     Set (0, 1) so the peer at incr_slot=0 is one slot behind. */
+  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 1UL );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  /* Peer at full_slot=0, incr_slot=0, latency 2ms.  Cluster is at
+     (0, 1), which means the peer is 1 slot behind.  Then the score is
+     2_000_000 + 1*1000 = 2_001_000. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 1000UL );
+
+  /* Full selection: peer should be valid and best. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==0UL );
+  FD_TEST( best.incr_slot==0UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+
+  /* Incremental selection with base_slot=0: peer's full_slot==0
+     matches base_slot, and incr_slot==0 != FD_SSPEER_SLOT_UNKNOWN. */
+  best = fd_sspeer_selector_best( selector, 1, 0UL );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==0UL );
+  FD_TEST( best.incr_slot==0UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+
+  /* Peer with full_slot==0, incr_slot==FD_SSPEER_SLOT_UNKNOWN: valid
+     for full but NOT for incremental selection.  full_slot uses the
+     full cluster slot branch: slots_behind = cluster_full(0) - 0 = 0.
+     score = 3_000_000. */
+  FD_TEST( add_peer( selector, key_B, addr_B, 0UL, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+  best = fd_sspeer_selector_best( selector, 1, 0UL );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==0UL );
+
+  /* Score with incr_slot=0 when cluster has advanced.  Re-add peer A
+     to observe the rescored value via the add_peer return. */
+  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 100UL );
+  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 100UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_score_saturation( fd_sspeer_selector_t * selector,
+                       fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing score saturation" ));
+
+  fd_sspeer_key_t key[1]; FD_TEST( generate_rand_sspeer_key( key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t   addr;   FD_TEST( generate_rand_addr_non_zero( &addr, rng ) );
+
+  /* Cluster incremental is FD_SSPEER_SLOT_UNKNOWN (initial state):
+     the score function falls back to comparing full_slot against
+     cluster full slot.  Cluster full is 0, peer full is 10000, so
+     the peer is ahead of the cluster and slots_behind=0.
+     score = 5_000_000. */
+  ulong score = add_peer( selector, key, addr, 10000UL, 10500UL, 5UL*1000UL*1000UL );
+  FD_TEST( score==5UL*1000UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Score is never FD_SSPEER_SCORE_INVALID: verify the cap prevents
+     confusion with the "no peer" sentinel. */
+  FD_TEST( score!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( FD_SSPEER_SCORE_MAX<FD_SSPEER_SCORE_INVALID );
+
+  /* Establish a cluster with both full and incremental slots. */
+  ulong cluster_full_slot = 10000UL;
+  ulong cluster_incr_slot = 10500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  /* Normal score, no overflow: peer at cluster slot, latency 5ms.
+     score = 5_000_000 + 0 = 5_000_000. */
+  FD_TEST( add_peer( selector, key, addr, 10000UL, 10500UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Slots-behind penalty: peer incr_slot 100 behind cluster.
+     score = 5_000_000 + 100*1000 = 5_100_000. */
+  FD_TEST( add_peer( selector, key, addr, 10000UL, 10400UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL + 100UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Default latency (FD_SSPEER_LATENCY_UNKNOWN input): peer at cluster slot.
+     score = DEFAULT_PEER_LATENCY = 100_000_000. */
+  FD_TEST( add_peer( selector, key, addr, 10000UL, 10500UL, FD_SSPEER_LATENCY_UNKNOWN )==100UL*1000UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Default latency + slot-behind penalty combined: peer has unknown
+     latency and incr_slot 100 behind cluster.
+     score = DEFAULT_PEER_LATENCY + 100*1000 = 100_100_000. */
+  FD_TEST( add_peer( selector, key, addr, 10000UL, 10400UL, FD_SSPEER_LATENCY_UNKNOWN )==100UL*1000UL*1000UL + 100UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Unresolved full slot: peer has FD_SSPEER_SLOT_UNKNOWN for both slots.
+     slots_behind = DEFAULT_SLOTS_BEHIND = 1_000_000.
+     score = 5_000_000 + 1_000_000*1000 = 1_005_000_000. */
+  FD_TEST( add_peer( selector, key, addr, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL + 1000UL*1000UL*1000UL );
+  fd_sspeer_selector_remove( selector, key );
+
+  /* Unresolved full slot with valid incr_slot:
+     full_slot==FD_SSPEER_SLOT_UNKNOWN with incr_slot!=UNKNOWN is now
+     rejected (an incremental slot requires a known full slot). */
+  FD_TEST( add_peer( selector, key, addr, FD_SSPEER_SLOT_UNKNOWN, 10500UL, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+
+  /* Score saturation: peer's full_slot is far behind a very high cluster
+     full slot.  slots_behind = (ULONG_MAX-1) - 0 = ULONG_MAX-1, which
+     causes sat_mul(1000, ULONG_MAX-1) to overflow, then sat_add also
+     overflows, and the result is clamped to FD_SSPEER_SCORE_MAX. */
+  fd_sspeer_selector_process_cluster_slot( selector, ULONG_MAX-1UL, ULONG_MAX-1UL );
+  FD_TEST( add_peer( selector, key, addr, 0UL, FD_SSPEER_SLOT_UNKNOWN, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_MAX );
+  fd_sspeer_selector_remove( selector, key );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cluster_slot_monotonicity( fd_sspeer_selector_t * selector_incr,
+                                fd_sspeer_selector_t * selector_full ) {
+  FD_LOG_NOTICE(( "testing cluster slot monotonicity" ));
+
+  /* Incremental mode (incremental_snapshot_fetch=1).
+     Use slot values higher than any previous test to avoid
+     monotonicity rejection from prior cluster slot state. */
+
+  /* Establish baseline: full=20000, incr=20200. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20000UL, 20200UL );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20000UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* Both FD_SSPEER_SLOT_UNKNOWN => no-op. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20000UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* full_slot==FD_SSPEER_SLOT_UNKNOWN with valid incr_slot => no-op. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, FD_SSPEER_SLOT_UNKNOWN, 99999UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20000UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* incr_slot==stored incr (20200), same full => rejected (no forward
+     progress on either axis). */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20000UL, 20200UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20000UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* incr_slot==stored incr (20200), but full advances (20050 > 20000):
+     accepted because the full slot has made forward progress. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20200UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20050UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* incr_slot < stored incr => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20199UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20050UL );
+  FD_TEST( cs.incremental==20200UL );
+
+  /* incr_slot > stored incr => accepted. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20201UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20050UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* Advance full with incr==FD_SSPEER_SLOT_UNKNOWN.  Full advances but
+     incremental is preserved (not reset). */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* incr==FD_SSPEER_SLOT_UNKNOWN, full<=stored full => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* incr==FD_SSPEER_SLOT_UNKNOWN, full<stored full => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20149UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* incr_slot==stored incr, full<=stored full => rejected (no forward
+     progress). */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20201UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* incr_slot < stored incr => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20200UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20201UL );
+
+  /* incr_slot > stored incr => accepted. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20202UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20150UL );
+  FD_TEST( cs.incremental==20202UL );
+
+  /* Advance full past incremental with incr==FD_SSPEER_SLOT_UNKNOWN.
+     The stored incremental (20202) is now stale because the full slot
+     (20300) advanced past it.  It must be invalidated. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20300UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20300UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Re-establish incremental after invalidation. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20300UL, 20400UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20300UL );
+  FD_TEST( cs.incremental==20400UL );
+
+  /* full_slot regression with valid incr_slot: rejected.  Even though
+     incr_slot (20500) advances past stored incremental (20400),
+     full_slot (20200) is less than stored full (20300), so the update
+     must be rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20200UL, 20500UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20300UL );
+  FD_TEST( cs.incremental==20400UL );
+
+  /* full_slot regression with valid incr_slot, stored incr unknown:
+     rejected.  First invalidate the stored incremental by advancing
+     full past it. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20500UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20500UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20400UL, 20600UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20500UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Re-establish for subsequent tests. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20500UL, 20600UL );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20500UL );
+  FD_TEST( cs.incremental==20600UL );
+
+  /* Advance full to exactly the incremental slot with
+     incr==FD_SSPEER_SLOT_UNKNOWN.  incr==full is not stale
+     (incremental is at the same slot), so incremental is preserved. */
+  fd_sspeer_selector_process_cluster_slot( selector_incr, 20600UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_incr );
+  FD_TEST( cs.full==20600UL );
+  FD_TEST( cs.incremental==20600UL );
+
+  /* Full-only mode (incremental_snapshot_fetch=0). */
+
+  /* Establish baseline: full=500. */
+  fd_sspeer_selector_process_cluster_slot( selector_full, 500UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_full );
+  FD_TEST( cs.full==500UL );
+
+  /* full<=stored full => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_full, 500UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_full );
+  FD_TEST( cs.full==500UL );
+
+  /* full<stored full => rejected. */
+  fd_sspeer_selector_process_cluster_slot( selector_full, 499UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_full );
+  FD_TEST( cs.full==500UL );
+
+  /* full>stored full => accepted. */
+  fd_sspeer_selector_process_cluster_slot( selector_full, 501UL, FD_SSPEER_SLOT_UNKNOWN );
+  cs = fd_sspeer_selector_cluster_slot( selector_full );
+  FD_TEST( cs.full==501UL );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_pool_exhaustion( fd_sspeer_selector_t * selector,
+                      fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing pool exhaustion" ));
+
+  ulong cluster_full = 1000UL;
+  ulong cluster_incr = 1500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full, cluster_incr );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, 0 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, 0 ) );
+  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, 0 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
+
+  /* Fill to max capacity. */
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full, cluster_incr, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full, cluster_incr, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* 3rd unique peer should be rejected (max capacity). */
+  FD_TEST( add_peer( selector, key_C, addr_C, cluster_full, cluster_incr, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+
+  /* Existing peers are unaffected. */
+  FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Updating an existing peer still succeeds. */
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full, cluster_incr, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Best peer should be A (updated to 1ms latency, score 1_000_000). */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  /* Remove a peer, then adding the 3rd peer should succeed. */
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( add_peer( selector, key_C, addr_C, cluster_full, cluster_incr, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  /* Clean up. */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_C );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_add_null_key( fd_sspeer_selector_t * selector,
+                   fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing add null key" ));
+
+  fd_ip4_port_t addr_A[1];
+  FD_TEST( generate_rand_addr_non_zero( addr_A, rng ) );
+
+  /* Adding with NULL key should return FD_SSPEER_SCORE_INVALID and not modify state. */
+
+  FD_TEST( add_peer( selector, NULL, *addr_A, 100UL, 200UL, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Add a valid peer, then try NULL key again to confirm no corruption. */
+
+  fd_sspeer_key_t key_A[1];
+  FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
+
+  ulong cluster_full_slot = 100UL;
+  ulong cluster_incr_slot = 200UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_TEST( add_peer( selector, NULL, *addr_A, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Cleanup. */
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_remove_null_key( fd_sspeer_selector_t * selector,
+                      fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing remove null key" ));
+
+  /* Remove with NULL key on empty selector should be a safe no-op. */
+
+  fd_sspeer_selector_remove( selector, NULL );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Add a valid peer, then remove with NULL key to confirm no corruption. */
+
+  fd_sspeer_key_t key_A[1];
+  FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
+  fd_ip4_port_t addr_A[1];
+  FD_TEST( generate_rand_addr_non_zero( addr_A, rng ) );
+
+  ulong cluster_full_slot = 100UL;
+  ulong cluster_incr_slot = 200UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  fd_sspeer_selector_remove( selector, NULL );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Cleanup. */
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_remove_unknown_key( fd_sspeer_selector_t * selector,
+                         fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing remove unknown key" ));
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
+  fd_ip4_port_t addr_A[1]; FD_TEST( generate_rand_addr_non_zero( addr_A, rng ) );
+
+  /* Remove unknown key on empty selector should be a safe no-op. */
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Add a valid peer, then remove a different unknown key. */
+
+  ulong cluster_full_slot = 100UL;
+  ulong cluster_incr_slot = 200UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Cleanup. */
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_remove_by_addr_unknown( fd_sspeer_selector_t * selector,
+                             fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing remove by addr unknown" ));
+
+  fd_ip4_port_t addr_A[1]; FD_TEST( generate_rand_addr_non_zero( addr_A, rng ) );
+  fd_ip4_port_t addr_B[1]; FD_TEST( generate_rand_addr_non_zero( addr_B, rng ) );
+
+  /* Remove unknown addr on empty selector should be a safe no-op. */
+
+  fd_sspeer_selector_remove_by_addr( selector, *addr_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Add a valid peer, then remove a different unknown addr. */
+
+  fd_sspeer_key_t key_A[1];
+  FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
+
+  ulong cluster_full_slot = 100UL;
+  ulong cluster_incr_slot = 200UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  fd_sspeer_selector_remove_by_addr( selector, *addr_B );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Cleanup. */
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_best_empty_selector( fd_sspeer_selector_t * selector,
+                          fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing best on empty selector" ));
+  (void)rng;
+
+  /* Best on empty selector should return sentinel values. */
+
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==0UL );
+  FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_best_incremental_on_full_only_selector( fd_sspeer_selector_t * selector,
+                                             fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing best incremental on full-only selector" ));
+
+  /* The selector was created with incr_snap_fetch=0 (full-only mode).
+     Verify that fd_sspeer_selector_best(selector, 1, base_slot) still
+     works correctly.  The incremental flag in best() filters by peer
+     attributes (full_slot==base_slot && incr_slot!=FD_SSPEER_SLOT_UNKNOWN),
+     it does NOT depend on the selector's incremental_snapshot_fetch
+     setting. */
+
+  ulong cluster_full_slot = 30000UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
+
+  /* Peer A: has incremental.  Peer B: no incremental.  Peer C: has
+     incremental at a different base slot. */
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_full_slot + 500UL, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_C, addr_C, cluster_full_slot - 1UL, cluster_full_slot + 400UL, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Full selection: peer C has the lowest score.  Cluster incremental
+     is UNKNOWN so all peers with incr_slot fall back to the full_slot
+     comparison.  Peer C: latency=1ms, slots_behind=1 (30000-29999),
+     score = 1_000_000 + 1_000 = 1_001_000.  Peer B: latency=2ms,
+     slots_behind=0, score = 2_000_000.  Peer A: latency=3ms,
+     slots_behind=0, score = 3_000_000. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_C.l );
+  FD_TEST( best.score==1UL*1000UL*1000UL + 1UL*1000UL );
+
+  /* Incremental selection with the right base_slot: only peer A
+     qualifies (peer B has no incr, peer C has a different full_slot). */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_full_slot + 500UL );
+
+  /* Incremental selection with a base_slot that no peer matches. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot + 999UL );
+  FD_TEST( best.addr.l==0UL );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Incremental selection with peer C's base_slot. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot - 1UL );
+  FD_TEST( best.addr.l==addr_C.l );
+  FD_TEST( best.full_slot==cluster_full_slot - 1UL );
+  FD_TEST( best.incr_slot==cluster_full_slot + 400UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  fd_sspeer_selector_remove( selector, key_C );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_ping_preserves_cleared_incremental( fd_sspeer_selector_t * selector,
+                                         fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing ping preserves cleared incremental" ));
+
+  /* Verify that update_on_ping does NOT restore stale incremental data
+     after a peer's incremental was cleared via slot-based clearing.
+
+     The update_on_ping codepath passes NULL, NULL for hashes and
+     FD_SSPEER_SLOT_UNKNOWN for both slots.  In fd_sspeer_selector_update,
+     since full_slot==UNKNOWN, no slot-based clearing fires and the
+     existing incr_slot/incr_hash are preserved (already cleared).
+     So the peer's incr_slot and incr_hash should remain as they were
+     (cleared to FD_SSPEER_SLOT_UNKNOWN and zeroed, respectively). */
+
+  ulong cluster_full_slot = 31000UL;
+  ulong cluster_incr_slot = 31500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+
+  uchar full_hash[ FD_HASH_FOOTPRINT ];
+  uchar incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( full_hash, 0xAA, FD_HASH_FOOTPRINT );
+  fd_memset( incr_hash, 0xBB, FD_HASH_FOOTPRINT );
+
+  /* Add peer A with valid full + incremental and explicit hashes. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, 2UL*1000UL*1000UL,
+                                   cluster_full_slot, cluster_incr_slot,
+                                   full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Peer A should be a valid incremental candidate. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( fd_memeq( best.incr_hash, incr_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Clear the peer's incremental via slot-based clearing.  Advance
+     full_slot past incr_slot: new_full_slot (31501) > incr_slot
+     (31500), so the incremental is stale and will be cleared. */
+  ulong new_full_slot = cluster_incr_slot + 1UL;
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Peer A should no longer be an incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Verify cleared state. */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==new_full_slot );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  uchar zeroed_hash[ FD_HASH_FOOTPRINT ] = {0};
+  FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
+
+  /* Send a ping update.  This must NOT restore the cleared
+     incremental data. */
+  FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_A, 1UL*1000UL*1000UL ) );
+
+  /* The peer's incr_slot should still be FD_SSPEER_SLOT_UNKNOWN and
+     incr_hash should still be zeroed. */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
+  /* full_hash should be preserved through the ping. */
+  FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
+  /* Latency should have updated. */
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  /* Still not a valid incremental candidate. */
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Send another ping update to verify repeated pings
+     never restore stale incremental data. */
+  FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_A, 500UL*1000UL ) );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
+
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( !best.addr.l );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_stress_peer_count( fd_sspeer_selector_t * selector,
+                        fd_rng_t *             rng,
+                        ulong                  max_peers ) {
+  FD_LOG_NOTICE(( "testing stress peer count (max_peers=%lu)", max_peers ));
+
+  /* Stress the selector with max_peers=32.  Try to add 34 peers
+     (exceeding capacity by 2) to exercise pool exhaustion, then
+     remove and re-add peers to verify the maps and treap stay
+     consistent under churn. */
+
+  ulong const MAX_PEERS = 32UL;
+  FD_TEST( MAX_PEERS==max_peers );
+  ulong const TRY_CNT   = 34UL;
+
+  ulong cluster_full_slot = 50000UL;
+  ulong cluster_incr_slot = 50500UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t keys[ 34 ];
+  fd_ip4_port_t   addrs[ 34 ];
+
+  /* Try to add 34 peers.  The first 32 should succeed, the remaining
+     2 should be rejected (pool exhaustion). */
+
+  ulong best_full_score = FD_SSPEER_SCORE_INVALID;
+  ulong best_full_idx   = ULONG_MAX;
+  ulong best_incr_score = FD_SSPEER_SCORE_INVALID;
+  ulong best_incr_idx   = ULONG_MAX;
+  ulong added_cnt       = 0UL;
+
+  for( ulong i=0UL; i<TRY_CNT; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &addrs[i], rng ) );
+
+    ulong latency = (i + 1UL) * 1000UL * 1000UL;
+
+    ulong peer_incr_slot;
+    if( i % 2UL == 0UL ) {
+      ulong behind = i % 10UL;
+      peer_incr_slot = cluster_incr_slot - behind;
+    } else {
+      peer_incr_slot = FD_SSPEER_SLOT_UNKNOWN;
+    }
+
+    ulong score = add_peer( selector, &keys[i], addrs[i], cluster_full_slot, peer_incr_slot, latency );
+
+    if( i<MAX_PEERS ) {
+      FD_TEST( score!=FD_SSPEER_SCORE_INVALID );
+      added_cnt++;
+      if( score<best_full_score ) {
+        best_full_score = score;
+        best_full_idx   = i;
+      }
+      if( i % 2UL == 0UL && score<best_incr_score ) {
+        best_incr_score = score;
+        best_incr_idx   = i;
+      }
+    } else {
+      FD_TEST( score==FD_SSPEER_SCORE_INVALID );
+    }
+  }
+
+  FD_TEST( added_cnt==MAX_PEERS );
+  FD_TEST( best_full_idx==0UL );
+  FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Verify best full and incremental peers. */
+
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addrs[ best_full_idx ].l );
+  FD_TEST( best.score==best_full_score );
+
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  FD_TEST( best.addr.l==addrs[ best_incr_idx ].l );
+  FD_TEST( best.score==best_incr_score );
+
+  /* Remove the best full peer and verify the next best. */
+
+  fd_sspeer_selector_remove( selector, &keys[ best_full_idx ] );
+  FD_TEST( (MAX_PEERS - 1UL)==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l!=0UL );
+  FD_TEST( best.score>=best_full_score );
+
+  /* Now that a slot is free, one of the previously rejected peers
+     (index 32) should succeed. */
+
+  {
+    ulong overflow_idx = 32UL;
+    ulong overflow_lat = (overflow_idx + 1UL) * 1000UL * 1000UL;
+    ulong overflow_inc = overflow_idx % 2UL == 0UL
+                         ? cluster_incr_slot - (overflow_idx % 10UL)
+                         : FD_SSPEER_SLOT_UNKNOWN;
+    FD_TEST( add_peer( selector, &keys[ overflow_idx ], addrs[ overflow_idx ],
+                       cluster_full_slot, overflow_inc, overflow_lat )!=FD_SSPEER_SCORE_INVALID );
+    FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+    /* Remove the overflow peer and half the original peers (note:
+       best_full_idx==0 was already removed, so i==0 is a no-op). */
+
+    fd_sspeer_selector_remove( selector, &keys[ overflow_idx ] );
+  }
+  for( ulong i=0UL; i<MAX_PEERS; i+=2UL ) {
+    fd_sspeer_selector_remove( selector, &keys[ i ] );
+  }
+
+  /* 31 peers before the loop (32 - best_full + overflow - overflow).
+     Loop touches 16 even indices but best_full_idx==0 was already
+     removed, so only 15 actual removals => 16 remaining (odd indices). */
+
+  ulong remaining = fd_sspeer_selector_peer_map_by_key_ele_cnt( selector );
+  FD_TEST( remaining==16UL );
+  FD_TEST( remaining==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  if( remaining>0UL ) {
+    FD_TEST( best.addr.l!=0UL );
+    FD_TEST( best.score!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Advance the cluster slot and verify rescoring. */
+
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot + 100UL, cluster_incr_slot + 100UL );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  if( remaining>0UL ) {
+    FD_TEST( best.addr.l!=0UL );
+    FD_TEST( best.score!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Re-add removed peers to fill back to capacity. */
+
+  for( ulong i=0UL; i<MAX_PEERS; i+=2UL ) {
+    ulong lat = (i + 1UL) * 1000UL * 1000UL;
+    ulong inc = i % 2UL == 0UL
+                ? cluster_incr_slot + 100UL - (i % 10UL)
+                : FD_SSPEER_SLOT_UNKNOWN;
+    add_peer( selector, &keys[ i ], addrs[ i ], cluster_full_slot + 100UL, inc, lat );
+  }
+
+  FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* Verify incremental selection still works. */
+
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot + 100UL );
+  if( best.addr.l ) {
+    FD_TEST( best.full_slot==cluster_full_slot + 100UL );
+    FD_TEST( best.incr_slot!=FD_SSPEER_SLOT_UNKNOWN );
+    FD_TEST( best.score!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Clean up all peers. */
+  for( ulong i=0UL; i<TRY_CNT; i++ ) {
+    fd_sspeer_selector_remove( selector, &keys[i] );
+  }
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_genesis_cluster_slot( fd_sspeer_selector_t * selector,
+                           fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing genesis cluster slot (0, 0)" ));
+
+  /* Verify that process_cluster_slot(0, 0) succeeds from the initial
+     state {full=0, incremental=FD_SSPEER_SLOT_UNKNOWN}.  This is the
+     genesis case where both the full and incremental snapshots are at
+     slot 0. */
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 0UL );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==0UL );
+
+  /* Verify scoring when cluster.incremental == cluster.full == 0.
+     Peer with incr_slot=0: slots_behind = 0.  Score = latency.
+     Peer with incr_slot=FD_SSPEER_SLOT_UNKNOWN: uses full branch,
+     slots_behind = 0.  Score = latency. */
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL,        2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key_B, addr_B, 0UL, FD_SSPEER_SLOT_UNKNOWN,  3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+
+  /* Peer A has lower score, so it's best for full selection. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* Peer A is the only incremental candidate (B has
+     incr_slot==FD_SSPEER_SLOT_UNKNOWN). */
+  best = fd_sspeer_selector_best( selector, 1, 0UL );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.incr_slot==0UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* Advance cluster to (0, 5).  Peer A is now 5 slots behind.
+     Score = 2_000_000 + 5*1000 = 2_005_000. */
+  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 5UL );
+  best = fd_sspeer_selector_best( selector, 1, 0UL );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 5UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cluster_slot_rescore_full_only( fd_sspeer_selector_t * selector,
+                                     fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing cluster slot rescore full only" ));
+
+  ulong cluster_full_slot = 1000UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  /* Peer A at cluster slot, peer B 2 slots behind.
+     A: slots_behind=0, score=3_000_000.
+     B: slots_behind=2, score=2_000_000 + 2*1000 = 2_002_000. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 1000UL, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key_B, addr_B,  998UL, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 2UL*1000UL );
+
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_B.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 2UL*1000UL );
+
+  /* Advance cluster full slot.  All peers should be rescored.
+     A: slots_behind=100, score=3_000_000 + 100*1000 = 3_100_000.
+     B: slots_behind=102, score=2_000_000 + 102*1000 = 2_102_000. */
+  fd_sspeer_selector_process_cluster_slot( selector, 1100UL, FD_SSPEER_SLOT_UNKNOWN );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_B.l );
+  FD_TEST( best.score==2UL*1000UL*1000UL + 102UL*1000UL );
+
+  /* Cleanup. */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
+                                      fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing invalid clear and best sentinel" ));
+
+  ulong cluster_full_slot = 9500UL;
+  ulong cluster_incr_slot = 9600UL;
+  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+
+  uchar full_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( full_hash, 0xAB, FD_HASH_FOOTPRINT );
+  uchar incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_memset( incr_hash, 0xCD, FD_HASH_FOOTPRINT );
+
+  /* Add peer A with valid full+incremental. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, 2UL*1000UL*1000UL,
+                                   cluster_full_slot, cluster_incr_slot,
+                                   full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
+
+  /* full_hash set, incr_hash NULL, incr_slot != FD_SSPEER_SLOT_UNKNOWN
+     is now valid (slot-based clearing handles the decision).  The
+     update should succeed because the existing peer's incr_slot (9600)
+     >= full_slot (9500), so the incremental is preserved. */
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+
+  /* Peer A should be unaffected (incremental preserved). */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+  FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
+  FD_TEST( fd_memeq( best.incr_hash, incr_hash, FD_HASH_FOOTPRINT ) );
+
+  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is invalid.  add() for
+     a new peer with this combination must be rejected. */
+  fd_sspeer_key_t key_new[1]; FD_TEST( generate_rand_sspeer_key( key_new, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_new; FD_TEST( generate_rand_addr_non_zero( &addr_new, rng ) );
+  FD_TEST( fd_sspeer_selector_add( selector, key_new, addr_new, 2UL*1000UL*1000UL,
+                                   FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot,
+                                   NULL, NULL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* update_on_resolve with full_slot==UNKNOWN and incr_slot!=UNKNOWN
+     on an existing peer with known full_slot succeeds because the
+     effective full_slot is the peer's stored value (not UNKNOWN). */
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot,
+                                                 NULL, incr_hash )==FD_SSPEER_UPDATE_SUCCESS );
+
+  /* fd_sspeer_selector_best with incremental=1 and
+     base_slot=FD_SSPEER_SLOT_UNKNOWN should return the sentinel. */
+  best = fd_sspeer_selector_best( selector, 1, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* incr_slot < full_slot rejection. */
+
+  /* add() for a new peer with incr_slot < full_slot must be rejected. */
+  FD_TEST( add_peer( selector, key_new, addr_new, 200UL, 100UL, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* add() updating an existing peer with incr_slot < full_slot must be
+     rejected, and the peer must remain unmodified. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 300UL, 100UL, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* update_on_resolve with incr_slot < full_slot must be rejected. */
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 200UL, 100UL,
+                                                 full_hash, incr_hash )==FD_SSPEER_UPDATE_ERR_INVALID_ARG );
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.full_slot==cluster_full_slot );
+  FD_TEST( best.incr_slot==cluster_incr_slot );
+
+  /* process_cluster_slot with incr_slot < full_slot should be silently
+     rejected (cluster slot unchanged). */
+  fd_sscluster_slot_t cs_before = fd_sspeer_selector_cluster_slot( selector );
+  fd_sspeer_selector_process_cluster_slot( selector, 50000UL, 40000UL );
+  fd_sscluster_slot_t cs_after = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs_before.full==cs_after.full );
+  FD_TEST( cs_before.incremental==cs_after.incremental );
+
+  /* incr_slot == full_slot boundary (non-genesis). */
+
+  /* add() for a new peer with incr_slot == full_slot must be accepted. */
+  FD_TEST( add_peer( selector, key_new, addr_new, 500UL, 500UL, 5UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_remove( selector, key_new );
+
+  /* add() updating an existing peer with incr_slot == full_slot must
+     be accepted. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 500UL, 500UL, 5UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* update_on_resolve with incr_slot == full_slot must be accepted. */
+  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
+                                                 600UL, 600UL,
+                                                 full_hash, incr_hash )==FD_SSPEER_UPDATE_SUCCESS );
+
+  /* process_cluster_slot with incr_slot == full_slot must be accepted. */
+  fd_sspeer_selector_process_cluster_slot( selector, 60000UL, 60000UL );
+  fd_sscluster_slot_t cs_eq = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs_eq.full==60000UL );
+  FD_TEST( cs_eq.incremental==60000UL );
+
+  /* Cleanup. */
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   FD_LOG_NOTICE(( "... pass" ));
 }
@@ -599,26 +2095,131 @@ main( int     argc,
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, rng_seed, 0UL ) );
   FD_LOG_NOTICE(( "rng seed %u", rng_seed ));
 
+  /* Initialize and verify. */
+
   FD_TEST( wksp );
-  void *                 shmem    = fd_wksp_alloc_laddr( wksp, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( 65535UL ), 1UL );
-  fd_sspeer_selector_t * selector = fd_sspeer_selector_join( fd_sspeer_selector_new( shmem, 65535UL, 1, fd_rng_ulong( rng )/*seed*/ ) );
-  FD_TEST( selector );
+  test_wksp_t t_wksp_base  = {0};
+  test_wksp_t t_wksp_full  = {0};
+  test_wksp_t t_wksp_small = {0};
+  test_wksp_t t_wksp_stress= {0};
 
-  test_basic_peer_selection( selector, rng );
+  test_wksp_init( wksp,
+                  &t_wksp_base,
+                  65536UL/*max_peers*/,
+                  1/*incr_snap_fetch*/,
+                  fd_rng_ulong( rng )/*seed*/ );
 
-  test_duplicate_peers( selector, rng );
+  test_wksp_init( wksp,
+                  &t_wksp_full,
+                  4UL/*max_peers*/,
+                  0/*incr_snap_fetch*/,
+                  fd_rng_ulong( rng )/*seed*/ );
 
-  test_peer_addr_change( selector, rng );
+  test_wksp_init( wksp,
+                  &t_wksp_small,
+                  2UL/*max_peers*/,
+                  1/*incr_snap_fetch*/,
+                  fd_rng_ulong( rng )/*seed*/ );
 
-  test_update_on_ping( selector, rng );
+  test_wksp_init( wksp,
+                  &t_wksp_stress,
+                  32UL/*max_peers*/,
+                  1/*incr_snap_fetch*/,
+                  fd_rng_ulong( rng )/*seed*/ );
 
-  test_update_on_resolve( selector, rng );
+  verify_initial_cluster_slot( t_wksp_base.selector );
+  verify_initial_cluster_slot( t_wksp_full.selector );
+  verify_initial_cluster_slot( t_wksp_small.selector );
+  verify_initial_cluster_slot( t_wksp_stress.selector );
 
-  test_address_zero( selector, rng );
+  /* Subtests.  To make them independent from each other, the test
+     workspaces need to be re-initialized before usage.  This is because
+     the cluster slot can only increase monotonically over time. */
 
-  test_duplicate_hostnames( selector, rng );
+  test_wksp_reinit( &t_wksp_base );
+  test_slot_zero( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_basic_peer_selection( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_duplicate_peers( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_peer_addr_change( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_update_on_ping( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_update_on_resolve( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_address_zero( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_duplicate_hostnames( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_add_clears_incremental( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_on_resolve_clears_incremental( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_cluster_slot_incremental( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_score_saturation( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_wksp_reinit( &t_wksp_full );
+  test_cluster_slot_monotonicity( t_wksp_base.selector, t_wksp_full.selector );
+
+  test_wksp_reinit( &t_wksp_small );
+  test_pool_exhaustion( t_wksp_small.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_add_null_key( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_remove_null_key( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_remove_unknown_key( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_remove_by_addr_unknown( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_best_empty_selector( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_genesis_cluster_slot( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_full );
+  test_cluster_slot_rescore_full_only( t_wksp_full.selector, rng );
+
+  test_wksp_reinit( &t_wksp_full );
+  test_best_incremental_on_full_only_selector( t_wksp_full.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_invalid_clear_and_best_sentinel( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_ping_preserves_cleared_incremental( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_stress );
+  test_stress_peer_count( t_wksp_stress.selector, rng, t_wksp_stress.max_peers );
+
+  /* Cleanup. */
 
   fd_rng_delete( fd_rng_leave( rng ) );
-  fd_wksp_free_laddr( fd_sspeer_selector_delete( fd_sspeer_selector_leave( selector ) ) );
+  test_wksp_fini( &t_wksp_base );
+  test_wksp_fini( &t_wksp_full );
+  test_wksp_fini( &t_wksp_small );
+  test_wksp_fini( &t_wksp_stress );
+
+  fd_halt();
   return 0;
 }


### PR DESCRIPTION
The following upgrades are introduces in `fd_sspeer_selector.h/.c` and direct consumers:
- incr_slot initialization and handling
- cluster_slot.incremental intialization
- new FD_SSPEER_... sentinel values
- selector score saturation arithmetic
- slot-based incremental data clearing
- enhancing process_cluster_slot rejection logic
- http resolver minor upgrades
- snapct minor upgrades
- extended sspeer_selector unit test.

Update: addressed points 4 and 24 in https://github.com/firedancer-io/firedancer/issues/9176.