### PR TITLE
solfuzz: ensure coverage compiler flags for honggfuzz fuzzing

### DIFF
--- a/config/extra/with-honggfuzz.mk
+++ b/config/extra/with-honggfuzz.mk
@@ -2,6 +2,11 @@ CC:=hfuzz-clang
 CXX:=hfuzz-clang++
 LD:=hfuzz-clang++
 CPPFLAGS+=-fno-omit-frame-pointer
+CPPFLAGS+=-fsanitize-coverage=trace-pc-guard,inline-8bit-counters,pc-table
+CPPFLAGS+=-fno-sanitize-coverage=stack-depth
+
+LDFLAGS+=-fsanitize-coverage=trace-pc-guard,inline-8bit-counters,pc-table
+LDFLAGS+=-fno-sanitize-coverage=stack-depth
 
 FD_HAS_FUZZ:=1
 


### PR DESCRIPTION
for honggfuzz fuzzing specifically, we need both PC guards (for coverage nodes) and 8-bit counters (for coverage edges), along with the PC table (for guard<->line resolution)

we also need to ensure stack depth is OFF because it overloads the TLS and causes crashes e.g. with block fuzzer v2

previously, this was all enforced by Octane's scripts, but users want to fuzz locally with honggfuzz and keep hitting these snags which fail in surprising / non-descriptive ways (e.g. silently unproductive fuzzing, random crashes due to guard overflows)