### PR TITLE
Improve help print

### DIFF
--- a/src/app/shared/commands/help.c
+++ b/src/app/shared/commands/help.c
@@ -38,7 +38,7 @@ help_cmd_fn( args_t *   args   FD_PARAM_UNUSED,
                    action_cnt,
                    (ulong)sizeof( action_t * ),
                    action_cnt * (ulong)sizeof( action_t * ) ));
-      }
+    }
 
     for( ulong i=0UL; i<action_cnt; i++ ) {
       sorted[ i ] = ACTIONS[ i ];


### PR DESCRIPTION
PR relates to https://github.com/firedancer-io/firedancer/issues/6083

PR was already reviewed once in https://github.com/firedancer-io/firedancer/pull/7542. This PR fixes the comments.

The src/app/shared/commands/help.c has been updated to ensure the output is sorted using project sorting utils.

- [X] The code has been built successfully.
- [X] The code has been tested after changes.
- [X] Existing tests pass.

Current output of the help command after the fix is as follows (disregard the alignment being github copy/paste formatting issue):

$build/native/gcc/bin/fddev help
Frankendancer control binary

Usage: fddev <SUBCOMMAND> [OPTIONS]


OPTIONS:
        --config <PATH>    Path to config TOML file
        --version          Show the current software version
        --help             Print this help message

SUBCOMMANDS:
           bench    Test validator TPS benchmark
   bundle-client    Run bundle tile in isolation
       configure    Configure the local host so it can run Firedancer correctly
             dev    Start up a development validator
            dev1    Start up a single tile
            dump    Dump tango links to a packet capture file
           flame    Capture a perf flamegraph
    get-identity    Get the current active identity of the running validator
            help    Print this help message
            keys    Generate new keypairs for use with the validator or print a public key
            load    Load test an external validator
             mem    Print workspace memory and tile topology information
         metrics    Print the current validator Prometheus metrics to STDOUT
         monitor    Monitor a locally running Firedancer instance with a terminal GUI
         netconf    Print network configuration
          pktgen    Flood interface with invalid Ethernet frames
      quic-trace    Trace quic tile
           ready    Wait for all tiles to be running
             run    Start up a Firedancer validator
       run-agave    Start up the Agave side of a Firedancer validator
            run1    Start up a single Firedancer tile
    set-identity    Change the identity of a running validator
             txn    Send a transaction to an fddev instance
         udpecho    Run a UDP echo server
         version    Show the current software version
            wksp    Initialize workspaces
