### PR TITLE
Revert "events: remove hardcoded server TCP port"

### DIFF
--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -134,6 +134,7 @@ fd_event_client_new( void *                 shmem,
                                           "[tiles.event.url]" ) ) ) {
     FD_LOG_ERR(( "Could not parse [tiles.event.url]" ));
   }
+  client->server_tcp_port = 7878;
   if( FD_UNLIKELY( url->host_len > 255 ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }


### PR DESCRIPTION
This reverts commit afb62fc4fb0bc4668c2650b0f001419246d17dcb. Causes errors like this:
WARNING 03-24 22:20:39.590702 3597570 17   event:0 src/disco/events/fd_event_client.c(475): Event gRPC connection closed due to error (6-invalid frame size)
WARNING 03-24 22:20:39.591673 3597570 17   event:0 src/disco/events/fd_event_client.c(272): disconnected: peer closed connection
WARNING 03-24 22:20:39.591816 3597570 17   event:0 src/waltz/grpc/fd_grpc_client.c(389): fd_h2_rbuf_sendmsg failed (9-EBADF-bad file descriptor)
WARNING 03-24 22:20:39.591933 3597570 17   event:0 src/disco/events/fd_event_client.c(268): disconnected: transport failed (9-EBADF-bad file descriptor)