### PR TITLE
progcache: use the shared progcache object

### DIFF
--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -621,7 +621,7 @@ fd_progcache_verify( fd_progcache_join_t * join ) {
 
 void
 fd_progcache_wksp_metrics_update( fd_progcache_join_t * cache ) {
-  fd_wksp_t * wksp = fd_wksp_containing( cache );
+  fd_wksp_t * wksp = fd_wksp_containing( cache->shmem );
   if( FD_UNLIKELY( !wksp ) ) return;
   if( FD_UNLIKELY( fd_wksp_private_lock( wksp ) ) ) FD_LOG_CRIT(( "fd_wksp_private_lock failed" ));
 


### PR DESCRIPTION
I think `fd_wksp_containing( cache )` would return the replay workspace otherwise since it lives inside `ctx` (`struct fd_replay_tile`).

and cache->shmem comes from the join on `progcache_obj_id`.