### PR TITLE
progcache: reset potentially stale records

### DIFF
--- a/src/flamenco/progcache/fd_progcache.c
+++ b/src/flamenco/progcache/fd_progcache.c
@@ -163,6 +163,9 @@ fd_progcache_shmem_new( void * shmem,
   pc->rec.ele_gaddr = fd_wksp_gaddr_fast( wksp, rec_ele );
   pc->rec.max = (uint)rec_max;
   for( ulong i=0UL; i<rec_max; i++ ) {
+    uint next = rec_ele[ i ].map_next;
+    fd_memset( &rec_ele[ i ], 0, sizeof(fd_progcache_rec_t) );
+    rec_ele[ i ].map_next = next;
     fd_rwlock_new( &rec_ele[ i ].lock );
   }
   fd_prog_recp_leave( rec_join );


### PR DESCRIPTION
a new progcache can begin life with stale records when a workspace is reused (eg. stale `exists=1`, old `(xid,key)`, etc..). This can happen following a node restart or if an operator uses `fd_wksp_ctl reset` (only frees but does not reset).