### PR TITLE
restore: http head resolve (full and incr)

### DIFF
--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -28,10 +28,12 @@ $(call make-unit-test,test_sspeer_selector,utils/test_sspeer_selector,fd_discof 
 $(call make-unit-test,test_ssping,utils/test_ssping,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_ssarchive,utils/test_ssarchive,fd_discof fdctl_platform fd_ballet fd_util)
 $(call make-unit-test,test_ssparse,utils/test_ssparse,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_sshead,utils/test_sshead,fd_discof fd_waltz fd_flamenco fd_ballet fd_util,$(OPENSSL_LIBS))
 $(call run-unit-test,test_slot_delta_parser)
 $(call run-unit-test,test_sspeer_selector)
 $(call run-unit-test,test_ssarchive)
 $(call run-unit-test,test_ssparse)
+$(call run-unit-test,test_sshead)
 
 $(call make-fuzz-test,fuzz_snapshot_parser,utils/fuzz_snapshot_parser,fd_discof fd_flamenco fd_ballet fd_util)
 ifdef FD_HAS_INT128
@@ -42,6 +44,7 @@ $(call make-fuzz-test,fuzz_slot_delta_parser,utils/fuzz_slot_delta_parser,fd_dis
 $(call make-fuzz-test,fuzz_sshttp,utils/fuzz_sshttp,fd_discof fd_waltz fd_flamenco fd_ballet fd_util,$(OPENSSL_LIBS))
 
 $(call add-objs,utils/fd_ssresolve,fd_discof)
+$(call add-objs,utils/fd_sshead,fd_discof)
 $(call add-objs,utils/fd_sshttp,fd_discof)
 $(call add-objs,utils/fd_ssarchive,fd_discof)
 $(call add-objs,utils/fd_sspeer_selector,fd_discof)

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -5,6 +5,7 @@
 #include "utils/fd_ssctrl.h"
 #include "utils/fd_ssarchive.h"
 #include "utils/fd_http_resolver.h"
+#include "utils/fd_sshead.h"
 #include "utils/fd_ssmsg.h"
 
 #include "../../disco/topo/fd_topo.h"
@@ -140,6 +141,10 @@ struct fd_snapct_tile {
     int   pending;
   } predicted_incremental;
 
+  void *        head_resolve_mem;
+  fd_sshead_t * head_resolve;
+  fd_sspeer_t   head_resolve_peer; /* the peer being pre-resolved */
+
   struct {
     ulong full_snapshot_slot;
     char  full_snapshot_path[ PATH_MAX ];
@@ -211,8 +216,9 @@ scratch_align( void ) {
          fd_ulong_max( gossip_ci_map_align(),
          fd_ulong_max( fd_http_resolver_align(),
          fd_ulong_max( fd_sspeer_selector_align(),
+         fd_ulong_max( fd_sshead_align(),
          fd_ulong_max( blacklist_pool_align(),
-                       blacklist_map_align() ) ) ) ) ) ) );
+                       blacklist_map_align() ) ) ) ) ) ) ) );
 }
 
 static ulong
@@ -224,6 +230,7 @@ scratch_footprint( fd_topo_tile_t const * tile FD_PARAM_UNUSED ) {
   l = FD_LAYOUT_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
   l = FD_LAYOUT_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX )                             );
   l = FD_LAYOUT_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX )                            );
+  l = FD_LAYOUT_APPEND( l, fd_sshead_align(),          fd_sshead_footprint()                                                      );
   l = FD_LAYOUT_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX )                               );
   l = FD_LAYOUT_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) )  );
   l = FD_LAYOUT_APPEND( l, fd_alloc_align(),           fd_alloc_footprint()                                                       );
@@ -414,7 +421,8 @@ rlimit_file_cnt( fd_topo_t const *      topo FD_PARAM_UNUSED,
   if( download_enabled( tile ) ) {
     cnt +=    FD_SSPING_FD_CNT +                /* ssping sockets */
               2UL +                             /* dirfd + full snapshot download temp fd */
-              tile->snapct.sources.servers_cnt; /* http resolver peer full sockets */
+              tile->snapct.sources.servers_cnt + /* http resolver peer full sockets */
+              1UL;                              /* head_resolve HEAD socket */
     if( tile->snapct.incremental_snapshots ) {
       cnt +=  1UL +                             /* incr snapshot download temp fd */
               tile->snapct.sources.servers_cnt; /* http resolver peer incr sockets */
@@ -655,6 +663,178 @@ blacklist_peer( fd_snapct_tile_t * ctx ) {
   }
 }
 
+/* blacklist_peer_and_retry sets ctx->peer to the given peer, calls
+   blacklist_peer (which does permanent identity-based blacklisting,
+   ssping invalidation, and selector removal), and sets the deadline
+   to 0 so the next peer is tried immediately. */
+static inline void
+blacklist_peer_and_retry( fd_snapct_tile_t *  ctx,
+                          fd_sspeer_t const * peer ) {
+  ctx->peer = *peer;
+  blacklist_peer( ctx );
+  ctx->deadline_nanos = 0L;
+}
+
+/* peer_configured_server_idx returns the index of the configured
+   server matching addr, or ULONG_MAX if not found. */
+static inline ulong
+peer_configured_server_idx( fd_snapct_tile_t const * ctx,
+                            fd_ip4_port_t            addr ) {
+  for( ulong i=0UL; i<ctx->config.sources.servers_cnt; i++ ) {
+    if( FD_UNLIKELY( addr.l==ctx->config.sources.servers[ i ].addr.l ) )
+      return i;
+  }
+  return ULONG_MAX;
+}
+
+/* drive_head_resolve advances an in-flight HEAD pre-resolve and
+   validates the result.  head is the fd_sshead_t instance to advance.
+   peer is the peer being resolved (for logging / blacklist).
+   expected_base_slot is ULONG_MAX for full snapshots, or the full_slot
+   that the incremental must match.  gossip_slot is the slot advertised
+   by gossip (for stale check).  out_result is populated on success
+   with the resolve result.  is_full (0==incremental, otherwise full)
+   adjusts the log message.  now is the current wallclock time.
+   Returns 1 if resolve completed successfully (out_result is valid),
+   0 if still in progress (call again later), -1 if the peer was
+   blacklisted and removed (caller should retry). */
+static int
+drive_head_resolve( fd_snapct_tile_t *      ctx,
+                    fd_sshead_t *           head,
+                    fd_sspeer_t const *     peer,
+                    ulong                   expected_base_slot,
+                    ulong                   gossip_slot,
+                    fd_ssresolve_result_t * out_result,
+                    int                     is_full,
+                    long                    now ) {
+  int rc = fd_sshead_advance( head, out_result, now );
+
+  if( FD_LIKELY( rc==FD_SSHEAD_ADVANCE_AGAIN ) ) return 0;
+
+  if( FD_UNLIKELY( rc==FD_SSHEAD_ADVANCE_IDLE ) ) {
+    FD_LOG_WARNING(( "%s pre-resolve: unexpected IDLE return from fd_sshead_advance for "
+                     FD_IP4_ADDR_FMT ":%hu, skipping peer",
+                     is_full?"full":"incremental",
+                     FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                     fd_ushort_bswap( peer->addr.port ) ));
+    blacklist_peer_and_retry( ctx, peer );
+    return -1;
+  }
+
+  if( FD_LIKELY( rc==FD_SSHEAD_ADVANCE_DONE ) ) {
+    /* Validate: base_slot must match expected_base_slot.
+       For full snapshots this is ULONG_MAX (no base).
+       For incremental snapshots this is the full snapshot's slot. */
+    if( FD_UNLIKELY( out_result->base_slot!=expected_base_slot ) ) {
+      if( FD_LIKELY( expected_base_slot==ULONG_MAX ) ) {
+        FD_LOG_WARNING(( "%s pre-resolve: peer " FD_IP4_ADDR_FMT ":%hu serves base_slot %lu "
+                         "but full snapshots should have no base_slot, skipping peer",
+                         is_full?"full":"incremental",
+                         FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                         fd_ushort_bswap( peer->addr.port ),
+                         out_result->base_slot ));
+      } else {
+        FD_LOG_WARNING(( "%s pre-resolve: peer " FD_IP4_ADDR_FMT ":%hu serves base_slot %lu "
+                         "but we need base_slot %lu, skipping peer",
+                         is_full?"full":"incremental",
+                         FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                         fd_ushort_bswap( peer->addr.port ),
+                         out_result->base_slot, expected_base_slot ));
+      }
+      blacklist_peer_and_retry( ctx, peer );
+      return -1;
+    }
+
+    /* Validate: resolved slot must not be older than what gossip
+       advertised.  If the peer is serving stale data, skip it. */
+    if( FD_UNLIKELY( out_result->slot<gossip_slot ) ) {
+      FD_LOG_WARNING(( "%s pre-resolve: peer " FD_IP4_ADDR_FMT ":%hu serves slot=%lu "
+                       "which is older than gossip slot=%lu, skipping peer",
+                       is_full?"full":"incremental",
+                       FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                       fd_ushort_bswap( peer->addr.port ),
+                       out_result->slot, gossip_slot ));
+      blacklist_peer_and_retry( ctx, peer );
+      return -1;
+    }
+
+    if( FD_UNLIKELY( out_result->slot!=gossip_slot ) ) {
+      FD_LOG_WARNING(( "%s pre-resolve: peer " FD_IP4_ADDR_FMT ":%hu serves slot=%lu "
+                       "but gossip advertised slot=%lu",
+                       is_full?"full":"incremental",
+                       FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                       fd_ushort_bswap( peer->addr.port ),
+                       out_result->slot, gossip_slot ));
+    } else {
+      FD_LOG_NOTICE(( "%s pre-resolve: peer " FD_IP4_ADDR_FMT ":%hu confirmed slot=%lu (gossip=%lu)",
+                      is_full?"full":"incremental",
+                      FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                      fd_ushort_bswap( peer->addr.port ),
+                      out_result->slot, gossip_slot ));
+    }
+    return 1;
+  }
+
+  /* FD_SSHEAD_ADVANCE_ERROR or FD_SSHEAD_ADVANCE_TIMEOUT. */
+  if( FD_UNLIKELY( rc==FD_SSHEAD_ADVANCE_TIMEOUT ) ) {
+    FD_LOG_WARNING(( "%s pre-resolve HEAD timed out for " FD_IP4_ADDR_FMT ":%hu",
+                     is_full?"full":"incremental",
+                     FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                     fd_ushort_bswap( peer->addr.port ) ));
+  } else {
+    FD_LOG_WARNING(( "%s pre-resolve failed with error for " FD_IP4_ADDR_FMT ":%hu, trying next peer",
+                     is_full?"full":"incremental",
+                     FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ),
+                     fd_ushort_bswap( peer->addr.port ) ));
+  }
+  blacklist_peer_and_retry( ctx, peer );
+  return -1;
+}
+
+/* Send expected_slot, set up peer/state, and start the download.
+   full selects full (1) vs incremental (0) snapshot; slot is the
+   snapshot slot to download.  For full snapshots, checks incremental
+   coverage first.  Returns 0 on success.  Returns -1 if no
+   incremental coverage exists (peer removed from selector, deadline
+   set to 0).  Always returns 0 for incremental snapshots. */
+static int
+start_download( fd_snapct_tile_t *  ctx,
+                fd_stem_context_t * stem,
+                fd_sspeer_t         peer,
+                ulong               slot,
+                int                 full ) {
+  if( full ) {
+    if( FD_UNLIKELY( !ctx->config.incremental_snapshots ) ) {
+      send_expected_slot( ctx, stem, slot );
+    } else {
+      fd_sspeer_t best_incremental = fd_sspeer_selector_best( ctx->selector, 1, slot );
+      if( FD_LIKELY( best_incremental.addr.l ) ) {
+        ctx->predicted_incremental.slot = best_incremental.incr_slot;
+        send_expected_slot( ctx, stem, best_incremental.incr_slot );
+      } else {
+        FD_LOG_WARNING(( "full snapshot: peer " FD_IP4_ADDR_FMT ":%hu serves full_slot=%lu "
+                         "but no incremental peers exist for that base, skipping peer",
+                         FD_IP4_ADDR_FMT_ARGS( peer.addr.addr ),
+                         fd_ushort_bswap( peer.addr.port ),
+                         slot ));
+        fd_sspeer_selector_remove_by_addr( ctx->selector, peer.addr );
+        ctx->deadline_nanos = 0L;
+        return -1;
+      }
+    }
+    ctx->predicted_incremental.full_slot = slot;
+  } else {
+    ctx->predicted_incremental.slot = slot;
+    send_expected_slot( ctx, stem, slot );
+  }
+
+  ctx->peer  = peer;
+  ctx->state = full ? FD_SNAPCT_STATE_READING_FULL_HTTP : FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP;
+  init_load( ctx, stem, full, 0 );
+  log_download( ctx, full, peer.addr, slot );
+  return 0;
+}
+
 static void
 after_credit( fd_snapct_tile_t *  ctx,
               fd_stem_context_t * stem,
@@ -728,65 +908,70 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_COLLECTING_PEERS: {
       if( FD_UNLIKELY( !ctx->gossip.saturated && now<ctx->deadline_nanos ) ) break;
 
-      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-      if( FD_UNLIKELY( !best.addr.l ) ) {
-        if( !ctx->gossip_enabled ) {
-          FD_LOG_ERR(( "no peers are available and discovery of new peers via gossip is disabled. aborting." ));
-        }
-        ctx->deadline_nanos = now + FD_SNAPCT_WAITING_FOR_PEERS_TIMEOUT;
-        ctx->state = FD_SNAPCT_STATE_WAITING_FOR_PEERS;
-        break;
-      }
-
-      fd_sscluster_slot_t cluster = fd_sspeer_selector_cluster_slot( ctx->selector );
-      if( FD_UNLIKELY( cluster.incremental==FD_SSPEER_SLOT_UNKNOWN && ctx->config.incremental_snapshots ) ) {
-        /* We must have a cluster full slot to be in this state. */
-        FD_TEST( cluster.full!=FD_SSPEER_SLOT_UNKNOWN );
-        /* fall back to full snapshot only if the highest cluster slot
-           is a full snapshot only */
-        FD_LOG_WARNING(( "incremental snapshots were enabled via [snapshots.incremental_snapshots], but no incremental snapshot is available in the cluster. "
-                         "falling back to full snapshots only." ));
-        ctx->config.incremental_snapshots = 0;
-      }
-
-      ulong cluster_slot = ctx->config.incremental_snapshots ? cluster.incremental : cluster.full;
-
-      /* Determine the best effective slot achievable using the local
-         full snapshot.  When incrementals are disabled, the effective
-         slot is the full snapshot slot itself.  When enabled, it is the
-         best incremental we can pair with the local full (either from
-         a local file or downloaded from a peer). */
-
-      ulong local_effective_slot = ULONG_MAX;
-      if( FD_LIKELY( ctx->local_in.full_snapshot_slot!=ULONG_MAX ) ) {
-        if( FD_LIKELY( ctx->config.incremental_snapshots ) ) {
-          ulong local_incr = ctx->local_in.incremental_snapshot_slot;
-          if( local_incr!=ULONG_MAX && local_incr>=fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_incremental_age ) ) {
-            local_effective_slot = local_incr;
-          } else {
-            fd_sspeer_t best_incr = fd_sspeer_selector_best( ctx->selector, 1, ctx->local_in.full_snapshot_slot );
-            if( FD_LIKELY( best_incr.addr.l ) ) {
-              ctx->predicted_incremental.slot         = best_incr.incr_slot;
-              ctx->local_in.incremental_snapshot_slot = ULONG_MAX; /* don't use the local incremental */
-              local_effective_slot                    = best_incr.incr_slot;
-            }
+      /* Phase 1: No HEAD resolve in flight, select a peer and start
+         one. */
+      if( !fd_sshead_active( ctx->head_resolve ) ) {
+        fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+        if( FD_UNLIKELY( !best.addr.l ) ) {
+          if( !ctx->gossip_enabled ) {
+            FD_LOG_ERR(( "no peers are available and discovery of new peers via gossip is disabled. aborting." ));
           }
-        } else {
-          local_effective_slot = ctx->local_in.full_snapshot_slot;
+          ctx->deadline_nanos = now + FD_SNAPCT_WAITING_FOR_PEERS_TIMEOUT;
+          ctx->state = FD_SNAPCT_STATE_WAITING_FOR_PEERS;
+          break;
         }
-      }
 
-      int can_use_local_full = local_effective_slot!=ULONG_MAX &&
-                               local_effective_slot>=fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_full_effective_age );
-      if( FD_LIKELY( can_use_local_full ) ) {
-        send_expected_slot( ctx, stem, local_effective_slot );
+        fd_sscluster_slot_t cluster = fd_sspeer_selector_cluster_slot( ctx->selector );
+        if( FD_UNLIKELY( cluster.incremental==FD_SSPEER_SLOT_UNKNOWN && ctx->config.incremental_snapshots ) ) {
+          /* We must have a cluster full slot to be in this state. */
+          FD_TEST( cluster.full!=FD_SSPEER_SLOT_UNKNOWN );
+          /* fall back to full snapshot only if the highest cluster slot
+             is a full snapshot only */
+          FD_LOG_WARNING(( "incremental snapshots were enabled via [snapshots.incremental_snapshots], but no incremental snapshot is available in the cluster. "
+                           "falling back to full snapshots only." ));
+          ctx->config.incremental_snapshots = 0;
+        }
 
-        FD_LOG_NOTICE(( "reading full snapshot at slot %lu with cluster slot %lu from local file `%s`",
-                        ctx->local_in.full_snapshot_slot, cluster_slot, ctx->local_in.full_snapshot_path ));
-        ctx->predicted_incremental.full_slot = ctx->local_in.full_snapshot_slot;
-        ctx->state                           = FD_SNAPCT_STATE_READING_FULL_FILE;
-        init_load( ctx, stem, 1, 1 );
-      } else {
+        ulong cluster_slot = ctx->config.incremental_snapshots ? cluster.incremental : cluster.full;
+
+        /* Determine the best effective slot achievable using the local
+           full snapshot.  When incrementals are disabled, the effective
+           slot is the full snapshot slot itself.  When enabled, it is the
+           best incremental we can pair with the local full (either from
+           a local file or downloaded from a peer). */
+
+        ulong local_effective_slot = ULONG_MAX;
+        if( FD_LIKELY( ctx->local_in.full_snapshot_slot!=ULONG_MAX ) ) {
+          if( FD_LIKELY( ctx->config.incremental_snapshots ) ) {
+            ulong local_incr = ctx->local_in.incremental_snapshot_slot;
+            if( local_incr!=ULONG_MAX && local_incr>=fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_incremental_age ) ) {
+              local_effective_slot = local_incr;
+            } else {
+              fd_sspeer_t best_incr = fd_sspeer_selector_best( ctx->selector, 1, ctx->local_in.full_snapshot_slot );
+              if( FD_LIKELY( best_incr.addr.l ) ) {
+                ctx->predicted_incremental.slot         = best_incr.incr_slot;
+                ctx->local_in.incremental_snapshot_slot = ULONG_MAX; /* don't use the local incremental */
+                local_effective_slot                    = best_incr.incr_slot;
+              }
+            }
+          } else {
+            local_effective_slot = ctx->local_in.full_snapshot_slot;
+          }
+        }
+
+        int can_use_local_full = local_effective_slot!=ULONG_MAX &&
+                                 local_effective_slot>=fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_full_effective_age );
+        if( FD_LIKELY( can_use_local_full ) ) {
+          send_expected_slot( ctx, stem, local_effective_slot );
+
+          FD_LOG_NOTICE(( "reading full snapshot at slot %lu with cluster slot %lu from local file `%s`",
+                          ctx->local_in.full_snapshot_slot, cluster_slot, ctx->local_in.full_snapshot_path ));
+          ctx->predicted_incremental.full_slot = ctx->local_in.full_snapshot_slot;
+          ctx->state                           = FD_SNAPCT_STATE_READING_FULL_FILE;
+          init_load( ctx, stem, 1, 1 );
+          break;
+        }
+
         if( FD_LIKELY( ctx->local_in.full_snapshot_slot!=ULONG_MAX ) ) {
           if( local_effective_slot==ULONG_MAX ) {
             if( ctx->local_in.incremental_snapshot_slot!=ULONG_MAX ) {
@@ -805,62 +990,115 @@ after_credit( fd_snapct_tile_t *  ctx,
         } else {
           FD_LOG_NOTICE(( "no local snapshot available, downloading from peer" ));
         }
-
-        if( FD_UNLIKELY( !ctx->config.incremental_snapshots ) ) {
-          send_expected_slot( ctx, stem, best.full_slot );
-        } else {
-          fd_sspeer_t best_incremental = fd_sspeer_selector_best( ctx->selector, 1, best.full_slot );
-          if( FD_LIKELY( best_incremental.addr.l ) ) {
-            ctx->predicted_incremental.slot = best_incremental.incr_slot;
-            send_expected_slot( ctx, stem, best_incremental.incr_slot );
-          }
+        ulong server_idx = peer_configured_server_idx( ctx, best.addr );
+        if( FD_UNLIKELY( server_idx!=ULONG_MAX ) ) {
+          start_download( ctx, stem, best, best.full_slot, 1 );
+          break;
         }
 
-        ctx->peer                            = best;
-        ctx->state                           = FD_SNAPCT_STATE_READING_FULL_HTTP;
-        ctx->predicted_incremental.full_slot = best.full_slot;
-        init_load( ctx, stem, 1, 0 );
-        log_download( ctx, 1, best.addr, best.full_slot );
+        /* Start a HEAD pre-resolve before downloading. */
+        int err = fd_sshead_start( ctx->head_resolve, best.addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT );
+        if( FD_UNLIKELY( err ) ) {
+          blacklist_peer_and_retry( ctx, &best );
+          break;
+        }
+        ctx->head_resolve_peer = best;
+        FD_LOG_NOTICE(( "starting full pre-resolve HEAD to " FD_IP4_ADDR_FMT ":%hu (gossip full_slot=%lu)",
+                        FD_IP4_ADDR_FMT_ARGS( best.addr.addr ), fd_ushort_bswap( best.addr.port ), best.full_slot ));
+        break;
       }
-      break;
+
+      /* Phase 2: Drive the HEAD resolve. */
+      fd_ssresolve_result_t resolve_result;
+      int resolve_rc = drive_head_resolve( ctx, ctx->head_resolve, &ctx->head_resolve_peer,
+                                           ULONG_MAX, ctx->head_resolve_peer.full_slot,
+                                           &resolve_result, 1/*full*/, now );
+      if( FD_LIKELY( !resolve_rc ) ) break;  /* still in progress */
+      if( FD_UNLIKELY( resolve_rc<0 ) ) break; /* peer blacklisted, retry */
+
+      /* Success: use the resolved slot/hash for the download */
+      ctx->head_resolve_peer.full_slot = resolve_result.slot;
+      fd_memcpy( ctx->head_resolve_peer.full_hash, resolve_result.hash, FD_HASH_FOOTPRINT );
+
+      start_download( ctx, stem, ctx->head_resolve_peer, resolve_result.slot, 1 );
+      break;  /* download started */
     }
 
     /* ============================================================== */
     case FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL: {
       if( FD_UNLIKELY( now<ctx->deadline_nanos ) ) break;
 
-      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 1, ctx->predicted_incremental.full_slot );
-      if( FD_UNLIKELY( !best.addr.l ) ) {
-        if( !ctx->gossip_enabled ) {
-          FD_LOG_ERR(( "no incremental snapshot peers are available and discovery of new peers via gossip is disabled. aborting." ));
+      /* Phase 1: No HEAD resolve in flight, select a peer and start
+         one. */
+      if( !fd_sshead_active( ctx->head_resolve ) ) {
+        fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 1, ctx->predicted_incremental.full_slot );
+        if( FD_UNLIKELY( !best.addr.l ) ) {
+          if( !ctx->gossip_enabled ) {
+            FD_LOG_ERR(( "no incremental snapshot peers are available and discovery of new peers via gossip is disabled. aborting." ));
+          }
+          ctx->deadline_nanos = now + FD_SNAPCT_WAITING_FOR_PEERS_TIMEOUT;
+          ctx->state = FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL;
+          break;
         }
-        ctx->deadline_nanos = now + FD_SNAPCT_WAITING_FOR_PEERS_TIMEOUT;
-        ctx->state = FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL;
+        /* decide whether to use the local incremental snapshot if one
+           exists and is not too old, otherwise download a new
+           incremental snapshot. */
+        ulong cluster_slot  = fd_sspeer_selector_cluster_slot( ctx->selector ).incremental;
+        ulong local_slot    = ctx->local_in.incremental_snapshot_slot;
+        /* Guard against ULONG_MAX cluster_slot: if unknown, never
+           consider the local snapshot to be too old. */
+        int   local_too_old = cluster_slot!=ULONG_MAX && local_slot<fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_incremental_age );
+        if( FD_LIKELY( local_slot!=ULONG_MAX && !local_too_old ) ) {
+          ctx->predicted_incremental.slot = local_slot;
+          send_expected_slot( ctx, stem, local_slot );
+
+          FD_LOG_NOTICE(( "reading incremental snapshot at slot %lu from local file `%s`", ctx->local_in.incremental_snapshot_slot, ctx->local_in.incremental_snapshot_path ));
+          ctx->state = FD_SNAPCT_STATE_READING_INCREMENTAL_FILE;
+          init_load( ctx, stem, 0, 1 );
+          break;
+        }
+        ulong server_idx = peer_configured_server_idx( ctx, best.addr );
+        if( FD_UNLIKELY( server_idx!=ULONG_MAX ) ) {
+          if( FD_UNLIKELY( best.full_slot!=ctx->predicted_incremental.full_slot ) ) {
+            FD_LOG_WARNING(( "incremental configured peer " FD_IP4_ADDR_FMT ":%hu (%s://%s) serves base_slot %lu "
+                             "but we need base_slot %lu, skipping peer",
+                             FD_IP4_ADDR_FMT_ARGS( best.addr.addr ),
+                             fd_ushort_bswap( best.addr.port ),
+                             ctx->config.sources.servers[ server_idx ].is_https ? "https" : "http",
+                             ctx->config.sources.servers[ server_idx ].hostname,
+                             best.full_slot, ctx->predicted_incremental.full_slot ));
+            blacklist_peer_and_retry( ctx, &best );
+            break;
+          }
+          start_download( ctx, stem, best, best.incr_slot, 0 );
+          break;
+        }
+        /* Start a HEAD pre-resolve before downloading. */
+        int err = fd_sshead_start( ctx->head_resolve, best.addr, 0/*incremental*/, now, FD_SSHEAD_DEFAULT_TIMEOUT );
+        if( FD_UNLIKELY( err ) ) {
+          blacklist_peer_and_retry( ctx, &best );
+          break;
+        }
+        ctx->head_resolve_peer = best;
+        FD_LOG_NOTICE(( "starting incremental pre-resolve HEAD to " FD_IP4_ADDR_FMT ":%hu (gossip incr_slot=%lu)",
+                        FD_IP4_ADDR_FMT_ARGS( best.addr.addr ), fd_ushort_bswap( best.addr.port ), best.incr_slot ));
         break;
       }
 
-      /* decide whether to use the local incremental snapshot if one
-         exists and is not too old, otherwise download a new incremental
-         snapshot. */
-      ulong cluster_slot  = fd_sspeer_selector_cluster_slot( ctx->selector ).incremental;
-      ulong local_slot    = ctx->local_in.incremental_snapshot_slot;
-      int   local_too_old = local_slot<fd_ulong_sat_sub( cluster_slot, ctx->config.sources.max_local_incremental_age );
-      if( FD_LIKELY( local_slot!=ULONG_MAX && !local_too_old ) ) {
-        ctx->predicted_incremental.slot = local_slot;
-        send_expected_slot( ctx, stem, local_slot );
+      /* Phase 2: Drive the HEAD resolve. */
+      fd_ssresolve_result_t resolve_result;
+      int resolve_rc = drive_head_resolve( ctx, ctx->head_resolve, &ctx->head_resolve_peer,
+                                           ctx->predicted_incremental.full_slot, ctx->head_resolve_peer.incr_slot,
+                                           &resolve_result, 0/*incremental*/, now );
+      if( FD_LIKELY( !resolve_rc ) ) break;  /* still in progress */
+      if( FD_UNLIKELY( resolve_rc<0 ) ) break; /* peer blacklisted, retry */
 
-        FD_LOG_NOTICE(( "reading incremental snapshot at slot %lu from local file `%s`", ctx->local_in.incremental_snapshot_slot, ctx->local_in.incremental_snapshot_path ));
-        ctx->state = FD_SNAPCT_STATE_READING_INCREMENTAL_FILE;
-        init_load( ctx, stem, 0, 1 );
-      } else {
-        ctx->predicted_incremental.slot = best.incr_slot;
-        send_expected_slot( ctx, stem, best.incr_slot );
+      /* Success: use the resolved slot/hash for the download */
+      ctx->head_resolve_peer.incr_slot = resolve_result.slot;
+      ctx->head_resolve_peer.full_slot = resolve_result.base_slot;
+      fd_memcpy( ctx->head_resolve_peer.incr_hash, resolve_result.hash, FD_HASH_FOOTPRINT );
 
-        ctx->peer  = best;
-        ctx->state = FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP;
-        init_load( ctx, stem, 0, 0 );
-        log_download( ctx, 0, best.addr, best.incr_slot );
-      }
+      start_download( ctx, stem, ctx->head_resolve_peer, resolve_result.slot, 0 );
       break;
     }
 
@@ -1063,21 +1301,11 @@ after_credit( fd_snapct_tile_t *  ctx,
         break;
       }
 
-      /* Get the best incremental peer to download from */
-      fd_sspeer_t best = fd_sspeer_selector_best( ctx->selector, 1, ctx->predicted_incremental.full_slot );
-      if( FD_UNLIKELY( !best.addr.l ) ) {
-        ctx->deadline_nanos = now;
-        ctx->state = FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL;
-        break;
-      }
-
-      ctx->predicted_incremental.slot = best.incr_slot;
-      send_expected_slot( ctx, stem, best.incr_slot );
-
-      ctx->peer  = best;
-      ctx->state = FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP;
-      init_load( ctx, stem, 0, 0 );
-      log_download( ctx, 0, best.addr, best.incr_slot );
+      /* Always go through COLLECTING_PEERS_INCREMENTAL which performs
+         a HEAD pre-resolve before starting the incremental download.
+         This ensures the peer's incremental slot is verified fresh. */
+      ctx->deadline_nanos = 0L;
+      ctx->state = FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL;
       break;
 
     /* ============================================================== */
@@ -1085,7 +1313,10 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET:
       if( !ctx->flush_ack || !ctx->flush_load ) break;
 
-      if( ctx->metrics.full.num_retries==ctx->config.max_retry_abort ) {
+      /* Cancel any in-flight HEAD pre-resolve. */
+      fd_sshead_cancel( ctx->head_resolve );
+
+      if( ctx->metrics.full.num_retries>=ctx->config.max_retry_abort ) {
         FD_LOG_ERR(( "hit retry limit of %u for full snapshot, aborting", ctx->config.max_retry_abort ));
       }
 
@@ -1117,8 +1348,11 @@ after_credit( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET:
       if( !ctx->flush_ack || !ctx->flush_load ) break;
 
-      if( ctx->metrics.incremental.num_retries==ctx->config.max_retry_abort ) {
-        FD_LOG_ERR(("hit retry limit of %u for incremental snapshot. aborting", ctx->config.max_retry_abort ));
+      /* Cancel any in-flight HEAD pre-resolve. */
+      fd_sshead_cancel( ctx->head_resolve );
+
+      if( ctx->metrics.incremental.num_retries>=ctx->config.max_retry_abort ) {
+        FD_LOG_ERR(( "hit retry limit of %u for incremental snapshot. aborting", ctx->config.max_retry_abort ));
       }
 
       ctx->metrics.incremental.num_retries++;
@@ -1697,6 +1931,7 @@ privileged_init( fd_topo_t *      topo,
                                    FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
   void *             _ssresolver = FD_SCRATCH_ALLOC_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX )  );
                                    FD_SCRATCH_ALLOC_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX ) );
+  void *            _sshead      = FD_SCRATCH_ALLOC_APPEND( l, fd_sshead_align(),          fd_sshead_footprint() );
                                    FD_SCRATCH_ALLOC_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX ) );
                                    FD_SCRATCH_ALLOC_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) ) );
 
@@ -1710,6 +1945,10 @@ privileged_init( fd_topo_t *      topo,
   if( FD_LIKELY( download_enabled( tile ) ) )         ctx->ssping = fd_ssping_join( fd_ssping_new( _ssping, TOTAL_PEERS_MAX, 1UL, on_ping, ctx ) );
   if( FD_LIKELY( tile->snapct.sources.servers_cnt ) ) ctx->ssresolver = fd_http_resolver_join( fd_http_resolver_new( _ssresolver, SERVER_PEERS_MAX, tile->snapct.incremental_snapshots, on_resolve, ctx ) );
   else                                                ctx->ssresolver = NULL;
+
+  ctx->head_resolve_mem = _sshead;
+  ctx->head_resolve     = fd_sshead_join( fd_sshead_new( ctx->head_resolve_mem ) );
+  if( FD_UNLIKELY( !ctx->head_resolve ) ) FD_LOG_ERR(( "fd_sshead_new/join failed for head_resolve" ));
 
   fd_ssarchive_remove_old_snapshots( tile->snapct.snapshots_path,
                                      tile->snapct.max_full_snapshots_to_keep,
@@ -1845,12 +2084,15 @@ unprivileged_init( fd_topo_t *      topo,
   void * _ci_map          = FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
                             FD_SCRATCH_ALLOC_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX ) );
   void * _selector        = FD_SCRATCH_ALLOC_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX ) );
+                            FD_SCRATCH_ALLOC_APPEND( l, fd_sshead_align(),          fd_sshead_footprint() );
   void * _bl_pool         = FD_SCRATCH_ALLOC_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX ) );
   void * _bl_map          = FD_SCRATCH_ALLOC_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) ) );
 
   ctx->config = tile->snapct;
   ctx->gossip_enabled   = gossip_enabled( tile );
   ctx->download_enabled = download_enabled( tile );
+
+  memset( &ctx->head_resolve_peer, 0, sizeof(fd_sspeer_t) );
 
   ctx->selector       = fd_sspeer_selector_join( fd_sspeer_selector_new( _selector, TOTAL_PEERS_MAX, ctx->selector_seed ) );
   ctx->blacklist_pool = blacklist_pool_join( blacklist_pool_new( _bl_pool, TOTAL_PEERS_MAX ) );

--- a/src/discof/restore/utils/fd_sshead.c
+++ b/src/discof/restore/utils/fd_sshead.c
@@ -1,0 +1,281 @@
+#include "fd_sshead.h"
+
+#include "../../../util/fd_util.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+
+#define FD_SSHEAD_MAGIC (0xF17EDA2CE55DEAD0UL) /* FIREDANCER SSHEAD V0 */
+
+struct fd_sshead_private {
+  fd_ssresolve_t * ssresolve;
+  int              active;
+  long             deadline;
+  struct pollfd    pfd;
+  ulong            magic;
+};
+
+FD_FN_CONST ulong
+fd_sshead_align( void ) {
+  return fd_ulong_max( alignof(fd_sshead_t), fd_ssresolve_align() );
+}
+
+FD_FN_CONST ulong
+fd_sshead_footprint( void ) {
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof(fd_sshead_t), sizeof(fd_sshead_t) );
+  l = FD_LAYOUT_APPEND( l, fd_ssresolve_align(), fd_ssresolve_footprint() );
+  return FD_LAYOUT_FINI( l, fd_sshead_align() );
+}
+
+void *
+fd_sshead_new( void * shmem ) {
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_sshead_align() ) ) ) {
+    FD_LOG_WARNING(( "unaligned shmem" ));
+    return NULL;
+  }
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  fd_sshead_t * head       = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sshead_t), sizeof(fd_sshead_t) );
+  void *        _ssresolve = FD_SCRATCH_ALLOC_APPEND( l, fd_ssresolve_align(), fd_ssresolve_footprint() );
+
+  head->ssresolve = fd_ssresolve_join( fd_ssresolve_new( _ssresolve ) );
+  if( FD_UNLIKELY( !head->ssresolve ) ) {
+    FD_LOG_WARNING(( "fd_ssresolve_new/join failed" ));
+    return NULL;
+  }
+  head->active    = 0;
+  head->deadline  = 0L;
+  head->pfd       = (struct pollfd){ .fd = -1, .events = 0, .revents = 0 };
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( head->magic ) = FD_SSHEAD_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return (void *)head;
+}
+
+fd_sshead_t *
+fd_sshead_join( void * shhead ) {
+  if( FD_UNLIKELY( !shhead ) ) {
+    FD_LOG_WARNING(( "NULL shhead" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shhead, fd_sshead_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shhead" ));
+    return NULL;
+  }
+
+  fd_sshead_t * head = (fd_sshead_t *)shhead;
+
+  if( FD_UNLIKELY( head->magic!=FD_SSHEAD_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return head;
+}
+
+void *
+fd_sshead_leave( fd_sshead_t * head ) {
+  if( FD_UNLIKELY( !head ) ) {
+    FD_LOG_WARNING(( "NULL head" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)head, fd_sshead_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned head" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( head->magic!=FD_SSHEAD_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return (void *)head;
+}
+
+void *
+fd_sshead_delete( void * shhead ) {
+  if( FD_UNLIKELY( !shhead ) ) {
+    FD_LOG_WARNING(( "NULL shhead" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shhead, fd_sshead_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shhead" ));
+    return NULL;
+  }
+
+  fd_sshead_t * head = (fd_sshead_t *)shhead;
+
+  if( FD_UNLIKELY( head->magic!=FD_SSHEAD_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  fd_sshead_cancel( head );
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( head->magic ) = 0UL;
+  FD_COMPILER_MFENCE();
+
+  return (void *)head;
+}
+
+int
+fd_sshead_start( fd_sshead_t * head,
+                 fd_ip4_port_t addr,
+                 int           full,
+                 long          now,
+                 long          timeout_nanos ) {
+  if( FD_UNLIKELY( !head ) ) {
+    FD_LOG_WARNING(( "fd_sshead_start called with NULL head" ));
+    return FD_SSHEAD_START_ERR_CONN;
+  }
+
+  if( FD_UNLIKELY( head->active ) ) {
+    FD_LOG_WARNING(( "unable to start sshead with an active session" ));
+    return FD_SSHEAD_START_ERR_ACTIVE;
+  }
+
+  int sockfd = socket( AF_INET, SOCK_STREAM|SOCK_NONBLOCK, 0 );
+  if( FD_UNLIKELY( -1==sockfd ) ) {
+    FD_LOG_WARNING(( "socket() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    return FD_SSHEAD_START_ERR_CONN;
+  }
+
+  int optval = 1;
+  if( FD_UNLIKELY( -1==setsockopt( sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(int) ) ) ) {
+    FD_LOG_WARNING(( "setsockopt() failed (%d-%s)", errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( -1==close( sockfd ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    return FD_SSHEAD_START_ERR_CONN;
+  }
+
+  struct sockaddr_in sin = {
+    .sin_family = AF_INET,
+    .sin_port   = addr.port,
+    .sin_addr   = { .s_addr = addr.addr },
+  };
+
+  if( FD_UNLIKELY( -1==connect( sockfd, fd_type_pun( &sin ), sizeof(sin) ) && errno!=EINPROGRESS ) ) {
+    FD_LOG_WARNING(( "connect() to " FD_IP4_ADDR_FMT ":%hu failed for HEAD pre-resolve (%i-%s)",
+                     FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ),
+                     errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( -1==close( sockfd ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    return FD_SSHEAD_START_ERR_CONN;
+  }
+
+  fd_ssresolve_init( head->ssresolve, addr, sockfd, full, NULL );
+
+  head->active   = 1;
+  head->deadline = now + timeout_nanos;
+  head->pfd      = (struct pollfd){ .fd = sockfd, .events = POLLIN|POLLOUT, .revents = 0 };
+
+  FD_LOG_INFO(( "starting HEAD pre-resolve to " FD_IP4_ADDR_FMT ":%hu",
+                FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
+  return FD_SSHEAD_START_OK;
+}
+
+int
+fd_sshead_advance( fd_sshead_t *           head,
+                   fd_ssresolve_result_t * result,
+                   long                    now ) {
+  if( FD_UNLIKELY( !head ) ) {
+    FD_LOG_WARNING(( "NULL head" ));
+    return FD_SSHEAD_ADVANCE_ERROR;
+  }
+  if( FD_UNLIKELY( !result ) ) {
+    FD_LOG_WARNING(( "NULL result" ));
+    return FD_SSHEAD_ADVANCE_ERROR;
+  }
+  if( FD_UNLIKELY( !head->active ) ) return FD_SSHEAD_ADVANCE_IDLE;
+
+  /* Check timeout (strictly past deadline). */
+  if( FD_UNLIKELY( now>head->deadline ) ) {
+    fd_ssresolve_cancel( head->ssresolve ); /* closes socket */
+    head->active = 0;
+    head->pfd.fd = -1;
+    return FD_SSHEAD_ADVANCE_TIMEOUT;
+  }
+
+  /* Poll the socket */
+  int nfds = fd_syscall_poll( &head->pfd, 1U, 0 );
+  if( FD_LIKELY( !nfds ) ) return FD_SSHEAD_ADVANCE_AGAIN;
+  if( FD_UNLIKELY( -1==nfds && errno==EINTR ) ) return FD_SSHEAD_ADVANCE_AGAIN;
+  if( FD_UNLIKELY( -1==nfds ) ) FD_LOG_ERR(( "poll failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  /* Drive the ssresolve state machine.  Process POLLOUT then POLLIN
+     before checking POLLERR/POLLHUP, as the server may have already
+     sent the redirect response before closing the connection. */
+  int resolve_error = 0;
+
+  if( FD_LIKELY( !fd_ssresolve_is_done( head->ssresolve ) ) ) {
+    if( FD_LIKELY( head->pfd.revents & POLLOUT ) ) {
+      int res = fd_ssresolve_advance_poll_out( head->ssresolve );
+      if( FD_UNLIKELY( res==FD_SSRESOLVE_ADVANCE_ERROR ) ) resolve_error = 1;
+    }
+
+    if( !resolve_error && (head->pfd.revents & POLLIN) ) {
+      int res = fd_ssresolve_advance_poll_in( head->ssresolve, result );
+
+      if( FD_UNLIKELY( res==FD_SSRESOLVE_ADVANCE_ERROR ) ) {
+        resolve_error = 1;
+      } else if( FD_LIKELY( res==FD_SSRESOLVE_ADVANCE_RESULT ) ) {
+        /* Got a valid result from the redirect. */
+        fd_ssresolve_cancel( head->ssresolve ); /* closes socket */
+        head->active = 0;
+        head->pfd.fd = -1;
+        return FD_SSHEAD_ADVANCE_DONE;
+      }
+    }
+
+    /* POLLERR is always fatal.  POLLHUP means the peer closed its end
+       but readable data may still sit in the kernel receive buffer;
+       only treat POLLHUP as fatal when POLLIN is not set (no data
+       left to drain).  This lets fragmented responses that arrive
+       just before the peer closes be fully parsed. */
+    if( !resolve_error && !fd_ssresolve_is_done( head->ssresolve ) ) {
+      if( (head->pfd.revents & POLLERR) ||
+          ( (head->pfd.revents & POLLHUP) && !(head->pfd.revents & POLLIN) ) ) {
+        resolve_error = 1;
+      }
+    }
+  }
+
+  if( FD_UNLIKELY( resolve_error ) ) {
+    fd_ssresolve_cancel( head->ssresolve ); /* closes socket */
+    head->active = 0;
+    head->pfd.fd = -1;
+    return FD_SSHEAD_ADVANCE_ERROR;
+  }
+
+  return FD_SSHEAD_ADVANCE_AGAIN;
+}
+
+void
+fd_sshead_cancel( fd_sshead_t * head ) {
+  if( FD_UNLIKELY( !head ) ) return;
+  if( FD_UNLIKELY( head->active ) ) {
+    fd_ssresolve_cancel( head->ssresolve );
+    head->active = 0;
+    head->pfd.fd = -1;
+  }
+}
+
+int
+fd_sshead_active( fd_sshead_t const * head ) {
+  if( FD_UNLIKELY( !head ) ) return 0;
+  return head->active;
+}

--- a/src/discof/restore/utils/fd_sshead.h
+++ b/src/discof/restore/utils/fd_sshead.h
@@ -1,0 +1,102 @@
+#ifndef HEADER_fd_src_discof_restore_utils_fd_sshead_h
+#define HEADER_fd_src_discof_restore_utils_fd_sshead_h
+
+/* fd_sshead is a higher-level wrapper around fd_ssresolve that manages
+   the full lifecycle of a single non-blocking HTTP HEAD pre-resolve
+   against a plain-HTTP peer (HTTPS is not supported).  It handles
+   socket creation, non-blocking connect, polling, timeout, and cleanup.
+
+   Typical usage:
+
+    fd_sshead_start( head, addr, 0, now, FD_SSHEAD_DEFAULT_TIMEOUT );
+    ...
+    // in the event loop:
+      fd_ssresolve_result_t result;
+      int rc = fd_sshead_advance( head, &result, now );
+      if( rc==FD_SSHEAD_ADVANCE_DONE ) { ... use result ... }
+*/
+
+#include "fd_ssresolve.h"
+
+#define FD_SSHEAD_DEFAULT_TIMEOUT  (1L*1000L*1000L*1000L) /* 1 second  */
+
+#define FD_SSHEAD_START_OK         ( 0) /* success */
+#define FD_SSHEAD_START_ERR_CONN   (-1) /* socket/connect failure */
+#define FD_SSHEAD_START_ERR_ACTIVE (-2) /* a session is already active */
+
+#define FD_SSHEAD_ADVANCE_DONE    ( 2) /* resolve completed, result is valid */
+#define FD_SSHEAD_ADVANCE_AGAIN   ( 1) /* in progress, call again */
+#define FD_SSHEAD_ADVANCE_IDLE    ( 0) /* no resolve in flight */
+#define FD_SSHEAD_ADVANCE_ERROR   (-1) /* resolve failed */
+#define FD_SSHEAD_ADVANCE_TIMEOUT (-2) /* resolve timed out */
+
+struct fd_sshead_private;
+typedef struct fd_sshead_private fd_sshead_t;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_CONST ulong
+fd_sshead_align( void );
+
+FD_FN_CONST ulong
+fd_sshead_footprint( void );
+
+void *
+fd_sshead_new( void * shmem );
+
+fd_sshead_t *
+fd_sshead_join( void * shhead );
+
+void *
+fd_sshead_leave( fd_sshead_t * head );
+
+void *
+fd_sshead_delete( void * shhead );
+
+/* fd_sshead_start begins a HEAD pre-resolve against the peer at the
+   given addr.  It creates a non-blocking TCP socket, connects, and
+   initializes the internal fd_ssresolve_t for an HTTP HEAD request.
+   full: 1 for full snapshot, 0 for incremental.
+   now: current time in nanoseconds (fd_log_wallclock).
+   timeout_nanos: how long before the attempt is considered timed out.
+
+   Returns FD_SSHEAD_START_OK on success, FD_SSHEAD_START_ERR_CONN on
+   socket/connect failure, FD_SSHEAD_START_ERR_ACTIVE if a session was
+   already active. */
+int
+fd_sshead_start( fd_sshead_t * head,
+                 fd_ip4_port_t addr,
+                 int           full,
+                 long          now,
+                 long          timeout_nanos );
+
+/* fd_sshead_advance drives the HEAD resolve forward.  This should be
+   called periodically from the event loop.
+
+   On FD_SSHEAD_ADVANCE_DONE, the result struct is populated with the
+   resolved slot, base_slot, and hash.  The socket is closed.
+
+   On FD_SSHEAD_ADVANCE_ERROR or FD_SSHEAD_ADVANCE_TIMEOUT, the socket
+   is closed internally.
+
+   On FD_SSHEAD_ADVANCE_AGAIN, the resolve is still in progress.
+
+   On FD_SSHEAD_ADVANCE_IDLE, no resolve is in flight. */
+int
+fd_sshead_advance( fd_sshead_t *           head,
+                   fd_ssresolve_result_t * result,
+                   long                    now );
+
+/* fd_sshead_cancel cancels any in-flight HEAD resolve and closes the
+   socket.  Safe to call even if no resolve is active. */
+void
+fd_sshead_cancel( fd_sshead_t * head );
+
+/* fd_sshead_active returns 1 if a HEAD resolve is currently in
+   flight, 0 otherwise. */
+int
+fd_sshead_active( fd_sshead_t const * head );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_restore_utils_fd_sshead_h */

--- a/src/discof/restore/utils/fd_ssresolve.c
+++ b/src/discof/restore/utils/fd_ssresolve.c
@@ -187,16 +187,16 @@ fd_ssresolve_render_req( fd_ssresolve_t * ssresolve ) {
            "User-Agent: Firedancer\r\n"
            "Accept: */*\r\n"
            "Accept-Encoding: identity\r\n"
-           "Host: %s\r\n\r\n",
-           path, ssresolve->hostname ) );
+           "Host: %s:%hu\r\n\r\n",
+           path, ssresolve->hostname, fd_ushort_bswap( ssresolve->addr.port ) ) );
   } else {
     FD_TEST( fd_cstr_printf_check( ssresolve->request, sizeof(ssresolve->request), &ssresolve->request_len,
            "HEAD %s HTTP/1.1\r\n"
            "User-Agent: Firedancer\r\n"
            "Accept: */*\r\n"
            "Accept-Encoding: identity\r\n"
-           "Host: " FD_IP4_ADDR_FMT "\r\n\r\n",
-           path, FD_IP4_ADDR_FMT_ARGS( ssresolve->addr.addr ) ) );
+           "Host: " FD_IP4_ADDR_FMT ":%hu\r\n\r\n",
+           path, FD_IP4_ADDR_FMT_ARGS( ssresolve->addr.addr ), fd_ushort_bswap( ssresolve->addr.port ) ) );
   }
 }
 
@@ -285,8 +285,12 @@ fd_ssresolve_parse_redirect( fd_ssresolve_t *        ssresolve,
   uchar decoded_hash[ FD_HASH_FOOTPRINT ];
   int err = fd_ssarchive_parse_filename( snapshot_name, &full_entry_slot, &incremental_entry_slot, decoded_hash, &is_zstd );
 
-  if( FD_UNLIKELY( err || !is_zstd ) ) {
+  if( FD_UNLIKELY( err ) ) {
     FD_LOG_WARNING(( "unrecognized snapshot file `%s` in redirect location header", snapshot_name ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
+  if( FD_UNLIKELY( !is_zstd ) ) {
+    FD_LOG_WARNING(( "snapshot file `%s` in redirect is not zstd-compressed", snapshot_name ));
     return FD_SSRESOLVE_ADVANCE_ERROR;
   }
 
@@ -308,6 +312,11 @@ static int
 fd_ssresolve_read_response( fd_ssresolve_t *        ssresolve,
                             fd_ssresolve_result_t * result ) {
   FD_TEST( ssresolve->state==FD_SSRESOLVE_STATE_RESP );
+
+  if( FD_UNLIKELY( ssresolve->response_len==sizeof(ssresolve->response) ) ) {
+    FD_LOG_WARNING(( "response buffer full before complete HTTP response received" ));
+    return FD_SSRESOLVE_ADVANCE_ERROR;
+  }
 
   long read = 0L;
   if( FD_LIKELY( ssresolve->is_https ) ) {
@@ -333,6 +342,9 @@ fd_ssresolve_read_response( fd_ssresolve_t *        ssresolve,
     if( FD_UNLIKELY( -1==read && errno==EAGAIN ) ) return FD_SSRESOLVE_ADVANCE_AGAIN;
     else if( FD_UNLIKELY( -1==read ) ) {
       FD_LOG_WARNING(( "recvfrom() failed (%d-%s)", errno, fd_io_strerror( errno ) ));
+      return FD_SSRESOLVE_ADVANCE_ERROR;
+    } else if( FD_UNLIKELY( 0==read ) ) {
+      FD_LOG_WARNING(( "peer disconnected before sending complete response" ));
       return FD_SSRESOLVE_ADVANCE_ERROR;
     }
   }
@@ -368,12 +380,15 @@ fd_ssresolve_read_response( fd_ssresolve_t *        ssresolve,
 
   if( FD_UNLIKELY( status!=200 ) ) {
     char req_path[ 4096UL ];
-    if( FD_LIKELY( ssresolve->is_https ) ) {
+    char const * path = ssresolve->full ? "/snapshot.tar.bz2" : "/incremental-snapshot.tar.bz2";
+    if( FD_LIKELY( ssresolve->hostname && ssresolve->hostname[ 0 ]!='\0' ) ) {
       FD_TEST( fd_cstr_printf_check( req_path, sizeof(req_path), NULL,
-               "https://%s:%u%s", ssresolve->hostname, fd_ushort_bswap( ssresolve->addr.port ), ssresolve->full ? "/snapshot.tar.bz2" : "/incremental-snapshot.tar.bz2" ) );
+               "%s://%s:%hu%s", ssresolve->is_https ? "https" : "http",
+               ssresolve->hostname, fd_ushort_bswap( ssresolve->addr.port ), path ) );
     } else {
       FD_TEST( fd_cstr_printf_check( req_path, sizeof(req_path), NULL,
-               "http://%s:%u%s", ssresolve->hostname, fd_ushort_bswap( ssresolve->addr.port ), ssresolve->full ? "/snapshot.tar.bz2" : "/incremental-snapshot.tar.bz2" ) );
+               "http://" FD_IP4_ADDR_FMT ":%hu%s",
+               FD_IP4_ADDR_FMT_ARGS( ssresolve->addr.addr ), fd_ushort_bswap( ssresolve->addr.port ), path ) );
     }
     FD_LOG_WARNING(( "unexpected response code %d accessing %s", status, req_path ));
     return FD_SSRESOLVE_ADVANCE_ERROR;
@@ -508,4 +523,5 @@ fd_ssresolve_cancel( fd_ssresolve_t * ssresolve ) {
     ssresolve->ssl = NULL;
   }
 #endif
+  ssresolve->state = FD_SSRESOLVE_STATE_DONE;
 }

--- a/src/discof/restore/utils/test_sshead.c
+++ b/src/discof/restore/utils/test_sshead.c
@@ -1,0 +1,907 @@
+#define _GNU_SOURCE
+#include "fd_sshead.h"
+
+#include "../../../ballet/base58/fd_base58.h"
+#include "../../../util/fd_util.h"
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+/* HTTP redirect responses using known-good base58 hashes from
+   test_ssarchive.c. */
+
+#define FULL_REDIRECT \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n" \
+  "\r\n"
+
+#define INCR_REDIRECT \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: /incremental-snapshot-1000-1500-J7FkN5APJtHepZGwd155s3V26TUHQ3r2Xu7UbX9y75mN.tar.zst\r\n" \
+  "\r\n"
+
+#define MALFORMED_RESPONSE "GARBAGE\r\n\r\n"
+
+#define OK_200_RESPONSE "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+
+#define REDIRECT_301 \
+  "HTTP/1.1 301 Moved Permanently\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_303 \
+  "HTTP/1.1 303 See Other\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_307 \
+  "HTTP/1.1 307 Temporary Redirect\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_308 \
+  "HTTP/1.1 308 Permanent Redirect\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_NO_LOCATION \
+  "HTTP/1.1 302 Found\r\n" \
+  "\r\n"
+
+#define REDIRECT_BAD_LOCATION \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: http://example.com/snapshot.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_NON_ZSTD \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar\r\n" \
+  "\r\n"
+
+#define REDIRECT_BAD_FILENAME \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: /not-a-snapshot-filename.tar.zst\r\n" \
+  "\r\n"
+
+#define REDIRECT_EMPTY_PATH \
+  "HTTP/1.1 302 Found\r\n" \
+  "Location: /\r\n" \
+  "\r\n"
+
+#define ERROR_404_RESPONSE "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+
+/* Creates a TCP listening socket on 127.0.0.1 with an OS-assigned port.
+   Populates addr with the bound address. Returns the listen fd. */
+static int
+create_test_server( fd_ip4_port_t * addr ) {
+  int listen_fd = socket( AF_INET, SOCK_STREAM|SOCK_NONBLOCK, 0 );
+  FD_TEST( listen_fd>=0 );
+
+  int optval = 1;
+  FD_TEST( !setsockopt( listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(int) ) );
+
+  struct sockaddr_in sin = {
+    .sin_family = AF_INET,
+    .sin_addr   = { .s_addr = FD_IP4_ADDR( 127, 0, 0, 1 ) },
+    .sin_port   = 0, /* OS-assigned */
+  };
+
+  FD_TEST( !bind( listen_fd, fd_type_pun( &sin ), sizeof(sin) ) );
+  FD_TEST( !listen( listen_fd, 1 ) );
+
+  socklen_t len = sizeof(sin);
+  FD_TEST( !getsockname( listen_fd, fd_type_pun( &sin ), &len ) );
+
+  addr->addr = sin.sin_addr.s_addr;
+  addr->port = sin.sin_port;
+  return listen_fd;
+}
+
+/* Drives fd_sshead_advance in a loop, interleaving server-side
+   accept/recv/send.  Returns the final advance return code.
+   If response is NULL, the server accepts but never sends (for
+   timeout/hangup tests).  If close_immediately is set, the server
+   closes the accepted socket right after accepting. */
+static int
+drive_to_completion( fd_sshead_t *           head,
+                     fd_ssresolve_result_t * result,
+                     int                     listen_fd,
+                     char const *            response,
+                     ulong                   response_len,
+                     int                     close_immediately,
+                     long                    now ) {
+  int   peer_fd       = -1;
+  int   request_read  = 0;
+  int   response_sent = 0;
+  ulong response_off  = 0UL;
+
+  for( ulong iter=0; iter<10000UL; iter++ ) {
+    int rc = fd_sshead_advance( head, result, now );
+    if( rc!=FD_SSHEAD_ADVANCE_AGAIN ) {
+      if( peer_fd!=-1 ) FD_TEST( !close( peer_fd ) );
+      return rc;
+    }
+
+    /* Try to accept if not yet done */
+    if( peer_fd==-1 ) {
+      peer_fd = accept4( listen_fd, NULL, NULL, SOCK_NONBLOCK );
+      if( peer_fd!=-1 && close_immediately ) {
+        FD_TEST( !close( peer_fd ) );
+        peer_fd = -1;
+        /* Keep looping to let fd_sshead see POLLERR/POLLHUP */
+        continue;
+      }
+    }
+
+    /* Try to read the request from peer */
+    if( peer_fd!=-1 && !request_read ) {
+      char buf[ 4096 ];
+      long n = recv( peer_fd, buf, sizeof(buf), MSG_DONTWAIT );
+      if( n>0 ) request_read = 1;
+    }
+
+    /* Send response once request is read */
+    if( request_read && !response_sent && response ) {
+      long n = send( peer_fd, response+response_off, response_len-response_off, MSG_NOSIGNAL );
+      if( n>0 ) {
+        response_off += (ulong)n;
+        if( response_off==response_len ) response_sent = 1;
+      }
+    }
+  }
+
+  if( peer_fd!=-1 ) FD_TEST( !close( peer_fd ) );
+  FD_LOG_ERR(( "drive_to_completion did not complete within iteration limit" ));
+}
+
+static void
+test_align_and_footprint( void ) {
+  FD_LOG_NOTICE(( "testing align and footprint" ));
+
+  FD_TEST( fd_sshead_align()>0UL );
+  FD_TEST( fd_ulong_is_pow2( fd_sshead_align() ) );
+  FD_TEST( fd_sshead_footprint()>0UL );
+  FD_TEST( fd_ulong_is_aligned( fd_sshead_footprint(), fd_sshead_align() ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_new_join( void * shmem ) {
+  FD_LOG_NOTICE(( "testing new and join" ));
+
+  FD_TEST( !fd_sshead_new( NULL ) );
+  FD_TEST( !fd_sshead_join( NULL ) );
+
+  fd_sshead_t * head = fd_sshead_join( fd_sshead_new( shmem ) );
+  FD_TEST( head );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_advance_idle( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing advance when idle" ));
+
+  fd_ssresolve_result_t result;
+  long now = fd_log_wallclock();
+  FD_TEST( fd_sshead_advance( head, &result, now )==FD_SSHEAD_ADVANCE_IDLE );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cancel_idle( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing cancel when idle" ));
+
+  FD_TEST( !fd_sshead_active( head ) );
+  fd_sshead_cancel( head ); /* must not crash */
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_lifecycle_full( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing full snapshot lifecycle" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                FULL_REDIRECT, sizeof(FULL_REDIRECT)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+  FD_TEST( result.base_slot==ULONG_MAX ); /* full snapshot */
+
+  uchar expected_hash[ 32 ];
+  FD_TEST( fd_base58_decode_32( "AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM", expected_hash ) );
+  FD_TEST( !memcmp( result.hash, expected_hash, FD_HASH_FOOTPRINT ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_lifecycle_incremental( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing incremental snapshot lifecycle" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 0/*incremental*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                INCR_REDIRECT, sizeof(INCR_REDIRECT)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1500UL );
+  FD_TEST( result.base_slot==1000UL );
+
+  uchar expected_hash[ 32 ];
+  FD_TEST( fd_base58_decode_32( "J7FkN5APJtHepZGwd155s3V26TUHQ3r2Xu7UbX9y75mN", expected_hash ) );
+  FD_TEST( !memcmp( result.hash, expected_hash, FD_HASH_FOOTPRINT ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_timeout( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing timeout" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now     = fd_log_wallclock();
+  long timeout = 1000L; /* 1 microsecond */
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, timeout ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  /* Advance with a time past the deadline */
+  fd_ssresolve_result_t result;
+  int rc = fd_sshead_advance( head, &result, now + timeout + 1L );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_TIMEOUT );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cancel_active( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing cancel while active" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  /* Starting again while active should fail */
+  FD_TEST( fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT )==FD_SSHEAD_START_ERR_ACTIVE );
+
+  fd_sshead_cancel( head );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  /* Advance after cancel should return IDLE */
+  fd_ssresolve_result_t result;
+  FD_TEST( fd_sshead_advance( head, &result, now )==FD_SSHEAD_ADVANCE_IDLE );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_connect_failure( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing connect failure" ));
+
+  /* Use port 1 (tcpmux) on loopback — virtually never has a listener,
+     but the test handles both immediate ECONNREFUSED and async failure
+     via EINPROGRESS so it is safe even if a service is bound. */
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 127, 0, 0, 1 ), .port = fd_ushort_bswap( 1 ) };
+  long now = fd_log_wallclock();
+  int rc = fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT );
+
+  if( rc==FD_SSHEAD_START_ERR_CONN ) {
+    /* connect() returned ECONNREFUSED immediately, which is expected
+       on most systems for localhost. */
+    FD_TEST( !fd_sshead_active( head ) );
+  } else {
+    /* On some systems connect to localhost:1 returns EINPROGRESS and
+       the error surfaces asynchronously via poll.  Drive until we get
+       an error or timeout. */
+    FD_TEST( fd_sshead_active( head ) );
+    fd_ssresolve_result_t result;
+    int adv = FD_SSHEAD_ADVANCE_AGAIN;
+    for( ulong i=0UL; i<10000UL; i++ ) {
+      adv = fd_sshead_advance( head, &result, now );
+      if( adv!=FD_SSHEAD_ADVANCE_AGAIN ) {
+        FD_TEST( adv==FD_SSHEAD_ADVANCE_ERROR || adv==FD_SSHEAD_ADVANCE_TIMEOUT );
+        break;
+      }
+    }
+    FD_TEST( adv!=FD_SSHEAD_ADVANCE_AGAIN );
+    if( fd_sshead_active( head ) ) fd_sshead_cancel( head );
+  }
+
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_malformed_response( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing malformed response" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                MALFORMED_RESPONSE, sizeof(MALFORMED_RESPONSE)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_non_redirect_response( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing non-redirect (200 OK) response" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                OK_200_RESPONSE, sizeof(OK_200_RESPONSE)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_peer_hangup( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing peer hangup" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                NULL, 0,
+                                1/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_301( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing 301 redirect" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_301, sizeof(REDIRECT_301)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+  FD_TEST( result.base_slot==ULONG_MAX );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_307( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing 307 redirect" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_307, sizeof(REDIRECT_307)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+  FD_TEST( result.base_slot==ULONG_MAX );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_303( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing 303 redirect" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_303, sizeof(REDIRECT_303)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+  FD_TEST( result.base_slot==ULONG_MAX );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_308( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing 308 redirect" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_308, sizeof(REDIRECT_308)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+  FD_TEST( result.base_slot==ULONG_MAX );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_no_location( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing redirect with no Location header" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_NO_LOCATION, sizeof(REDIRECT_NO_LOCATION)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_bad_location( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing redirect with bad Location header" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_BAD_LOCATION, sizeof(REDIRECT_BAD_LOCATION)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_non_zstd( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing redirect to non-zstd file" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_NON_ZSTD, sizeof(REDIRECT_NON_ZSTD)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_bad_filename( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing redirect with unparseable filename" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_BAD_FILENAME, sizeof(REDIRECT_BAD_FILENAME)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_redirect_empty_path( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing redirect with empty path (Location: /)" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                REDIRECT_EMPTY_PATH, sizeof(REDIRECT_EMPTY_PATH)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_error_status_code( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing 404 error response" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                ERROR_404_RESPONSE, sizeof(ERROR_404_RESPONSE)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_timeout_boundary( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing timeout boundary (now == deadline should NOT timeout)" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now     = fd_log_wallclock();
+  long timeout = 1000L;
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, timeout ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  /* Advance with now == deadline (strictly > is needed to timeout) */
+  fd_ssresolve_result_t result;
+  int rc = fd_sshead_advance( head, &result, now + timeout );
+  FD_TEST( rc!=FD_SSHEAD_ADVANCE_TIMEOUT );
+  FD_TEST( fd_sshead_active( head ) );
+
+  fd_sshead_cancel( head );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_fragmented_response( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing fragmented response" ));
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  /* Drive manually: accept, read request, send response in two parts
+     to exercise the phr_parse_response partial-parse (-2) code path. */
+  int peer_fd      = -1;
+  int request_read = 0;
+  int frag1_sent   = 0;
+  int frag2_sent   = 0;
+
+  char const frag1[] = "HTTP/1.1 302 Found\r\n";
+  char const frag2[] = "Location: /snapshot-1000-AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM.tar.zst\r\n\r\n";
+
+  fd_ssresolve_result_t result;
+  for( ulong iter=0; iter<10000UL; iter++ ) {
+    int rc = fd_sshead_advance( head, &result, now );
+    if( rc!=FD_SSHEAD_ADVANCE_AGAIN ) {
+      FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+      FD_TEST( result.slot==1000UL );
+      FD_TEST( result.base_slot==ULONG_MAX );
+
+      uchar expected_hash[ 32 ];
+      FD_TEST( fd_base58_decode_32( "AGoNxxXQK4kCjeK4y8eJDaEfobS4QjMmCQm5zbEGq9kM", expected_hash ) );
+      FD_TEST( !memcmp( result.hash, expected_hash, FD_HASH_FOOTPRINT ) );
+
+      if( peer_fd!=-1 ) FD_TEST( !close( peer_fd ) );
+      FD_TEST( !close( listen_fd ) );
+      FD_LOG_NOTICE(( "... pass" ));
+      return;
+    }
+
+    if( peer_fd==-1 ) {
+      peer_fd = accept4( listen_fd, NULL, NULL, SOCK_NONBLOCK );
+    }
+    if( peer_fd!=-1 && !request_read ) {
+      char buf[ 4096 ];
+      long n = recv( peer_fd, buf, sizeof(buf), MSG_DONTWAIT );
+      if( n>0 ) request_read = 1;
+    }
+    if( request_read && !frag1_sent ) {
+      FD_TEST( (long)(sizeof(frag1)-1)==send( peer_fd, frag1, sizeof(frag1)-1, MSG_NOSIGNAL ) );
+      frag1_sent = 1;
+    } else if( frag1_sent && !frag2_sent ) {
+      FD_TEST( (long)(sizeof(frag2)-1)==send( peer_fd, frag2, sizeof(frag2)-1, MSG_NOSIGNAL ) );
+      frag2_sent = 1;
+    }
+  }
+
+  if( peer_fd!=-1 ) FD_TEST( !close( peer_fd ) );
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_ERR(( "fragmented response test did not complete" ));
+}
+
+static void
+test_response_buffer_full( fd_sshead_t * head,
+                           fd_wksp_t *   wksp ) {
+  FD_LOG_NOTICE(( "testing response buffer full" ));
+
+  /* Send a response that fills the USHORT_MAX (65535 byte) response
+     buffer in fd_ssresolve without completing a valid HTTP response.
+     This exercises the buffer-full error path. */
+
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  /* Build an incomplete HTTP response that is larger than USHORT_MAX.
+     Use a valid status line followed by a huge header that never
+     terminates (no \r\n\r\n). */
+  ulong buf_sz = USHORT_MAX + 1UL;
+  char * big_response = (char *)fd_wksp_alloc_laddr( wksp, 1UL, buf_sz, 2UL );
+  FD_TEST( big_response );
+
+  char const prefix[] = "HTTP/1.1 302 Found\r\nX-Pad: ";
+  ulong prefix_len = sizeof(prefix) - 1;
+  memcpy( big_response, prefix, prefix_len );
+  memset( big_response + prefix_len, 'A', buf_sz - prefix_len );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                big_response, buf_sz,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+
+  fd_wksp_free_laddr( big_response );
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_start_after_error( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing start after error lifecycle" ));
+
+  /* First: drive to an error via malformed response */
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+
+  fd_ssresolve_result_t result;
+  int rc = drive_to_completion( head, &result, listen_fd,
+                                MALFORMED_RESPONSE, sizeof(MALFORMED_RESPONSE)-1,
+                                0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_ERROR );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( !close( listen_fd ) );
+
+  /* Second: start a new session and drive to success */
+  listen_fd = create_test_server( &addr );
+  now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  rc = drive_to_completion( head, &result, listen_fd,
+                            FULL_REDIRECT, sizeof(FULL_REDIRECT)-1,
+                            0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_leave_delete( void * shmem ) {
+  FD_LOG_NOTICE(( "testing leave and delete" ));
+
+  FD_TEST( !fd_sshead_leave( NULL ) );
+  FD_TEST( !fd_sshead_delete( NULL ) );
+
+  fd_sshead_t * head = fd_sshead_join( fd_sshead_new( shmem ) );
+  FD_TEST( head );
+
+  void * shhead = fd_sshead_leave( head );
+  FD_TEST( shhead==shmem );
+
+  /* After leave, join should still work (magic intact). */
+  head = fd_sshead_join( shhead );
+  FD_TEST( head );
+
+  /* Leave again before delete. */
+  shhead = fd_sshead_leave( head );
+  FD_TEST( shhead );
+
+  void * deleted = fd_sshead_delete( shhead );
+  FD_TEST( deleted==shmem );
+
+  /* After delete, join should fail (magic zeroed). */
+  FD_TEST( !fd_sshead_join( deleted ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_start_after_timeout( fd_sshead_t * head ) {
+  FD_LOG_NOTICE(( "testing start after timeout lifecycle" ));
+
+  /* First: drive to a timeout */
+  fd_ip4_port_t addr;
+  int listen_fd = create_test_server( &addr );
+
+  long now     = fd_log_wallclock();
+  long timeout = 1000L;
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, timeout ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  fd_ssresolve_result_t result;
+  int rc = fd_sshead_advance( head, &result, now + timeout + 1L );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_TIMEOUT );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( !close( listen_fd ) );
+
+  /* Second: start a new session and drive to success */
+  listen_fd = create_test_server( &addr );
+  now = fd_log_wallclock();
+  FD_TEST( !fd_sshead_start( head, addr, 1/*full*/, now, FD_SSHEAD_DEFAULT_TIMEOUT ) );
+  FD_TEST( fd_sshead_active( head ) );
+
+  rc = drive_to_completion( head, &result, listen_fd,
+                            FULL_REDIRECT, sizeof(FULL_REDIRECT)-1,
+                            0/*close_immediately*/, now );
+  FD_TEST( rc==FD_SSHEAD_ADVANCE_DONE );
+  FD_TEST( !fd_sshead_active( head ) );
+  FD_TEST( result.slot==1000UL );
+
+  FD_TEST( !close( listen_fd ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong       page_cnt = 1;
+  char *      _page_sz = "gigantic";
+  ulong       numa_idx = fd_shmem_numa_idx( 0 );
+  fd_wksp_t * wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_TEST( wksp );
+
+  void * shmem = fd_wksp_alloc_laddr( wksp, fd_sshead_align(), fd_sshead_footprint(), 1UL );
+  FD_TEST( shmem );
+
+  test_align_and_footprint();
+  test_new_join( shmem );
+
+  fd_sshead_t * head = fd_sshead_join( fd_sshead_new( shmem ) );
+  FD_TEST( head );
+
+  test_advance_idle( head );
+  test_cancel_idle( head );
+  test_connect_failure( head );
+  test_lifecycle_full( head );
+  test_lifecycle_incremental( head );
+  test_timeout( head );
+  test_cancel_active( head );
+  test_malformed_response( head );
+  test_non_redirect_response( head );
+  test_peer_hangup( head );
+  test_redirect_301( head );
+  test_redirect_303( head );
+  test_redirect_307( head );
+  test_redirect_308( head );
+  test_redirect_no_location( head );
+  test_redirect_bad_location( head );
+  test_redirect_non_zstd( head );
+  test_redirect_bad_filename( head );
+  test_redirect_empty_path( head );
+  test_error_status_code( head );
+  test_timeout_boundary( head );
+  test_fragmented_response( head );
+  test_response_buffer_full( head, wksp );
+  test_start_after_error( head );
+  test_start_after_timeout( head );
+  fd_sshead_delete( fd_sshead_leave( head ) );
+  test_leave_delete( shmem );
+
+  fd_wksp_free_laddr( shmem );
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
There are two parts in this PR:

1) Peers that are geographically far have a tendency to observe stale incremental snapshot information via gossip (regarding other `http` peers): by the time an incremental snapshot for the given `full_slot` and advertised `incr_slot` is requested, the incremental snapshot may not be available (and the snapshot load pipeline blacklists the peer). To make the `http get` more robust against gossip, this PR introduces `fd_sshead`. Then the `snapct` tile performs an `http head` against the best peer, validates the `incr_slot` that is being actually served, and (if valid) adjusts the incremental snapshot name before proceeding with the download request.
As an example of the observed behavior:
```
WARNING .../fd_snapct_tile.c(803)[after_credit]: incremental pre-resolve: peer ...:... serves incr_slot=409016727 but gossip advertised incr_slot=409016427
```
Closes https://github.com/firedancer-io/firedancer/issues/8956.

2) Also includes https://github.com/firedancer-io/firedancer/pull/9088 as a second commit, extending `http head` resolve to the full snapshot (to filter gossip peers that advertise an RPC address but does not respond to http requests.

Closes https://github.com/firedancer-io/firedancer/issues/9091.

Update 2026-05-15: updated to latest main (rewrite).