### PR TITLE
bls: disallow infinity pubkey before giving it to blst

### DIFF
--- a/src/ballet/bls/fd_bls12_381.c
+++ b/src/ballet/bls/fd_bls12_381.c
@@ -463,6 +463,10 @@ fd_bls12_381_core_verify( uchar const  msg[], /* msg_sz */
   if( FD_UNLIKELY( !blst_p1_affine_in_g1( a1 ) ) ) {
     return -1;
   }
+  /* https://github.com/anza-xyz/solana-sdk/blob/b66abfddd564aef5b4b82cf4e76381e96f2459f0/bls-signatures/src/pubkey/verify.rs#L120 */
+  if( FD_UNLIKELY( blst_p1_affine_is_inf( a1 ) ) ) {
+    return -1;
+  }
 
   /* hash msg into b1. the check that it's a valid point in G2 is implicit/guaranteed */
   fd_bls12_381_g2_t _b1[1];


### PR DESCRIPTION
No behavioural change, a proof where the public key is the point-at-infinity would already fail. This just explicitly matches the Agave check.