### PR TITLE
ballet: use a cleaner subtract chain for ed25519 scalar validation

### DIFF
--- a/src/ballet/ed25519/fd_curve25519_scalar.h
+++ b/src/ballet/ed25519/fd_curve25519_scalar.h
@@ -8,6 +8,7 @@
    to secret data) */
 
 #include "../fd_ballet_base.h"
+#include "../bigint/fd_uint256.h"
 
 static const uchar fd_curve25519_scalar_zero[ 32 ] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -75,12 +76,12 @@ fd_curve25519_scalar_validate( uchar const s[ 32 ] ) {
     ulong l1 = *(ulong *)(&fd_curve25519_scalar_minus_one[  8 ]);
     ulong l2 = *(ulong *)(&fd_curve25519_scalar_minus_one[ 16 ]);
     ulong l3 = *(ulong *)(&fd_curve25519_scalar_minus_one[ 24 ]);
-    return (
-      (s3 < l3)
-      || ((s3 == l3) && (s2 < l2))
-      || ((s3 == l3) && (s2 == l2) && (s1 < l1))
-      || ((s3 == l3) && (s2 == l2) && (s1 == l1) && (s0 <= l0))
-    ) ? s : NULL;
+    ulong r; int b;
+    fd_ulong_sub_borrow( &r, &b, s0, l0, 1 );
+    fd_ulong_sub_borrow( &r, &b, s1, l1, b );
+    fd_ulong_sub_borrow( &r, &b, s2, l2, b );
+    fd_ulong_sub_borrow( &r, &b, s3, l3, b );
+    return b ? s : NULL;
   }
   return s;
 }


### PR DESCRIPTION
Proven to be identical to the previous approach with a small CBMC proof:
https://gist.github.com/drubin-fd/2babb755fa079d5753aae957df5dee1a
Not an important improvement, but produces a little nicer code, killing the last few branches in this function. LLVM & GCC are unable to see the sbb version themselves unfortunately.