### PR TITLE
pack, poh: use a dynamic microblock bound

### DIFF
--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -229,8 +229,8 @@ before_frag( fd_gui_ctx_t * ctx,
              ulong          sig ) {
   (void)seq;
 
-  /* Ignore "done draining banks" signal from pack->poh */
-  if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK_POH && sig==ULONG_MAX ) ) return 1;
+  /* Ignore "done draining banks" and "reduce microblock bound" signals from pack->poh */
+  if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK_POH && (sig==FD_PACK_MSG_DONE_DRAINING || sig==FD_PACK_MSG_REDUCE_MB_BOUND) ) ) return 1;
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP_OUT &&
                  (sig==FD_GOSSIP_UPDATE_TAG_WFS_DONE || sig==FD_GOSSIP_UPDATE_TAG_PEER_SATURATED) ) ) return 1;

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -206,6 +206,15 @@ typedef struct {
      for, if we are currently packing for a slot.*/
   long slot_end_ns;
 
+  /* The current dynamic upper bound on total microblocks for this slot.
+     Monotonically decreasing over the slot lifetime. */
+  ulong slot_dynamic_max_microblocks;
+
+  /* Set by during_housekeeping when the dynamic bound drops below
+     slot_max_microblocks.  Consumed by after_credit which publishes
+     the updated bound to POH over the pack_poh link. */
+  int pending_reduce_mb_bound;
+
   /* pacer and ticks_per_ns are used for pacing CUs through the slot,
      i.e. deciding when to schedule a microblock given the number of CUs
      that have been consumed so far.  pacer is an opaque pacing object,
@@ -442,6 +451,40 @@ metrics_write( fd_pack_ctx_t * ctx ) {
   fd_pack_metrics_write( ctx->pack );
 }
 
+/* compute_dynamic_max_microblocks: Computes the upper bound on total
+   microblocks based on remaining time and bank count.
+
+   The basic idea here is that if there is 1ms left in the slot, we
+   don't expect to schedule 130k microblocks.  We can reduce our
+   remaining budget which allows POH to advance hashing a bit further
+   and avoid having to do a lot of hashing after the slot ends.
+
+   The fastest we can execute a transaction is about 1us.  With n
+   execle tiles, that means we can execute at most n txn/us.  If we have
+   k ms left in the block, only reserve up to k*n*1000 microblocks. */
+
+static inline ulong
+compute_dynamic_max_microblocks( fd_pack_ctx_t * ctx ) {
+  long  now = ctx->approx_wallclock_ns + (long)((double)(fd_tickcount() - ctx->approx_tickcount) / ctx->ticks_per_ns);
+  long  end = ctx->slot_end_ns;
+
+  /* If the slot has ended, don't reserve any more microblocks. */
+  if( FD_UNLIKELY( now>=end ) ) return ctx->slot_microblock_cnt;
+
+  /* remaining_ns * n / 1000 = (remaining_ns/1e6 ms) * n * 1000.
+
+     Overflow: remaining_ns is at most ~4e8, n at most 64, so
+     remaining_ns * n is at most ~2.6e10 << 1.8e19. */
+
+  ulong remaining_ns = (ulong)(end - now);
+  ulong n            = ctx->execle_cnt;
+  ulong cnt          = ctx->slot_microblock_cnt;
+  ulong R            = ctx->slot_max_microblocks - cnt;
+  ulong can_execute  = remaining_ns * n / 1000UL;
+
+  return cnt + fd_ulong_min( R, can_execute );
+}
+
 static inline void
 during_housekeeping( fd_pack_ctx_t * ctx ) {
   ctx->approx_wallclock_ns = fd_log_wallclock();
@@ -450,6 +493,34 @@ during_housekeeping( fd_pack_ctx_t * ctx ) {
   if( FD_UNLIKELY( ctx->crank->enabled && fd_keyswitch_state_query( ctx->crank->keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
     fd_memcpy( ctx->crank->identity_pubkey, ctx->crank->keyswitch->bytes, 32UL );
     fd_keyswitch_state( ctx->crank->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
+  }
+
+  if( FD_LIKELY( ctx->leader_slot!=ULONG_MAX ) ) {
+    ulong raw = compute_dynamic_max_microblocks( ctx );
+    ulong prev = ctx->slot_dynamic_max_microblocks;
+
+    /* Enforce monotonically decreasing. This ensures pack's bound is
+       always smaller than POH's.  */
+    ctx->slot_dynamic_max_microblocks = fd_ulong_min( raw, prev );
+
+    /* If the bound decreased, we must update pack's internal scheduling
+       limit.  Otherwise, pack could schedule a microblock that exceeds
+       the remaining capacity from the tile's and poh's perspectives
+       (e.g. pack might produce a 5-transaction microblock when only 4
+       microblocks worth of space remain). */
+    if( FD_UNLIKELY( ctx->slot_dynamic_max_microblocks < prev ) ) {
+      fd_pack_limits_t limits[1];
+      limits->max_cost_per_block           = ctx->limits.slot_max_cost;
+      limits->max_data_bytes_per_block     = ctx->slot_max_data;
+      limits->max_microblocks_per_block    = ctx->slot_dynamic_max_microblocks;
+      limits->max_vote_cost_per_block      = ctx->limits.slot_max_vote_cost;
+      limits->max_write_cost_per_acct      = ctx->limits.slot_max_write_cost_per_acct;
+      limits->max_txn_per_microblock       = ULONG_MAX; /* unused */
+      limits->max_allocated_data_per_block = FD_PACK_MAX_ALLOCATED_DATA_PER_BLOCK;
+      fd_pack_set_block_limits( ctx->pack, limits );
+
+      ctx->pending_reduce_mb_bound = 1; /* publish bound decrease */
+    }
   }
 }
 
@@ -518,8 +589,6 @@ after_credit( fd_pack_ctx_t *     ctx,
               fd_stem_context_t * stem,
               int *               opt_poll_in,
               int *               charge_busy ) {
-  (void)opt_poll_in;
-
   if( FD_UNLIKELY( (ctx->skip_cnt--)>0L ) ) return; /* It would take ages for this to hit LONG_MIN */
 
   long now = fd_tickcount();
@@ -626,19 +695,30 @@ after_credit( fd_pack_ctx_t *     ctx,
 
       /* Pack notifies poh when execle are drained so that poh can
          relinquish pack's ownership over the slot execle (by decrementing
-         its Arc). We do this by sending a ULONG_MAX sig over the
-         pack_poh mcache.
+         its Arc). We do this by sending a FD_PACK_MSG_DONE_DRAINING
+         sig over the pack_poh mcache.
 
          TODO: This is only needed for Frankendancer, not Firedancer,
          which manages bank lifetime different. */
-      fd_stem_publish( stem, 1UL, ULONG_MAX, 0UL, 0UL, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
+      fd_stem_publish( stem, 1UL, FD_PACK_MSG_DONE_DRAINING, 0UL, 0UL, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
     } else {
       return;
     }
   }
 
+  if( FD_UNLIKELY( ctx->pending_reduce_mb_bound ) ) {
+    ctx->pending_reduce_mb_bound = 0;
+    ulong * dst = fd_chunk_to_laddr( ctx->poh_out_mem, ctx->poh_out_chunk );
+    *dst = ctx->slot_dynamic_max_microblocks;
+    fd_stem_publish( stem, 1UL, FD_PACK_MSG_REDUCE_MB_BOUND, ctx->poh_out_chunk, sizeof(ulong), 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
+    ctx->poh_out_chunk = fd_dcache_compact_next( ctx->poh_out_chunk, sizeof(ulong), ctx->poh_out_chunk0, ctx->poh_out_wmark );
+    *charge_busy = 1;
+    *opt_poll_in = 0;
+    return;
+  }
+
   /* Have I sent the max allowed microblocks? Nothing to do. */
-  if( FD_UNLIKELY( ctx->slot_microblock_cnt>=ctx->slot_max_microblocks ) ) return;
+  if( FD_UNLIKELY( ctx->slot_microblock_cnt>=ctx->slot_dynamic_max_microblocks ) ) return;
 
   /* Do I have enough transactions and/or have I waited enough time? */
 #if !SMALL_MICROBLOCKS
@@ -767,6 +847,10 @@ after_credit( fd_pack_ctx_t *     ctx,
       trailer->pack_txn_idx = ctx->pack_txn_cnt;
       trailer->is_bundle = !!(microblock_dst->txnp->flags & FD_TXN_P_FLAGS_BUNDLE);
 
+      /* When sending MAX_TXN_PER_MICROBLOCK transactions as fd_txn_e_t
+         to execle, there must be room for the trailer at the end. */
+      FD_STATIC_ASSERT( MAX_TXN_PER_MICROBLOCK*sizeof(fd_txn_e_t)+sizeof(fd_microblock_execle_trailer_t)<=MAX_MICROBLOCK_SZ, pack_execle_mtu );
+
       ulong sig = fd_disco_poh_sig( ctx->leader_slot, POH_PKT_TYPE_MICROBLOCK, (ulong)i );
       fd_stem_publish( stem, 0UL, sig, chunk, msg_sz+sizeof(fd_microblock_execle_trailer_t), 0UL, tsorig, tspub );
       ctx->execle_expect[ i ] = stem->seqs[0]-1UL;
@@ -809,7 +893,7 @@ after_credit( fd_pack_ctx_t *     ctx,
 #endif
 
   /* Did we send the maximum allowed microblocks? Then end the slot. */
-  if( FD_UNLIKELY( ctx->slot_microblock_cnt==ctx->slot_max_microblocks )) {
+  if( FD_UNLIKELY( ctx->slot_microblock_cnt==ctx->slot_dynamic_max_microblocks )) {
     update_metric_state( ctx, now, FD_PACK_METRIC_STATE_LEADER,       0 );
     update_metric_state( ctx, now, FD_PACK_METRIC_STATE_EXECLES,      0 );
     update_metric_state( ctx, now, FD_PACK_METRIC_STATE_MICROBLOCKS,  0 );
@@ -1098,6 +1182,8 @@ after_frag( fd_pack_ctx_t *     ctx,
     update_metric_state( ctx, fd_tickcount(), FD_PACK_METRIC_STATE_LEADER, 1 );
 
     ctx->slot_end_ns = ctx->_became_leader->slot_end_ns;
+    ctx->slot_dynamic_max_microblocks  = ctx->slot_max_microblocks;
+    ctx->pending_reduce_mb_bound       = 0;
     fd_pack_limits_t limits[ 1 ];
     limits->max_cost_per_block = ctx->limits.slot_max_cost;
     limits->max_data_bytes_per_block = ctx->slot_max_data;
@@ -1321,6 +1407,8 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->slot_microblock_cnt           = 0UL;
   ctx->pack_txn_cnt                  = 0UL;
   ctx->slot_max_microblocks          = 0UL;
+  ctx->slot_dynamic_max_microblocks  = 0UL;
+  ctx->pending_reduce_mb_bound       = 0;
   ctx->slot_max_data                 = 0UL;
   ctx->larger_shred_limits_per_block = tile->pack.larger_shred_limits_per_block;
   ctx->drain_execle                  = 0;

--- a/src/disco/tiles.h
+++ b/src/disco/tiles.h
@@ -122,8 +122,14 @@ struct fd_microblock_trailer {
   uchar txn_load_end_pct;
   uchar txn_end_pct;
   uchar txn_preload_end_pct;
+
 };
 typedef struct fd_microblock_trailer fd_microblock_trailer_t;
+
+/* Sentinel sig values for messages on the pack_poh.  Normal
+   done_packing messages use fd_disco_execle_sig( slot, pack_idx ). */
+#define FD_PACK_MSG_DONE_DRAINING   (ULONG_MAX)
+#define FD_PACK_MSG_REDUCE_MB_BOUND (ULONG_MAX-1UL)
 
 #define FD_PACK_END_SLOT_REASON_TIME          (1)
 #define FD_PACK_END_SLOT_REASON_MICROBLOCK    (2)

--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -267,6 +267,17 @@ fd_poh_must_publish_skipped_tick( fd_poh_t const * poh ) {
 }
 
 void
+fd_poh_update_max_microblocks( fd_poh_t * poh,
+                               ulong      new_max ) {
+  ulong inflated = new_max + 1UL;
+
+  /* Guaranteed to be monotonically decreasing. */
+  FD_TEST( inflated <= poh->max_microblocks_per_slot );
+  poh->max_microblocks_per_slot = inflated;
+  FD_TEST( poh->max_microblocks_per_slot >= poh->microblocks_lower_bound );
+}
+
+void
 fd_poh_done_packing( fd_poh_t * poh,
                      ulong      microblocks_in_slot ) {
   FD_TEST( poh->state==STATE_LEADER );

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -521,6 +521,15 @@ fd_poh1_mixin( fd_poh_t *          poh,
                ulong               txn_cnt,
                fd_txn_p_t const *  txns );
 
+/* fd_poh_update_max_microblocks: Tighten the upper bound on
+   max_microblocks_per_slot using the latest bound from pack.
+   new_max is the un-inflated bound (pack's view).  PoH inflates
+   by +1 which causes it to wait for pack's slot_done message before
+   finishing a slot. */
+void
+fd_poh_update_max_microblocks( fd_poh_t * poh,
+                               ulong      new_max );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_discof_poh_fd_poh_h */

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -127,7 +127,17 @@ returnable_frag( fd_poh_tile_t *     ctx,
   /* TODO: Pack has a workaround for Frankendancer that sequences bank
      release to manage lifetimes, but it's not needed in Firedancer so
      we just drop it.  We shouldn't send it at all in future. */
-  if( FD_UNLIKELY( sig==ULONG_MAX && ctx->in_kind[ in_idx ]==IN_KIND_PACK ) ) {
+  if( FD_UNLIKELY( sig==FD_PACK_MSG_DONE_DRAINING && ctx->in_kind[ in_idx ]==IN_KIND_PACK ) ) {
+    ctx->idle_cnt = 0UL;
+    return 0;
+  }
+
+  /* Pack periodically publishes a tighter microblock bound over the
+     pack_poh link. */
+  if( FD_UNLIKELY( sig==FD_PACK_MSG_REDUCE_MB_BOUND && ctx->in_kind[ in_idx ]==IN_KIND_PACK ) ) {
+    FD_TEST( sz==sizeof(ulong) );
+    ulong const * new_max = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
+    fd_poh_update_max_microblocks( ctx->poh, *new_max );
     ctx->idle_cnt = 0UL;
     return 0;
   }

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -26,6 +26,7 @@ typedef struct {
   ulong _pack_idx;
   ulong _txn_idx;
   int _is_bundle;
+
   fd_acct_addr_t _alt_accts[MAX_TXN_PER_MICROBLOCK][FD_TXN_ACCT_ADDR_MAX];
 
   ulong * busy_fseq;

--- a/src/discoh/pohh/fd_pohh_tile.c
+++ b/src/discoh/pohh/fd_pohh_tile.c
@@ -1851,12 +1851,16 @@ before_frag( fd_pohh_tile_t * ctx,
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]!=IN_KIND_BANK && ctx->in_kind[ in_idx ]!=IN_KIND_PACK ) ) return 0;
 
-  if( FD_UNLIKELY( sig==ULONG_MAX ) ) {
-    /* Banks are drained, release pack's owenership of the current bank */
+  if( FD_UNLIKELY( sig==FD_PACK_MSG_DONE_DRAINING ) ) {
+    /* Banks are drained, release pack's ownership of the current bank */
     if( FD_UNLIKELY( ctx->pack_leader_bank ) ) fd_ext_bank_release( ctx->pack_leader_bank );
     ctx->pack_leader_bank = NULL;
     return 1; /* discard */
   }
+
+  /* Firedancer publishes dynamic microblock bound updates over the
+     pack_poh link.  Frankendancer does not use them. */
+  if( FD_UNLIKELY( sig==FD_PACK_MSG_REDUCE_MB_BOUND ) ) return 1; /* discard */
 
   uint pack_idx = (uint)fd_disco_execle_sig_pack_idx( sig );
   FD_TEST( ((int)(pack_idx-ctx->expect_pack_idx))>=0L );


### PR DESCRIPTION
closes https://github.com/firedancer-io/firedancer/issues/8989

Problem
--------
pack's slot_done message arrives at POH at 350ms after slot start. At this point POH still has to do ~130K hashes, which takes 4-5ms.

Solution
--------
By reducing the microblock bound over the course of the slot (and eventually to 1/3 of the remaining budget at the end of the slot), we should be able to cut this down to ~1-2ms. 1/3 is probably a bit conservative and we could go lower but I think it's a good starting point.