### PR TITLE
shred: send out shred early

### DIFF
--- a/src/disco/shred/fd_shred_batch.h
+++ b/src/disco/shred/fd_shred_batch.h
@@ -109,13 +109,14 @@ FD_STATIC_ASSERT( ( FD_SHRED_BATCH_RAW_BUF_SZ ) >= ( FD_SHRED_BATCH_WMARK_RESIGN
    FEC_SETS_MAX * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ, and then
    we subtract from there the worst-case overheads from: padding,
    watermark regression and batch header.
-   - OHEAD_PAD (padding overhead): except for the last batch in a
-   block, each batch typically has FD_SHRED_BATCH_FEC_SETS_WMARK FEC
-   sets, but can contain as little as one FEC set.  However, the
+   - OHEAD_PAD (padding overhead): except for the first and last batch
+   in a block, each batch typically has FD_SHRED_BATCH_FEC_SETS_WMARK
+   FEC sets, but can contain as little as one FEC set.  However, the
    worst case occurs when each batch has two FEC sets, of which the
    second one contains a single byte of data and the rest is padding.
-   In that case, OHEAD_PAD -> 1/2 of the maximum raw capacity, i.e.
-   ( FEC_SETS_MAX / 2 ) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ.
+   In that case, OHEAD_PAD is approximately 1/2 of the maximum raw
+   capacity, i.e.
+   (FEC_SETS_MAX / 2) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ.
    - OHEAD_REG (watermark regression overhead): this is basically
    FD_SHRED_BATCH_FEC_SETS_MAX * 2048 bytes (the difference in
    payload size between chained and (chained+)resigned FEC sets).
@@ -129,6 +130,6 @@ FD_STATIC_ASSERT( ( FD_SHRED_BATCH_FEC_SETS_MAX ) == ( 4UL ), FD_SHRED_BATCH_FEC
 #define FD_SHRED_BATCH_BLOCK_DATA_OHEAD  (  512UL * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ + 8192UL + 8192UL )
 FD_STATIC_ASSERT( ( FD_SHRED_BATCH_BLOCK_DATA_OHEAD ) < ( 1024UL * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ ), FD_SHRED_BATCH_BLOCK_DATA_OHEAD );
 /* Define FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX. */
-#define FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX ( 1024UL * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ - FD_SHRED_BATCH_BLOCK_DATA_OHEAD )
+#define FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX ( (1024UL-2UL) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ - FD_SHRED_BATCH_BLOCK_DATA_OHEAD )
 
 #endif /* HEADER_fd_src_disco_shred_fd_shred_batch_h */

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -572,10 +572,14 @@ during_frag( fd_shred_ctx_t * ctx,
       }
 
       ctx->pending_batch.slot = target_slot;
+      /* We want to send out some shreds immediately when we start a new
+         slot to help with leader targeting. */
+      int new_slot = 0;
       if( FD_UNLIKELY( target_slot!=ctx->slot )) {
         /* Reset batch count if we are in a new slot */
         ctx->batch_cnt = 0UL;
         ctx->slot      = target_slot;
+        new_slot       = 1;
 
         /* At the beginning of a new slot, prepare chained_merkle_root.
            chained_merkle_root is initialized at the block_id of the parent
@@ -644,9 +648,10 @@ during_frag( fd_shred_ctx_t * ctx,
          batch is closed now, shredded, and a new batch is started
          with the incoming microblock.  If false, no shredding takes
          place, and the microblock is added to the current batch. */
+      int forced_end_batch         = entry_meta->block_complete | new_slot;
       int batch_would_exceed_wmark = ( ctx->pending_batch.pos + entry_sz ) > pending_batch_wmark;
-      int include_in_current_batch = entry_meta->block_complete | ( !batch_would_exceed_wmark );
-      int process_current_batch    = entry_meta->block_complete | batch_would_exceed_wmark;
+      int include_in_current_batch = forced_end_batch | ( !batch_would_exceed_wmark );
+      int process_current_batch    = forced_end_batch | batch_would_exceed_wmark;
       int init_new_batch           = !include_in_current_batch;
 
       if( FD_LIKELY( include_in_current_batch ) ) {


### PR DESCRIPTION
Send out the first tick/microblock immediately.  This wastes most of an FEC set, but it seems to help with leader targeting, which is much more important with today's block sizes.