### PR TITLE
firedancer: mainnet and testnet toml update

### DIFF
--- a/src/app/firedancer/config/mainnet.toml
+++ b/src/app/firedancer/config/mainnet.toml
@@ -10,7 +10,9 @@
     expected_genesis_hash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d"
 [accounts]
     file_size_gib = 600
-    max_accounts = 1_100_000_000
+    max_accounts = 1_300_000_000
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-mainnet-rpc.jumpisolated.com:8899" ]
+        [snapshots.sources.gossip]
+            allow_any = false

--- a/src/app/firedancer/config/testnet.toml
+++ b/src/app/firedancer/config/testnet.toml
@@ -11,3 +11,5 @@
 [snapshots]
     [snapshots.sources]
         servers = [ "http://solana-testnet-rpc.jumpisolated.com:8899", "https://solana-testnet-tls.jumpisolated.com" ]
+        [snapshots.sources.gossip]
+            allow_any = false


### PR DESCRIPTION
Updating `mainnet.toml` and `testnet.toml` to only fetch snapshots from configured servers under `[snapshot.sources]`, excluding gossip peers. This is particularly useful when doing `firedancer-dev --mainnet` and `firedancer-dev --testnet`.
Increasing `max_accounts` to 1.3B in `mainnet.toml`.