### PR TITLE
Fix test_http_server when not building with ZSTD

### DIFF
--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -68,7 +68,12 @@ test_oring( void ) {
   };
 
   uchar scratch[ 1633024 ] __attribute__((aligned(128UL)));
+#ifdef FD_HAS_ZSTD
   FD_TEST( fd_http_server_footprint( params )==1633024 );
+#else
+  FD_TEST( fd_http_server_footprint( params )==329344 );
+  FD_TEST( fd_http_server_footprint( params )<=sizeof( scratch ) );
+#endif
   fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, NULL ) );
 
   http->stage_off = 6UL;


### PR DESCRIPTION
As title, we noticed this because Shelby recently updated firedancer version and this test was failing because Shelby is not built with ZSTD.

Originally added in #5337 so hoping @jherrera-jump and @mmcgee-jump could take a look.