### PR TITLE
Fix test_http_server ZSTD macro check

### DIFF
--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -68,7 +68,7 @@ test_oring( void ) {
   };
 
   uchar scratch[ 1633024 ] __attribute__((aligned(128UL)));
-#ifdef FD_HAS_ZSTD
+#if FD_HAS_ZSTD
   FD_TEST( fd_http_server_footprint( params )==1633024 );
 #else
   FD_TEST( fd_http_server_footprint( params )==329344 );


### PR DESCRIPTION
Follow up with #9104 , in some builds we `-DFD_HAS_ZSTD=0` instead of not defining the macro...
`fd_http_server.c` already does the correct macro check