### PR TITLE
Fix test_http_server flooding logs

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -1231,8 +1231,8 @@ fd_http_server_reserve( fd_http_server_t * http,
                   else.  Mark the hcache as errored and exit. */
 
       FD_LOG_WARNING(( "tried to reserve %lu bytes for an outgoing message which exceeds the entire data size", http->stage_len+len ));
-      FD_LOG_HEXDUMP_WARNING(( "start of message:\n%.*s", http->oring+(http->stage_off%http->oring_sz), fd_ulong_min( 500UL, http->oring_sz-(http->stage_off%http->oring_sz)-1UL ) ));
-      FD_LOG_HEXDUMP_WARNING(( "start of buffer:\n%.*s",  http->oring,                                  fd_ulong_min( 500UL, http->oring_sz )                     ));
+      FD_LOG_HEXDUMP_WARNING(( "start of message", http->oring+(http->stage_off%http->oring_sz), fd_ulong_min( 500UL, http->oring_sz-(http->stage_off%http->oring_sz) ) ));
+      FD_LOG_HEXDUMP_WARNING(( "start of buffer",  http->oring,                                  fd_ulong_min( 500UL, http->oring_sz )                     ));
       http->stage_err = 1;
       return;
     } else {

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -86,22 +86,26 @@ test_oring( void ) {
   FD_TEST( !memcmp( "ABC", http->oring, 3UL ) );
   fd_http_server_unstage( http );
 
-  for( ulong i=1UL; i<32UL; i++ ) {
+  for( ulong i=1UL; i<=7UL; i++ ) {
     for( ulong j=0UL; j<1024UL; j++ ) {
       for( ulong k=0UL; k<i; k++ ) fd_http_server_printf( http, "%c", (char)('a'+i) );
 
       fd_http_server_response_t response;
-      if( i>7 ) {
-        FD_TEST( fd_http_server_stage_body( http, &response ) );
-      } else {
-        FD_TEST( !fd_http_server_stage_body( http, &response ) );
-        FD_TEST( response._body_len==i );
-        FD_TEST( (response._body_off%8UL)<=8-i );
-        for( ulong l=0UL; l<i; l++ ) {
-          FD_TEST( http->oring[(response._body_off%8UL)+l]==(uchar)('a'+i) );
-        }
+      FD_TEST( !fd_http_server_stage_body( http, &response ) );
+      FD_TEST( response._body_len==i );
+      FD_TEST( (response._body_off%8UL)<=8-i );
+      for( ulong l=0UL; l<i; l++ ) {
+        FD_TEST( http->oring[(response._body_off%8UL)+l]==(uchar)('a'+i) );
       }
     }
+  }
+
+  /* Verify overflow is handled correctly for body sizes exceeding the
+     oring (only one iteration needed per size since no wrapping occurs). */
+  for( ulong i=8UL; i<32UL; i++ ) {
+    for( ulong k=0UL; k<i; k++ ) fd_http_server_printf( http, "%c", (char)('a'+i) );
+    fd_http_server_response_t response;
+    FD_TEST( fd_http_server_stage_body( http, &response ) );
   }
 
   fd_http_server_response_t response;


### PR DESCRIPTION
In `test_http_server`, the test `test_oring` loops on size [1, 32) with 1024 inner iterations each. When the size is greater than 7 (buffer size 8 minus NULL terminator), it would trigger overflow handling path in `fd_http_server_reserve`. In #7417 extra logging was added for that code path. Together these will result in 24 * 1024 overflow failures with 7 warning log lines for each failure.  It would make the Shelby test runner appear to hang indefinitely while printing these ~170K log lines...

This commit fixes this behavior by test "normal logic" with 1024 iterations, while for overflow cares only run each size once.

Moreover, `FD_LOG_HEXDUMP_WARNING` actually takes `(description, data_ptr, data_len)` and will format things automatically, so no need for `\n%.*s` in the description string. Fixed this as well.

Before:
```
WARNING 04-01 00:54:08.756568 2333850 f0   0    src/waltz/http/fd_http_server.c(1233): tried to reserve 9 bytes for an outgoing message which exceeds the entire data size
WARNING 04-01 00:54:08.757447 2333850 f0   0    src/waltz/http/fd_http_server.c(1234): HEXDUMP "start of message:
%.*s" (7 bytes at 0x7ffcfedff260)
        0000:  7e 7e 7e 7e 7e 7e 7e                             ~~~~~~~
WARNING 04-01 00:54:08.758222 2333850 f0   0    src/waltz/http/fd_http_server.c(1235): HEXDUMP "start of buffer:
%.*s" (8 bytes at 0x7ffcfedff260)
        0000:  7e 7e 7e 7e 7e 7e 7e 00                          ~~~~~~~.
```
After:
```
WARNING 04-01 00:58:11.870591 2337787 f0   0    src/waltz/http/fd_http_server.c(1233): tried to reserve 9 bytes for an outgoing message which exceeds the entire data size
WARNING 04-01 00:58:11.871433 2337787 f0   0    src/waltz/http/fd_http_server.c(1234): HEXDUMP "start of message" (8 bytes at 0x7ffe71ccf0e0)
        0000:  7e 7e 7e 7e 7e 7e 7e 00                          ~~~~~~~.
WARNING 04-01 00:58:11.872293 2337787 f0   0    src/waltz/http/fd_http_server.c(1235): HEXDUMP "start of buffer" (8 bytes at 0x7ffe71ccf0e0)
        0000:  7e 7e 7e 7e 7e 7e 7e 00                          ~~~~~~~.
```

Sorry for the flow or PRs trying to fix this seemingly unimportant test. We are trying to upgrade Shelby's firedancer submodule version to the latest and we run all unit tests in CI always, so we hit this while doing the upgrade... I think this should be the last fix needed, fingers crossed! Thanks! cc @jherrera-jump @mmcgee-jump @ripatel-fd 