### PR TITLE
deps.sh: make bzip2 default

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -138,8 +138,8 @@ fetch () {
   checkout_repo s2n       https://github.com/awslabs/s2n-bignum       "" "4d2e22a"
   checkout_repo openssl   https://github.com/openssl/openssl          "openssl-3.6.0"
   checkout_repo blst      https://github.com/supranational/blst       "v0.3.13"
+  checkout_repo bzip2     https://gitlab.com/bzip2/bzip2              "bzip2-1.0.8"
   if [[ $DEVMODE == 1 ]]; then
-    checkout_repo bzip2   https://gitlab.com/bzip2/bzip2              "bzip2-1.0.8"
     checkout_repo rocksdb https://github.com/facebook/rocksdb         "v10.5.1"
     checkout_repo snappy  https://github.com/google/snappy            "1.2.2"
     checkout_repo flatcc  https://github.com/dvidelabs/flatcc         "" "3ae5eda"
@@ -631,9 +631,9 @@ install () {
   ( install_lz4       )
   ( install_s2n       )
   ( install_openssl   )
-  ( install_blst )
+  ( install_blst      )
+  ( install_bzip2     )
   if [[ $DEVMODE == 1 ]]; then
-    ( install_bzip2     )
     ( install_snappy    )
     ( install_rocksdb   )
     ( install_flatcc    )


### PR DESCRIPTION
Fixes Firedancer full client build without +dev deps

Closes #8288