### PR TITLE
lthash: increase parallelism from 512 to 1024 bytes

### DIFF
--- a/src/ballet/lthash/fd_lthash_adder.h
+++ b/src/ballet/lthash/fd_lthash_adder.h
@@ -67,7 +67,7 @@ fd_lthash_adder_push( fd_lthash_adder_t * adder,
                       void const *        input,
                       ulong               input_sz ) {
   fd_lthash_value_t value[1];
-  if( FD_LTHASH_ADDER_PARA_CNT<=1 || FD_UNLIKELY( input_sz>512UL ) ) {
+  if( FD_LTHASH_ADDER_PARA_CNT<=1 || FD_UNLIKELY( input_sz>FD_BLAKE3_CHUNK_SZ ) ) {
     fd_blake3_t blake[1];
     fd_blake3_init( blake );
     fd_blake3_append( blake, input, input_sz );
@@ -132,7 +132,7 @@ fd_lthash_adder_push_solana_account(
   /* FIXME opportunities for memcpy hax here */
 
   ulong const static_sz       =  73UL;
-  ulong const batch_threshold = 512UL;
+  ulong const batch_threshold = FD_BLAKE3_CHUNK_SZ;
   if( FD_LTHASH_ADDER_PARA_CNT<=1 ||
       FD_UNLIKELY( data_sz > batch_threshold-static_sz ) ) {
     fd_blake3_t blake[1];

--- a/src/ballet/lthash/test_lthash_adder.c
+++ b/src/ballet/lthash/test_lthash_adder.c
@@ -181,21 +181,22 @@ test_lthash_adder_no_avx_regression( void ) {
 }
 
 static void
-bench_lthash_adder( void ) {
-  FD_LOG_NOTICE(( "Benchmarking lthash_adder (128 byte input)" ));
+bench_lthash_adder_sz( ulong input_sz ) {
+  FD_LOG_NOTICE(( "Benchmarking lthash_adder (%lu byte input)", input_sz ));
 
-  uchar input[ 128 ];
-  fd_memset( input, 0x41, sizeof(input) );
+  uchar input[ FD_BLAKE3_CHUNK_SZ ];
+  fd_memset( input, 0x41, fd_ulong_min( input_sz, sizeof(input) ) );
 
   fd_lthash_value_t out[1];
   fd_lthash_adder_t adder[1];
 
-  /* warmup */
   ulong iter_target = 1<<22UL;
+
+  /* warmup */
   ulong iter = iter_target>>7;
   long dt = fd_log_wallclock();
   fd_lthash_adder_new( adder );
-  for( ulong rem=iter; rem; rem-- ) fd_lthash_adder_push( adder, out, input, 128UL );
+  for( ulong rem=iter; rem; rem-- ) fd_lthash_adder_push( adder, out, input, input_sz );
   fd_lthash_adder_flush( adder, out );
   fd_lthash_adder_delete( adder );
   dt = fd_log_wallclock() - dt;
@@ -204,7 +205,7 @@ bench_lthash_adder( void ) {
   iter = iter_target;
   dt = fd_log_wallclock();
   fd_lthash_adder_new( adder );
-  for( ulong rem=iter; rem; rem-- ) fd_lthash_adder_push( adder, out, input, 128UL );
+  for( ulong rem=iter; rem; rem-- ) fd_lthash_adder_push( adder, out, input, input_sz );
   fd_lthash_adder_flush( adder, out );
   fd_lthash_adder_delete( adder );
   dt = fd_log_wallclock() - dt;
@@ -212,4 +213,14 @@ bench_lthash_adder( void ) {
   FD_LOG_NOTICE(( "~%.2e hash/s; %f ns per hash",
                   (double)(((float)(iter))/((float)dt*1e-9f)),
                   (double)dt/(double)iter ));
+}
+
+static void
+bench_lthash_adder( void ) {
+  bench_lthash_adder_sz( 128UL );
+  bench_lthash_adder_sz( 165UL );
+  bench_lthash_adder_sz( 256UL );
+  bench_lthash_adder_sz( 512UL );
+  bench_lthash_adder_sz( 768UL );
+  bench_lthash_adder_sz( 1024UL );
 }


### PR DESCRIPTION
Increase the fd_lthash_adder batch from 512 to 1024 bytes (FD_BLAKE3_CHUNK_SZ).

The accounts in the 513-1024 byte range take the SIMD-batched path instead of the scalar fallback. Estimated on a mainnet snapshot, this should affect 54M mainnet accounts (5.4%) or 33 GiB data (11.3%). These accounts should be hashed more or less 3x faster.
(There's no risk for correctness, since the batch buffer slots are already 1024 bytes and fd_blake3_lthash_batch16 natively supports inputs up to one BLAKE3 chunk.)

We're evaluating the total perf impact on a mainnet snapshot.