### PR TITLE
replay: remove useless test

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -738,7 +738,6 @@ publish_slot_completed( fd_replay_tile_t *  ctx,
 
   fd_hash_t const * bank_hash  = &bank->f.bank_hash;
   fd_hash_t const * block_hash = fd_blockhashes_peek_last_hash( &bank->f.block_hash_queue );
-  FD_TEST( bank_hash  );
   FD_TEST( block_hash );
 
   if( FD_LIKELY( !is_initial ) ) fd_txncache_finalize_fork( ctx->txncache, bank->txncache_fork_id, 0UL, block_hash->uc );


### PR DESCRIPTION
`bank_hash` can never be NULL, because we just took the address of `bank->f.bank_hash` which cannot be NULL (except from extreme UB conditions).
Fixes https://github.com/firedancer-io/firedancer/security/code-scanning/465