### PR TITLE
restore: snapwr/vinyl wr_seq tile cnt check

### DIFF
--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -214,6 +214,7 @@ fd_snapwm_vinyl_unprivileged_init( fd_snapwm_tile_t * ctx,
   fd_lthash_zero( &ctx->vinyl.running_lthash );
 
   ulong wr_cnt      = fd_topo_tile_name_cnt( topo, "snapwr" );
+  FD_TEST( wr_cnt<=FD_VINYL_ADMIN_WR_SEQ_CNT_MAX );
   ctx->vinyl.wr_cnt = wr_cnt;
 
   ctx->vinyl.admin = NULL;
@@ -734,7 +735,7 @@ fd_snapwm_vinyl_init_admin( fd_snapwm_tile_t * ctx,
     goto init_admin_error;
   }
 
-  if( FD_UNLIKELY( !ctx->vinyl.wr_cnt ) ) {
+  if( FD_UNLIKELY( !ctx->vinyl.wr_cnt || ctx->vinyl.wr_cnt>FD_VINYL_ADMIN_WR_SEQ_CNT_MAX ) ) {
     FD_LOG_WARNING(( "vinyl admin sees unexpected write tile count %lu", ctx->vinyl.wr_cnt ));
     goto init_admin_error;
   }

--- a/src/discof/restore/fd_snapwr_tile.c
+++ b/src/discof/restore/fd_snapwr_tile.c
@@ -125,50 +125,39 @@ unprivileged_init( fd_topo_t *      topo,
   fd_snapwr_t * snapwr = fd_topo_obj_laddr( topo, tile->tile_obj_id );
   memset( &snapwr->metrics, 0, sizeof(snapwr->metrics) );
 
-  if( FD_UNLIKELY( tile->in_cnt < 1UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected 1 or 2",  tile->in_cnt  ));
-  if( FD_UNLIKELY( tile->in_cnt > 2UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected 1 or 2",  tile->in_cnt  ));
+  if( FD_UNLIKELY( tile->in_cnt!=1UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected 1", tile->in_cnt ));
   if( FD_UNLIKELY( tile->out_cnt!=0UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu outs, expected 0", tile->out_cnt ));
 
   if( FD_UNLIKELY( !tile->in_link_reliable[ 0 ] ) ) FD_LOG_ERR(( "tile `" NAME "` in link 0 must be reliable" ));
   FD_TEST( tile->snapwr.dcache_obj_id!=ULONG_MAX );
+
+  fd_topo_link_t * in_link = &topo->links[ tile->in_link_id[ 0 ] ];
+  if( FD_UNLIKELY( 0!=strcmp( in_link->name, "snapwh_wr" ) ) ) FD_LOG_ERR(( "tile `" NAME "` has unexpected in link name `%s`", in_link->name ));
 
   uchar const * in_dcache = fd_dcache_join( fd_topo_obj_laddr( topo, tile->snapwr.dcache_obj_id ) );
   FD_TEST( in_dcache );
   snapwr->base     = in_dcache;
   snapwr->seq_sync = tile->in_link_fseq[ 0 ];
 
-  snapwr->bstream_seq = NULL; /* set to NULL by default, before checking input links. */
-  for( ulong i=0UL; i<tile->in_cnt; i++ ) {
-    fd_topo_link_t * in_link = &topo->links[ tile->in_link_id[ i ] ];
-
-    if( FD_LIKELY( 0==strcmp( in_link->name, "snapwh_wr" ) ) ) {
-      if( FD_UNLIKELY( !tile->in_link_reliable[ i ] ) ) FD_LOG_ERR(( "tile `" NAME "` in link %lu must be reliable", i ));
-
-    } else if( FD_LIKELY( 0==strcmp( in_link->name, "snaplv_wr" ) ) ) {
-      if( FD_UNLIKELY( !tile->in_link_reliable[ i ] ) ) FD_LOG_ERR(( "tile `" NAME "` in link %lu must be reliable", i ));
-      snapwr->bstream_seq = fd_mcache_seq_laddr( fd_mcache_join( fd_topo_obj_laddr( topo, in_link->mcache_obj_id ) ) ) + tile->kind_id;
-
-    } else {
-      FD_LOG_ERR(( "tile `" NAME "` has unexpected in link name `%s`", in_link->name ));
-    }
-  }
-
+  ulong const wr_tile_cnt = fd_topo_tile_name_cnt( topo, "snapwr" );
   snapwr->vinyl_admin     = NULL;
   snapwr->bstream_seq     = NULL;
   snapwr->lthash_disabled = !!tile->snapwr.lthash_disabled;
   if( !snapwr->lthash_disabled ) {
+    if( FD_UNLIKELY( wr_tile_cnt>FD_VINYL_ADMIN_WR_SEQ_CNT_MAX ) ) FD_LOG_ERR(( "tile `" NAME "` count %lu exceeds vinyl admin limit %lu", wr_tile_cnt, FD_VINYL_ADMIN_WR_SEQ_CNT_MAX ));
     ulong vinyl_admin_obj_id = fd_pod_query_ulong( topo->props, "vinyl_admin", ULONG_MAX );
     FD_TEST( vinyl_admin_obj_id!=ULONG_MAX );
     fd_vinyl_admin_t * vinyl_admin = fd_vinyl_admin_join( fd_topo_obj_laddr( topo, vinyl_admin_obj_id ) );
     FD_TEST( vinyl_admin );
     snapwr->vinyl_admin = vinyl_admin;
+    FD_TEST( tile->kind_id<FD_VINYL_ADMIN_WR_SEQ_CNT_MAX );
     snapwr->bstream_seq = &snapwr->vinyl_admin->wr_seq[ tile->kind_id ];
   }
 
   snapwr->state = FD_SNAPSHOT_STATE_IDLE;
 
   snapwr->req_seen = 0UL;
-  snapwr->tile_cnt = fd_topo_tile_name_cnt( topo, "snapwr" );
+  snapwr->tile_cnt = wr_tile_cnt;
   snapwr->tile_idx = tile->kind_id;
 }
 


### PR DESCRIPTION
Three changes:
1) `snapwm` and `snapwr` validate `snapwr` tile cnt.
2) `snapwr` validates that `bstream_seq` points to a valid location in `vinyl_admin`'s `wr_seq` array (it validates the idx).
3) removes support in `snapwr` tile for superseded link `snaplv_wr`.

Addresses points 15 and 27 of https://github.com/firedancer-io/firedancer/issues/9176.