### PR TITLE
restore: snapwh init stack entries in AVX512

### DIFF
--- a/src/discof/restore/fd_snapwh_tile.c
+++ b/src/discof/restore/fd_snapwh_tile.c
@@ -217,12 +217,12 @@ handle_data_frag( fd_snapwh_t * ctx,
 
     if( FD_UNLIKELY( ( pair_cnt==PAIR_HASH_N ) || ( !rem_sz ) ) ) {
 #     if FD_HAS_AVX512 && defined(__AVX512DQ__)
-      ulong        h_seed[PAIR_HASH_N];
-      ulong        h_trail[PAIR_HASH_N];
-      ulong        h_block[PAIR_HASH_N];
-      void const * h_tin  [PAIR_HASH_N];
+      ulong        h_seed [PAIR_HASH_N] = {0};
+      ulong        h_trail[PAIR_HASH_N]; /* no initialization needed */
+      ulong        h_block[PAIR_HASH_N]; /* no initialization needed */
+      void const * h_tin  [PAIR_HASH_N] = {0};
       ulong        h_tinsz[PAIR_HASH_N] = {0};
-      void const * h_bin  [PAIR_HASH_N];
+      void const * h_bin  [PAIR_HASH_N] = {0};
       ulong        h_binsz[PAIR_HASH_N] = {0};
       for( ulong i=0UL; i<pair_cnt; i++ ) {
         h_seed[ i ] = io_seed;


### PR DESCRIPTION
Initialize to zero hash stack entries under AVX512.
This was missing for `h_seed`, `h_tin` and `h_bin`.
Not needed for `h_trail`, and `h_block`, which are written before read.

Addresses point 13 in https://github.com/firedancer-io/firedancer/issues/9176.