### PR TITLE
restore: snapls in_cnt validation

### DIFF
--- a/src/discof/restore/fd_snapla_tile.c
+++ b/src/discof/restore/fd_snapla_tile.c
@@ -391,6 +391,8 @@ unprivileged_init( fd_topo_t *      topo,
   void * _ssparse         = FD_SCRATCH_ALLOC_APPEND( l, fd_ssparse_align(),           fd_ssparse_footprint( 1UL<<24UL ));
   void * _manifest_parser = FD_SCRATCH_ALLOC_APPEND( l, fd_ssmanifest_parser_align(), fd_ssmanifest_parser_footprint() );
 
+  FD_TEST( fd_topo_tile_name_cnt( topo, "snapla" )<=FD_SNAPSHOT_MAX_SNAPLA_TILES );
+
   if( FD_UNLIKELY( tile->in_cnt!=1UL ) )  FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected 1",  tile->in_cnt  ));
   if( FD_UNLIKELY( tile->out_cnt!=1UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu outs, expected 1", tile->out_cnt  ));
 

--- a/src/discof/restore/fd_snapls_tile.c
+++ b/src/discof/restore/fd_snapls_tile.c
@@ -412,7 +412,8 @@ unprivileged_init( fd_topo_t *      topo,
   fd_snapls_tile_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapls_tile_t), sizeof(fd_snapls_tile_t)         );
 
   ulong expected_in_cnt = 1UL + fd_topo_tile_name_cnt( topo, "snapla" );
-  if( FD_UNLIKELY( tile->in_cnt!=expected_in_cnt ) )  FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected %lu",  tile->in_cnt, expected_in_cnt ));
+  if( FD_UNLIKELY( tile->in_cnt!=expected_in_cnt ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected %lu", tile->in_cnt, expected_in_cnt ));
+  if( FD_UNLIKELY( tile->in_cnt>MAX_IN_LINKS ) )     FD_LOG_ERR(( "tile `" NAME "` has %lu ins, max %lu",      tile->in_cnt, (ulong)MAX_IN_LINKS ));
   if( FD_UNLIKELY( tile->out_cnt!=1UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu outs, expected 1", tile->out_cnt ));
 
   ulong adder_idx = 0UL;


### PR DESCRIPTION
`snapls` now validates in_cnt (which includes `snapla` tile cnt).
`snapla` now validates tile cnt.

Addresses point 10 in https://github.com/firedancer-io/firedancer/issues/9176.