### PR TITLE
restore: manifest struct streamlined snapin

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -224,7 +224,7 @@ backtest_topo( config_t * config ) {
     fd_topob_link( topo, "snapld_dc",    "snapld_dc",    16384UL, USHORT_MAX,                     1UL );
     fd_topob_link( topo, "snapdc_in",    "snapdc_in",    16384UL, USHORT_MAX,                     1UL );
 
-    fd_topob_link( topo, "snapin_manif", "snapin_manif", 4UL,     sizeof(fd_snapshot_manifest_t), 1UL ); /* TODO: Should be depth 1 or 2 but replay backpressures */
+    fd_topob_link( topo, "snapin_manif", "snapin_manif", 16UL,    0UL,                            1UL ); /* depth=16UL to avoid any stem bust backpressure due to this link */
     fd_topob_link( topo, "snapct_repr",  "snapct_repr",  128UL,   0UL,                            1UL )->permit_no_consumers = 1;
 
     if( vinyl_enabled ) {
@@ -460,7 +460,28 @@ backtest_topo( config_t * config ) {
   fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, 0 );
   fd_topob_tile_uses( topo, replay_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  if( FD_LIKELY( !disable_snap_loader ) ) {
+    fd_topob_tile_uses( topo, snapin_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
+
+  /* runtime_stack obj: concurrent access is safe because snapin
+     completes before replay begins execution. */
+  fd_topob_wksp( topo, "rtstack" );
+  fd_topo_obj_t * rtstack_obj = setup_topo_runtime_stack( topo, "rtstack" );
+  fd_topob_tile_uses( topo, replay_tile, rtstack_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  if( FD_LIKELY( !disable_snap_loader ) ) {
+    fd_topob_tile_uses( topo, snapin_tile, rtstack_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
+  FD_TEST( fd_pod_insertf_ulong( topo->props, rtstack_obj->id, "rtstack" ) );
+
+  if( FD_LIKELY( !disable_snap_loader ) ) {
+    fd_topo_obj_t * snapshot_manif_obj = fd_topob_obj( topo, "snap_manif", "snapin_manif" );
+    fd_topob_tile_uses( topo, snapin_tile, snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, replay_tile, snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    fd_topob_tile_uses( topo, backt_tile,  snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, snapshot_manif_obj->id, "snap_manif" ) );
+  }
 
   /* txncache_obj shared by replay, snapin, and execrp tiles */
   fd_topob_wksp( topo, "txncache"    );

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -164,7 +164,7 @@ repair_topo( config_t * config ) {
 
   /**/                 fd_topob_link( topo, "txsend_out",   "txsend_out",   128UL,                                    FD_TXN_MTU,                    1UL );
 
-  /**/                 fd_topob_link( topo, "snapin_manif", "snapin_manif", 2UL,                                      sizeof(fd_snapshot_manifest_t),1UL );
+  /**/                 fd_topob_link( topo, "snapin_manif", "snapin_manif", 16UL,                                     0UL,                           1UL ); /* depth=16UL to avoid any stem bust backpressure due to this link */
 
   /**/                 fd_topob_link( topo, "genesi_out",   "genesi_out",   1UL,                                      FD_GENESIS_TILE_MTU,            1UL );
   /**/                 fd_topob_link( topo, "tower_out",    "tower_out",    1024UL,                                   sizeof(fd_tower_msg_t),         1UL );
@@ -286,6 +286,11 @@ repair_topo( config_t * config ) {
     fd_topob_tile_uses( topo, scap_tile, root_slot_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
     fd_topob_tile_out( topo, "scap", 0UL, "replay_epoch", 0UL );
     fd_topob_tile_out( topo, "scap", 0UL, "snapin_manif", 0UL );
+
+    fd_topo_obj_t * snapshot_manif_obj = fd_topob_obj( topo, "snap_manif", "snapin_manif" );
+    fd_topob_tile_uses( topo, scap_tile,   snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, repair_tile, snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, snapshot_manif_obj->id, "snap_manif" ) );
   }
 
   /* Repair and shred share a secret they use to generate the nonces.

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -149,7 +149,7 @@ snapshot_load_topo( config_t * config ) {
   fd_topob_link( topo, "snapct_ld",   "snapct_ld",     128UL,   sizeof(fd_ssctrl_init_t),       1UL );
   fd_topob_link( topo, "snapld_dc",   "snapld_dc",     16384UL, USHORT_MAX,                     1UL );
   fd_topob_link( topo, "snapdc_in",   "snapdc_in",     16384UL, USHORT_MAX,                     1UL );
-  fd_topob_link( topo, "snapin_manif", "snapin_manif", 4UL,     sizeof(fd_snapshot_manifest_t), 1UL )->permit_no_consumers = 1;
+  fd_topob_link( topo, "snapin_manif", "snapin_manif", 16UL,    0UL,                            1UL )->permit_no_consumers = 1; /* depth=16UL to avoid any stem bust backpressure due to this link */
   fd_topob_link( topo, "snapct_repr", "snapct_repr",   128UL,   0UL,                            1UL )->permit_no_consumers = 1;
 
   if( vinyl_enabled ) {
@@ -285,6 +285,10 @@ snapshot_load_topo( config_t * config ) {
   }
 
   snapin_tile->snapin.max_live_slots  = config->firedancer.runtime.max_live_slots;
+
+  fd_topo_obj_t * snapshot_manif_obj = fd_topob_obj( topo, "snap_manif", "snapin_manif" );
+  fd_topob_tile_uses( topo, snapin_tile, snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, snapshot_manif_obj->id, "snap_manif" ) );
 
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
     fd_topo_tile_t * tile = &topo->tiles[ i ];

--- a/src/app/firedancer-dev/main.h
+++ b/src/app/firedancer-dev/main.h
@@ -25,6 +25,8 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_funk_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_progcache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_acc_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss;
+extern fd_topo_obj_callbacks_t fd_obj_cb_runtime_stack;
+extern fd_topo_obj_callbacks_t fd_obj_cb_snapshot_manif;
 
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta_ele;
@@ -61,6 +63,8 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_vinyl_cq,
   &fd_obj_cb_vinyl_admin,
   &fd_obj_cb_rnonce_ss,
+  &fd_obj_cb_runtime_stack,
+  &fd_obj_cb_snapshot_manif,
   NULL,
 };
 

--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -4,10 +4,13 @@
 #include "../../disco/store/fd_store.h"
 #include "../../flamenco/runtime/fd_bank.h"
 #include "../../flamenco/runtime/fd_acc_pool.h"
+#include "../../flamenco/runtime/fd_runtime_stack.h"
+#include "../../flamenco/runtime/fd_runtime_const.h"
 #include "../../flamenco/runtime/fd_txncache_shmem.h"
 #include "../../flamenco/progcache/fd_progcache.h"
 #include "../../funk/fd_funk.h"
 #include "../../disco/shred/fd_rnonce_ss.h"
+#include "../../discof/restore/utils/fd_ssmsg.h"
 
 #define VAL(name) (__extension__({                                                             \
   ulong __x = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "obj.%lu.%s", obj->id, name );      \
@@ -282,6 +285,57 @@ fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss = {
   .footprint = rnonce_ss_footprint,
   .align     = rnonce_ss_align,
   .new       = rnonce_ss_new,
+};
+
+static ulong
+runtime_stack_footprint( fd_topo_t const *     topo FD_FN_UNUSED,
+                         fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return fd_runtime_stack_footprint( FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS );
+}
+
+static ulong
+runtime_stack_align( fd_topo_t const *     topo FD_FN_UNUSED,
+                     fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return fd_runtime_stack_align();
+}
+
+static void
+runtime_stack_new( fd_topo_t const *     topo,
+                   fd_topo_obj_t const * obj ) {
+  ulong seed = fd_pod_queryf_ulong( topo->props, 0UL, "obj.%lu.seed", obj->id );
+  FD_TEST( fd_runtime_stack_new( fd_topo_obj_laddr( topo, obj->id ), FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS, seed ) );
+}
+
+fd_topo_obj_callbacks_t fd_obj_cb_runtime_stack = {
+  .name      = "rtstack",
+  .footprint = runtime_stack_footprint,
+  .align     = runtime_stack_align,
+  .new       = runtime_stack_new,
+};
+
+static ulong
+snapshot_manif_footprint( fd_topo_t const *     topo FD_FN_UNUSED,
+                          fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return 2UL * sizeof(fd_snapshot_manifest_t);
+}
+
+static ulong
+snapshot_manif_align( fd_topo_t const *     topo FD_FN_UNUSED,
+                      fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return alignof(fd_snapshot_manifest_t);
+}
+
+static void
+snapshot_manif_new( fd_topo_t const *     topo,
+                    fd_topo_obj_t const * obj ) {
+  memset( fd_topo_obj_laddr( topo, obj->id ), 0, snapshot_manif_footprint( topo, obj ) );
+}
+
+fd_topo_obj_callbacks_t fd_obj_cb_snapshot_manif = {
+  .name      = "snap_manif",
+  .footprint = snapshot_manif_footprint,
+  .align     = snapshot_manif_align,
+  .new       = snapshot_manif_new,
 };
 
 #undef VAL

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -24,6 +24,8 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_funk_locks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_progcache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_acc_pool;
 extern fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss;
+extern fd_topo_obj_callbacks_t fd_obj_cb_runtime_stack;
+extern fd_topo_obj_callbacks_t fd_obj_cb_snapshot_manif;
 
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta;
 extern fd_topo_obj_callbacks_t fd_obj_cb_vinyl_meta_ele;
@@ -60,6 +62,8 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_vinyl_cq,
   &fd_obj_cb_vinyl_admin,
   &fd_obj_cb_rnonce_ss,
+  &fd_obj_cb_runtime_stack,
+  &fd_obj_cb_snapshot_manif,
   NULL,
 };
 

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -78,6 +78,15 @@ setup_topo_banks( fd_topo_t *  topo,
   return obj;
 }
 
+fd_topo_obj_t *
+setup_topo_runtime_stack( fd_topo_t * topo, char const * wksp_name ) {
+  fd_topo_obj_t * obj = fd_topob_obj( topo, "rtstack", wksp_name );
+  ulong seed;
+  FD_TEST( fd_rng_secure( &seed, sizeof(ulong) ) );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, seed, "obj.%lu.seed", obj->id ) );
+  return obj;
+}
+
 static fd_topo_obj_t *
 setup_topo_fec_sets( fd_topo_t * topo, char const * wksp_name, ulong sz ) {
   fd_topo_obj_t * obj = fd_topob_obj( topo, "fec_sets", wksp_name );
@@ -471,6 +480,7 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "fec_sets"      );
   fd_topob_wksp( topo, "txncache"      );
   fd_topob_wksp( topo, "banks"         );
+  fd_topob_wksp( topo, "rtstack"       );
   fd_topob_wksp( topo, "store"         )->core_dump_level = FD_TOPO_CORE_DUMP_LEVEL_FULL;
   fd_topob_wksp( topo, "rnonce"        );
 
@@ -553,7 +563,7 @@ fd_topo_initialize( config_t * config ) {
     /**/               fd_topob_link( topo, "snapld_dc",     "snapld_dc",     16384UL,                                  USHORT_MAX,                    1UL );
     /**/               fd_topob_link( topo, "snapdc_in",     "snapdc_in",     16384UL,                                  USHORT_MAX,                    1UL );
 
-    /**/               fd_topob_link( topo, "snapin_manif",  "snapin_manif",  4UL,                                      sizeof(fd_snapshot_manifest_t),1UL );
+    /**/               fd_topob_link( topo, "snapin_manif",  "snapin_manif",  16UL,                                     0UL,                           1UL ); /* depth=16UL to avoid any stem bust backpressure due to this link */
     /**/               fd_topob_link( topo, "snapct_repr",   "snapct_repr",   128UL,                                    0UL,                           1UL )->permit_no_consumers = 1; /* TODO: wire in repair later */
     if( FD_LIKELY( config->tiles.gui.enabled ) ) {
       /**/             fd_topob_link( topo, "snapct_gui",    "snapct_gui",    128UL,                                    sizeof(fd_snapct_update_t),    1UL );
@@ -1238,7 +1248,28 @@ fd_topo_initialize( config_t * config ) {
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execle_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execle", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(resolv_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "resolv", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+  if( FD_LIKELY( snapshots_enabled ) ) {
+    fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
+
+  /* runtime_stack obj: concurrent access is safe because snapin
+     completes before replay begins execution. */
+  fd_topo_obj_t * rtstack_obj = setup_topo_runtime_stack( topo, "rtstack" );
+  /**/   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], rtstack_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  if( FD_LIKELY( snapshots_enabled ) ) {
+    /**/ fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], rtstack_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
+  FD_TEST( fd_pod_insertf_ulong( topo->props, rtstack_obj->id, "rtstack" ) );
+
+  if( FD_LIKELY( snapshots_enabled ) ) {
+    fd_topo_obj_t * snapshot_manif_obj = fd_topob_obj( topo, "snap_manif", "snapin_manif" );
+    /**/   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    /**/   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "gossip", 0UL ) ], snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    /**/   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "repair", 0UL ) ], snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    /**/   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], snapshot_manif_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, snapshot_manif_obj->id, "snap_manif" ) );
+  }
 
   if( FD_UNLIKELY( config->tiles.bundle.enabled ) ) {
     if( FD_UNLIKELY( config->firedancer.runtime.concurrent_account_limit<FD_ACC_POOL_MIN_ACCOUNT_CNT_PER_BUNDLE ) ) {
@@ -1299,6 +1330,9 @@ fd_topo_initialize( config_t * config ) {
     /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "snapct_gui",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "snapin_gui",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "snapin_manif",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+    ulong snap_manif_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+    FD_TEST( snap_manif_id!=ULONG_MAX );
+    fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "gui", 0UL ) ], &topo->objs[ snap_manif_id ], FD_SHMEM_JOIN_MODE_READ_ONLY );
     }
     if( FD_UNLIKELY( config->tiles.bundle.enabled ) ) {
     /**/                   fd_topob_tile_in(  topo, "gui",    0UL,           "metric_in", "bundle_status", 0UL,         FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );

--- a/src/app/firedancer/topology.h
+++ b/src/app/firedancer/topology.h
@@ -59,6 +59,10 @@ setup_topo_accdb_cache( fd_topo_t *    topo,
                         fd_configf_t * config );
 
 fd_topo_obj_t *
+setup_topo_runtime_stack( fd_topo_t *  topo,
+                          char const * wksp_name );
+
+fd_topo_obj_t *
 setup_topo_vinyl_admin( fd_topo_t *  topo,
                         char const * wksp_name );
 

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -1134,9 +1134,9 @@ fd_gui_peers_stage_snapshot_manifest( fd_gui_peers_ctx_t *           peers,
   fd_vote_stake_weight_t * vote_scratch = peers->scratch.manifest_vote_weights;
   ulong vote_scratch_cnt = 0UL;
   ulong vote_accounts_sz = manifest->vote_accounts_len;
-  if( FD_UNLIKELY( vote_accounts_sz>40200UL ) ) {
-    FD_LOG_WARNING(( "exceeded 40200UL vote accounts" ));
-    vote_accounts_sz = 40200UL;
+  if( FD_UNLIKELY( vote_accounts_sz>FD_RUNTIME_MAX_VOTE_ACCOUNTS ) ) {
+    FD_LOG_WARNING(( "exceeded FD_RUNTIME_MAX_VOTE_ACCOUNTS vote accounts" ));
+    vote_accounts_sz = FD_RUNTIME_MAX_VOTE_ACCOUNTS;
   }
   for( ulong i=0UL; i<vote_accounts_sz; i++ ) {
     if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -417,11 +417,11 @@ struct fd_gui_peers_ctx {
       ulong idxs   [ FD_CONTACT_INFO_TABLE_SIZE ];
     };
     struct {
-      ulong wfs_peers[ 40200UL ];
+      ulong wfs_peers[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
     };
     struct {
-      fd_stake_weight_t      manifest_id_weights  [ 40200UL ];
-      fd_vote_stake_weight_t manifest_vote_weights[ 40200UL ];
+      fd_stake_weight_t      manifest_id_weights  [ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+      fd_vote_stake_weight_t manifest_vote_weights[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
     };
     fd_gui_peers_voter_t voters_scratch[ MAX_STAKED_LEADERS ];
   } scratch;
@@ -433,7 +433,7 @@ struct fd_gui_peers_ctx {
   fd_gui_ip_db_t dbip;
 
   int                       wfs_enabled;
-  fd_gui_wfs_peer_t         wfs_peers[ 40200UL ];
+  fd_gui_wfs_peer_t         wfs_peers[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
   ulong                     wfs_peers_cnt;
   int                       wfs_peers_valid;
   int                       wfs_stakes_sent;

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -33,6 +33,7 @@ static fd_http_static_file_t * STATIC_FILES;
 #include "../../util/clock/fd_clock.h"
 #include "../../discof/repair/fd_repair.h"
 #include "../../discof/replay/fd_replay_tile.h"
+#include "../../util/pod/fd_pod.h"
 
 #define IN_KIND_PLUGIN        ( 0UL)
 #define IN_KIND_POH_PACK      ( 1UL)
@@ -138,6 +139,8 @@ typedef struct {
 
   int               has_vote_key;
   fd_pubkey_t const vote_key[ 1UL ];
+
+  fd_snapshot_manifest_t const * snapshot_manif;
 
   ulong           in_kind[ 64UL ];
   ulong           in_bank_idx[ 64UL ];
@@ -246,6 +249,8 @@ during_frag( fd_gui_ctx_t * ctx,
              ulong          sz,
              ulong          ctl ) {
 
+  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_SNAPIN_MANIF ) ) return;
+
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
 
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PLUGIN ) ) {
@@ -328,6 +333,20 @@ after_frag( fd_gui_ctx_t *      ctx,
             fd_stem_context_t * stem ) {
   (void)seq; (void)stem;
 
+  if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_SNAPIN_MANIF ) ) {
+    FD_TEST( ctx->is_full_client );
+    if( fd_ssmsg_sig_message( sig )==FD_SSMSG_DONE ) {
+      fd_gui_peers_commit_snapshot_manifest( ctx->peers );
+    } else {
+      ulong manif_idx = fd_ssmsg_manif_idx_from_sig( sig );
+      FD_TEST( manif_idx!=ULONG_MAX );
+      fd_snapshot_manifest_t const * manifest = &ctx->snapshot_manif[ manif_idx ];
+      fd_gui_stage_snapshot_manifest( ctx->gui, manifest );
+      fd_gui_peers_stage_snapshot_manifest( ctx->peers, manifest, fd_clock_now( ctx->clock ) );
+    }
+    return;
+  }
+
   uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[ in_idx ].mem, ctx->chunk );
 
   switch ( ctx->in_kind[ in_idx ] ) {
@@ -384,17 +403,6 @@ after_frag( fd_gui_ctx_t *      ctx,
     case IN_KIND_SNAPIN: {
       FD_TEST( ctx->is_full_client );
       fd_gui_peers_handle_config_account( ctx->peers, src, sz );
-      break;
-    }
-    case IN_KIND_SNAPIN_MANIF: {
-      FD_TEST( ctx->is_full_client );
-
-      if( fd_ssmsg_sig_message( sig )==FD_SSMSG_DONE ) {
-        fd_gui_peers_commit_snapshot_manifest( ctx->peers );
-      } else {
-        fd_gui_stage_snapshot_manifest( ctx->gui, (fd_snapshot_manifest_t const *)src );
-        fd_gui_peers_stage_snapshot_manifest( ctx->peers, (fd_snapshot_manifest_t const *)src, fd_clock_now( ctx->clock ) );
-      }
       break;
     }
     case IN_KIND_GENESI_OUT: {
@@ -791,10 +799,17 @@ unprivileged_init( fd_topo_t *      topo,
       ctx->in_bank_idx[ i ] = topo->tiles[ producer ].kind_id;
     }
 
+    if( FD_UNLIKELY( !link->mtu ) ) continue;
+
     ctx->in[ i ].mem    = link_wksp->wksp;
     ctx->in[ i ].mtu    = link->mtu;
     ctx->in[ i ].chunk0 = fd_dcache_compact_chunk0( ctx->in[ i ].mem, link->dcache );
     ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
+  }
+
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t const *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
   }
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );

--- a/src/discof/backtest/fd_backtest_tile.c
+++ b/src/discof/backtest/fd_backtest_tile.c
@@ -83,6 +83,8 @@ struct fd_backt_tile {
 
   fd_store_t * store;
 
+  fd_snapshot_manifest_t const * snapshot_manif;
+
   int in_kind[ 16UL ];
   fd_backt_in_t in[ 16UL ];
 
@@ -363,7 +365,9 @@ returnable_frag( fd_backt_tile_t *   ctx,
         return 0;
       }
 
-      fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
+      ulong manif_idx = fd_ssmsg_manif_idx_from_sig( sig );
+      FD_TEST( manif_idx!=ULONG_MAX );
+      fd_snapshot_manifest_t const * manifest = &ctx->snapshot_manif[ manif_idx ];
 
       ctx->initialized = 1;
       ctx->reading_slot = manifest->slot;
@@ -579,17 +583,24 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( tile->in_cnt<=sizeof(ctx->in)/sizeof(ctx->in[0]) );
   for( uint i=0UL; i<tile->in_cnt; i++ ) {
     fd_topo_link_t * link = &topo->links[ tile->in_link_id[ i ] ];
-    fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->dcache_obj_id ].wksp_id ];
-
-    ctx->in[ i ].mem    = link_wksp->wksp;
-    ctx->in[ i ].chunk0 = fd_dcache_compact_chunk0( ctx->in[ i ].mem, link->dcache );
-    ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
-    ctx->in[ i ].mtu    = link->mtu;
 
     if(      !strcmp( link->name, "replay_out"   ) ) ctx->in_kind[ i ] = IN_KIND_REPLAY;
     else if( !strcmp( link->name, "snapin_manif" ) ) ctx->in_kind[ i ] = IN_KIND_SNAP;
     else if( !strcmp( link->name, "genesi_out"   ) ) ctx->in_kind[ i ] = IN_KIND_GENESI;
     else FD_LOG_ERR(( "backtest tile has unexpected input link %s", link->name ));
+
+    if( !strcmp( link->name, "snapin_manif" ) ) continue;
+
+    fd_topo_wksp_t * link_wksp = &topo->workspaces[ topo->objs[ link->dcache_obj_id ].wksp_id ];
+    ctx->in[ i ].mem    = link_wksp->wksp;
+    ctx->in[ i ].chunk0 = fd_dcache_compact_chunk0( ctx->in[ i ].mem, link->dcache );
+    ctx->in[ i ].wmark  = fd_dcache_compact_wmark ( ctx->in[ i ].mem, link->dcache, link->mtu );
+    ctx->in[ i ].mtu    = link->mtu;
+  }
+
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t const *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
   }
 
   *ctx->repair_out = out1( topo, tile, "repair_out" );

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -11,6 +11,7 @@
 #include "../../disco/fd_txn_m.h"
 #include "../tower/fd_tower_tile.h"
 #include "../restore/utils/fd_ssmsg.h"
+#include "../../util/pod/fd_pod.h"
 
 #define IN_KIND_GOSSVF        (0)
 #define IN_KIND_SHRED_VERSION (1)
@@ -367,9 +368,9 @@ returnable_frag( fd_gossip_tile_ctx_t * ctx,
         break;
       }
 
-      /* FIXME: Replace handling for this when manifest supports larger
-         vote and stake account bounds. */
-      fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
+      ulong manif_idx = fd_ssmsg_manif_idx_from_sig( sig );
+      FD_TEST( manif_idx!=ULONG_MAX );
+      fd_snapshot_manifest_t const * manifest = &ctx->snapshot_manif[ manif_idx ];
 
       ulong wfs_stakes_unconverted_cnt = 0UL;
       ctx->wfs_stake.online = 0UL;
@@ -378,7 +379,7 @@ returnable_frag( fd_gossip_tile_ctx_t * ctx,
       ctx->wfs_peers.total  = 0UL;
       memset( ctx->wfs_active, 0, sizeof(ctx->wfs_active) );
 
-      FD_TEST( manifest->vote_accounts_len<=40200UL );
+      FD_TEST( manifest->vote_accounts_len<=FD_RUNTIME_MAX_VOTE_ACCOUNTS );
       for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
           if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;
           ctx->wfs_stake.total += manifest->vote_accounts[ i ].stake;
@@ -503,6 +504,11 @@ unprivileged_init( fd_topo_t *      topo,
 
   if( FD_UNLIKELY( sign_in_tile_idx==ULONG_MAX ) )
     FD_LOG_ERR(( "tile %s:%lu had no input link named sign_gossip", tile->name, tile->kind_id ));
+
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t const *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
+  }
 
   *ctx->net_out    = out1( topo, tile, "gossip_net"    );
   *ctx->sign_out   = out1( topo, tile, "gossip_sign"   );

--- a/src/discof/gossip/fd_gossip_tile.h
+++ b/src/discof/gossip/fd_gossip_tile.h
@@ -6,6 +6,7 @@
 #include "../../flamenco/runtime/fd_runtime_const.h"
 #include "../../disco/keyguard/fd_keyguard_client.h"
 #include "../../disco/keyguard/fd_keyswitch.h"
+#include "../../discof/restore/utils/fd_ssmsg.h"
 
 typedef struct {
   int         kind;
@@ -59,13 +60,13 @@ struct fd_gossip_tile_ctx {
 
      We keep a copy of the snapshot bank's votes states in an array here
      for quick look up. */
-  fd_vote_stake_weight_t wfs_stakes_scratch[ 40200UL ];
-  fd_stake_weight_t      wfs_stakes        [ 40200UL ];
+  fd_vote_stake_weight_t wfs_stakes_scratch[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
+  fd_stake_weight_t      wfs_stakes        [ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
   ulong                  wfs_stakes_cnt;
 
   /* wfs_active is used to keep track of nodes we've already labeled as
      being active on gossip, so we don't double count their stake. */
-  uchar             wfs_active[ 40200UL ];
+  uchar             wfs_active[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
   int               wfs_state;
 
   struct {
@@ -80,6 +81,8 @@ struct fd_gossip_tile_ctx {
   ulong peer_sat_hwm;        /* high-water mark of peer count       */
   long  peer_sat_hwm_nanos;  /* wallclock when HWM last increased   */
   int   peer_sat_published;  /* one-shot latch (0 -> 1)             */
+
+  fd_snapshot_manifest_t const * snapshot_manif;
 };
 
 typedef struct fd_gossip_tile_ctx fd_gossip_tile_ctx_t;

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -370,7 +370,8 @@ struct ctx {
 
   /* Store chunk for incoming reliable frags */
   ulong chunk;
-  ulong snap_out_chunk; /* store second to last chunk for snap_out */
+  fd_snapshot_manifest_t const * snapshot_manif;
+  ulong snap_manif_idx;
 
   fd_ip4_udp_hdrs_t intake_hdr[1];
   fd_ip4_udp_hdrs_t serve_hdr [1];
@@ -593,7 +594,10 @@ during_frag( ctx_t * ctx,
     FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu] in kind %u", chunk, sz, in_ctx->chunk0, in_ctx->wmark, in_kind ));
 
   if( FD_UNLIKELY( in_kind==IN_KIND_SNAP ) ) {
-    if( FD_UNLIKELY( fd_ssmsg_sig_message( sig )!=FD_SSMSG_DONE ) ) ctx->snap_out_chunk = chunk;
+    if( FD_UNLIKELY( fd_ssmsg_sig_message( sig )!=FD_SSMSG_DONE ) ) {
+      ctx->snap_manif_idx = fd_ssmsg_manif_idx_from_sig( sig );
+      FD_TEST( ctx->snap_manif_idx!=ULONG_MAX );
+    }
     return;
   }
 
@@ -608,10 +612,9 @@ during_frag( ctx_t * ctx,
 
 static inline void
 after_snap( ctx_t * ctx,
-                 ulong                  sig,
-                 uchar const          * chunk ) {
+            ulong   sig ) {
   if( FD_UNLIKELY( fd_ssmsg_sig_message( sig )!=FD_SSMSG_DONE ) ) return;
-  fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)chunk;
+  fd_snapshot_manifest_t const * manifest = &ctx->snapshot_manif[ ctx->snap_manif_idx ];
 
   fd_forest_init( ctx->forest, manifest->slot );
 }
@@ -920,7 +923,7 @@ after_frag( ctx_t *             ctx,
     }
     /* Reliable frags read directly from dcache */
     case IN_KIND_SNAP: {
-      after_snap( ctx, sig, fd_chunk_to_laddr( ctx->in_links[ in_idx ].mem, ctx->snap_out_chunk ) );
+      after_snap( ctx, sig );
       break;
     }
     case IN_KIND_GENESIS: {
@@ -1232,7 +1235,7 @@ unprivileged_init( fd_topo_t *      topo,
     else if( 0==strcmp( link->name, "gossip_out"   ) ) ctx->in_kind[ in_idx ] = IN_KIND_GOSSIP;
     else if( 0==strcmp( link->name, "tower_out"    ) ) ctx->in_kind[ in_idx ] = IN_KIND_TOWER;
     else if( 0==strcmp( link->name, "shred_out"    ) ) ctx->in_kind[ in_idx ] = IN_KIND_SHRED;
-    else if( 0==strcmp( link->name, "snapin_manif" ) ) ctx->in_kind[ in_idx ] = IN_KIND_SNAP;
+    else if( 0==strcmp( link->name, "snapin_manif" ) ) { ctx->in_kind[ in_idx ] = IN_KIND_SNAP; continue; }
     else if( 0==strcmp( link->name, "genesi_out"   ) ) ctx->in_kind[ in_idx ] = IN_KIND_GENESIS;
     else if( 0==strcmp( link->name, "replay_out"   ) ) ctx->in_kind[ in_idx ] = IN_KIND_REPLAY;
     else FD_LOG_ERR(( "repair tile has unexpected input link %s", link->name ));
@@ -1243,6 +1246,12 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->in_links[ in_idx ].mtu    = link->mtu;
 
     FD_TEST( fd_dcache_compact_is_safe( ctx->in_links[in_idx].mem, link->dcache, link->mtu, link->depth ) );
+  }
+
+  ctx->snap_manif_idx = 0UL;
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t const *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
   }
 
   ctx->net_out_ctx->idx    = UINT_MAX;

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -423,6 +423,8 @@ struct fd_replay_tile {
 
   ulong  resolv_tile_cnt;
 
+  fd_snapshot_manifest_t const * snapshot_manif;
+
   int in_kind[ 128 ];
   fd_replay_in_link_t in[ 128 ];
 
@@ -478,7 +480,6 @@ struct fd_replay_tile {
 
   uchar __attribute__((aligned(FD_MULTI_EPOCH_LEADERS_ALIGN))) mleaders_mem[ FD_MULTI_EPOCH_LEADERS_FOOTPRINT ];
 
-  ulong                runtime_stack_seed;
   fd_runtime_stack_t * runtime_stack;
 };
 
@@ -494,7 +495,6 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
 
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof(fd_replay_tile_t),    sizeof(fd_replay_tile_t) );
-  l = FD_LAYOUT_APPEND( l, fd_runtime_stack_align(),     fd_runtime_stack_footprint( FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS ) );
   l = FD_LAYOUT_APPEND( l, alignof(fd_block_id_ele_t),   sizeof(fd_block_id_ele_t) * tile->replay.max_live_slots );
   l = FD_LAYOUT_APPEND( l, fd_block_id_map_align(),      fd_block_id_map_footprint( chain_cnt ) );
   l = FD_LAYOUT_APPEND( l, fd_txncache_align(),          fd_txncache_footprint( tile->replay.max_live_slots ) );
@@ -1517,8 +1517,6 @@ maybe_verify_cluster_type( fd_replay_tile_t * ctx ) {
 static void
 on_snapshot_message( fd_replay_tile_t *  ctx,
                      fd_stem_context_t * stem,
-                     ulong               in_idx,
-                     ulong               chunk,
                      ulong               sig ) {
   ulong msg = fd_ssmsg_sig_message( sig );
   if( FD_LIKELY( msg==FD_SSMSG_DONE ) ) {
@@ -1620,20 +1618,9 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
   switch( msg ) {
     case FD_SSMSG_MANIFEST_FULL:
     case FD_SSMSG_MANIFEST_INCREMENTAL: {
-      /* We may either receive a full snapshot manifest or an
-         incremental snapshot manifest.  Note that this external message
-         id is only used temporarily because replay cannot yet receive
-         the firedancer-internal snapshot manifest message. */
-      if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
-        FD_LOG_ERR(( "chunk %lu from in %d corrupt, not in range [%lu,%lu]", chunk, ctx->in_kind[ in_idx ], ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
-      fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
-                         ctx->banks,
-                         fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX ),
-                         ctx->runtime_stack,
-                         msg==FD_SSMSG_MANIFEST_INCREMENTAL );
-
-      fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
+      ulong manif_idx = fd_ssmsg_manif_idx_from_sig( sig );
+      FD_TEST( manif_idx!=ULONG_MAX );
+      fd_snapshot_manifest_t const * manifest = &ctx->snapshot_manif[ manif_idx ];
       ctx->hard_forks_cnt = manifest->hard_forks_len;
       for( ulong i=0UL; i<manifest->hard_forks_len; i++ ) {
         ctx->hard_forks[ i ] = manifest->hard_forks[ i ];
@@ -2674,7 +2661,7 @@ returnable_frag( fd_replay_tile_t *  ctx,
       break;
     }
     case IN_KIND_SNAP: {
-      on_snapshot_message( ctx, stem, in_idx, chunk, sig );
+      on_snapshot_message( ctx, stem, sig );
       maybe_verify_shred_version( ctx );
       maybe_verify_genesis_timestamp( ctx );
       break;
@@ -2811,9 +2798,6 @@ privileged_init( fd_topo_t *      topo,
     FD_LOG_CRIT(( "fd_rng_secure failed" ));
   }
 
-  if( FD_UNLIKELY( !fd_rng_secure( &ctx->runtime_stack_seed, sizeof(ulong) ) ) ) {
-    FD_LOG_CRIT(( "fd_rng_secure failed" ));
-  }
 }
 
 static void
@@ -2825,7 +2809,6 @@ unprivileged_init( fd_topo_t *      topo,
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   fd_replay_tile_t * ctx    = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_replay_tile_t),   sizeof(fd_replay_tile_t) );
-  void * runtime_stack_mem  = FD_SCRATCH_ALLOC_APPEND( l, fd_runtime_stack_align(),    fd_runtime_stack_footprint( FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS ) );
   void * block_id_arr_mem   = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_block_id_ele_t),  sizeof(fd_block_id_ele_t) * tile->replay.max_live_slots );
   void * block_id_map_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_block_id_map_align(),     fd_block_id_map_footprint( chain_cnt ) );
   void * _txncache          = FD_SCRATCH_ALLOC_APPEND( l, fd_txncache_align(),         fd_txncache_footprint( tile->replay.max_live_slots ) );
@@ -2842,7 +2825,9 @@ unprivileged_init( fd_topo_t *      topo,
   }
 # endif
 
-  ctx->runtime_stack = fd_runtime_stack_join( fd_runtime_stack_new( runtime_stack_mem, FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_VOTE_ACCOUNTS, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS, ctx->runtime_stack_seed ) );
+  ulong rtstack_obj_id = fd_pod_query_ulong( topo->props, "rtstack", ULONG_MAX );
+  FD_TEST( rtstack_obj_id!=ULONG_MAX );
+  ctx->runtime_stack = fd_runtime_stack_join( fd_topo_obj_laddr( topo, rtstack_obj_id ) );
   FD_TEST( ctx->runtime_stack );
 
   ctx->wksp = topo->workspaces[ topo->objs[ tile->tile_obj_id ].wksp_id ].wksp;
@@ -3046,6 +3031,11 @@ unprivileged_init( fd_topo_t *      topo,
     else if( !strcmp( link->name, "rpc_replay"    ) ) ctx->in_kind[ i ] = IN_KIND_RPC;
     else if( !strcmp( link->name, "gossip_out"    ) ) ctx->in_kind[ i ] = IN_KIND_GOSSIP_OUT;
     else FD_LOG_ERR(( "unexpected input link name %s", link->name ));
+  }
+
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t const *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
   }
 
   *ctx->epoch_out  = out1( topo, tile, "replay_epoch" ); FD_TEST( ctx->epoch_out->idx!=ULONG_MAX );

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -1118,7 +1118,7 @@ after_credit( fd_snapct_tile_t *  ctx,
       break;
 
     /* ============================================================== */
-    default: FD_LOG_ERR(( "unexpected state %d", ctx->state ));
+    default: FD_LOG_ERR(( "unexpected state %s", fd_snapct_state_str( (ulong)ctx->state ) ));
   }
 }
 
@@ -1277,8 +1277,12 @@ snapld_frag( fd_snapct_tile_t *  ctx,
 
       case FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET:
       case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET:
-        return; /* Ignore */
-      default: FD_LOG_ERR(( "invalid meta frag in state %d", ctx->state ));
+      case FD_SNAPCT_STATE_WAITING_FOR_PEERS:
+      case FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL:
+      case FD_SNAPCT_STATE_COLLECTING_PEERS:
+      case FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL:
+        return; /* Ignore: stale meta from a cancelled download */
+      default: FD_LOG_ERR(( "invalid meta frag in state %s", fd_snapct_state_str( (ulong)ctx->state ) ));
     }
 
     FD_TEST( sz==sizeof(fd_ssctrl_meta_t) );
@@ -1329,10 +1333,24 @@ snapld_frag( fd_snapct_tile_t *  ctx,
     case FD_SNAPCT_STATE_WAITING_FOR_PEERS_INCREMENTAL:
     case FD_SNAPCT_STATE_COLLECTING_PEERS:
     case FD_SNAPCT_STATE_COLLECTING_PEERS_INCREMENTAL:
+      /* After a failed download, snapld may still have in-flight data
+         frags from the cancelled HTTP connection.  These arrive after
+         the FLUSHING_*_RESET -> COLLECTING_PEERS_* transition because
+         the CTRL_FAIL ack only confirms the downstream pipeline reset,
+         not that snapld has stopped producing data.  Drop silently. */
+      return;
     case FD_SNAPCT_STATE_SHUTDOWN:
     default:
-      FD_LOG_ERR(( "invalid data frag in state %d", ctx->state ));
+      FD_LOG_ERR(( "invalid data frag in state %s", fd_snapct_state_str( (ulong)ctx->state ) ));
       return;
+  }
+
+  /* For HTTP downloads, bytes_total is set by a META message from
+     snapld.  If a DATA frag arrives before the META, it is a stale
+     frag from a previous cancelled download.  Drop silently. */
+  if( FD_UNLIKELY( !file ) ) {
+    ulong bytes_total = full ? ctx->metrics.full.bytes_total : ctx->metrics.incremental.bytes_total;
+    if( FD_UNLIKELY( bytes_total==0UL ) ) return;
   }
 
   if( full ) FD_TEST( ctx->metrics.full.bytes_total       !=0UL );
@@ -1381,7 +1399,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_READING_FULL_FILE ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_INIT_INCR:
@@ -1389,7 +1407,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_READING_INCREMENTAL_FILE ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_NEXT:
@@ -1397,7 +1415,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_FLUSHING_FULL_FILE_DONE ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_DONE:
@@ -1407,7 +1425,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_DONE ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_FINI:
@@ -1417,7 +1435,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_FINI ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_FAIL:
@@ -1427,7 +1445,7 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
                      ctx->state==FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_RESET ) ) {
         FD_TEST( !ctx->flush_ack );
         ctx->flush_ack = 1;
-      } else FD_LOG_ERR(( "invalid control frag %lu in state %d", sig, ctx->state ));
+      } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( (ulong)ctx->state ) ));
       break;
 
     case FD_SNAPSHOT_MSG_CTRL_SHUTDOWN:

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -1,5 +1,6 @@
 #include "fd_snapin_tile_private.h"
 #include "utils/fd_ssctrl.h"
+#include "utils/fd_ssload.h"
 #include "utils/fd_ssmsg.h"
 #include "utils/fd_vinyl_io_wd.h"
 
@@ -51,6 +52,106 @@ typedef struct fd_blockhash_entry fd_blockhash_entry_t;
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
 
+static void
+on_vote_stakes( void *                                     ctx_,
+                ulong                                      epoch_idx,
+                fd_snapshot_manifest_vote_stakes_t const * vs ) {
+  fd_snapin_tile_t * ctx = (fd_snapin_tile_t *)ctx_;
+
+  if( FD_UNLIKELY( ctx->callback_error ) ) return;
+
+  fd_snapshot_manifest_t * manifest = &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( ctx->full ) ];
+
+  /* Discard entries for epochs we're not tracking */
+  if( FD_UNLIKELY( epoch_idx==ULONG_MAX ) ) return;
+  FD_TEST( epoch_idx<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
+
+  /* Compact: skip entries with no stake and no epoch credit history */
+  if( vs->stake==0UL && vs->epoch_credits_history_len==0UL ) return;
+
+  /* Increment the manifest counter (used by verify_epoch_stakes and
+     other scalar checks). */
+  manifest->epoch_stakes[ epoch_idx ].vote_stakes_len++;
+
+  if( epoch_idx==1UL ) {
+    /* E+1: process on-the-fly (writes directly to runtime_stack arrays
+       and vote_stakes tree).  Skip if banks/runtime_stack are not
+       available (e.g. shredcap or profiler mode). */
+    if( FD_UNLIKELY( ctx->vote_stakes_e1_len>=FD_RUNTIME_MAX_VOTE_ACCOUNTS ) ) {
+      FD_LOG_WARNING(( "vote_stakes E+1 overflow: len=%lu max=%lu", ctx->vote_stakes_e1_len, (ulong)FD_RUNTIME_MAX_VOTE_ACCOUNTS ));
+      ctx->callback_error = 1;
+      return;
+    }
+    if( FD_LIKELY( ctx->banks && ctx->runtime_stack ) ) {
+      fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+      FD_TEST( bank );
+
+      /* On the first E+1 entry, compute epoch from manifest fields.
+         bank->f.epoch is not yet set during parsing, but slot and
+         epoch_schedule_params are guaranteed to be parsed before
+         versioned_epoch_stakes in the binary format. */
+      if( FD_UNLIKELY( ctx->vote_stakes_e1_len==0UL ) ) {
+        FD_TEST( manifest->epoch_schedule_params.slots_per_epoch!=0UL );
+        fd_epoch_schedule_t epoch_schedule = (fd_epoch_schedule_t){
+          .slots_per_epoch             = manifest->epoch_schedule_params.slots_per_epoch,
+          .leader_schedule_slot_offset = manifest->epoch_schedule_params.leader_schedule_slot_offset,
+          .warmup                      = manifest->epoch_schedule_params.warmup,
+          .first_normal_epoch          = manifest->epoch_schedule_params.first_normal_epoch,
+          .first_normal_slot           = manifest->epoch_schedule_params.first_normal_slot,
+        };
+        ctx->epoch = fd_slot_to_epoch( &epoch_schedule, manifest->slot, NULL );
+      }
+
+      fd_ssload_recover_epoch_stakes_e1_entry( vs, ctx->vote_stakes_e1_len, ctx->epoch,
+                                               bank, ctx->runtime_stack );
+    }
+    ctx->vote_stakes_e1_len++;
+  } else {
+    /* E: slim struct (only needs vote/identity/has_identity_bls/stake/commission) */
+    if( FD_UNLIKELY( ctx->vote_stakes_e0_len>=FD_SNAPIN_MAX_VOTE_STAKES_BUFFERED ) ) {
+      FD_LOG_WARNING(( "vote_stakes E buffer overflow: len=%lu max=%lu", ctx->vote_stakes_e0_len, (ulong)FD_SNAPIN_MAX_VOTE_STAKES_BUFFERED ));
+      ctx->callback_error = 1;
+      return;
+    }
+    fd_snapshot_epoch_stakes_slim_t * dst = &ctx->vote_stakes_e0[ ctx->vote_stakes_e0_len++ ];
+    fd_memcpy( dst->vote,     vs->vote,     32UL );
+    fd_memcpy( dst->identity, vs->identity, 32UL );
+    dst->has_identity_bls = vs->has_identity_bls;
+    dst->stake            = vs->stake;
+    dst->commission       = vs->commission;
+  }
+}
+
+static void
+on_stake_delegation( void *                                          ctx_,
+                     fd_snapshot_manifest_stake_delegation_t const * delegation ) {
+  fd_snapin_tile_t * ctx = (fd_snapin_tile_t *)ctx_;
+
+  if( FD_UNLIKELY( ctx->callback_error ) ) return;
+
+  if( FD_UNLIKELY( delegation->stake_delegation==0UL ) ) return;
+  FD_TEST( ctx->banks );
+
+  if( FD_UNLIKELY( ctx->stake_delegations_inserted>=FD_RUNTIME_MAX_STAKE_ACCOUNTS ) ) {
+    FD_LOG_WARNING(( "stake_delegations overflow: inserted=%lu max=%lu", ctx->stake_delegations_inserted, (ulong)FD_RUNTIME_MAX_STAKE_ACCOUNTS ));
+    ctx->callback_error = 1;
+    return;
+  }
+
+  fd_stake_delegations_t * stake_delegations = fd_banks_stake_delegations_root_query( ctx->banks );
+  fd_stake_delegations_root_update(
+      stake_delegations,
+      (fd_pubkey_t const *)delegation->stake_pubkey,
+      (fd_pubkey_t const *)delegation->vote_pubkey,
+      delegation->stake_delegation,
+      delegation->activation_epoch,
+      delegation->deactivation_epoch,
+      0UL, /* credits_observed — not in wire format, the correct value
+             is populated later by fd_stake_delegations_refresh(). */
+      delegation->warmup_cooldown_rate );
+  ctx->stake_delegations_inserted++;
+}
+
 static inline int
 should_shutdown( fd_snapin_tile_t * ctx ) {
   if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_SHUTDOWN && !ctx->use_vinyl ) ) {
@@ -76,14 +177,15 @@ static ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   (void)tile;
   ulong l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, alignof(fd_snapin_tile_t),      sizeof(fd_snapin_tile_t)                             );
-  l = FD_LAYOUT_APPEND( l, fd_ssparse_align(),             fd_ssparse_footprint( 1UL<<24UL )                    );
-  l = FD_LAYOUT_APPEND( l, fd_txncache_align(),            fd_txncache_footprint( tile->snapin.max_live_slots ) );
-  l = FD_LAYOUT_APPEND( l, fd_ssmanifest_parser_align(),   fd_ssmanifest_parser_footprint()                     );
-  l = FD_LAYOUT_APPEND( l, fd_slot_delta_parser_align(),   fd_slot_delta_parser_footprint()                     );
-  l = FD_LAYOUT_APPEND( l, alignof(blockhash_group_t),     sizeof(blockhash_group_t)*FD_SNAPIN_MAX_SLOT_DELTA_GROUPS );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_snapin_tile_t),                   sizeof(fd_snapin_tile_t)                                                      );
+  l = FD_LAYOUT_APPEND( l, fd_ssparse_align(),                          fd_ssparse_footprint( 1UL<<24UL )                                             );
+  l = FD_LAYOUT_APPEND( l, fd_txncache_align(),                         fd_txncache_footprint( tile->snapin.max_live_slots )                          );
+  l = FD_LAYOUT_APPEND( l, fd_ssmanifest_parser_align(),                fd_ssmanifest_parser_footprint()                                              );
+  l = FD_LAYOUT_APPEND( l, fd_slot_delta_parser_align(),                fd_slot_delta_parser_footprint()                                              );
+  l = FD_LAYOUT_APPEND( l, alignof(blockhash_group_t),                  sizeof(blockhash_group_t)*FD_SNAPIN_MAX_SLOT_DELTA_GROUPS                     );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t),    sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SNAPIN_MAX_VOTE_STAKES_BUFFERED    ); /* E */
   if( !tile->snapin.use_vinyl ) {
-    l = FD_LAYOUT_APPEND( l, alignof(fd_sstxncache_entry_t), sizeof(fd_sstxncache_entry_t)*FD_SNAPIN_TXNCACHE_MAX_ENTRIES );
+    l = FD_LAYOUT_APPEND( l, alignof(fd_sstxncache_entry_t),            sizeof(fd_sstxncache_entry_t)*FD_SNAPIN_TXNCACHE_MAX_ENTRIES                  );
   }
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
@@ -532,8 +634,8 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
 }
 
 static void
-process_manifest( fd_snapin_tile_t * ctx ) {
-  fd_snapshot_manifest_t * manifest = fd_chunk_to_laddr( ctx->manifest_out.mem, ctx->manifest_out.chunk );
+process_snapshot_manifest( fd_snapin_tile_t * ctx ) {
+  fd_snapshot_manifest_t * manifest = &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( ctx->full ) ];
 
   if( FD_UNLIKELY( ctx->advertised_slot!=manifest->slot ) ) {
     /* SnapshotError::MismatchedSlot
@@ -625,6 +727,18 @@ process_manifest( fd_snapin_tile_t * ctx ) {
 
   manifest->txncache_fork_id = ctx->txncache_root_fork_id.val;
 
+  if( FD_LIKELY( ctx->banks ) ) {
+    fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+    FD_TEST( bank );
+    fd_ssload_recover_bank( manifest, bank );
+    if( FD_LIKELY( ctx->runtime_stack ) ) {
+      /* E+1 entries were already processed on-the-fly in on_vote_stakes.
+         Only E entries remain to be bulk-processed here. */
+      fd_ssload_recover_epoch_stakes_e0( ctx->vote_stakes_e0, ctx->vote_stakes_e0_len,
+                                         bank, ctx->runtime_stack );
+    }
+  }
+
   if( FD_LIKELY( !ctx->lthash_disabled ) ) {
     if( FD_LIKELY( ctx->use_vinyl ) ) {
       fd_ssctrl_hash_result_t * data = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
@@ -646,8 +760,7 @@ process_manifest( fd_snapin_tile_t * ctx ) {
 
   ulong sig = ctx->full ? fd_ssmsg_sig( FD_SSMSG_MANIFEST_FULL ) :
                           fd_ssmsg_sig( FD_SSMSG_MANIFEST_INCREMENTAL );
-  fd_stem_publish( ctx->stem, ctx->manifest_out.idx, sig, ctx->manifest_out.chunk, sizeof(fd_snapshot_manifest_t), 0UL, 0UL, 0UL );
-  ctx->manifest_out.chunk = fd_dcache_compact_next( ctx->manifest_out.chunk, sizeof(fd_snapshot_manifest_t), ctx->manifest_out.chunk0, ctx->manifest_out.wmark );
+  fd_stem_publish( ctx->stem, ctx->manifest_out.idx, sig, 0UL, 0UL, 0UL, 0UL, 0UL );
 }
 
 
@@ -704,7 +817,15 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
           FD_LOG_WARNING(( "error while parsing snapshot manifest" ));
           transition_malformed( ctx, stem );
           return 0;
-        } else if( FD_LIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) {
+        }
+        /* A parser callback (on_vote_stakes, on_stake_delegation) may
+           have detected an overflow.  The parser itself is unaware,
+           so check the flag here. */
+        if( FD_UNLIKELY( ctx->callback_error ) ) {
+          transition_malformed( ctx, stem );
+          return 0;
+        }
+        if( FD_LIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) {
           ctx->flags.manifest_done = 1;
         }
         break;
@@ -723,13 +844,21 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
             transition_malformed( ctx, stem );
             return 0;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) ) {
-            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) FD_LOG_ERR(( "blockhash offsets overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) {
+              FD_LOG_WARNING(( "blockhash offsets overflow: len=%lu max=%lu", ctx->blockhash_offsets_len, (ulong)FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
 
             memcpy( ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].blockhash, sd_result->group.blockhash, 32UL );
             ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].txnhash_offset = sd_result->group.txnhash_offset;
             ctx->blockhash_offsets_len++;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) ) {
-            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) FD_LOG_ERR(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) {
+              FD_LOG_WARNING(( "txncache entries overflow: len=%lu max=%lu", ctx->txncache_entries_len, (ulong)FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
             ctx->txncache_entries[ ctx->txncache_entries_len++ ] = *sd_result->entry;
           }
 
@@ -796,7 +925,7 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
     }
 
     if( FD_UNLIKELY( !ctx->flags.manifest_processed && ctx->flags.manifest_done && ctx->flags.status_cache_done ) ) {
-      process_manifest( ctx );
+      process_snapshot_manifest( ctx );
       if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_ERROR ) ) break;
       ctx->flags.manifest_processed = 1;
     }
@@ -841,7 +970,7 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
        it is possible to be in error state and still receive otherwise
        valid messages.  Only a fail message can revert this. */
     return;
-  };
+  }
 
   int forward_msg = 1;
 
@@ -850,6 +979,7 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
     case FD_SNAPSHOT_MSG_CTRL_INIT_INCR: {
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_IDLE );
       ctx->state = FD_SNAPSHOT_STATE_PROCESSING;
+      ctx->in.pos = 0UL;
       fd_ssparse_batch_enable( ctx->ssparse, ctx->use_vinyl || sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL );
       ctx->full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
       ctx->txncache_entries_len    = 0UL;
@@ -857,10 +987,36 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       ctx->manifest_capitalization = 0UL;
       fd_txncache_reset( ctx->txncache );
       fd_ssparse_reset( ctx->ssparse );
-      fd_ssmanifest_parser_init( ctx->manifest_parser, fd_chunk_to_laddr( ctx->manifest_out.mem, ctx->manifest_out.chunk ) );
+      fd_ssmanifest_parser_init( ctx->manifest_parser, &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( ctx->full ) ] );
+      fd_ssmanifest_parser_set_vote_stakes_cb( ctx->manifest_parser, on_vote_stakes, ctx );
+      if( FD_LIKELY( ctx->banks ) ) {
+        fd_ssmanifest_parser_set_stake_delegation_cb( ctx->manifest_parser, on_stake_delegation, ctx );
+      }
       fd_slot_delta_parser_init( ctx->slot_delta_parser );
       fd_memset( &ctx->flags,    0, sizeof(ctx->flags)    );
       fd_memset( &ctx->vinyl_op, 0, sizeof(ctx->vinyl_op) );
+
+      /* Reset vote_stakes buffers, manifest counters, and stake
+         delegation counter. */
+      ctx->callback_error             = 0;
+      ctx->vote_stakes_e1_len         = 0UL;
+      ctx->vote_stakes_e0_len         = 0UL;
+      ctx->stake_delegations_inserted = 0UL;
+      fd_snapshot_manifest_t * manif = &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( ctx->full ) ];
+      for( ulong i=0UL; i<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN; i++ ) {
+        manif->epoch_stakes[ i ].vote_stakes_len = 0UL;
+      }
+
+      /* Unconditionally reset vote_stakes tree, vote_rewards map,
+         top_votes_t_1, and top_votes_t_2.  This is safe for both full and incremental
+         snapshots and fixes the retry crash where a full snapshot's
+         vote_stakes tree is already populated when retried. */
+      if( FD_LIKELY( ctx->banks && ctx->runtime_stack ) ) {
+        fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+        if( FD_LIKELY( bank ) ) {
+          fd_ssload_recover_epoch_stakes_e1_init( bank, ctx->runtime_stack );
+        }
+      }
 
       /* Rewind metric counters (no-op unless recovering from a fail) */
       if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL ) {
@@ -885,6 +1041,12 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
 
         ctx->capitalization     = ctx->recovery.capitalization;
         ctx->dup_capitalization = 0UL;
+      }
+
+      /* Always reset stake delegations during INIT.  This helps in
+         recovering cleanly from FAIL. */
+      if( FD_LIKELY( ctx->banks ) ) {
+        fd_stake_delegations_reset( fd_banks_stake_delegations_root_query( ctx->banks ) );
       }
 
       /* Save the slot advertised by the snapshot peer and verify it
@@ -933,6 +1095,20 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       ctx->metrics.full_accounts_loaded   = ctx->metrics.accounts_loaded;
       ctx->metrics.full_accounts_replaced = ctx->metrics.accounts_replaced;
       ctx->metrics.full_accounts_ignored  = ctx->metrics.accounts_ignored;
+
+      /* Backup bank state for incremental snapshot rollback.  If an
+         incremental snapshot fails after its manifest has been
+         processed, these backups allow restoring the bank to the full
+         snapshot's state. */
+      if( FD_LIKELY( ctx->banks ) ) {
+        fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+        if( FD_LIKELY( bank ) ) {
+          fd_memcpy( ctx->recovery.bank_f, &bank->f, sizeof(bank->f) );
+          ctx->recovery.txncache_fork_id = bank->txncache_fork_id;
+          fd_memcpy( ctx->recovery.top_votes_t_1, bank->top_votes_t_1_mem, FD_TOP_VOTES_MAX_FOOTPRINT );
+          fd_memcpy( ctx->recovery.top_votes_t_2, bank->top_votes_t_2_mem, FD_TOP_VOTES_MAX_FOOTPRINT );
+        }
+      }
       break;
     }
 
@@ -999,6 +1175,39 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       if( !ctx->full ) {
         fd_accdb_cancel( ctx->accdb_admin, ctx->xid );
         fd_funk_txn_xid_copy( ctx->xid, fd_funk_last_publish( ctx->funk ) );
+
+        /* Restore bank state to the full snapshot's values.  The
+           incremental snapshot's process_snapshot_manifest() may have
+           already overwritten bank fields via fd_ssload_recover_bank
+           and fd_ssload_recover_epoch_stakes.  Restoring here ensures
+           the bank is consistent with the rolled-back accdb state.
+
+           bank->f covers every field written by fd_ssload_recover_bank
+           (slot, bank_hash, lthash, blockhashes, inflation,
+           epoch_schedule, rent, total_epoch_stake, etc.) except
+           txncache_fork_id and top_votes, which are restored below.
+
+           Note: stake delegations are intentionally not restored here.
+           The fd_stake_delegations_t structure is backed by
+           FD_RUNTIME_MAX_STAKE_ACCOUNTS entries and is far too large
+           to back up and restore.  Safe, because no consumer reads
+           stake delegations between CTRL_FAIL and the next
+           CTRL_INIT_*, and the next CTRL_INIT_FULL or CTRL_INIT_INCR
+           unconditionally resets and repopulates them from scratch.
+
+           Vote stakes, vote rewards, top_votes_t_1, and top_votes_t_2
+           (written by fd_ssload_recover_epoch_stakes_e1_entry) are
+           unconditionally reset by fd_ssload_recover_epoch_stakes_e1_init
+           at the next CTRL_INIT_*. */
+        if( FD_LIKELY( ctx->banks ) ) {
+          fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+          if( FD_LIKELY( bank ) ) {
+            fd_memcpy( &bank->f, ctx->recovery.bank_f, sizeof(bank->f) );
+            bank->txncache_fork_id = ctx->recovery.txncache_fork_id;
+            fd_memcpy( bank->top_votes_t_1_mem, ctx->recovery.top_votes_t_1, FD_TOP_VOTES_MAX_FOOTPRINT );
+            fd_memcpy( bank->top_votes_t_2_mem, ctx->recovery.top_votes_t_2, FD_TOP_VOTES_MAX_FOOTPRINT );
+          }
+        }
       }
       break;
     }
@@ -1105,12 +1314,13 @@ unprivileged_init( fd_topo_t *      topo,
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );
-  fd_snapin_tile_t * ctx  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapin_tile_t),     sizeof(fd_snapin_tile_t)                             );
-  void * _ssparse         = FD_SCRATCH_ALLOC_APPEND( l, fd_ssparse_align(),            fd_ssparse_footprint( 1UL<<24UL )                    );
-  void * _txncache        = FD_SCRATCH_ALLOC_APPEND( l, fd_txncache_align(),           fd_txncache_footprint( tile->snapin.max_live_slots ) );
-  void * _manifest_parser = FD_SCRATCH_ALLOC_APPEND( l, fd_ssmanifest_parser_align(),  fd_ssmanifest_parser_footprint()                              );
-  void * _sd_parser       = FD_SCRATCH_ALLOC_APPEND( l, fd_slot_delta_parser_align(),  fd_slot_delta_parser_footprint()                              );
-  ctx->blockhash_offsets  = FD_SCRATCH_ALLOC_APPEND( l, alignof(blockhash_group_t),     sizeof(blockhash_group_t)*FD_SNAPIN_MAX_SLOT_DELTA_GROUPS    );
+  fd_snapin_tile_t * ctx  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapin_tile_t),                   sizeof(fd_snapin_tile_t)                                                      );
+  void * _ssparse         = FD_SCRATCH_ALLOC_APPEND( l, fd_ssparse_align(),                          fd_ssparse_footprint( 1UL<<24UL )                                             );
+  void * _txncache        = FD_SCRATCH_ALLOC_APPEND( l, fd_txncache_align(),                         fd_txncache_footprint( tile->snapin.max_live_slots )                          );
+  void * _manifest_parser = FD_SCRATCH_ALLOC_APPEND( l, fd_ssmanifest_parser_align(),                fd_ssmanifest_parser_footprint()                                              );
+  void * _sd_parser       = FD_SCRATCH_ALLOC_APPEND( l, fd_slot_delta_parser_align(),                fd_slot_delta_parser_footprint()                                              );
+  ctx->blockhash_offsets  = FD_SCRATCH_ALLOC_APPEND( l, alignof(blockhash_group_t),                  sizeof(blockhash_group_t)*FD_SNAPIN_MAX_SLOT_DELTA_GROUPS                     );
+  void * _vote_stakes_e0  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t),    sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SNAPIN_MAX_VOTE_STAKES_BUFFERED    ); /* E */
 
   if( tile->snapin.use_vinyl ) {
     /* snapwm needs all txn_cache data in order to verify the slot
@@ -1131,6 +1341,12 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->txncache_entries_len_vinyl_ptr = NULL;
   }
 
+  ctx->callback_error             = 0;
+  ctx->vote_stakes_e1_len         = 0UL;
+  ctx->vote_stakes_e0             = _vote_stakes_e0;
+  ctx->vote_stakes_e0_len         = 0UL;
+  ctx->stake_delegations_inserted = 0UL;
+
   ctx->full = 1;
   ctx->state = FD_SNAPSHOT_STATE_IDLE;
   ctx->lthash_disabled = tile->snapin.lthash_disabled;
@@ -1145,6 +1361,22 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( fd_accdb_user_v1_init ( ctx->accdb,       shfunk, shfunk_locks, tile->snapin.accdb_max_depth ) );
   ctx->funk = fd_accdb_user_v1_funk( ctx->accdb );
   fd_funk_txn_xid_copy( ctx->xid, fd_funk_root( ctx->funk ) );
+
+  ulong banks_obj_id = fd_pod_query_ulong( topo->props, "banks", ULONG_MAX );
+  if( FD_LIKELY( banks_obj_id!=ULONG_MAX ) ) {
+    ctx->banks = fd_banks_join( fd_topo_obj_laddr( topo, banks_obj_id ) );
+    FD_TEST( ctx->banks );
+  } else {
+    ctx->banks = NULL;
+  }
+
+  ulong rtstack_obj_id = fd_pod_query_ulong( topo->props, "rtstack", ULONG_MAX );
+  if( FD_LIKELY( rtstack_obj_id!=ULONG_MAX ) ) {
+    ctx->runtime_stack = fd_runtime_stack_join( fd_topo_obj_laddr( topo, rtstack_obj_id ) );
+    FD_TEST( ctx->runtime_stack );
+  } else {
+    ctx->runtime_stack = NULL;
+  }
 
   void * _txncache_shmem = fd_topo_obj_laddr( topo, tile->snapin.txncache_obj_id );
   fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( _txncache_shmem );
@@ -1169,6 +1401,10 @@ unprivileged_init( fd_topo_t *      topo,
   if( FD_UNLIKELY( tile->kind_id ) ) FD_LOG_ERR(( "There can only be one `" NAME "` tile" ));
   if( FD_UNLIKELY( tile->in_cnt!=1UL ) ) FD_LOG_ERR(( "tile `" NAME "` has %lu ins, expected 1", tile->in_cnt ));
 
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  FD_TEST( snapshot_manif_obj_id!=ULONG_MAX );
+  ctx->snapshot_manif = (fd_snapshot_manifest_t *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
+
   ctx->manifest_out = out1( topo, tile, "snapin_manif" );
   ctx->gui_out      = out1( topo, tile, "snapin_gui"   );
   ulong out_link_ct_idx = fd_topo_find_tile_out_link( topo, tile, "snapin_ct", 0UL );
@@ -1188,7 +1424,7 @@ unprivileged_init( fd_topo_t *      topo,
   }
 
   fd_ssparse_reset( ctx->ssparse );
-  fd_ssmanifest_parser_init( ctx->manifest_parser, fd_chunk_to_laddr( ctx->manifest_out.mem, ctx->manifest_out.chunk ) );
+  fd_ssmanifest_parser_init( ctx->manifest_parser, &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( 1 ) ] );
   fd_slot_delta_parser_init( ctx->slot_delta_parser );
 
   fd_topo_link_t const * in_link = &topo->links[ tile->in_link_id[ 0UL ] ];
@@ -1228,7 +1464,7 @@ unprivileged_init( fd_topo_t *      topo,
     | 1a. snapin_ct (no lthash verification)
     | 1b. snapin_ls (with lthash verification, funk)
     | 1c. snapin_wm (with lthash verification, vinyl)
-    | - worst case: 2 messages, e.g. process_manifest (lthash) +
+    | - worst case: 2 messages, e.g. process_snapshot_manifest (lthash) +
     |            FD_SSPARSE_ADVANCE_ACCOUNT_{HEADER,DATA,BATCH,ERROR}
     2. snapin_manif - worst case: 1 message
     3. snapin_gui   - worst case: 1 message (config program account)

--- a/src/discof/restore/fd_snapin_tile_private.h
+++ b/src/discof/restore/fd_snapin_tile_private.h
@@ -11,6 +11,9 @@
 #include "utils/fd_ssctrl.h"
 #include "../../flamenco/accdb/fd_accdb_admin.h"
 #include "../../flamenco/accdb/fd_accdb_user.h"
+#include "../../flamenco/runtime/fd_bank.h"
+#include "../../flamenco/runtime/fd_runtime_const.h"
+#include "../../flamenco/runtime/fd_runtime_stack.h"
 #include "../../flamenco/runtime/fd_txncache.h"
 #include "../../disco/stem/fd_stem.h"
 #include "../../vinyl/meta/fd_vinyl_meta.h"
@@ -18,6 +21,11 @@
 /* 300 here is from status_cache.rs::MAX_CACHE_ENTRIES which is the most
    root slots Agave could possibly serve in a snapshot. */
 #define FD_SNAPIN_TXNCACHE_MAX_ENTRIES (300UL*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT)
+
+/* Maximum number of vote_stakes entries buffered in tile's scratch
+   memory during manifest parsing.  E entries use the slim struct and
+   are buffered for deferred processing. */
+#define FD_SNAPIN_MAX_VOTE_STAKES_BUFFERED (FD_RUNTIME_MAX_VOTE_ACCOUNTS)
 
 struct blockhash_group {
   uchar blockhash[ 32UL ];
@@ -51,6 +59,7 @@ struct fd_snapin_tile {
   uint full      : 1;       /* loading a full snapshot? */
   uint use_vinyl : 1;       /* using vinyl-backed accdb? */
   uint lthash_disabled : 1; /* disable lthash checking? */
+  int  callback_error;      /* set by parser callbacks on overflow */
 
   ulong seed;
   long boot_timestamp;
@@ -58,6 +67,8 @@ struct fd_snapin_tile {
   fd_accdb_admin_t accdb_admin[1];
   fd_accdb_user_t  accdb[1];
   fd_funk_t *      funk;
+  fd_banks_t *     banks;
+  fd_runtime_stack_t * runtime_stack;
 
   fd_txncache_t * txncache;
   uchar *         acc_data;
@@ -93,7 +104,17 @@ struct fd_snapin_tile {
 
   struct {
     ulong capitalization;
-  } recovery; /* stores the capitalization value from the last full snapshot */
+
+    /* Backup of bank fields populated at CTRL_NEXT (full snapshot
+       completion) for rollback during incremental snapshot CTRL_FAIL.
+       This ensures the bank state can be properly reverted to the full
+       snapshot's values if an incremental snapshot fails at any point
+       after its manifest has been processed. */
+    uchar bank_f[ sizeof(((fd_bank_t *)NULL)->f) ];
+    fd_txncache_fork_id_t txncache_fork_id;
+    uchar top_votes_t_1[ FD_TOP_VOTES_MAX_FOOTPRINT ];
+    uchar top_votes_t_2[ FD_TOP_VOTES_MAX_FOOTPRINT ];
+  } recovery;
 
   ulong blockhash_offsets_len;
   blockhash_group_t * blockhash_offsets;
@@ -126,6 +147,19 @@ struct fd_snapin_tile {
     ulong       mtu;
     ulong       pos;
   } in;
+
+  fd_snapshot_manifest_t * snapshot_manif; /* array of 2 manifests [full, incr] (shared object) */
+
+  /* vote_stakes buffers (removed from fd_snapshot_manifest_t struct):
+       E+1 is processed on-the-fly in the on_vote_stakes callback
+           (no buffer needed; writes directly to runtime_stack arrays).
+       E   uses the slim struct (only vote/identity/has_identity_bls/
+                                 stake/commission). */
+  ulong                                vote_stakes_e1_len; /* running counter for E+1 entries */
+  fd_snapshot_epoch_stakes_slim_t    * vote_stakes_e0;
+  ulong                                vote_stakes_e0_len;
+
+  ulong                                stake_delegations_inserted; /* running counter */
 
   ulong                out_ct_idx;
   fd_snapin_out_link_t manifest_out;

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -59,11 +59,9 @@ blockhashes_recover( fd_blockhashes_t *                       blockhashes,
 }
 
 void
-fd_ssload_recover( fd_snapshot_manifest_t * manifest,
-                   fd_banks_t *             banks,
-                   fd_bank_t *              bank,
-                   fd_runtime_stack_t *     runtime_stack,
-                   int                      is_incremental ) {
+fd_ssload_recover_bank( fd_snapshot_manifest_t * manifest,
+                        fd_bank_t *             bank ) {
+
   /* Slot */
 
   bank->f.slot = manifest->slot;
@@ -181,26 +179,6 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
     }
   }
 
-  /* Stake delegations for the current epoch. */
-  fd_stake_delegations_t * stake_delegations = fd_banks_stake_delegations_root_query( banks );
-  if( is_incremental ) fd_stake_delegations_reset( stake_delegations );
-  for( ulong i=0UL; i<manifest->stake_delegations_len; i++ ) {
-    fd_snapshot_manifest_stake_delegation_t const * elem = &manifest->stake_delegations[ i ];
-    if( FD_UNLIKELY( elem->stake_delegation==0UL ) ) {
-      continue;
-    }
-    fd_stake_delegations_root_update(
-        stake_delegations,
-        (fd_pubkey_t *)elem->stake_pubkey,
-        (fd_pubkey_t *)elem->vote_pubkey,
-        elem->stake_delegation,
-        elem->activation_epoch,
-        elem->deactivation_epoch,
-        elem->credits_observed,
-        elem->warmup_cooldown_rate
-    );
-  }
-
   /* We also want to set the total stake to be the total amount of stake
      at the end of the previous epoch. This value is used for the
      get_epoch_stake syscall.
@@ -222,71 +200,101 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
      in fd_ssmanifest_parser.c. */
   bank->f.total_epoch_stake = manifest->epoch_stakes[1].total_stake;
 
-  fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
-  if( is_incremental ) fd_vote_stakes_reset( vote_stakes );
+  bank->txncache_fork_id = (fd_txncache_fork_id_t){ .val = manifest->txncache_fork_id };
+}
 
-  fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+void
+fd_ssload_recover_epoch_stakes_e1_init( fd_bank_t *          bank,
+                                        fd_runtime_stack_t * runtime_stack ) {
+  fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
+  fd_vote_stakes_reset( vote_stakes );
+
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map( runtime_stack );
   fd_vote_rewards_map_reset( vote_ele_map );
 
   fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
-  fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
   fd_top_votes_init( top_votes_t_1 );
+
+  fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
   fd_top_votes_init( top_votes_t_2 );
+}
 
-  /* Vote stakes for the previous epoch (E-1). */
-  for( ulong i=0UL; i<manifest->epoch_stakes[1].vote_stakes_len; i++ ) {
-    fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[1].vote_stakes[i];
-    /* First convert the epoch credits to the format expected by the
-       vote states.  We need to do this because we may need the vote
-       state credits from the end of the previous epoch in case we need
-       to recalculate the stake reward partitions. */
-    fd_vote_rewards_t * vote_ele = &runtime_stack->stakes.vote_ele[i];
-    fd_memcpy( vote_ele->pubkey.uc, elem->vote, 32UL );
-    vote_ele->commission_t_2 = vote_ele->commission_t_1 = (uchar)elem->commission;
-    fd_vote_rewards_map_idx_insert( vote_ele_map, i, runtime_stack->stakes.vote_ele );
-    fd_vote_stakes_root_insert_key(
-        vote_stakes,
-        (fd_pubkey_t *)elem->vote,
-        (fd_pubkey_t *)elem->identity,
-        elem->stake,
-        vote_ele->commission_t_1,
-        bank->f.epoch );
+void
+fd_ssload_recover_epoch_stakes_e1_entry( fd_snapshot_manifest_vote_stakes_t const * entry,
+                                         ulong                                      idx,
+                                         ulong                                      epoch,
+                                         fd_bank_t *                                bank,
+                                         fd_runtime_stack_t *                       runtime_stack ) {
+  FD_TEST( idx<FD_RUNTIME_MAX_VOTE_ACCOUNTS );
 
-    if( FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) ) {
-      if( FD_UNLIKELY( !elem->has_identity_bls ) ) continue;
-    }
+  fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
 
-    fd_top_votes_insert( top_votes_t_1, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, (uchar)elem->commission );
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map( runtime_stack );
 
-    fd_epoch_credits_t * ec = &runtime_stack->stakes.epoch_credits[i];
-    ec->cnt          = elem->epoch_credits_history_len;
-    ec->base_credits = ec->cnt > 0UL ? elem->epoch_credits[0].prev_credits : 0UL;
-    for( ulong j=0UL; j<elem->epoch_credits_history_len; j++ ) {
-      ec->epoch[ j ]              = (ushort)elem->epoch_credits[ j ].epoch;
-      ec->credits_delta[ j ]      = (uint)( elem->epoch_credits[ j ].credits      - ec->base_credits );
-      ec->prev_credits_delta[ j ] = (uint)( elem->epoch_credits[ j ].prev_credits - ec->base_credits );
-    }
+  /* First convert epoch credits to the format expected by vote states.
+     This is because we may need the vote state credits from the end of
+     the previous epoch if required to recalculate the stake reward
+     partitions. */
+  fd_vote_rewards_t * vote_ele = &fd_runtime_stack_vote_ele( runtime_stack )[ idx ];
+  fd_memcpy( vote_ele->pubkey.uc, entry->vote, 32UL );
+  vote_ele->commission_t_2 = vote_ele->commission_t_1 = (uchar)entry->commission;
+  fd_vote_rewards_map_idx_insert( vote_ele_map, idx, fd_runtime_stack_vote_ele( runtime_stack ) );
+  fd_vote_stakes_root_insert_key(
+      vote_stakes,
+      (fd_pubkey_t const *)entry->vote,
+      (fd_pubkey_t const *)entry->identity,
+      entry->stake,
+      vote_ele->commission_t_1,
+      epoch );
+
+  int insert_top_vote = 1;
+  if( FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) ) {
+    if( FD_UNLIKELY( !entry->has_identity_bls ) ) insert_top_vote = 0;
   }
 
-  /* Vote stakes for the previous epoch (E-2) */
-  for( ulong i=0UL; i<manifest->epoch_stakes[0].vote_stakes_len; i++ ) {
-    fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[0].vote_stakes[i];
+  if( FD_LIKELY( insert_top_vote ) ) {
+    fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
+    fd_top_votes_insert( top_votes_t_1, (fd_pubkey_t const *)entry->vote, (fd_pubkey_t const *)entry->identity, entry->stake, (uchar)entry->commission );
+  }
 
-    fd_vote_rewards_t * vote_ele = fd_vote_rewards_map_ele_query( vote_ele_map, (const fd_pubkey_t *)elem->vote, NULL, runtime_stack->stakes.vote_ele );
+  fd_epoch_credits_t * ec = &fd_runtime_stack_epoch_credits( runtime_stack )[ idx ];
+  ec->cnt          = entry->epoch_credits_history_len;
+  ec->base_credits = ec->cnt > 0UL ? entry->epoch_credits[0].prev_credits : 0UL;
+  for( ulong j=0UL; j<entry->epoch_credits_history_len; j++ ) {
+    ec->epoch[ j ]              = (ushort)entry->epoch_credits[ j ].epoch;
+    ec->credits_delta[ j ]      = (uint)( entry->epoch_credits[ j ].credits      - ec->base_credits );
+    ec->prev_credits_delta[ j ] = (uint)( entry->epoch_credits[ j ].prev_credits - ec->base_credits );
+  }
+}
+
+void
+fd_ssload_recover_epoch_stakes_e0( fd_snapshot_epoch_stakes_slim_t const * entries,
+                                   ulong                                   len,
+                                   fd_bank_t *                             bank,
+                                   fd_runtime_stack_t *                    runtime_stack ) {
+  fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
+
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map( runtime_stack );
+
+  fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
+
+  /* Vote stakes for the previous epoch (E-2) */
+  for( ulong i=0UL; i<len; i++ ) {
+    fd_snapshot_epoch_stakes_slim_t const * elem = &entries[i];
+
+    fd_vote_rewards_t * vote_ele = fd_vote_rewards_map_ele_query( vote_ele_map, (fd_pubkey_t const *)elem->vote, NULL, fd_runtime_stack_vote_ele( runtime_stack ) );
     if( FD_LIKELY( vote_ele ) ) vote_ele->commission_t_2 = (uchar)elem->commission;
 
     if( FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) ) {
       if( FD_UNLIKELY( !elem->has_identity_bls ) ) continue;
     }
-    fd_top_votes_insert( top_votes_t_2, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, (uchar)elem->commission );
+    fd_top_votes_insert( top_votes_t_2, (fd_pubkey_t const *)elem->vote, (fd_pubkey_t const *)elem->identity, elem->stake, (uchar)elem->commission );
     fd_vote_stakes_root_update_meta(
         vote_stakes,
-        (fd_pubkey_t *)elem->vote,
-        (fd_pubkey_t *)elem->identity,
+        (fd_pubkey_t const *)elem->vote,
+        (fd_pubkey_t const *)elem->identity,
         elem->stake,
         (uchar)elem->commission,
         bank->f.epoch );
   }
-
-  bank->txncache_fork_id = (fd_txncache_fork_id_t){ .val = manifest->txncache_fork_id };
 }

--- a/src/discof/restore/utils/fd_ssload.h
+++ b/src/discof/restore/utils/fd_ssload.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_discof_restore_utils_fd_ssload_h
 
 #include "fd_ssmsg.h"
-#include "../../../flamenco//runtime/fd_blockhashes.h"
+#include "../../../flamenco/runtime/fd_blockhashes.h"
 
 FD_PROTOTYPES_BEGIN
 
@@ -12,12 +12,44 @@ blockhashes_recover( fd_blockhashes_t *                       blockhashes,
                      ulong                                    age_cnt,
                      ulong                                    seed );
 
+/* fd_ssload_recover_bank populates bank state fields from the snapshot
+   manifest.  This includes slot, hashes, inflation, epoch schedule,
+   rent, blockhashes, etc.  Called from snapin. */
 void
-fd_ssload_recover( fd_snapshot_manifest_t *  manifest,
-                   fd_banks_t *              banks,
-                   fd_bank_t *               bank,
-                   fd_runtime_stack_t *      runtime_stack,
-                   int                       is_incremental );
+fd_ssload_recover_bank( fd_snapshot_manifest_t * manifest,
+                        fd_bank_t *             bank );
+
+/* fd_ssload_recover_epoch_stakes_e1_init resets the vote_stakes tree,
+   vote_rewards map, top_votes_t_1, and top_votes_t_2.  Must be called
+   before any fd_ssload_recover_epoch_stakes_e1_entry or
+   fd_ssload_recover_epoch_stakes_e0 call. */
+void
+fd_ssload_recover_epoch_stakes_e1_init( fd_bank_t *          bank,
+                                        fd_runtime_stack_t * runtime_stack );
+
+/* fd_ssload_recover_epoch_stakes_e1_entry processes a single E+1
+   vote_stakes entry.  idx is the running counter (0-based) for this
+   entry among filtered E+1 entries.  epoch is the bank epoch computed
+   from the manifest slot and epoch schedule. */
+void
+fd_ssload_recover_epoch_stakes_e1_entry( fd_snapshot_manifest_vote_stakes_t const * entry,
+                                         ulong                                      idx,
+                                         ulong                                      epoch,
+                                         fd_bank_t *                                bank,
+                                         fd_runtime_stack_t *                       runtime_stack );
+
+/* fd_ssload_recover_epoch_stakes_e0 processes E vote_stakes entries
+   (two epochs ago).  Updates commission_t_2, top_votes_t_2, and
+   vote_stakes metadata.
+   Requires fd_ssload_recover_epoch_stakes_e1_init to have been called
+   first to initialize vote_stakes, vote_rewards map, and top_votes_t_2.
+   entries points to the tile's E buffer (slim struct).  len is the
+   number of entries. */
+void
+fd_ssload_recover_epoch_stakes_e0( fd_snapshot_epoch_stakes_slim_t const * entries,
+                                   ulong                                   len,
+                                   fd_bank_t *                             bank,
+                                   fd_runtime_stack_t *                    runtime_stack );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -409,6 +409,24 @@ struct fd_ssmanifest_parser_private {
   ulong seed;
 
   fd_snapshot_manifest_t * manifest;
+
+  /* Scratch fields for vote account data parsed but not stored in manifest */
+  ushort va_commission;           /* scratch for commission (validated, then discarded) */
+  ulong  va_epoch_credits_len;   /* scratch for epoch_credits_history_len (needed by state_size) */
+
+  /* Staging buffer for streaming stake_delegations */
+  fd_snapshot_manifest_stake_delegation_t staging_delegation;
+
+  /* Callback invoked for each parsed stake delegation */
+  void (* on_stake_delegation)( void * ctx, fd_snapshot_manifest_stake_delegation_t const * delegation );
+  void * cb_ctx;
+
+  /* Staging buffer for streaming epoch_stakes vote_stakes */
+  fd_snapshot_manifest_vote_stakes_t staging_vote_stakes;
+
+  /* Callback invoked for each parsed epoch_stakes vote_stake entry */
+  void (* on_vote_stakes)( void * ctx, ulong epoch_idx, fd_snapshot_manifest_vote_stakes_t const * vs );
+  void *  vs_cb_ctx;
 };
 
 static inline ulong
@@ -504,7 +522,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                          return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return 24UL*parser->va_epoch_credits_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                                return 32UL        ;
@@ -518,7 +536,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                          return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                               return 9UL+48UL*32UL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return 24UL*parser->va_epoch_credits_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                            return 32UL        ;
@@ -532,7 +550,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                      return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                           return 9UL+48UL*32UL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return 24UL*parser->va_epoch_credits_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                             return 32UL        ;
@@ -546,7 +564,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                        return 1UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                               return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return 24UL*parser->va_epoch_credits_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                         return parser->length2-(parser->off-parser->account_data_start);
@@ -594,7 +612,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                    return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return 32UL        ;
@@ -608,7 +626,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                    return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                         return 9UL+48UL*32UL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return 32UL        ;
@@ -622,7 +640,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                     return 9UL+48UL*32UL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return 32UL        ;
@@ -636,7 +654,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                  return 1UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                         return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                   return parser->length3-(parser->off-parser->account_data_start);
@@ -716,7 +734,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                   return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return 32UL        ;
@@ -730,7 +748,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                   return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                        return 9UL+48UL*32UL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return 32UL        ;
@@ -744,7 +762,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:               return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                    return 9UL+48UL*32UL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return 32UL        ;
@@ -758,7 +776,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                 return 1UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                        return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return 24UL*parser->staging_vote_stakes.epoch_credits_history_len;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                  return parser->length3-(parser->off-parser->account_data_start);
@@ -795,7 +813,6 @@ state_size( fd_ssmanifest_parser_t * parser ) {
 static inline uchar *
 state_dst( fd_ssmanifest_parser_t * parser ) {
   ulong idx1 = parser->idx1;
-  ulong idx2 = parser->idx2;
   fd_snapshot_manifest_t * manifest = parser->manifest;
 
   switch( parser->state ) {
@@ -872,7 +889,7 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:                                return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:                                    return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                           return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                           return (uchar*)&parser->va_commission;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:                               return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:                               return &parser->option;
@@ -883,13 +900,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                                   return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                          return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&parser->va_epoch_credits_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                                return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:                                      return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                                 return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                                 return (uchar*)&parser->va_commission;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                                               return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                                           return &parser->option;
@@ -897,13 +914,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:                                   return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                          return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                               return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&parser->va_epoch_credits_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                            return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:                                  return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                             return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                             return (uchar*)&parser->va_commission;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                                           return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                                       return &parser->option;
@@ -911,35 +928,35 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:                               return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                           return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return (uchar*)&parser->va_epoch_credits_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                             return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                                        return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                                            return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:                                   return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                              return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                              return (uchar*)&parser->va_commission;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                                            return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                        return &parser->option;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                               return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return (uchar*)&parser->va_epoch_credits_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                         return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                                              return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                                         return (uchar*)&parser->option;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                                                         return NULL;
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH:                                                               return (uchar*)&manifest->stake_delegations_len;
-    case STATE_STAKES_STAKE_DELEGATIONS_KEY:                                                                  return (uchar*)&manifest->stake_delegations[ idx1 ].stake_pubkey;
-    case STATE_STAKES_STAKE_DELEGATIONS_VOTER_PUBKEY:                                                         return (uchar*)&manifest->stake_delegations[ idx1 ].vote_pubkey;
-    case STATE_STAKES_STAKE_DELEGATIONS_STAKE:                                                                return (uchar*)&manifest->stake_delegations[ idx1 ].stake_delegation;
-    case STATE_STAKES_STAKE_DELEGATIONS_ACTIVATION_EPOCH:                                                     return (uchar*)&manifest->stake_delegations[ idx1 ].activation_epoch;
-    case STATE_STAKES_STAKE_DELEGATIONS_DEACTIVATION_EPOCH:                                                   return (uchar*)&manifest->stake_delegations[ idx1 ].deactivation_epoch;
-    case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                                                 return (uchar*)&manifest->stake_delegations[ idx1 ].warmup_cooldown_rate;
+    case STATE_STAKES_STAKE_DELEGATIONS_KEY:                                                                  return (uchar*)&parser->staging_delegation.stake_pubkey;
+    case STATE_STAKES_STAKE_DELEGATIONS_VOTER_PUBKEY:                                                         return (uchar*)&parser->staging_delegation.vote_pubkey;
+    case STATE_STAKES_STAKE_DELEGATIONS_STAKE:                                                                return (uchar*)&parser->staging_delegation.stake_delegation;
+    case STATE_STAKES_STAKE_DELEGATIONS_ACTIVATION_EPOCH:                                                     return (uchar*)&parser->staging_delegation.activation_epoch;
+    case STATE_STAKES_STAKE_DELEGATIONS_DEACTIVATION_EPOCH:                                                   return (uchar*)&parser->staging_delegation.deactivation_epoch;
+    case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                                                 return (uchar*)&parser->staging_delegation.warmup_cooldown_rate;
     case STATE_STAKES_UNUSED:                                                                                 return NULL;
     case STATE_STAKES_EPOCH:                                                                                  return NULL;
     case STATE_STAKES_STAKE_HISTORY_LENGTH:                                                                   return (uchar*)&parser->length1;
@@ -952,34 +969,34 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_UNUSED_ACCOUNTS3_UNUSED:                                                                       return NULL;
     case STATE_EPOCH_STAKES_LENGTH:                                                                           return (uchar*)&parser->epoch_stakes_len;
     case STATE_EPOCH_STAKES_KEY:                                                                              return (uchar*)&parser->epoch_stakes_epoch;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                                                             return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : (uchar*)&parser->length2;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_KEY:                                                                return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].vote : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_STAKE:                                                              return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].stake : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                                                             return (uchar*)&parser->length2;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_KEY:                                                                return parser->staging_vote_stakes.vote;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_STAKE:                                                              return (uchar*)&parser->staging_vote_stakes.stake;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_LAMPORTS:                                                     return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                                                  return (uchar*)&parser->length3;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_VARIANT:                                                 return (uchar*)&parser->variant;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                                          return parser->staging_vote_stakes.identity;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:                          return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:                              return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                     return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:                         return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:                         return &parser->option;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:                                return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity_bls : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES_LENGTH:                                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES:                                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION:                                     return &parser->option;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                             return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                    return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return parser->staging_vote_stakes.identity;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:                                return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                           return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                           return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                                     return &parser->option;
@@ -987,13 +1004,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:                             return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                    return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                         return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return parser->staging_vote_stakes.identity;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:                            return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                       return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                                     return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                                 return &parser->option;
@@ -1001,24 +1018,24 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                     return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return parser->staging_vote_stakes.identity;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                                  return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                                      return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:                             return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                        return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                                      return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                                             return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                  return &parser->option;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                         return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                   return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                                        return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                                   return NULL;
@@ -1034,7 +1051,7 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_EPOCH:                                                                            return NULL;
     case STATE_EPOCH_STAKES_STAKE_HISTORY_LENGTH:                                                             return (uchar*)&parser->length2;
     case STATE_EPOCH_STAKES_STAKE_HISTORY:                                                                    return NULL;
-    case STATE_EPOCH_STAKES_TOTAL_STAKE:                                                                      return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].total_stake : NULL;;
+    case STATE_EPOCH_STAKES_TOTAL_STAKE:                                                                      return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].total_stake : NULL;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH:                                                  return (uchar*)&parser->length2;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_KEY:                                                     return NULL;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_VOTE_ACCOUNTS_LENGTH:                                    return (uchar*)&parser->length3;
@@ -1074,34 +1091,34 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_LENGTH:                                                                 return (uchar*)&parser->epoch_stakes_len;
     case STATE_VERSIONED_EPOCH_STAKES_EPOCH:                                                                  return (uchar*)&parser->epoch_stakes_epoch;
     case STATE_VERSIONED_EPOCH_STAKES_VARIANT:                                                                return (uchar*)&parser->variant;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:                                            return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : (uchar*)&parser->length2;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_KEY:                                               return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].vote : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_STAKE:                                             return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].stake : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:                                            return (uchar*)&parser->length2;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_KEY:                                               return parser->staging_vote_stakes.vote;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_STAKE:                                             return (uchar*)&parser->staging_vote_stakes.stake;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_LAMPORTS:                                    return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                                 return (uchar*)&parser->length3;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_VARIANT:                                return (uchar*)&parser->variant;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                         return parser->staging_vote_stakes.identity;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:         return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:             return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:    return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:        return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:        return &parser->option;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:               return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity_bls : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES_LENGTH:                        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES:                               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION:                    return &parser->option;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:            return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                   return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return parser->staging_vote_stakes.identity;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:               return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                          return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                          return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                    return &parser->option;
@@ -1109,13 +1126,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:            return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                   return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                        return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return parser->staging_vote_stakes.identity;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:           return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                      return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                      return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                    return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                return &parser->option;
@@ -1123,24 +1140,24 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                    return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return parser->staging_vote_stakes.identity;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                 return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                     return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:            return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                       return (uchar *)&parser->staging_vote_stakes.commission;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                     return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                            return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                 return &parser->option;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                        return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return (uchar *)parser->staging_vote_stakes.epoch_credits;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                  return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                       return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                  return NULL;
@@ -1387,22 +1404,22 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
       break;
     }
     case STATE_STAKES_VOTE_ACCOUNTS_LENGTH: {
-      if( FD_UNLIKELY( manifest->vote_accounts_len>sizeof(manifest->vote_accounts)/sizeof(manifest->vote_accounts[0]) ) ) {
+      if( FD_UNLIKELY( manifest->vote_accounts_len>FD_RUNTIME_MAX_VOTE_ACCOUNTS ) ) {
         FD_LOG_WARNING(( "invalid vote_accounts_len %lu", manifest->vote_accounts_len ));
         return -1;
       }
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH: {
-      if( FD_UNLIKELY( manifest->stake_delegations_len>( 1UL<<22UL ) ) ) { /* 2^21 needed, arbitrarily put 2^22 to have some margin */
+      if( FD_UNLIKELY( manifest->stake_delegations_len>FD_RUNTIME_MAX_STAKE_ACCOUNTS ) ) {
         FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu", manifest->stake_delegations_len ));
         return -1;
       }
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE: {
-      if( FD_UNLIKELY( manifest->stake_delegations[ parser->idx1 ].warmup_cooldown_rate>1.0 ) ) {
-        FD_LOG_WARNING(( "invalid stakes_stake_delegations warmup cooldown rate %f", manifest->stake_delegations[ parser->idx1 ].warmup_cooldown_rate ));
+      if( FD_UNLIKELY( parser->staging_delegation.warmup_cooldown_rate>1.0 ) ) {
+        FD_LOG_WARNING(( "invalid stakes_stake_delegations warmup cooldown rate %f", parser->staging_delegation.warmup_cooldown_rate ));
         return -1;
       }
       break;
@@ -1411,8 +1428,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
-      if( FD_UNLIKELY( manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len>64UL ) ) {
-        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu", manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len ));
+      if( FD_UNLIKELY( parser->va_epoch_credits_len>64UL ) ) {
+        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu", parser->va_epoch_credits_len ));
         return -1;
       }
       break;
@@ -1477,10 +1494,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     }
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH: {
-      ulong stakes_len = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2;
-      ulong stakes_cap = sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes)/sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes[ 0UL ]);
-      if( FD_UNLIKELY( stakes_len>stakes_cap ) ) {
-        FD_LOG_WARNING(( "invalid versioned epoch stakes vote accounts length %lu", stakes_len ));
+      if( FD_UNLIKELY( parser->length2>FD_RUNTIME_MAX_VOTE_ACCOUNTS ) ) {
+        FD_LOG_WARNING(( "invalid versioned epoch stakes vote accounts length %lu", parser->length2 ));
         return -1;
       }
       break;
@@ -1515,7 +1530,7 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
-      ulong length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : parser->length4;
+      ulong length = parser->staging_vote_stakes.epoch_credits_history_len;
       if( FD_UNLIKELY( length>64UL ) ) {
         FD_LOG_WARNING(( "invalid version_epoch_stakes.vote_accounts value data current epoch credits length %lu", length ));
         return -1;
@@ -1654,13 +1669,13 @@ state_process( fd_ssmanifest_parser_t * parser,
   /* Vote state v4 commission is stored in bps, and needs to be
      converted to a percentage for commission calculations. */
   if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->vote_accounts[ parser->idx1 ].commission /= 100;
+    parser->va_commission /= 100;
   }
-  if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX && parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission /= 100;
+  if( FD_UNLIKELY( parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
+    parser->staging_vote_stakes.commission /= 100;
   }
-  if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX && parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission /= 100;
+  if( FD_UNLIKELY( parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
+    parser->staging_vote_stakes.commission /= 100;
   }
 
   /* Older vote states only populate bottom 8 bytes of the commission
@@ -1668,16 +1683,16 @@ state_process( fd_ssmanifest_parser_t * parser,
   if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
                 || parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
                 || parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION) ) {
-    parser->manifest->vote_accounts[ parser->idx1 ].commission &= 0xFF;
+    parser->va_commission &= 0xFF;
   }
-  if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX &&
+  if( FD_UNLIKELY(
       (  parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
       || parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
       || parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION ) ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission &= 0xFF;
+    parser->staging_vote_stakes.commission &= 0xFF;
   }
 
   if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH ) ) parser->account_data_start = parser->off;
@@ -1711,18 +1726,6 @@ state_process( fd_ssmanifest_parser_t * parser,
   if( FD_UNLIKELY( parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH ) ) parser->account_data_start = parser->off;
 
 
-  if( FD_UNLIKELY( parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_OWNER && parser->epoch_idx!=ULONG_MAX ) ) {
-    /* We're only interested in vote accounts with stakes>0 that have
-       valid epoch credits.  If these conditions are not met, we
-       decrement the counters so that we store all vote/stakes in a
-       compact array. */
-    fd_snapshot_manifest_vote_stakes_t * vote_stakes = &parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ];
-    if( vote_stakes->stake==0UL && vote_stakes->epoch_credits_history_len==0UL ) {
-      parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len--;
-      parser->idx2--;
-    }
-  }
-
   switch( parser->state ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:
@@ -1751,17 +1754,6 @@ state_process( fd_ssmanifest_parser_t * parser,
 
   if( FD_UNLIKELY( parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH ) ) parser->account_data_start = parser->off;
 
-  if( FD_UNLIKELY( parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_OWNER && parser->epoch_idx!=ULONG_MAX ) ) {
-    /* We're only interested in vote accounts with stakes>0. When
-       stakes==0 and there is no epoch credit history, we decrement the
-       counters so that we store all vote/stakes in a compact array. */
-    fd_snapshot_manifest_vote_stakes_t * vote_stakes = &parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ];
-    if( vote_stakes->stake==0UL && vote_stakes->epoch_credits_history_len==0UL ) {
-      parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len--;
-      parser->idx2--;
-    }
-  }
-
   switch( parser->state ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:
@@ -1786,13 +1778,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_LTHASH_OPTION:             manifest->has_accounts_lthash    = !!parser->option; parser->state += 2-!!parser->option; return 0;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: parser->staging_vote_stakes.has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
 
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: parser->staging_vote_stakes.has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
@@ -1810,13 +1802,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_STAKES_VOTE_ACCOUNTS_LENGTH:                            length = manifest->vote_accounts_len; idx = &parser->idx1; next_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH;                        break;
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH:                        length = manifest->stake_delegations_len;        idx = &parser->idx1; next_target = STATE_STAKES_UNUSED;                                          break;
     case STATE_EPOCH_STAKES_LENGTH:                                    length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_IS_DELTA;                                               break;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                      length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  break;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                      length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  break;
     case STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH:                  length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_UNUSED;                                    break;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH:           length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;            break;
     case STATE_ACCOUNTS_DB_STORAGES_LENGTH:                            length = parser->length1;             idx = &parser->idx1; next_target = STATE_ACCOUNTS_DB_VERSION;                                    break;
     case STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_LENGTH:               length = parser->length2;             idx = &parser->idx2; next_target = STATE_ACCOUNTS_DB_STORAGES_DUMMY;                             break;
     case STATE_VERSIONED_EPOCH_STAKES_LENGTH:                          length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_LTHASH_OPTION;                                          break;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:     length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; break;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:     length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; break;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_UNUSED;                   break;
     case STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;  break;
     default: break;
@@ -1837,13 +1829,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_HARD_FORKS_VAL:                                                   length = manifest->hard_forks_len;        idx = &parser->idx1; next_target = STATE_TRANSACTION_COUNT;                                      iter_target = STATE_HARD_FORKS_LENGTH+1UL;                                      break;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                            length = manifest->vote_accounts_len;     idx = &parser->idx1; next_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH;                        iter_target = STATE_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                            break;
     case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                    length = manifest->stake_delegations_len; idx = &parser->idx1; next_target = STATE_STAKES_UNUSED;                                          iter_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH+1UL;                        break;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                      length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  iter_target = STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                      break;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                      length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  iter_target = STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                      break;
     case STATE_EPOCH_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:              length = parser->length2;                 idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_UNUSED;                                    iter_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH+1UL;                  break;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_TOTAL_STAKE:                length = parser->length2;                 idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;            iter_target = STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH+1UL;           break;
     case STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS:                             length = parser->epoch_stakes_len;        idx = &parser->idx1; next_target = STATE_IS_DELTA;                                               iter_target = STATE_EPOCH_STAKES_LENGTH+1UL;                                    break;
     case STATE_ACCOUNTS_DB_STORAGES_DUMMY:                                       length = parser->length1;                 idx = &parser->idx1; next_target = STATE_ACCOUNTS_DB_VERSION;                                    iter_target = STATE_ACCOUNTS_DB_STORAGES_LENGTH+1UL;                            break;
     case STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_FILE_SZ:                        length = parser->length2;                 idx = &parser->idx2; next_target = STATE_ACCOUNTS_DB_STORAGES_DUMMY;                             iter_target = STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_LENGTH+1UL;               break;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:     length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;     break;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:     length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;     break;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_CREDITS_OBSERVED: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_UNUSED;                   iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH+1UL; break;
     case STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_TOTAL_STAKE:      length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;  iter_target = STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH+1UL; break;
     case STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS:                   length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_LTHASH_OPTION;                                          iter_target = STATE_VERSIONED_EPOCH_STAKES_LENGTH+1UL;                          break;
@@ -1851,6 +1843,15 @@ state_process( fd_ssmanifest_parser_t * parser,
   }
 
   if( FD_UNLIKELY( iter_target!=INT_MAX ) ) {
+    if( FD_UNLIKELY( parser->state==STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE ) ) {
+      if( parser->on_stake_delegation ) parser->on_stake_delegation( parser->cb_ctx, &parser->staging_delegation );
+      fd_memset( &parser->staging_delegation, 0, sizeof(parser->staging_delegation) );
+    }
+    if( FD_UNLIKELY( parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH
+                  || parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH ) ) {
+      if( parser->on_vote_stakes ) parser->on_vote_stakes( parser->vs_cb_ctx, parser->epoch_idx, &parser->staging_vote_stakes );
+      fd_memset( &parser->staging_vote_stakes, 0, sizeof(parser->staging_vote_stakes) );
+    }
     *idx += 1UL;
     if( FD_LIKELY( *idx<length ) ) parser->state = iter_target;
     else                           parser->state = next_target;
@@ -1906,8 +1907,37 @@ fd_ssmanifest_parser_init( fd_ssmanifest_parser_t * parser,
   parser->dst_cur  = 0UL;
   parser->manifest = manifest;
 
+  parser->va_commission       = 0;
+  parser->va_epoch_credits_len = 0UL;
+
+  fd_memset( &parser->staging_delegation, 0, sizeof(parser->staging_delegation) );
+  parser->on_stake_delegation = NULL;
+  parser->cb_ctx              = NULL;
+
+  fd_memset( &parser->staging_vote_stakes, 0, sizeof(parser->staging_vote_stakes) );
+  parser->on_vote_stakes   = NULL;
+  parser->vs_cb_ctx        = NULL;
+
   FD_SCRATCH_ALLOC_INIT( l, parser );
                          FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_ssmanifest_parser_t), sizeof(fd_ssmanifest_parser_t)                 );
+}
+
+void
+fd_ssmanifest_parser_set_stake_delegation_cb(
+    fd_ssmanifest_parser_t * parser,
+    void (* cb)( void * ctx, fd_snapshot_manifest_stake_delegation_t const * delegation ),
+    void * cb_ctx ) {
+  parser->on_stake_delegation = cb;
+  parser->cb_ctx              = cb_ctx;
+}
+
+void
+fd_ssmanifest_parser_set_vote_stakes_cb(
+    fd_ssmanifest_parser_t * parser,
+    void (* cb)( void * ctx, ulong epoch_idx, fd_snapshot_manifest_vote_stakes_t const * vs ),
+    void * cb_ctx ) {
+  parser->on_vote_stakes = cb;
+  parser->vs_cb_ctx      = cb_ctx;
 }
 
 int
@@ -1969,4 +1999,3 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
 
   return FD_SSMANIFEST_PARSER_ADVANCE_DONE;
 }
-

--- a/src/discof/restore/utils/fd_ssmanifest_parser.h
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.h
@@ -35,6 +35,18 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
                               acc_vec_map_t *          acc_vec_map,
                               acc_vec_t *              acc_vec_pool );
 
+void
+fd_ssmanifest_parser_set_stake_delegation_cb(
+    fd_ssmanifest_parser_t * parser,
+    void (* cb)( void * ctx, fd_snapshot_manifest_stake_delegation_t const * delegation ),
+    void * cb_ctx );
+
+void
+fd_ssmanifest_parser_set_vote_stakes_cb(
+    fd_ssmanifest_parser_t * parser,
+    void (* cb)( void * ctx, ulong epoch_idx, fd_snapshot_manifest_vote_stakes_t const * vs ),
+    void * cb_ctx );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_discof_restore_utils_fd_ssmanifest_parser_h */

--- a/src/discof/restore/utils/fd_ssmsg.h
+++ b/src/discof/restore/utils/fd_ssmsg.h
@@ -15,6 +15,33 @@ fd_ssmsg_sig( ulong message ) {
 }
 
 FD_FN_CONST static inline ulong fd_ssmsg_sig_message( ulong sig ) { return (sig & 0x3UL); }
+
+/* fd_ssmsg_manif_idx_from_full returns the snapshot manifest array
+   index given the full/incremental snapshot flag:
+     full==1 -> idx 0,
+     full==0 -> idx 1. */
+FD_FN_CONST static inline ulong
+fd_ssmsg_manif_idx_from_full( int full ) {
+  return full ? 0UL : 1UL;
+}
+
+/* fd_ssmsg_manif_idx_from_sig returns the snapshot manifest array
+   index given the sig in an mcache message:
+     FD_SSMSG_MANIFEST_FULL        -> 0
+     FD_SSMSG_MANIFEST_INCREMENTAL -> 1
+     otherwise                     -> ULONG_MAX.
+   The caller must validate either sig or the returned idx. */
+FD_FN_CONST static inline ulong
+fd_ssmsg_manif_idx_from_sig( ulong sig ) {
+  ulong idx = ULONG_MAX;
+  switch( sig ) {
+    case FD_SSMSG_MANIFEST_FULL:        idx = 0UL; break;
+    case FD_SSMSG_MANIFEST_INCREMENTAL: idx = 1UL; break;
+    default: break;
+  }
+  return idx;
+}
+
 struct epoch_credits {
   ulong epoch;
   ulong credits;
@@ -49,24 +76,6 @@ struct fd_snapshot_manifest_vote_account {
   uchar node_account_pubkey[ 32UL ];
 
   ulong stake;
-  ulong last_slot;
-  long  last_timestamp;
-
-  /* The percent of inflation rewards earned by the validator and
-     deposited into the validator's vote account, from 0 to 100%.
-     The remaning percentage of inflation rewards is distributed to
-     all delegated stake accounts by stake weight. */
-  ushort commission;
-
-  /* The epoch credits array tracks the history of how many credits the
-     provided vote account earned in each of the past epochs.  The
-     entry at epoch_credits[0] is for the current epoch,
-     epoch_credits[1] is for the previous epoch, and so on.  In cases of
-     booting a new chain from genesis, or for new vote accounts the
-     epoch credits history may be short.  The maximum number of entries
-     in the epoch credits history is 64. */
-  ulong epoch_credits_history_len;
-  epoch_credits_t epoch_credits[ FD_EPOCH_CREDITS_MAX ];
 };
 
 typedef struct fd_snapshot_manifest_vote_account fd_snapshot_manifest_vote_account_t;
@@ -106,25 +115,11 @@ struct fd_snapshot_manifest_vote_stakes {
   /* The validator identity pubkey, aka node pubkey */
   uchar identity[ 32UL ];
 
-  /* The commission account for inflation rewards (vote, before SIMD-0232) */
-  uchar commission_inflation[ 32UL ];
-
-  /* The commission account for block revenue (identity, before SIMD-0232) */
-  uchar commission_block[ 32UL ];
-
   /* Whether this vote account has a BLS pubkey set */
   uchar has_identity_bls;
 
-  /* The validator BLS pubkey (used after SIMD-0326: Alpenglow) */
-  uchar identity_bls[ 48UL ];
-
   /* The total amount of active stake for the vote account */
   ulong stake;
-
-  /* The latest slot and timestmap that the vote account voted on in
-     the given epoch. */
-  ulong slot;
-  long  timestamp;
 
   /* The validator's commission rate as of the given epoch. */
   ushort commission;
@@ -142,18 +137,30 @@ struct fd_snapshot_manifest_vote_stakes {
 
 typedef struct fd_snapshot_manifest_vote_stakes fd_snapshot_manifest_vote_stakes_t;
 
+/* A streamlined version of epoch_stakes used for E (epoch_stakes[0])
+   entries.  E only needs vote/identity/has_identity_bls/stake/commission
+   (no epoch_credits). */
+struct fd_snapshot_epoch_stakes_slim {
+  uchar  vote[ 32UL ];
+  uchar  identity[ 32UL ];
+  uchar  has_identity_bls;
+  ulong  stake;
+  ushort commission;
+};
+typedef struct fd_snapshot_epoch_stakes_slim fd_snapshot_epoch_stakes_slim_t;
+
 #define FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN 2UL
 
 struct fd_snapshot_manifest_epoch_stakes {
-   /* The epoch for which these vote accounts and stakes are valid for */
-  ulong                              epoch;
+  /* The epoch for which these vote accounts and stakes are valid for */
+  ulong epoch;
   /* The total amount of active stake at the end of the given epoch.*/
-  ulong                              total_stake;
+  ulong total_stake;
 
   /* The vote accounts and their stakes for a given epoch.
-     FIXME: Snapshot manifest has to support a much larger bound. */
-  ulong                              vote_stakes_len;
-  fd_snapshot_manifest_vote_stakes_t vote_stakes[ 40200UL ];
+     vote_stakes_len tracks the count; actual entries are buffered in
+     the tile's scratch memory. */
+  ulong vote_stakes_len;
 };
 
 typedef struct fd_snapshot_manifest_epoch_stakes fd_snapshot_manifest_epoch_stakes_t;
@@ -461,11 +468,9 @@ struct fd_snapshot_manifest {
      uptime, which is measured by vote account vote credits.
      FIXME: Make this unbounded or support a much larger bound. */
   ulong                               vote_accounts_len;
-  fd_snapshot_manifest_vote_account_t vote_accounts[ 40200UL ];
+  fd_snapshot_manifest_vote_account_t vote_accounts[ FD_RUNTIME_MAX_VOTE_ACCOUNTS ];
 
-  /* FIXME: Make this unbounded or support a much larger bound. */
   ulong stake_delegations_len;
-  fd_snapshot_manifest_stake_delegation_t stake_delegations[ 3000000UL ];
 
   /* Epoch stakes represent the exact amount staked to each vote
      account at the beginning of the previous epoch. They are

--- a/src/discof/shredcap/fd_shredcap_tile.c
+++ b/src/discof/shredcap/fd_shredcap_tile.c
@@ -11,6 +11,7 @@
 #include "../../discof/replay/fd_replay_tile.h"
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../discof/restore/utils/fd_ssmanifest_parser.h"
+#include "../../flamenco/runtime/fd_runtime_const.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "../../disco/fd_disco.h"
 #include "../../util/pod/fd_pod_format.h"
@@ -42,6 +43,11 @@
 #define MAX_BUFFER_SIZE                    (20000UL * sizeof(fd_shred_dest_wire_t))
 #define MANIFEST_MAX_TOTAL_BANKS           (2UL) /* the minimum is 2 */
 #define MANIFEST_MAX_FORK_WIDTH            (1UL) /* banks are only needed during publish_stake_weights() */
+
+/* Maximum number of vote_stakes entries buffered in tile's scratch
+   memory during manifest parsing.  Both E and E+1 use slim structs
+   since shredcap only needs vote/identity/stake. */
+#define FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED (FD_RUNTIME_MAX_VOTE_ACCOUNTS)
 
 #define NET_SHRED        (0UL)
 #define REPAIR_NET       (1UL)
@@ -87,6 +93,7 @@ struct fd_capture_tile_ctx {
 
   out_link_t  stake_out[1];
   out_link_t  snap_out[1];
+  fd_snapshot_manifest_t * snapshot_manif;
   int         enable_publish_stake_weights;
   ulong *     manifest_wmark;
   char        manifest_path[ PATH_MAX ];
@@ -127,6 +134,12 @@ struct fd_capture_tile_ctx {
 
   fd_alloc_t * alloc;
   uchar contact_info_buffer[ MAX_BUFFER_SIZE ];
+
+  /* vote_stakes buffers for manifest epoch_stakes.  Both E and E+1 use
+     the slim struct since shredcap only needs vote/identity/stake
+     (no epoch_credits). */
+  fd_snapshot_epoch_stakes_slim_t * vote_stakes_slim[ 2 ];
+  ulong                             vote_stakes_slim_len[ 2 ];
 };
 typedef struct fd_capture_tile_ctx fd_capture_tile_ctx_t;
 
@@ -205,18 +218,21 @@ FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   (void)tile;
   ulong l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, alignof(fd_capture_tile_ctx_t),  sizeof(fd_capture_tile_ctx_t) );
-  l = FD_LAYOUT_APPEND( l, manifest_spad_max_alloc_align(), fd_spad_footprint( manifest_spad_max_alloc_footprint() ) );
-  l = FD_LAYOUT_APPEND( l, shared_spad_max_alloc_align(),   fd_spad_footprint( shared_spad_max_alloc_footprint() ) );
-  l = FD_LAYOUT_APPEND( l, fd_alloc_align(),                fd_alloc_footprint() );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_capture_tile_ctx_t),           sizeof(fd_capture_tile_ctx_t)                                                );
+  l = FD_LAYOUT_APPEND( l, manifest_spad_max_alloc_align(),          fd_spad_footprint( manifest_spad_max_alloc_footprint() )                     );
+  l = FD_LAYOUT_APPEND( l, shared_spad_max_alloc_align(),            fd_spad_footprint( shared_spad_max_alloc_footprint() )                       );
+  l = FD_LAYOUT_APPEND( l, fd_alloc_align(),                         fd_alloc_footprint()                                                         );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t), sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED ); /* E */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t), sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED ); /* E+1 */
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
 static inline ulong
-generate_epoch_info_msg_manifest( ulong                                       epoch,
-                                  fd_epoch_schedule_t const *                 epoch_schedule,
-                                  fd_snapshot_manifest_epoch_stakes_t const * epoch_stakes,
-                                  ulong *                                     epoch_info_msg_out ) {
+generate_epoch_info_msg_manifest( ulong                                      epoch,
+                                  fd_epoch_schedule_t const *                epoch_schedule,
+                                  fd_snapshot_epoch_stakes_slim_t const *    entries,
+                                  ulong                                      entries_len,
+                                  ulong *                                    epoch_info_msg_out ) {
   fd_epoch_info_msg_t *    epoch_info_msg = (fd_epoch_info_msg_t *)fd_type_pun( epoch_info_msg_out );
   fd_vote_stake_weight_t * stake_weights  = fd_epoch_info_msg_stake_weights( epoch_info_msg );
 
@@ -230,12 +246,12 @@ generate_epoch_info_msg_manifest( ulong                                       ep
 
   /* Filter zero-stake entries (match replay: wsample and leader schedule reject zero weight). */
   ulong idx = 0UL;
-  for( ulong i=0UL; i<epoch_stakes->vote_stakes_len; i++ ) {
-    ulong stake = epoch_stakes->vote_stakes[ i ].stake;
+  for( ulong i=0UL; i<entries_len; i++ ) {
+    ulong stake = entries[ i ].stake;
     if( FD_UNLIKELY( !stake ) ) continue;
     stake_weights[ idx ].stake = stake;
-    memcpy( stake_weights[ idx ].id_key.uc, epoch_stakes->vote_stakes[ i ].identity, sizeof(fd_pubkey_t) );
-    memcpy( stake_weights[ idx ].vote_key.uc, epoch_stakes->vote_stakes[ i ].vote, sizeof(fd_pubkey_t) );
+    memcpy( stake_weights[ idx ].id_key.uc, entries[ i ].identity, sizeof(fd_pubkey_t) );
+    memcpy( stake_weights[ idx ].vote_key.uc, entries[ i ].vote, sizeof(fd_pubkey_t) );
     idx++;
   }
   epoch_info_msg->staked_vote_cnt = idx;
@@ -253,6 +269,29 @@ generate_epoch_info_msg_manifest( ulong                                       ep
 }
 
 static void
+shredcap_on_vote_stakes( void *                                     ctx_,
+                         ulong                                      epoch_idx,
+                         fd_snapshot_manifest_vote_stakes_t const * vs ) {
+  fd_capture_tile_ctx_t * ctx = (fd_capture_tile_ctx_t *)ctx_;
+
+  if( FD_UNLIKELY( epoch_idx==ULONG_MAX ) ) return;
+  if( vs->stake==0UL && vs->epoch_credits_history_len==0UL ) return;
+  if( FD_UNLIKELY( epoch_idx>=2UL ) ) return;
+
+  ulong len = ctx->vote_stakes_slim_len[ epoch_idx ];
+  if( FD_UNLIKELY( len>=FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED ) )
+    FD_LOG_ERR(( "shredcap vote_stakes buffer overflow: epoch_idx=%lu len=%lu", epoch_idx, len ));
+
+  fd_snapshot_epoch_stakes_slim_t * dst = &ctx->vote_stakes_slim[ epoch_idx ][ len ];
+  fd_memcpy( dst->vote,     vs->vote,     32UL );
+  fd_memcpy( dst->identity, vs->identity, 32UL );
+  dst->has_identity_bls = vs->has_identity_bls;
+  dst->stake            = vs->stake;
+  dst->commission       = vs->commission;
+  ctx->vote_stakes_slim_len[ epoch_idx ] = len + 1UL;
+}
+
+static void
 publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
                                 fd_stem_context_t *    stem,
                                 fd_snapshot_manifest_t const * manifest ) {
@@ -261,7 +300,7 @@ publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
 
   /* current epoch */
   ulong * stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
-  ulong stake_weights_sz = generate_epoch_info_msg_manifest( epoch, schedule, &manifest->epoch_stakes[0], stake_weights_msg );
+  ulong stake_weights_sz = generate_epoch_info_msg_manifest( epoch, schedule, ctx->vote_stakes_slim[0], ctx->vote_stakes_slim_len[0], stake_weights_msg );
   ulong stake_weights_sig = 4UL;
   fd_stem_publish( stem, 0UL, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->stake_out->chunk = fd_dcache_compact_next( ctx->stake_out->chunk, stake_weights_sz, ctx->stake_out->chunk0, ctx->stake_out->wmark );
@@ -269,7 +308,7 @@ publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
 
   /* next current epoch */
   stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
-  stake_weights_sz = generate_epoch_info_msg_manifest( epoch + 1, schedule, &manifest->epoch_stakes[1], stake_weights_msg );
+  stake_weights_sz = generate_epoch_info_msg_manifest( epoch + 1, schedule, ctx->vote_stakes_slim[1], ctx->vote_stakes_slim_len[1], stake_weights_msg );
   stake_weights_sig = 4UL;
   fd_stem_publish( stem, 0UL, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->stake_out->chunk = fd_dcache_compact_next( ctx->stake_out->chunk, stake_weights_sz, ctx->stake_out->chunk0, ctx->stake_out->wmark );
@@ -454,6 +493,10 @@ after_credit( fd_capture_tile_ctx_t * ctx,
       } FD_SPAD_FRAME_END;
       FD_TEST( manifest );
 
+      /* Reset vote_stakes slim buffers. */
+      ctx->vote_stakes_slim_len[0] = 0UL;
+      ctx->vote_stakes_slim_len[1] = 0UL;
+
       FD_SPAD_FRAME_BEGIN( ctx->shared_spad ) {
         uchar * buf    = fd_spad_alloc( ctx->shared_spad, manifest_load_align(), manifest_load_footprint() );
         ulong   buf_sz = 0;
@@ -463,6 +506,7 @@ after_credit( fd_capture_tile_ctx_t * ctx,
                 fd_ssmanifest_parser_align(), fd_ssmanifest_parser_footprint() ) ) );
         FD_TEST( parser );
         fd_ssmanifest_parser_init( parser, manifest );
+        fd_ssmanifest_parser_set_vote_stakes_cb( parser, shredcap_on_vote_stakes, ctx );
         int parser_err = fd_ssmanifest_parser_consume( parser, buf, buf_sz, NULL, NULL );
         FD_TEST( parser_err==1 );
         // if( FD_UNLIKELY( parser_err ) ) FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed (%d)", parser_err ));
@@ -471,12 +515,9 @@ after_credit( fd_capture_tile_ctx_t * ctx,
 
       fd_fseq_update( ctx->manifest_wmark, manifest->slot );
 
-      uchar * chunk = fd_chunk_to_laddr( ctx->snap_out->mem, ctx->snap_out->chunk );
-      ulong   sz    = sizeof(fd_snapshot_manifest_t);
-      ulong   sig   = fd_ssmsg_sig( FD_SSMSG_MANIFEST_INCREMENTAL );
-      memcpy( chunk, manifest, sz );
-      fd_stem_publish( stem, ctx->snap_out->idx, sig, ctx->snap_out->chunk, sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
-      ctx->snap_out->chunk = fd_dcache_compact_next( ctx->snap_out->chunk, sz, ctx->snap_out->chunk0, ctx->snap_out->wmark );
+      FD_TEST( ctx->snapshot_manif );
+      memcpy( &ctx->snapshot_manif[ fd_ssmsg_manif_idx_from_full( 0 ) ], manifest, sizeof(fd_snapshot_manifest_t) );
+      fd_stem_publish( stem, ctx->snap_out->idx, fd_ssmsg_sig( FD_SSMSG_MANIFEST_INCREMENTAL ), 0UL, 0UL, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
 
       fd_stem_publish( stem, ctx->snap_out->idx, fd_ssmsg_sig( FD_SSMSG_DONE ), 0UL, 0UL, 0UL, 0UL, 0UL );
 
@@ -738,10 +779,14 @@ unprivileged_init( fd_topo_t *      topo,
 
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
   FD_SCRATCH_ALLOC_INIT( l, scratch );
-  fd_capture_tile_ctx_t * ctx       = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_capture_tile_ctx_t),  sizeof(fd_capture_tile_ctx_t) );
-  void * manifest_spad_mem          = FD_SCRATCH_ALLOC_APPEND( l, manifest_spad_max_alloc_align(), fd_spad_footprint( manifest_spad_max_alloc_footprint() ) );
-  void * shared_spad_mem            = FD_SCRATCH_ALLOC_APPEND( l, shared_spad_max_alloc_align(),   fd_spad_footprint( shared_spad_max_alloc_footprint() ) );
-  void * alloc_mem                  = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),                fd_alloc_footprint() );
+  fd_capture_tile_ctx_t * ctx  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_capture_tile_ctx_t),           sizeof(fd_capture_tile_ctx_t)                                                );
+  void * manifest_spad_mem     = FD_SCRATCH_ALLOC_APPEND( l, manifest_spad_max_alloc_align(),          fd_spad_footprint( manifest_spad_max_alloc_footprint() )                     );
+  void * shared_spad_mem       = FD_SCRATCH_ALLOC_APPEND( l, shared_spad_max_alloc_align(),            fd_spad_footprint( shared_spad_max_alloc_footprint() )                       );
+  void * alloc_mem             = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),                         fd_alloc_footprint()                                                         );
+  ctx->vote_stakes_slim[0]     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t), sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED );
+  ctx->vote_stakes_slim[1]     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapshot_epoch_stakes_slim_t), sizeof(fd_snapshot_epoch_stakes_slim_t)*FD_SHREDCAP_MAX_VOTE_STAKES_BUFFERED );
+  ctx->vote_stakes_slim_len[0] = 0UL;
+  ctx->vote_stakes_slim_len[1] = 0UL;
   FD_SCRATCH_ALLOC_FINI( l, scratch_align() );
 
   /* Input links */
@@ -794,13 +839,20 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->snap_out->idx          = fd_topo_find_tile_out_link( topo, tile, "snapin_manif", 0 );
   if( FD_LIKELY( ctx->snap_out->idx!=ULONG_MAX ) ) {
     fd_topo_link_t * snap_out = &topo->links[tile->out_link_id[ctx->snap_out->idx]];
-    ctx->snap_out->mem        = topo->workspaces[topo->objs[snap_out->dcache_obj_id].wksp_id].wksp;
-    ctx->snap_out->chunk0     = fd_dcache_compact_chunk0( ctx->snap_out->mem, snap_out->dcache );
-    ctx->snap_out->wmark      = fd_dcache_compact_wmark( ctx->snap_out->mem, snap_out->dcache, snap_out->mtu );
-    ctx->snap_out->chunk      = ctx->snap_out->chunk0;
+    if( FD_LIKELY( snap_out->mtu ) ) {
+      ctx->snap_out->mem      = topo->workspaces[topo->objs[snap_out->dcache_obj_id].wksp_id].wksp;
+      ctx->snap_out->chunk0   = fd_dcache_compact_chunk0( ctx->snap_out->mem, snap_out->dcache );
+      ctx->snap_out->wmark    = fd_dcache_compact_wmark( ctx->snap_out->mem, snap_out->dcache, snap_out->mtu );
+      ctx->snap_out->chunk    = ctx->snap_out->chunk0;
+    }
   } else {
     FD_LOG_WARNING(( "no connection to snap_out link" ));
     memset( ctx->snap_out, 0, sizeof(out_link_t) );
+  }
+
+  ulong snapshot_manif_obj_id = fd_pod_query_ulong( topo->props, "snap_manif", ULONG_MAX );
+  if( FD_LIKELY( snapshot_manif_obj_id!=ULONG_MAX ) ) {
+    ctx->snapshot_manif = (fd_snapshot_manifest_t *)fd_topo_obj_laddr( topo, snapshot_manif_obj_id );
   }
 
   /* If the manifest is enabled (for processing), the stake_out link

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -264,7 +264,7 @@ redeem_rewards( fd_stake_delegation_t const *   stake,
     return 1;
   }
 
-  uchar commission = delay_commission_updates ? runtime_stack->stakes.vote_ele[ vote_state_idx ].commission_t_2 : runtime_stack->stakes.vote_ele[ vote_state_idx ].commission_t_1;
+  uchar commission = delay_commission_updates ? fd_runtime_stack_vote_ele(runtime_stack)[ vote_state_idx ].commission_t_2 : fd_runtime_stack_vote_ele(runtime_stack)[ vote_state_idx ].commission_t_1;
   fd_commission_split_t split_result;
   fd_vote_commission_split( commission, rewards, &split_result );
   if( split_result.is_split && (split_result.voter_portion == 0 || split_result.staker_portion == 0) ) {
@@ -349,8 +349,8 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
   /* Calculate the points for each stake delegation */
   uint128 total_points = 0;
 
-  fd_vote_rewards_t *     vote_ele     = runtime_stack->stakes.vote_ele;
-  fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+  fd_vote_rewards_t *     vote_ele     = fd_runtime_stack_vote_ele(runtime_stack);
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map(runtime_stack);
 
   fd_stake_delegations_iter_t iter_[1];
   for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
@@ -373,10 +373,10 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
     if( FD_UNLIKELY( stake_delegation_idx>=runtime_stack->expected_stake_accounts ) ) {
       stake_points_result = stake_points_result_;
     } else {
-      stake_points_result = &runtime_stack->stakes.stake_points_result[ stake_delegation_idx ];
+      stake_points_result = &fd_runtime_stack_stake_points_result(runtime_stack)[ stake_delegation_idx ];
     }
 
-    fd_epoch_credits_t * epoch_credits = &runtime_stack->stakes.epoch_credits[ idx ];
+    fd_epoch_credits_t * epoch_credits = &fd_runtime_stack_epoch_credits(runtime_stack)[ idx ];
 
     calculate_stake_points_and_credits( epoch_credits,
                                         stake_history,
@@ -440,19 +440,19 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
     if( stake_delegation_idx>=runtime_stack->expected_stake_accounts ) {
       calculated_stake_rewards = calculated_stake_rewards_;
     } else {
-      calculated_stake_rewards = &runtime_stack->stakes.stake_rewards_result[ stake_delegation_idx ];
+      calculated_stake_rewards = &fd_runtime_stack_stake_rewards_result(runtime_stack)[ stake_delegation_idx ];
     }
     calculated_stake_rewards->success = 0;
 
-    fd_vote_rewards_t * vote_ele = runtime_stack->stakes.vote_ele;
-    fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+    fd_vote_rewards_t * vote_ele = fd_runtime_stack_vote_ele(runtime_stack);
+    fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map(runtime_stack);
     uint idx = (uint)fd_vote_rewards_map_idx_query( vote_ele_map, &stake_delegation->vote_account, UINT_MAX, vote_ele );
     if( FD_UNLIKELY( idx==UINT_MAX ) ) continue;
 
     fd_calculated_stake_points_t   stake_points_result_[1];
     fd_calculated_stake_points_t * stake_points_result;
     if( is_recalculation || FD_UNLIKELY( stake_delegation_idx>=runtime_stack->expected_stake_accounts ) ) {
-      fd_epoch_credits_t * epoch_credits = &runtime_stack->stakes.epoch_credits[ idx ];
+      fd_epoch_credits_t * epoch_credits = &fd_runtime_stack_epoch_credits(runtime_stack)[ idx ];
 
       /* We have not cached the stake points yet if we are recalculating
          stake rewards so we need to recalculate them. */
@@ -464,7 +464,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
           stake_points_result_ );
       stake_points_result = stake_points_result_;
     } else {
-      stake_points_result = &runtime_stack->stakes.stake_points_result[ stake_delegation_idx ];
+      stake_points_result = &fd_runtime_stack_stake_points_result(runtime_stack)[ stake_delegation_idx ];
     }
 
     /* redeem_rewards is actually just responsible for calculating the
@@ -488,7 +488,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
     calculated_stake_rewards->success = 1;
 
     if( capture_ctx && capture_ctx->capture_solcap ) {
-      uchar commission = delay_commission_updates ? runtime_stack->stakes.vote_ele[ idx ].commission_t_2 : runtime_stack->stakes.vote_ele[ idx ].commission_t_1;
+      uchar commission = delay_commission_updates ? fd_runtime_stack_vote_ele(runtime_stack)[ idx ].commission_t_2 : fd_runtime_stack_vote_ele(runtime_stack)[ idx ].commission_t_1;
       fd_capture_link_write_stake_reward_event( capture_ctx,
                                                 bank->f.slot,
                                                 stake_delegation->stake_account,
@@ -499,7 +499,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
                                                 (long)calculated_stake_rewards->new_credits_observed );
     }
 
-    runtime_stack->stakes.vote_ele[ idx ].vote_rewards += calculated_stake_rewards->voter_rewards;
+    fd_runtime_stack_vote_ele(runtime_stack)[ idx ].vote_rewards += calculated_stake_rewards->voter_rewards;
     runtime_stack->stakes.stake_rewards_cnt++;
   }
 }
@@ -536,12 +536,12 @@ setup_stake_partitions( fd_bank_t *                    bank,
 
       calculated_stake_rewards = calculated_stake_rewards_;
 
-      fd_vote_rewards_t * vote_ele = runtime_stack->stakes.vote_ele;
-      fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+      fd_vote_rewards_t * vote_ele = fd_runtime_stack_vote_ele(runtime_stack);
+      fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map(runtime_stack);
       uint idx = (uint)fd_vote_rewards_map_idx_query( vote_ele_map, &stake_delegation->vote_account, UINT_MAX, vote_ele );
       if( FD_UNLIKELY( idx==UINT_MAX ) ) continue;
 
-      fd_epoch_credits_t * epoch_credits = &runtime_stack->stakes.epoch_credits[ idx ];
+      fd_epoch_credits_t * epoch_credits = &fd_runtime_stack_epoch_credits(runtime_stack)[ idx ];
 
       fd_calculated_stake_points_t stake_points_result[1];
       calculate_stake_points_and_credits(
@@ -566,7 +566,7 @@ setup_stake_partitions( fd_bank_t *                    bank,
           delay_commission_updates );
       calculated_stake_rewards->success = err==0;
     } else {
-      calculated_stake_rewards = &runtime_stack->stakes.stake_rewards_result[ stake_delegation_idx ];
+      calculated_stake_rewards = &fd_runtime_stack_stake_rewards_result(runtime_stack)[ stake_delegation_idx ];
     }
 
     if( FD_UNLIKELY( !calculated_stake_rewards->success ) ) continue;
@@ -706,8 +706,8 @@ calculate_rewards_and_distribute_vote_rewards( fd_bank_t *                    ba
                                                fd_capture_ctx_t *             capture_ctx,
                                                ulong                          prev_epoch ) {
 
-  fd_vote_rewards_t *     vote_ele_pool = runtime_stack->stakes.vote_ele;
-  fd_vote_rewards_map_t * vote_ele_map  = runtime_stack->stakes.vote_map;
+  fd_vote_rewards_t *     vote_ele_pool = fd_runtime_stack_vote_ele(runtime_stack);
+  fd_vote_rewards_map_t * vote_ele_map  = fd_runtime_stack_vote_map(runtime_stack);
 
   /* First we must compute the stake and vote rewards for the just
      completed epoch.  We store the stake account rewards and vote
@@ -735,7 +735,7 @@ calculate_rewards_and_distribute_vote_rewards( fd_bank_t *                    ba
     uint idx = (uint)fd_vote_rewards_map_iter_idx( iter, vote_ele_map, vote_ele_pool );
     fd_vote_rewards_t * ele = &vote_ele_pool[idx];
 
-    ulong rewards = runtime_stack->stakes.vote_ele[ idx ].vote_rewards;
+    ulong rewards = fd_runtime_stack_vote_ele(runtime_stack)[ idx ].vote_rewards;
     if( rewards==0UL ) {
       continue;
     }

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -87,7 +87,7 @@ update_next_leaders( fd_bank_t *          bank,
   ulong slot_cnt = fd_epoch_slot_cnt( epoch_schedule, epoch );
 
   fd_top_votes_t const *   top_votes_t_1    = fd_bank_top_votes_t_1_query( bank );
-  fd_vote_stake_weight_t * epoch_weights    = runtime_stack->stakes.stake_weights;
+  fd_vote_stake_weight_t * epoch_weights    = fd_runtime_stack_stake_weights(runtime_stack);
   ulong                    stake_weight_cnt = fd_stake_weights_by_node_next( top_votes_t_1, vote_stakes, bank->vote_stakes_fork_id, epoch_weights, FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) );
 
   void * epoch_leaders_mem = fd_bank_epoch_leaders_modify( bank );
@@ -133,15 +133,15 @@ update_next_leaders( fd_bank_t *          bank,
 
   /* Produce truncated set of id weights to send to Shred tile for
      Turbine tree computation. */
-  ulong staked_cnt = compute_id_weights_from_vote_weights( runtime_stack->stakes.id_weights, epoch_weights, stake_weight_cnt );
+  ulong staked_cnt = compute_id_weights_from_vote_weights( fd_runtime_stack_id_weights(runtime_stack), epoch_weights, stake_weight_cnt );
   ulong excluded_stake = 0UL;
   if( FD_UNLIKELY( staked_cnt>MAX_SHRED_DESTS ) ) {
     for( ulong i=MAX_SHRED_DESTS; i<staked_cnt; i++ ) {
-      excluded_stake += runtime_stack->stakes.id_weights[i].stake;
+      excluded_stake += fd_runtime_stack_id_weights(runtime_stack)[i].stake;
     }
   }
   staked_cnt = fd_ulong_min( staked_cnt, MAX_SHRED_DESTS );
-  memcpy( runtime_stack->epoch_weights.next_id_weights, runtime_stack->stakes.id_weights, staked_cnt * sizeof(fd_stake_weight_t) );
+  memcpy( runtime_stack->epoch_weights.next_id_weights, fd_runtime_stack_id_weights(runtime_stack), staked_cnt * sizeof(fd_stake_weight_t) );
   runtime_stack->epoch_weights.next_id_weights_cnt      = staked_cnt;
   runtime_stack->epoch_weights.next_id_weights_excluded  = excluded_stake;
 }
@@ -161,7 +161,7 @@ fd_runtime_update_leaders( fd_bank_t *          bank,
   update_next_leaders( bank, runtime_stack, vote_stakes );
 
   fd_top_votes_t const *   top_votes_t_2    = fd_bank_top_votes_t_2_query( bank );
-  fd_vote_stake_weight_t * epoch_weights    = runtime_stack->stakes.stake_weights;
+  fd_vote_stake_weight_t * epoch_weights    = fd_runtime_stack_stake_weights(runtime_stack);
   ulong                    stake_weight_cnt = fd_stake_weights_by_node( top_votes_t_2, vote_stakes, bank->vote_stakes_fork_id, epoch_weights, FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) );
 
   /* TODO: Can optimize by avoiding recomputing if another fork has
@@ -209,15 +209,15 @@ fd_runtime_update_leaders( fd_bank_t *          bank,
 
   /* Produce truncated set of id weights to send to Shred tile for
      Turbine tree computation. */
-  ulong staked_cnt = compute_id_weights_from_vote_weights( runtime_stack->stakes.id_weights, epoch_weights, stake_weight_cnt );
+  ulong staked_cnt = compute_id_weights_from_vote_weights( fd_runtime_stack_id_weights(runtime_stack), epoch_weights, stake_weight_cnt );
   ulong excluded_stake = 0UL;
   if( FD_UNLIKELY( staked_cnt>MAX_SHRED_DESTS ) ) {
     for( ulong i=MAX_SHRED_DESTS; i<staked_cnt; i++ ) {
-      excluded_stake += runtime_stack->stakes.id_weights[i].stake;
+      excluded_stake += fd_runtime_stack_id_weights(runtime_stack)[i].stake;
     }
   }
   staked_cnt = fd_ulong_min( staked_cnt, MAX_SHRED_DESTS );
-  memcpy( runtime_stack->epoch_weights.id_weights, runtime_stack->stakes.id_weights, staked_cnt * sizeof(fd_stake_weight_t) );
+  memcpy( runtime_stack->epoch_weights.id_weights, fd_runtime_stack_id_weights(runtime_stack), staked_cnt * sizeof(fd_stake_weight_t) );
   runtime_stack->epoch_weights.id_weights_cnt      = staked_cnt;
   runtime_stack->epoch_weights.id_weights_excluded = excluded_stake;
 }

--- a/src/flamenco/runtime/fd_runtime_stack.h
+++ b/src/flamenco/runtime/fd_runtime_stack.h
@@ -75,8 +75,9 @@ typedef struct fd_stake_accum fd_stake_accum_t;
 #include "../../util/tmpl/fd_map_chain.c"
 
 /* fd_runtime_stack_t serves as stack memory to store temporary data
-   for the runtime.  This object should only be used and owned by the
-   replay tile and is used for short-lived allocations for the runtime,
+   for the runtime.  This object lives in shared topology memory and
+   is used by both the snapin tile (during snapshot loading) and the
+   replay tile (during block execution) for short-lived allocations,
    more specifically, for slot level calculations. */
 struct fd_runtime_stack {
 
@@ -87,7 +88,7 @@ struct fd_runtime_stack {
   struct {
     /* Staging memory to sort vote accounts by last vote timestamp for
        clock sysvar calculation. */
-    ts_est_ele_t * staked_ts;
+    ulong staked_ts_off;
   } clock_ts;
 
   struct {
@@ -110,15 +111,14 @@ struct fd_runtime_stack {
   } bpf_migration;
 
   struct {
-    fd_calculated_stake_points_t *  stake_points_result;
+    ulong stake_points_result_off;
+    ulong stake_rewards_result_off;
 
-    fd_calculated_stake_rewards_t * stake_rewards_result;
+    ulong stake_accum_off;
+    ulong stake_accum_map_off;
 
-    fd_stake_accum_t *     stake_accum;
-    fd_stake_accum_map_t * stake_accum_map;
-
-    fd_vote_rewards_t *     vote_ele;
-    fd_vote_rewards_map_t * vote_map;
+    ulong vote_ele_off;
+    ulong vote_map_off;
 
     ulong       total_rewards;
     ulong       distributed_rewards;
@@ -128,10 +128,10 @@ struct fd_runtime_stack {
 
     /* Staging memory used for calculating and sorting vote account
        stake weights for the leader schedule calculation. */
-    fd_vote_stake_weight_t * stake_weights;
-    fd_stake_weight_t *      id_weights;
+    ulong stake_weights_off;
+    ulong id_weights_off;
 
-    fd_epoch_credits_t * epoch_credits;
+    ulong epoch_credits_off;
 
   } stakes;
 
@@ -152,6 +152,60 @@ struct fd_runtime_stack {
   } epoch_weights;
 };
 typedef struct fd_runtime_stack fd_runtime_stack_t;
+
+/* Accessor functions to resolve offsets to pointers.  These are
+   position-independent: each tile computes absolute pointers from
+   its own mapping of the shared workspace. */
+
+static inline ts_est_ele_t *
+fd_runtime_stack_staked_ts( fd_runtime_stack_t * rs ) {
+  return (ts_est_ele_t *)((uchar *)rs + rs->clock_ts.staked_ts_off);
+}
+
+static inline fd_calculated_stake_points_t *
+fd_runtime_stack_stake_points_result( fd_runtime_stack_t * rs ) {
+  return (fd_calculated_stake_points_t *)((uchar *)rs + rs->stakes.stake_points_result_off);
+}
+
+static inline fd_calculated_stake_rewards_t *
+fd_runtime_stack_stake_rewards_result( fd_runtime_stack_t * rs ) {
+  return (fd_calculated_stake_rewards_t *)((uchar *)rs + rs->stakes.stake_rewards_result_off);
+}
+
+static inline fd_stake_accum_t *
+fd_runtime_stack_stake_accum( fd_runtime_stack_t * rs ) {
+  return (fd_stake_accum_t *)((uchar *)rs + rs->stakes.stake_accum_off);
+}
+
+static inline fd_stake_accum_map_t *
+fd_runtime_stack_stake_accum_map( fd_runtime_stack_t * rs ) {
+  return (fd_stake_accum_map_t *)((uchar *)rs + rs->stakes.stake_accum_map_off);
+}
+
+static inline fd_vote_rewards_t *
+fd_runtime_stack_vote_ele( fd_runtime_stack_t * rs ) {
+  return (fd_vote_rewards_t *)((uchar *)rs + rs->stakes.vote_ele_off);
+}
+
+static inline fd_vote_rewards_map_t *
+fd_runtime_stack_vote_map( fd_runtime_stack_t * rs ) {
+  return (fd_vote_rewards_map_t *)((uchar *)rs + rs->stakes.vote_map_off);
+}
+
+static inline fd_vote_stake_weight_t *
+fd_runtime_stack_stake_weights( fd_runtime_stack_t * rs ) {
+  return (fd_vote_stake_weight_t *)((uchar *)rs + rs->stakes.stake_weights_off);
+}
+
+static inline fd_stake_weight_t *
+fd_runtime_stack_id_weights( fd_runtime_stack_t * rs ) {
+  return (fd_stake_weight_t *)((uchar *)rs + rs->stakes.id_weights_off);
+}
+
+static inline fd_epoch_credits_t *
+fd_runtime_stack_epoch_credits( fd_runtime_stack_t * rs ) {
+  return (fd_epoch_credits_t *)((uchar *)rs + rs->stakes.epoch_credits_off);
+}
 
 FD_FN_CONST static inline ulong
 fd_runtime_stack_align( void ) {
@@ -206,23 +260,30 @@ fd_runtime_stack_new( void * shmem,
   runtime_stack->max_vote_accounts           = max_vote_accounts;
   runtime_stack->expected_vote_accounts      = expected_vote_accounts;
   runtime_stack->expected_stake_accounts     = expected_stake_accounts;
-  runtime_stack->clock_ts.staked_ts          = staked_ts;
-  runtime_stack->stakes.stake_weights        = stake_weights;
-  runtime_stack->stakes.id_weights           = id_weights;
-  runtime_stack->stakes.vote_ele             = vote_ele;
-  runtime_stack->stakes.epoch_credits        = epoch_credits;
-  runtime_stack->stakes.stake_points_result  = stake_points_result;
-  runtime_stack->stakes.stake_rewards_result = stake_rewards_result;
-  runtime_stack->stakes.stake_accum          = stake_accum;
 
-  runtime_stack->stakes.stake_accum_map = fd_stake_accum_map_join( fd_stake_accum_map_new( stake_accum_map_mem, chain_cnt, seed ) );
-  if( FD_UNLIKELY( !runtime_stack->stakes.stake_accum_map ) ) {
+  /* Store position-independent offsets from the struct base.  These
+     remain valid regardless of the virtual address at which the
+     workspace is mapped. */
+
+  runtime_stack->clock_ts.staked_ts_off          = (ulong)((uchar *)staked_ts            - (uchar *)runtime_stack);
+  runtime_stack->stakes.stake_weights_off        = (ulong)((uchar *)stake_weights        - (uchar *)runtime_stack);
+  runtime_stack->stakes.id_weights_off           = (ulong)((uchar *)id_weights           - (uchar *)runtime_stack);
+  runtime_stack->stakes.vote_ele_off             = (ulong)((uchar *)vote_ele             - (uchar *)runtime_stack);
+  runtime_stack->stakes.epoch_credits_off        = (ulong)((uchar *)epoch_credits        - (uchar *)runtime_stack);
+  runtime_stack->stakes.stake_points_result_off  = (ulong)((uchar *)stake_points_result  - (uchar *)runtime_stack);
+  runtime_stack->stakes.stake_rewards_result_off = (ulong)((uchar *)stake_rewards_result - (uchar *)runtime_stack);
+  runtime_stack->stakes.stake_accum_off          = (ulong)((uchar *)stake_accum          - (uchar *)runtime_stack);
+  runtime_stack->stakes.stake_accum_map_off      = (ulong)((uchar *)stake_accum_map_mem  - (uchar *)runtime_stack);
+  runtime_stack->stakes.vote_map_off             = (ulong)((uchar *)vote_map_mem         - (uchar *)runtime_stack);
+
+  /* Initialize the map data structures in-place. */
+
+  if( FD_UNLIKELY( !fd_stake_accum_map_new( stake_accum_map_mem, chain_cnt, seed ) ) ) {
     FD_LOG_WARNING(( "fd_runtime_stack_new: bad map" ));
     return NULL;
   }
 
-  runtime_stack->stakes.vote_map = fd_vote_rewards_map_join( fd_vote_rewards_map_new( vote_map_mem, chain_cnt, seed ) );
-  if( FD_UNLIKELY( !runtime_stack->stakes.vote_map ) ) {
+  if( FD_UNLIKELY( !fd_vote_rewards_map_new( vote_map_mem, chain_cnt, seed ) ) ) {
     FD_LOG_WARNING(( "fd_runtime_stack_new: bad map" ));
     return NULL;
   }
@@ -231,8 +292,8 @@ fd_runtime_stack_new( void * shmem,
 }
 
 FD_FN_CONST static inline fd_runtime_stack_t *
-fd_runtime_stack_join( void * shruntime_stack ) {
-  return (fd_runtime_stack_t *)shruntime_stack;
+fd_runtime_stack_join( void * shmem ) {
+  return (fd_runtime_stack_t *)shmem;
 }
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_runtime_stack_h */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -110,7 +110,7 @@ accum_vote_stakes_no_vat( fd_accdb_user_t *         accdb,
                           uint128 *                 total_stake_out,
                           ulong *                   ts_ele_cnt_out ) {
 
-  ts_est_ele_t * ts_eles = runtime_stack->clock_ts.staked_ts;
+  ts_est_ele_t * ts_eles = fd_runtime_stack_staked_ts(runtime_stack);
   ulong ts_ele_cnt = 0UL;
 
   uint128 total_stake = 0UL;
@@ -200,7 +200,7 @@ accum_vote_stakes_vat( fd_bank_t *          bank,
                        uint128 *            total_stake_out,
                        ulong *              ts_ele_cnt_out ) {
 
-  ts_est_ele_t * ts_eles = runtime_stack->clock_ts.staked_ts;
+  ts_est_ele_t * ts_eles = fd_runtime_stack_staked_ts(runtime_stack);
   ulong ts_ele_cnt = 0UL;
 
   uint128 total_stake = 0UL;
@@ -281,7 +281,7 @@ get_timestamp_estimate( fd_accdb_user_t *         accdb,
   ulong                       slot_duration  = bank->f.ns_per_slot.ul[0];
   ulong                       current_slot   = bank->f.slot;
 
-  ts_est_ele_t * ts_eles = runtime_stack->clock_ts.staked_ts;
+  ts_est_ele_t * ts_eles = fd_runtime_stack_staked_ts(runtime_stack);
 
   /* https://github.com/anza-xyz/agave/blob/v2.3.7/runtime/src/stake_weighted_timestamp.rs#L41 */
   ulong  ts_ele_cnt   = 0UL;

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -308,22 +308,22 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
      may call fd_vote_stakes_advance_root.  See fd_vote_stakes.h. */
 
   ulong chain_cnt = fd_vote_rewards_map_chain_cnt_est( runtime_stack->expected_vote_accounts );
-  FD_TEST( fd_vote_rewards_map_join( fd_vote_rewards_map_new( runtime_stack->stakes.vote_map, chain_cnt, 999 ) ) );
+  FD_TEST( fd_vote_rewards_map_join( fd_vote_rewards_map_new( fd_runtime_stack_vote_map( runtime_stack ), chain_cnt, 999 ) ) );
 
   /* Populate vote_ele and vote_ele_map for partitioned epoch rewards.
      Use epoch_credits from the proto if available (captured at epoch
      boundary time), otherwise fall back to the vote account in funk. */
-  fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map( runtime_stack );
   for( uint i=0U; i<block_bank->vote_accounts_t_1_count; i++ ) {
     fd_exec_test_prev_vote_account_t const * prev_vote_accs = &block_bank->vote_accounts_t_1[i];
     fd_pubkey_t                              vote_pubkey    = FD_LOAD( fd_pubkey_t, prev_vote_accs->address );
 
-    fd_vote_rewards_t * vote_ele = &runtime_stack->stakes.vote_ele[i];
+    fd_vote_rewards_t * vote_ele = &fd_runtime_stack_vote_ele( runtime_stack )[i];
     fd_memcpy( vote_ele->pubkey.uc, &vote_pubkey, sizeof(fd_pubkey_t) );
     vote_ele->commission_t_1 = (uchar)prev_vote_accs->commission;
 
     FD_TEST( prev_vote_accs->epoch_credits_count<=FD_EPOCH_CREDITS_MAX );
-    fd_epoch_credits_t * ec = &runtime_stack->stakes.epoch_credits[i];
+    fd_epoch_credits_t * ec = &fd_runtime_stack_epoch_credits( runtime_stack )[i];
     ec->cnt          = prev_vote_accs->epoch_credits_count;
     ec->base_credits = ec->cnt > 0UL ? prev_vote_accs->epoch_credits[0].prev_credits : 0UL;
     for( ulong j=0UL; j<prev_vote_accs->epoch_credits_count; j++ ) {
@@ -332,7 +332,7 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
       ec->prev_credits_delta[j] = (uint)( prev_vote_accs->epoch_credits[j].prev_credits - ec->base_credits );
     }
 
-    fd_vote_rewards_map_idx_insert( vote_ele_map, i, runtime_stack->stakes.vote_ele );
+    fd_vote_rewards_map_idx_insert( vote_ele_map, i, fd_runtime_stack_vote_ele( runtime_stack ) );
   }
 
   /* Update leader schedule */

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -655,12 +655,12 @@ create_block_context_protobuf_from_block( fd_block_dump_ctx_t * dump_ctx,
      vote_ele_map has been populated (happens after epoch boundary
      reward calculation).  Needed for the harness to correctly
      recalculate partitioned epoch rewards. */
-  fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
+  fd_vote_rewards_map_t * vote_ele_map = fd_runtime_stack_vote_map( runtime_stack );
   for( pb_size_t i=0U; i<va_t1_cnt; i++ ) {
     fd_pubkey_t va_pubkey = FD_LOAD( fd_pubkey_t, va_t1[i].address );
-    uint idx = (uint)fd_vote_rewards_map_idx_query( vote_ele_map, &va_pubkey, UINT_MAX, runtime_stack->stakes.vote_ele );
+    uint idx = (uint)fd_vote_rewards_map_idx_query( vote_ele_map, &va_pubkey, UINT_MAX, fd_runtime_stack_vote_ele( runtime_stack ) );
     if( idx==UINT_MAX ) continue;
-    fd_epoch_credits_t * ec = &runtime_stack->stakes.epoch_credits[idx];
+    fd_epoch_credits_t * ec = &fd_runtime_stack_epoch_credits( runtime_stack )[idx];
     ulong cnt  = ec->cnt;
     ulong base = ec->base_credits;
     va_t1[i].epoch_credits_count = (pb_size_t)cnt;

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -410,7 +410,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
                           fd_stake_history_t const *     history,
                           ulong *                        new_rate_activation_epoch ) {
 
-  fd_vote_rewards_map_t * vote_reward_map = runtime_stack->stakes.vote_map;
+  fd_vote_rewards_map_t * vote_reward_map = fd_runtime_stack_vote_map(runtime_stack);
   fd_vote_rewards_map_reset( vote_reward_map );
   ulong vote_reward_cnt = 0UL;
 
@@ -418,12 +418,12 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
      accounts.  At this point, don't care if they are valid accounts or
      if they will be inserted into the top votes set. */
 
-  fd_stake_accum_t *     stake_accum_pool = runtime_stack->stakes.stake_accum;
-  fd_stake_accum_map_t * stake_accum_map  = runtime_stack->stakes.stake_accum_map;
+  fd_stake_accum_t *     stake_accum_pool = fd_runtime_stack_stake_accum(runtime_stack);
+  fd_stake_accum_map_t * stake_accum_map  = fd_runtime_stack_stake_accum_map(runtime_stack);
 
   ushort parent_idx = bank->vote_stakes_fork_id;
 
-  fd_stake_accum_map_reset( runtime_stack->stakes.stake_accum_map );
+  fd_stake_accum_map_reset( fd_runtime_stack_stake_accum_map(runtime_stack) );
   ulong epoch              = bank->f.epoch;
   ulong total_stake        = 0UL;
   ulong total_activating   = 0UL;
@@ -449,7 +449,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
       if( FD_UNLIKELY( staked_accounts>=runtime_stack->max_vote_accounts ) ) {
         FD_LOG_ERR(( "invariant violation: staked_accounts >= max_vote_accounts" ));
       }
-      fd_stake_accum_t * sa = &runtime_stack->stakes.stake_accum[ staked_accounts ];
+      fd_stake_accum_t * sa = &fd_runtime_stack_stake_accum(runtime_stack)[ staked_accounts ];
       sa->pubkey = vs_pubkey;
       sa->stake  = 0UL;
       fd_stake_accum_map_ele_insert( stake_accum_map, sa, stake_accum_pool );
@@ -479,7 +479,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
       if( FD_UNLIKELY( staked_accounts>=runtime_stack->max_vote_accounts ) ) {
         FD_LOG_ERR(( "invariant violation: staked_accounts >= max_vote_accounts" ));
       }
-      stake_accum = &runtime_stack->stakes.stake_accum[ staked_accounts ];
+      stake_accum = &fd_runtime_stack_stake_accum(runtime_stack)[ staked_accounts ];
       stake_accum->pubkey = stake_delegation->vote_account;
       stake_accum->stake  = new_entry.effective;
       fd_stake_accum_map_ele_insert( stake_accum_map, stake_accum, stake_accum_pool );
@@ -532,14 +532,14 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
     if( FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) ) {
       uchar                commission_t_1   = 0;
       fd_pubkey_t          node_account_t_1 = {0};
-      fd_epoch_credits_t * epoch_credits    = &runtime_stack->stakes.epoch_credits[ vote_reward_cnt ];
+      fd_epoch_credits_t * epoch_credits    = &fd_runtime_stack_epoch_credits(runtime_stack)[ vote_reward_cnt ];
       get_vote_credits_commission( fd_accdb_ref_data_const( vote_ro ), fd_accdb_ref_data_sz( vote_ro ), &commission_t_1, &node_account_t_1, epoch_credits );
-      fd_vote_rewards_t * vote_ele = &runtime_stack->stakes.vote_ele[ vote_reward_cnt ];
+      fd_vote_rewards_t * vote_ele = &fd_runtime_stack_vote_ele(runtime_stack)[ vote_reward_cnt ];
       vote_ele->pubkey             = pubkey;
       vote_ele->vote_rewards       = 0UL;
       vote_ele->commission_t_1     = commission_t_1;
       vote_ele->commission_t_2     = commission_t_2;
-      fd_vote_rewards_map_ele_insert( vote_reward_map, vote_ele, runtime_stack->stakes.vote_ele );
+      fd_vote_rewards_map_ele_insert( vote_reward_map, vote_ele, fd_runtime_stack_vote_ele(runtime_stack) );
       vote_reward_cnt++;
     }
     fd_accdb_close_ro( accdb, vote_ro );
@@ -578,18 +578,18 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
       exists_curr = 0;
       fd_accdb_close_ro( accdb, vote_ro );
     } else {
-      fd_epoch_credits_t * epoch_credits = &runtime_stack->stakes.epoch_credits[ vote_reward_cnt ];
+      fd_epoch_credits_t * epoch_credits = &fd_runtime_stack_epoch_credits(runtime_stack)[ vote_reward_cnt ];
       get_vote_credits_commission( fd_accdb_ref_data_const( vote_ro ), fd_accdb_ref_data_sz( vote_ro ), &commission_t_1, &node_account_t_1, epoch_credits );
 
       stake_t_1 = stake_accum->stake;
 
       if( !FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) ) {
-        fd_vote_rewards_t * vote_ele = &runtime_stack->stakes.vote_ele[ vote_reward_cnt ];
+        fd_vote_rewards_t * vote_ele = &fd_runtime_stack_vote_ele(runtime_stack)[ vote_reward_cnt ];
         vote_ele->pubkey             = stake_accum->pubkey;
         vote_ele->vote_rewards       = 0UL;
         vote_ele->commission_t_1     = commission_t_1;
         vote_ele->commission_t_2     = exists_prev ? commission_t_2 : commission_t_1;
-        fd_vote_rewards_map_ele_insert( vote_reward_map, vote_ele, runtime_stack->stakes.vote_ele );
+        fd_vote_rewards_map_ele_insert( vote_reward_map, vote_ele, fd_runtime_stack_vote_ele(runtime_stack) );
         vote_reward_cnt++;
       }
 


### PR DESCRIPTION
This PR decouples the size of `fd_snapshot_manifest_t` from the max amount of `vote_stakes` and `stake_delegations`, and streamlines `vote_accounts` to just 72B (the array of `vote_accounts` is still required in `fd_snapshot_manifest_t` by downstream consumers).
To make this possible
- former `fd_ssload_recover()` is relocated from `replay` to `snapin`.
- `snapin` now needs to process the manifest data `on-the-fly`,
- while still being able to recover from manifest / snapshot load failures.
- Note that E+1 `vote_stakes` can be processed immediately, but E `vote_stakes` need to be buffered (since they are received in reverse order).
 
Additionally, this PR corrects a race condition between `snapct` and `snapld` on download failure, and resets `ctx->in.pos` on INIT, and `HTTP downloads` data before meta filtering.

Closes https://github.com/firedancer-io/firedancer/issues/8682.

Superseded by https://github.com/firedancer-io/firedancer/pull/9276 and https://github.com/firedancer-io/firedancer/pull/9257.