### PR TITLE
restore: ssping remove no-op untracked peers

### DIFF
--- a/src/discof/restore/utils/fd_ssping.c
+++ b/src/discof/restore/utils/fd_ssping.c
@@ -320,8 +320,8 @@ int
 fd_ssping_remove( fd_ssping_t * ssping,
                   fd_ip4_port_t addr ) {
   fd_ssping_peer_t * peer = peer_map_ele_query( ssping->map, &addr, NULL, ssping->pool );
-  FD_TEST( peer );
-  FD_TEST( peer->refcnt );
+  if( FD_UNLIKELY( !peer ) ) return 0;
+  if( FD_UNLIKELY( !peer->refcnt ) ) return 0;
   peer->refcnt--;
   if( FD_LIKELY( !peer->refcnt ) ) {
     switch( peer->state ) {

--- a/src/discof/restore/utils/fd_ssping.h
+++ b/src/discof/restore/utils/fd_ssping.h
@@ -5,10 +5,9 @@
    peers that are reachable for snapshot download, and returning the
    "best" such peer at any time.
 
-   The "best" peer is defined as the one with the lowest latency for
-   now, in response to an ICMP ping request, although this should likely
-   be changed to include snapshot age, or actual observed download speed
-   for a small sample, or other factors.
+   The "best" peer is defined as the one with the lowest combined score
+   of TCP connection latency and snapshot age (slots behind the
+   cluster), as computed by the peer selector.
 
    The snapshot pinger works on the assumption that there is a maximum
    size of peers that will ever be added, as we expect from the gossip


### PR DESCRIPTION
`fd_ssping_remove` should perform a no-op on untracked peers (instead of FD_TEST).

Addressed point 25 in https://github.com/firedancer-io/firedancer/issues/9176.