### PR TITLE
restore: ssresolve https tls sni

### DIFF
--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -117,7 +117,11 @@ http_init_ssl( fd_sshttp_t * http ) {
     FD_LOG_ERR(( "SSL_set_alpn_protos failed (%d) for %s", alpn_res, http->hostname ));
   }
 
-  /* set SNI */
+  /* set SNI and hostname verification */
+  long sni_res = SSL_set_tlsext_host_name( http->ssl, http->hostname );
+  if( FD_UNLIKELY( !sni_res ) ) {
+    FD_LOG_ERR(( "SSL_set_tlsext_host_name failed (%ld) for %s", sni_res, http->hostname ));
+  }
   int set1_host_res = SSL_set1_host( http->ssl, http->hostname );
   if( FD_UNLIKELY( !set1_host_res ) ) {
     FD_LOG_ERR(( "SSL_set1_host failed (%d) for %s", set1_host_res, http->hostname ));

--- a/src/discof/restore/utils/fd_ssresolve.c
+++ b/src/discof/restore/utils/fd_ssresolve.c
@@ -162,11 +162,15 @@ fd_ssresolve_init_https( fd_ssresolve_t * ssresolve,
     FD_LOG_ERR(( "SSL_set_alpn_protos failed (%d)", alpn_res ));
   }
 
-  /* set SNI */
+  /* set SNI and hostname verification */
   FD_TEST( hostname && hostname[ 0 ]!='\0' );
+  long sni_res = SSL_set_tlsext_host_name( ssresolve->ssl, hostname );
+  if( FD_UNLIKELY( !sni_res ) ) {
+    FD_LOG_ERR(( "SSL_set_tlsext_host_name failed (%ld) for %s", sni_res, hostname ));
+  }
   int set1_host_res = SSL_set1_host( ssresolve->ssl, hostname );
   if( FD_UNLIKELY( !set1_host_res ) ) {
-    FD_LOG_ERR(( "SSL_set1_host failed (%d)", set1_host_res ));
+    FD_LOG_ERR(( "SSL_set1_host failed (%d) for %s", set1_host_res, hostname ));
   }
 
   FD_TEST( fd_openssl_ssl_set_fd( ssresolve->ssl, ssresolve->sockfd ) );


### PR DESCRIPTION
`fd_ssresolve_init_https` should set TLS SNI.
The same applies to `http_init_ssl` in `fd_sshttp.c`.

Addresses point 26 in https://github.com/firedancer-io/firedancer/issues/9176.