### PR TITLE
restore: sshttp private double-close

### DIFF
--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -432,8 +432,11 @@ returnable_frag( fd_snapld_tile_t *  ctx,
           FD_LOG_ERR(( "lseek(0) failed on %s snapshot file (%i-%s)",
                        ctx->load_full ? "full" : "incremental", errno, fd_io_strerror( errno ) ));
       } else {
-        if( ctx->load_full ) fd_sshttp_init( ctx->sshttp, msg_in->addr, msg_in->hostname, msg_in->is_https, msg_in->path, msg_in->path_len, now );
-        else                 fd_sshttp_init( ctx->sshttp, msg_in->addr, msg_in->hostname, msg_in->is_https, msg_in->path, msg_in->path_len, now );
+        if( FD_UNLIKELY( fd_sshttp_init( ctx->sshttp, msg_in->addr, msg_in->hostname, msg_in->is_https, msg_in->path, msg_in->path_len, now ) ) ) {
+          transition_malformed( ctx, stem );
+          forward_msg = 0;
+          break;
+        }
       }
       fd_ssctrl_init_t * msg_out = fd_chunk_to_laddr( ctx->out_dc.mem, ctx->out_dc.chunk );
       fd_memcpy( msg_out, msg_in, sz );

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -129,7 +129,7 @@ http_init_ssl( fd_sshttp_t * http ) {
 }
 #endif
 
-void
+int
 fd_sshttp_init( fd_sshttp_t * http,
                 fd_ip4_port_t addr,
                 char const *  hostname,
@@ -196,7 +196,7 @@ fd_sshttp_init( fd_sshttp_t * http,
 #if FD_HAS_OPENSSL
       if( FD_LIKELY( http->ssl ) ) { SSL_free( http->ssl ); http->ssl = NULL; }
 #endif
-      return;
+      return -1;
     }
   }
 
@@ -210,6 +210,8 @@ fd_sshttp_init( fd_sshttp_t * http,
     http->state    = FD_SSHTTP_STATE_REQ;
     http->deadline = now + FD_SSHTTP_DEADLINE_NANOS;
   }
+
+  return 0;
 }
 
 #if FD_HAS_OPENSSL
@@ -315,7 +317,9 @@ static int
 setup_redirect( fd_sshttp_t * http,
               long          now ) {
   fd_sshttp_cancel( http );
-  fd_sshttp_init( http, http->addr, http->hostname, http->is_https, http->location, http->location_len, now );
+  if( FD_UNLIKELY( fd_sshttp_init( http, http->addr, http->hostname, http->is_https, http->location, http->location_len, now ) ) ) {
+    return FD_SSHTTP_ADVANCE_ERROR;
+  }
   return FD_SSHTTP_ADVANCE_AGAIN;
 }
 
@@ -514,7 +518,9 @@ follow_redirect( fd_sshttp_t *        http,
   } else {
     if( FD_LIKELY( !fd_sshttp_fuzz ) ) {
       fd_sshttp_cancel( http );
-      fd_sshttp_init( http, http->addr, http->hostname, http->is_https, location, location_len, now );
+      if( FD_UNLIKELY( fd_sshttp_init( http, http->addr, http->hostname, http->is_https, location, location_len, now ) ) ) {
+        return FD_SSHTTP_ADVANCE_ERROR;
+      }
     } else {
       http->state = FD_SSHTTP_STATE_RESP;
       http->response_len = 0UL;

--- a/src/discof/restore/utils/fd_sshttp.h
+++ b/src/discof/restore/utils/fd_sshttp.h
@@ -26,7 +26,7 @@ fd_sshttp_snapshot_name( fd_sshttp_t const * http );
 ulong
 fd_sshttp_content_len( fd_sshttp_t const * http );
 
-void
+int
 fd_sshttp_init( fd_sshttp_t * http,
                 fd_ip4_port_t addr,
                 char const *  hostname,


### PR DESCRIPTION
`fd_sshttp_init` now returns `int`. Before this, when `connect()` failed immediately with an error other than `EINPROGRESS`, `fd_sshttp_init` properly cleaned up the socket and SSL, but returned void (i.e. without informing the caller about the failure). 

Addresses point 19 in https://github.com/firedancer-io/firedancer/issues/9176.