### PR TITLE
bn254: optimized mul with dbl carry chain

### DIFF
--- a/src/ballet/bigint/fd_uint256_mul.h
+++ b/src/ballet/bigint/fd_uint256_mul.h
@@ -143,12 +143,30 @@ fd_uint256_add(fd_uint256_t *       r,
       function, otherwise performance degrades significantly.
       For this we added the macro FD_UINT256_FP_MUL_IMPL. */
 
+#if FD_HAS_X86 && defined(__BMI2__) && defined(__ADX__)
+__asm__( ".include \"src/ballet/bigint/fd_uint256_mul.inc\"" );
+#endif
+
 INLINE fd_uint256_t *
 fd_uint256_mul_mod_p( fd_uint256_t *       r,
                       fd_uint256_t const * a,
                       fd_uint256_t const * b,
                       fd_uint256_t const * p,
                       ulong const          p_inv ) {
+#if FD_HAS_X86 && defined(__BMI2__) && defined(__ADX__)
+  register fd_uint256_t *       _r    __asm__("rdi") = r;
+  register fd_uint256_t const * _a    __asm__("rsi") = a;
+  register fd_uint256_t const * _b    __asm__("rdx") = b;
+  register fd_uint256_t const * _p    __asm__("rcx") = p;
+  register ulong                _pinv __asm__("r8")  = p_inv;
+  __asm__ __volatile__ (
+    "_fd_uint256_mul_mod_p %[r], %[a], %[b], %[p], %[pinv]"
+    : [r]"+r"(_r), [a]"+r"(_a), [b]"+r"(_b), [pinv]"+r"(_pinv)
+    : [p]"r"(_p)
+    : "rax", "r9", "r10", "r11", "cc", "memory"
+  );
+  r = _r;
+#else
   ulong FD_ALIGNED t[4] = { 0 };
   ulong FD_ALIGNED u[4];
   ulong FD_ALIGNED h[4];
@@ -186,6 +204,7 @@ fd_uint256_mul_mod_p( fd_uint256_t *       r,
     fd_ulong_sub_borrow( &r->limbs[2], &b, r->limbs[2], p->limbs[2], b );
     fd_ulong_sub_borrow( &r->limbs[3], &b, r->limbs[3], p->limbs[3], b );
   }
+#endif
   return r;
 }
 

--- a/src/ballet/bigint/fd_uint256_mul.inc
+++ b/src/ballet/bigint/fd_uint256_mul.inc
@@ -1,0 +1,204 @@
+# fd_uint256_mul_mod_p
+#
+# CIOS Montgomery multiplication using BMI2 (mulx) and ADX (adcx/adox).
+# Computes r = inverse_mod(2^256, p) * a * b  (mod p).
+#
+# Parameters (must be pinned to specific registers, see fd_uint256_mul.h):
+#   \r      - rdi, pointer to output fd_uint256_t (preserved)
+#   \a      - rsi, pointer to first multiplicand (4 limbs, destroyed)
+#   \b      - rdx, pointer to second multiplicand (4 limbs, moved to rax)
+#   \p      - rcx, pointer to modulus (4 limbs, must be odd, < 2^256, preserved)
+#   \p_inv  - r8,  Montgomery inverse: (p_inv * p[0]) ≡ -1 (mod 2^64, destroyed)
+#
+# Saves/restores: rbp, r15, r14, r13, r12, rbx.
+# Clobbers: rax, rdx, r9-r11, \a (rsi), \p_inv (r8), flags, memory.
+
+.macro _fd_uint256_mul_mod_p r, a, b, p, p_inv
+
+    push    %rbp
+    push    %r15
+    push    %r14
+    push    %r13
+    push    %r12
+    push    %rbx
+
+    mov     \b, %rax
+
+    xor     %r9d, %r9d
+    xor     %r10d, %r10d
+    xor     %r11d, %r11d
+    xor     %ebx, %ebx
+    xor     %r14d, %r14d
+
+    /* Iteration 0: b[0] */
+    mov     (%rax), %rdx
+    xor     %r9d, %r9d
+    mulx    (\a), %r12, %r15
+    adcx    %r12, %r10
+    mulx    0x8(\a), %r12, %rbp
+    adox    %r15, %r11
+    adcx    %r12, %r11
+    mulx    0x10(\a), %r12, %r15
+    adox    %rbp, %rbx
+    adcx    %r12, %rbx
+    mulx    0x18(\a), %r12, %rbp
+    adox    %r15, %r14
+    adcx    %r12, %r14
+    adox    %r9, %rbp
+    adcx    %r9, %rbp
+
+    mov     %r10, %rdx
+    imul    \p_inv, %rdx
+    xor     %r9d, %r9d
+    mulx    (\p), %r12, %r15
+    adcx    %r10, %r12
+    mulx    0x8(\p), %r12, %r13
+    adox    %r15, %r11
+    adcx    %r12, %r11
+    mulx    0x10(\p), %r12, %r15
+    adox    %r13, %rbx
+    adcx    %r12, %rbx
+    mulx    0x18(\p), %r12, %r13
+    adox    %r15, %r14
+    adcx    %r12, %r14
+    adox    %r9, %r13
+    adcx    %r9, %r13
+    add     %r13, %rbp
+    mov     %rbp, %r10
+
+    /* Iteration 1: b[1] */
+    mov     0x8(%rax), %rdx
+    xor     %r9d, %r9d
+    mulx    (\a), %r12, %r15
+    adcx    %r12, %r11
+    mulx    0x8(\a), %r12, %rbp
+    adox    %r15, %rbx
+    adcx    %r12, %rbx
+    mulx    0x10(\a), %r12, %r15
+    adox    %rbp, %r14
+    adcx    %r12, %r14
+    mulx    0x18(\a), %r12, %rbp
+    adox    %r15, %r10
+    adcx    %r12, %r10
+    adox    %r9, %rbp
+    adcx    %r9, %rbp
+
+    mov     %r11, %rdx
+    imul    \p_inv, %rdx
+    xor     %r9d, %r9d
+    mulx    (\p), %r12, %r15
+    adcx    %r11, %r12
+    mulx    0x8(\p), %r12, %r13
+    adox    %r15, %rbx
+    adcx    %r12, %rbx
+    mulx    0x10(\p), %r12, %r15
+    adox    %r13, %r14
+    adcx    %r12, %r14
+    mulx    0x18(\p), %r12, %r13
+    adox    %r15, %r10
+    adcx    %r12, %r10
+    adox    %r9, %r13
+    adcx    %r9, %r13
+    add     %r13, %rbp
+    mov     %rbp, %r11
+
+    /* Iteration 2: b[2] */
+    mov     0x10(%rax), %rdx
+    xor     %r9d, %r9d
+    mulx    (\a), %r12, %r15
+    adcx    %r12, %rbx
+    mulx    0x8(\a), %r12, %rbp
+    adox    %r15, %r14
+    adcx    %r12, %r14
+    mulx    0x10(\a), %r12, %r15
+    adox    %rbp, %r10
+    adcx    %r12, %r10
+    mulx    0x18(\a), %r12, %rbp
+    adox    %r15, %r11
+    adcx    %r12, %r11
+    adox    %r9, %rbp
+    adcx    %r9, %rbp
+
+    mov     %rbx, %rdx
+    imul    \p_inv, %rdx
+    xor     %r9d, %r9d
+    mulx    (\p), %r12, %r15
+    adcx    %rbx, %r12
+    mulx    0x8(\p), %r12, %r13
+    adox    %r15, %r14
+    adcx    %r12, %r14
+    mulx    0x10(\p), %r12, %r15
+    adox    %r13, %r10
+    adcx    %r12, %r10
+    mulx    0x18(\p), %r12, %r13
+    adox    %r15, %r11
+    adcx    %r12, %r11
+    adox    %r9, %r13
+    adcx    %r9, %r13
+    add     %r13, %rbp
+    mov     %rbp, %rbx
+
+    /* Iteration 3: b[3] */
+    mov     0x18(%rax), %rdx
+    xor     %r9d, %r9d
+    mulx    (\a), %r12, %r15
+    adcx    %r12, %r14
+    mulx    0x8(\a), %r12, %rbp
+    adox    %r15, %r10
+    adcx    %r12, %r10
+    mulx    0x10(\a), %r12, %r15
+    adox    %rbp, %r11
+    adcx    %r12, %r11
+    mulx    0x18(\a), %r12, %rbp
+    adox    %r15, %rbx
+    adcx    %r12, %rbx
+    adox    %r9, %rbp
+    adcx    %r9, %rbp
+
+    mov     %r14, %rdx
+    imul    \p_inv, %rdx
+    xor     %r9d, %r9d
+    mulx    (\p), %r12, %r15
+    adcx    %r14, %r12
+    mulx    0x8(\p), %r12, %r13
+    adox    %r15, %r10
+    adcx    %r12, %r10
+    mulx    0x10(\p), %r12, %r15
+    adox    %r13, %r11
+    adcx    %r12, %r11
+    mulx    0x18(\p), %r12, %r13
+    adox    %r15, %rbx
+    adcx    %r12, %rbx
+    adox    %r9, %r13
+    adcx    %r9, %r13
+    add     %r13, %rbp
+    mov     %rbp, %r14
+
+    /* Conditional subtraction: result = min(t, t - p)
+       Result in r10, r11, rbx, r14.  Reuse \a, \p_inv as scratch. */
+    mov     %r10, %rax
+    sub     (\p), %rax
+    mov     %r11, %rdx
+    sbb     0x8(\p), %rdx
+    mov     %rbx, \a
+    sbb     0x10(\p), \a
+    mov     %r14, \p_inv
+    sbb     0x18(\p), \p_inv
+    cmovb   %r10, %rax
+    cmovb   %r11, %rdx
+    cmovb   %rbx, \a
+    cmovb   %r14, \p_inv
+
+    mov     %rax, (\r)
+    mov     %rdx, 0x8(\r)
+    mov     \a, 0x10(\r)
+    mov     \p_inv, 0x18(\r)
+
+    pop     %rbx
+    pop     %r12
+    pop     %r13
+    pop     %r14
+    pop     %r15
+    pop     %rbp
+
+.endm


### PR DESCRIPTION
This PR improves bn254 perf by ~20% across all the ops (g1, g2, pairing...), by using the x86 double carry chain.

Aside from the improvement, this is a proposal on how to adopt asm following s2b-bignum approach inside fd (this type of asm is necessary if we want the perf boost, because compilers can't emit adox/adcx instructions). Details follow.

---

Work by @drubin-fd, just putting some pieces together.

Proposal:
- asm function(s) should respect System V AMD64 ABI (push/pop rbp, rbx, r12-r15, can destroy all others)
- C wrapper binds var<>regs if needed (sometimes it's not) and deals with clobbered registers
- => we tend to use C wrapper in our code, but this way also asm fn would be safe to use
- asm in a clearly readable .inc file
- C wrapper doesn't introduce any fn call, i.e. the asm is directly inlined also in caller fn(s)
   - example: fd_bn254_fp_mul and even fd_bn254_fp_sqr have no calls
   - counter example: fd_bn254_fp2_mul, the compiler decides to not inline because the body would be too big -- all good
- we can get proofs similar to s2n-bignum https://gist.github.com/drubin-fd/1ed0d59ffe43511622b11be32e5c111d
   - compared to s2n-bignum, we have a better inline story

---

This is a minimal example that shows the trick.

```
#include <stdio.h>

typedef unsigned long ulong;

/* Pull the GAS macro definitions into this translation unit's asm stream.
   Must appear at file scope so the macro is defined before any use.       */
asm(".include \"fp_mul_impl.inc\"");

/* always_inline: GCC substitutes real register names for %0/%1/%2,
   then hands the text to the assembler, which expands fp_mul_body.
   Result: zero CALL instructions — the imulq is emitted directly.         */
static __attribute__((always_inline)) inline
ulong fp_mul(ulong a, ulong b) {
    ulong result;
    asm("fp_mul_body %0, %1, %2"
        : "=r"(result)
        : "r"(a), "r"(b));
    return result;
}

ulong fp2_mul(ulong a, ulong b) {
    ulong r1 = fp_mul(a, b);   /* inlined – no call */
    ulong r2 = fp_mul(b, a);   /* inlined – no call */
    return r1 + r2;
}

int main(void) {
    ulong result = fp2_mul(3, 4);
    printf("result: %lu\n", result);
    return 0;
}
```

And `fp_mul_impl.inc`
```
# Single source of truth for fp_mul.
# dst = src1 * src2  (unsigned 64-bit)
.macro fp_mul_body dst, src1, src2
    movq    \src1, \dst
    imulq   \src2, \dst
.endm
```

This all compiles to (note: no fn calls):
```
0000000000401170 <fp2_mul>:
  401170:       48 89 f8                mov    %rdi,%rax
  401173:       48 0f af c6             imul   %rsi,%rax
  401177:       48 89 f6                mov    %rsi,%rsi
  40117a:       48 0f af f7             imul   %rdi,%rsi
  40117e:       48 01 f0                add    %rsi,%rax
  401181:       c3                      retq
```

The minimal example shows the inline trick/improvement.
In the minimal example we don't need to bind variables to registers, but unfortunately in complex fn such as `fd_uint256_mul_mod_p` we do because the number of registers is limited and the mapping needs to be respected.