### PR TITLE
restore: snaplv buffered req cleanup on FAIL

### DIFF
--- a/src/discof/restore/fd_snaplv_tile.c
+++ b/src/discof/restore/fd_snaplv_tile.c
@@ -398,6 +398,17 @@ handle_control_frag( fd_snaplv_t *       ctx,
     case FD_SNAPSHOT_MSG_CTRL_FAIL: {
       FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
       ctx->state = FD_SNAPSHOT_STATE_IDLE;
+
+      /* Discard buffered pending duplicate requests, to prevent them
+         from being emitted from this point onward. */
+      memset( ctx->vinyl.pending.active, 0, FD_SNAPLV_DUP_PENDING_CNT_MAX*sizeof(int) );
+      ctx->vinyl.pending_cnt = 0UL;
+
+      /* Reset hash accumulation state, to avoid publishing FINI to
+         snapct if awaiting_results was set before CTRL_FAIL. */
+      ctx->hash_accum.awaiting_results = 0;
+      ctx->hash_accum.received_lthashes = 0UL;
+
       ctx->fail.exp_sig = FD_SNAPSHOT_MSG_CTRL_FAIL;
       ctx->fail.ack_cnt = 0UL;
       ctx->fail.wait = 1;


### PR DESCRIPTION
When `_MSG_CTRL_FAIL` is received, `snaplv` now cleans (discards) buffered pending duplicate requests, and immediately resets `awaiting_results` and `received_lthashes` (to avoid a spurious FINI message to `snapct`).

Addresses point 11 in https://github.com/firedancer-io/firedancer/issues/9176.