### PR TITLE
restore: snapla reset in.pos during init

### DIFF
--- a/src/discof/restore/fd_snapla_tile.c
+++ b/src/discof/restore/fd_snapla_tile.c
@@ -262,6 +262,7 @@ handle_control_frag( fd_snapla_tile_t *  ctx,
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_IDLE );
       ctx->full          = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
       ctx->state         = FD_SNAPSHOT_STATE_PROCESSING;
+      ctx->in.pos        = 0UL;
       ctx->accounts_seen = 0UL;
       ctx->hash_account  = 0;
       ctx->acc_data_sz   = 0UL;


### PR DESCRIPTION
`snapla` must reset `in.pos` when `_MSG_CTRL_INIT_` is received.
This makes a recovery from ERROR/FAIL more robust.

Addresses point 7 in https://github.com/firedancer-io/firedancer/issues/9176.

`snapin` must also do the same. This is addressed in https://github.com/firedancer-io/firedancer/pull/9224.