### PR TITLE
restore: manifest struct streamlined

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -459,6 +459,9 @@ backtest_topo( config_t * config ) {
   fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, 0 );
   fd_topob_tile_uses( topo, replay_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  if( FD_LIKELY( !disable_snap_loader ) ) {
+    fd_topob_tile_uses( topo, snapin_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
 
   /* txncache_obj shared by replay, snapin, and execrp tiles */

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -26,6 +26,7 @@ up the entire gossip subtopo.
 #include "../../../../disco/net/fd_net_tile.h" /* fd_topos_net_tiles */
 #include "../../../../discof/tower/fd_tower_tile.h"
 #include "../../../../flamenco/leaders/fd_leaders_base.h" /* FD_STAKE_OUT_MTU */
+#include "../../../../discof/restore/utils/fd_ssmsg.h" /* FD_SNAPSHOT_MAX_VOTE_ACCOUNTS */
 #include "../../../../app/firedancer/topology.h" /* fd_topo_configure_tile */
 #include "../../../../disco/keyguard/fd_keyload.h"
 
@@ -106,7 +107,7 @@ send_test_topo( config_t * config ) {
   if( !use_live_gossip ) {fd_topob_link( topo, "gossip_out",   "gossip_out",   65536UL*4UL, sizeof(fd_gossip_update_message_t), 1UL ); }
   /**/                    fd_topob_link( topo, "replay_epoch", "replay_epoch", 128UL,       FD_STAKE_OUT_MTU,                   1UL );
   /**/                    fd_topob_link( topo, "tower_out",    "tower_out",    1024UL,      sizeof(fd_tower_slot_done_t),       1UL );
-  /**/                    fd_topob_link( topo, "txsend_out",   "txsend_out",   128UL,       40200UL * 38UL,                     1UL );
+  /**/                    fd_topob_link( topo, "txsend_out",   "txsend_out",   128UL,       FD_SNAPSHOT_MAX_VOTE_ACCOUNTS * 38UL, 1UL );
 
   if( !use_live_gossip ) {fd_link_permit_no_producers( topo, "gossip_out" ); }
   if( !use_live_gossip ) {fd_link_permit_no_consumers( topo, "txsend_out" ); }

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1221,6 +1221,9 @@ fd_topo_initialize( config_t * config ) {
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execle_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execle", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(resolv_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "resolv", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+  if( FD_LIKELY( snapshots_enabled ) ) {
+    fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+  }
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
 
   if( FD_UNLIKELY( config->tiles.bundle.enabled ) ) {

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -1135,9 +1135,9 @@ fd_gui_peers_stage_snapshot_manifest( fd_gui_peers_ctx_t *           peers,
   fd_vote_stake_weight_t * vote_scratch = peers->scratch.manifest_vote_weights;
   ulong vote_scratch_cnt = 0UL;
   ulong vote_accounts_sz = manifest->vote_accounts_len;
-  if( FD_UNLIKELY( vote_accounts_sz>40200UL ) ) {
-    FD_LOG_WARNING(( "exceeded 40200UL vote accounts" ));
-    vote_accounts_sz = 40200UL;
+  if( FD_UNLIKELY( vote_accounts_sz>FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ) ) {
+    FD_LOG_WARNING(( "exceeded FD_SNAPSHOT_MAX_VOTE_ACCOUNTS vote accounts" ));
+    vote_accounts_sz = FD_SNAPSHOT_MAX_VOTE_ACCOUNTS;
   }
   for( ulong i=0UL; i<vote_accounts_sz; i++ ) {
     if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -417,11 +417,11 @@ struct fd_gui_peers_ctx {
       ulong idxs   [ FD_CONTACT_INFO_TABLE_SIZE ];
     };
     struct {
-      ulong wfs_peers[ 40200UL ];
+      ulong wfs_peers[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
     };
     struct {
-      fd_stake_weight_t      manifest_id_weights  [ 40200UL ];
-      fd_vote_stake_weight_t manifest_vote_weights[ 40200UL ];
+      fd_stake_weight_t      manifest_id_weights  [ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
+      fd_vote_stake_weight_t manifest_vote_weights[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
     };
     fd_gui_peers_voter_t voters_scratch[ MAX_COMPRESSED_STAKE_WEIGHTS ];
   } scratch;
@@ -433,7 +433,7 @@ struct fd_gui_peers_ctx {
   fd_gui_ip_db_t dbip;
 
   int                       wfs_enabled;
-  fd_gui_wfs_peer_t         wfs_peers[ 40200UL ];
+  fd_gui_wfs_peer_t         wfs_peers[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
   ulong                     wfs_peers_cnt;
   int                       wfs_peers_valid;
   int                       wfs_stakes_sent;

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -392,7 +392,7 @@ returnable_frag( fd_gossip_tile_ctx_t * ctx,
       ctx->wfs_peers.total  = 0UL;
       memset( ctx->wfs_active, 0, sizeof(ctx->wfs_active) );
 
-      FD_TEST( manifest->vote_accounts_len<=40200UL );
+      FD_TEST( manifest->vote_accounts_len<=FD_SNAPSHOT_MAX_VOTE_ACCOUNTS );
       for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
           if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;
           ctx->wfs_stake.total += manifest->vote_accounts[ i ].stake;

--- a/src/discof/gossip/fd_gossip_tile.h
+++ b/src/discof/gossip/fd_gossip_tile.h
@@ -4,6 +4,7 @@
 #include "../../disco/topo/fd_topo.h"
 #include "../../flamenco/gossip/fd_gossip.h"
 #include "../../flamenco/runtime/fd_runtime_const.h"
+#include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../disco/keyguard/fd_keyguard_client.h"
 #include "../../disco/keyguard/fd_keyswitch.h"
 
@@ -59,13 +60,13 @@ struct fd_gossip_tile_ctx {
 
      We keep a copy of the snapshot bank's votes states in an array here
      for quick look up. */
-  fd_vote_stake_weight_t wfs_stakes_scratch[ 40200UL ];
-  fd_stake_weight_t      wfs_stakes        [ 40200UL ];
+  fd_vote_stake_weight_t wfs_stakes_scratch[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
+  fd_stake_weight_t      wfs_stakes        [ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
   ulong                  wfs_stakes_cnt;
 
   /* wfs_active is used to keep track of nodes we've already labeled as
      being active on gossip, so we don't double count their stake. */
-  uchar             wfs_active[ 40200UL ];
+  uchar             wfs_active[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
   int               wfs_state;
 
   struct {

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -8,7 +8,7 @@
 #include "../poh/fd_poh_tile.h"
 #include "../tower/fd_tower_tile.h"
 #include "../resolv/fd_resolv_tile.h"
-#include "../restore/utils/fd_ssload.h"
+#include "../restore/utils/fd_ssmsg.h"
 
 #include "../../disco/tiles.h"
 #include "../../disco/fd_txn_m.h"
@@ -233,7 +233,7 @@ publish_epoch_info( fd_replay_tile_t *  ctx,
 
   ulong epoch_info_sz = fd_epoch_info_msg_sz( epoch_info_msg->staked_vote_cnt , epoch_info_msg->staked_id_cnt );
 
-  ulong epoch_info_sig = 4UL;
+  ulong epoch_info_sig = FD_EPOCH_OUT_SIG;
   fd_stem_publish( stem, ctx->epoch_out->idx, epoch_info_sig, ctx->epoch_out->chunk, epoch_info_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->epoch_out->chunk = fd_dcache_compact_next( ctx->epoch_out->chunk, epoch_info_sz, ctx->epoch_out->chunk0, ctx->epoch_out->wmark );
 
@@ -1247,17 +1247,11 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
   switch( msg ) {
     case FD_SSMSG_MANIFEST_FULL:
     case FD_SSMSG_MANIFEST_INCREMENTAL: {
-      /* We may either receive a full snapshot manifest or an
-         incremental snapshot manifest.  Note that this external message
-         id is only used temporarily because replay cannot yet receive
-         the firedancer-internal snapshot manifest message. */
+      /* Bank recovery (fd_ssload_recover) is now done by snapin before
+         the manifest is published.  Replay only needs to read the
+         manifest fields it uses directly. */
       if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
         FD_LOG_ERR(( "chunk %lu from in %d corrupt, not in range [%lu,%lu]", chunk, ctx->in_kind[ in_idx ], ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
-
-      fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
-                         ctx->banks,
-                         fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX ),
-                         msg==FD_SSMSG_MANIFEST_INCREMENTAL );
 
       fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
       ctx->hard_forks_cnt = manifest->hard_forks_len;

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -1,5 +1,6 @@
 #include "fd_snapin_tile_private.h"
 #include "utils/fd_ssctrl.h"
+#include "utils/fd_ssload.h"
 #include "utils/fd_ssmsg.h"
 #include "utils/fd_vinyl_io_wd.h"
 
@@ -613,6 +614,24 @@ process_manifest( fd_snapin_tile_t * ctx ) {
 
   manifest->txncache_fork_id = ctx->txncache_root_fork_id.val;
 
+  /* Recover bank state from the manifest.  This must happen before the
+     manifest is published to consumer tiles.  Concurrent access is safe
+     because snapin completes bank recovery before replay begins
+     execution. */
+  if( FD_LIKELY( ctx->banks ) ) {
+    fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+    fd_ssload_recover( manifest, bank );
+
+    /* Set total_epoch_stake from the T-1 epoch_stakes entry, using the
+       epoch-value-based index computed during vote_stakes initialization. */
+    if( ctx->t_1_epoch_idx != ULONG_MAX && ctx->t_1_epoch_idx < 3UL &&
+        ctx->epoch_stakes_vote_cnt[ ctx->t_1_epoch_idx ] > 0UL ) {
+      bank->f.total_epoch_stake = manifest->epoch_stakes[ ctx->t_1_epoch_idx ].total_stake;
+    } else {
+      bank->f.total_epoch_stake = 0UL;
+    }
+  }
+
   if( FD_LIKELY( !ctx->lthash_disabled ) ) {
     if( FD_LIKELY( ctx->use_vinyl ) ) {
       fd_ssctrl_hash_result_t * data = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
@@ -683,17 +702,179 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
       case FD_SSPARSE_ADVANCE_AGAIN:
         break;
       case FD_SSPARSE_ADVANCE_MANIFEST: {
-        int res = fd_ssmanifest_parser_consume( ctx->manifest_parser,
-                                                result->manifest.data,
-                                                result->manifest.data_sz,
-                                                result->manifest.acc_vec_map,
-                                                result->manifest.acc_vec_pool );
-        if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_ERROR ) ) {
-          FD_LOG_WARNING(( "error while parsing snapshot manifest" ));
-          transition_malformed( ctx, stem );
-          return 0;
-        } else if( FD_LIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) {
-          ctx->flags.manifest_done = 1;
+        uchar const * manifest_data    = result->manifest.data;
+        ulong         manifest_data_sz = result->manifest.data_sz;
+
+        /* Loop on consume to drain staged entries between calls.
+           The parser yields (returns AGAIN) when a staged entry is
+           ready for on-the-fly processing, with remaining bytes still
+           unconsumed.  We drain the entry and re-invoke consume with
+           the remaining bytes. */
+        for(;;) {
+          ulong bytes_consumed = 0UL;
+          int res = fd_ssmanifest_parser_consume( ctx->manifest_parser,
+                                                  manifest_data,
+                                                  manifest_data_sz,
+                                                  result->manifest.acc_vec_map,
+                                                  result->manifest.acc_vec_pool,
+                                                  &bytes_consumed );
+          manifest_data    += bytes_consumed;
+          manifest_data_sz -= bytes_consumed;
+
+          if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_ERROR ) ) {
+            FD_LOG_WARNING(( "error while parsing snapshot manifest" ));
+            transition_malformed( ctx, stem );
+            return 0;
+          }
+
+          int drained = 0;
+
+          /* Drain any stake delegation that became ready during parsing.
+             The parser stages one delegation at a time; we insert it into
+             the banks' stake delegation map immediately. */
+          if( FD_UNLIKELY( fd_ssmanifest_parser_delegation_ready( ctx->manifest_parser ) ) ) {
+            drained = 1;
+            if( FD_LIKELY( ctx->banks ) ) {
+              fd_snapshot_manifest_stake_delegation_t const * d =
+                  fd_ssmanifest_parser_delegation_peek( ctx->manifest_parser );
+              if( FD_LIKELY( d->stake_delegation!=0UL ) ) {
+                fd_stake_delegations_t * stake_delegations =
+                    fd_banks_stake_delegations_root_query( ctx->banks );
+                fd_stake_delegations_root_update(
+                    stake_delegations,
+                    (fd_pubkey_t *)d->stake_pubkey,
+                    (fd_pubkey_t *)d->vote_pubkey,
+                    d->stake_delegation,
+                    d->activation_epoch,
+                    d->deactivation_epoch,
+                    d->credits_observed,
+                    FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+              }
+            }
+            fd_ssmanifest_parser_delegation_done( ctx->manifest_parser );
+          }
+
+          /* Drain any vote_stakes entry that became ready during parsing.
+             The parser stages one vote_stakes entry at a time and signals
+             the epoch index it belongs to. */
+          if( FD_UNLIKELY( fd_ssmanifest_parser_vote_stakes_ready( ctx->manifest_parser ) ) ) {
+            drained = 1;
+
+            /* Lazy initialization of epoch stakes state on first entry.
+               Compute epoch index mapping from actual epoch values
+               rather than epoch_stakes_len, which can be stale when
+               both legacy and versioned epoch_stakes sections exist.
+               epoch_stakes_base = max(epoch-1, 0), and
+               t_1_epoch_idx = leader_schedule_epoch - epoch_stakes_base. */
+            if( FD_UNLIKELY( !ctx->epoch_stakes_initialized ) ) {
+              ctx->epoch_stakes_initialized = 1;
+              ulong epoch                 = fd_ssmanifest_parser_epoch( ctx->manifest_parser );
+              ulong leader_schedule_epoch = fd_ssmanifest_parser_leader_schedule_epoch( ctx->manifest_parser );
+              ulong epoch_stakes_base     = epoch > 0UL ? epoch - 1UL : 0UL;
+
+              FD_TEST( leader_schedule_epoch >= epoch_stakes_base );
+              ctx->t_1_epoch_idx = leader_schedule_epoch - epoch_stakes_base;
+              FD_TEST( ctx->t_1_epoch_idx < 3UL );
+              ctx->t_2_epoch_idx = ctx->t_1_epoch_idx > 0UL ? ctx->t_1_epoch_idx - 1UL : ULONG_MAX;
+              ctx->t_3_epoch_idx = (ctx->t_2_epoch_idx != ULONG_MAX && ctx->t_2_epoch_idx > 0UL)
+                                    ? ctx->t_2_epoch_idx - 1UL : ULONG_MAX;
+
+              /* Initialize bank vote_stakes and top_votes structures. */
+              if( FD_LIKELY( ctx->banks ) ) {
+                fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+                fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
+                if( !ctx->full ) fd_vote_stakes_reset( vote_stakes );
+                fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
+                fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
+                fd_top_votes_init( top_votes_t_1 );
+                fd_top_votes_init( top_votes_t_2 );
+                *fd_bank_snapshot_commission_t_3_len( bank ) = 0UL;
+                *fd_bank_epoch_credits_len( bank ) = 0UL;
+              }
+            }
+
+            if( FD_LIKELY( ctx->banks ) ) {
+              fd_snapshot_manifest_vote_stakes_t const * vs =
+                  fd_ssmanifest_parser_vote_stakes_peek( ctx->manifest_parser );
+              ulong vs_epoch_idx = fd_ssmanifest_parser_vote_stakes_epoch_idx( ctx->manifest_parser );
+              if( FD_LIKELY( vs_epoch_idx<3UL ) ) ctx->epoch_stakes_vote_cnt[ vs_epoch_idx ]++;
+
+              fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+
+              if( vs_epoch_idx==ctx->t_1_epoch_idx ) {
+                /* T-1: insert into vote_stakes, top_votes_t_1, epoch_credits */
+                fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
+                fd_vote_stakes_root_insert_key(
+                    vote_stakes,
+                    (fd_pubkey_t *)vs->vote,
+                    (fd_pubkey_t *)vs->identity,
+                    vs->stake,
+                    (uchar)vs->commission,
+                    bank->f.epoch );
+
+                if( !FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) || vs->has_identity_bls ) {
+                  fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
+                  fd_top_votes_insert( top_votes_t_1, (fd_pubkey_t *)vs->vote, (fd_pubkey_t *)vs->identity, vs->stake, (uchar)vs->commission );
+                }
+
+                /* Epoch credits */
+                ulong * epoch_credits_len = fd_bank_epoch_credits_len( bank );
+                if( FD_UNLIKELY( *epoch_credits_len >= ctx->banks->max_vote_accounts ) ) {
+                  FD_LOG_WARNING(( "epoch_credits overflow, max is %lu", ctx->banks->max_vote_accounts ));
+                  transition_malformed( ctx, stem );
+                  return 0;
+                }
+                fd_epoch_credits_t * ec = &fd_bank_epoch_credits( bank )[*epoch_credits_len];
+                fd_memcpy( ec->pubkey, vs->vote, 32UL );
+                ec->cnt          = vs->epoch_credits_history_len;
+                ec->base_credits = ec->cnt > 0UL ? vs->epoch_credits[0].prev_credits : 0UL;
+                for( ulong j=0UL; j<vs->epoch_credits_history_len; j++ ) {
+                  ec->epoch[ j ]              = (ushort)vs->epoch_credits[ j ].epoch;
+                  ec->credits_delta[ j ]      = (uint)( vs->epoch_credits[ j ].credits      - ec->base_credits );
+                  ec->prev_credits_delta[ j ] = (uint)( vs->epoch_credits[ j ].prev_credits - ec->base_credits );
+                }
+                (*epoch_credits_len)++;
+
+              } else if( vs_epoch_idx==ctx->t_2_epoch_idx ) {
+                /* T-2: update meta in vote_stakes, insert top_votes_t_2 */
+                if( !FD_FEATURE_ACTIVE_BANK( bank, validator_admission_ticket ) || vs->has_identity_bls ) {
+                  fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
+                  fd_top_votes_insert( top_votes_t_2, (fd_pubkey_t *)vs->vote, (fd_pubkey_t *)vs->identity, vs->stake, (uchar)vs->commission );
+                }
+                fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
+                fd_vote_stakes_root_update_meta(
+                    vote_stakes,
+                    (fd_pubkey_t *)vs->vote,
+                    (fd_pubkey_t *)vs->identity,
+                    vs->stake,
+                    (uchar)vs->commission,
+                    bank->f.epoch );
+
+              } else if( vs_epoch_idx==ctx->t_3_epoch_idx ) {
+                /* T-3: store commission */
+                ulong * commission_len = fd_bank_snapshot_commission_t_3_len( bank );
+                if( FD_UNLIKELY( *commission_len >= ctx->banks->max_vote_accounts ) ) {
+                  FD_LOG_WARNING(( "snapshot_commission_t_3 overflow, max is %lu", ctx->banks->max_vote_accounts ));
+                  transition_malformed( ctx, stem );
+                  return 0;
+                }
+                fd_stashed_commission_t * snapshot_commission = fd_bank_snapshot_commission_t_3( bank );
+                fd_memcpy( snapshot_commission[*commission_len].pubkey, vs->vote, 32UL );
+                snapshot_commission[*commission_len].commission = (uchar)vs->commission;
+                (*commission_len)++;
+              }
+            }
+            fd_ssmanifest_parser_vote_stakes_done( ctx->manifest_parser );
+          }
+
+          if( FD_LIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) {
+            ctx->flags.manifest_done = 1;
+            break;
+          }
+
+          /* If consume returned AGAIN and no ready entry was drained,
+             all data has been consumed for now. */
+          if( !drained ) break;
         }
         break;
       }
@@ -711,13 +892,21 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
             transition_malformed( ctx, stem );
             return 0;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) ) {
-            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) FD_LOG_ERR(( "blockhash offsets overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) {
+              FD_LOG_WARNING(( "blockhash offsets overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
 
             memcpy( ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].blockhash, sd_result->group.blockhash, 32UL );
             ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].txnhash_offset = sd_result->group.txnhash_offset;
             ctx->blockhash_offsets_len++;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) ) {
-            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) FD_LOG_ERR(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) {
+              FD_LOG_WARNING(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
             ctx->txncache_entries[ ctx->txncache_entries_len++ ] = *sd_result->entry;
           }
 
@@ -851,6 +1040,13 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       fd_memset( &ctx->flags,    0, sizeof(ctx->flags)    );
       fd_memset( &ctx->vinyl_op, 0, sizeof(ctx->vinyl_op) );
 
+      /* Initialize epoch stakes on-the-fly processing state. */
+      ctx->t_1_epoch_idx = ULONG_MAX;
+      ctx->t_2_epoch_idx = ULONG_MAX;
+      ctx->t_3_epoch_idx = ULONG_MAX;
+      ctx->epoch_stakes_initialized = 0;
+      fd_memset( ctx->epoch_stakes_vote_cnt, 0, sizeof(ctx->epoch_stakes_vote_cnt) );
+
       /* Rewind metric counters (no-op unless recovering from a fail) */
       if( sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL ) {
         ctx->metrics.accounts_loaded   = ctx->metrics.full_accounts_loaded   = 0;
@@ -874,6 +1070,15 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
 
         ctx->capitalization     = ctx->recovery.capitalization;
         ctx->dup_capitalization = 0UL;
+
+        /* Reset stake delegations for incremental snapshot reload.
+           The full snapshot populates them from scratch; the incremental
+           needs a clean slate so stale entries are discarded. */
+        if( FD_LIKELY( ctx->banks ) ) {
+          fd_stake_delegations_t * stake_delegations =
+              fd_banks_stake_delegations_root_query( ctx->banks );
+          fd_stake_delegations_reset( stake_delegations );
+        }
       }
 
       /* Save the slot advertised by the snapshot peer and verify it
@@ -916,6 +1121,22 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
         }
 
         ctx->recovery.capitalization = ctx->capitalization;
+      }
+
+      /* Backup bank state for incremental snapshot rollback.  If an
+         incremental snapshot fails after its manifest has been
+         processed, these backups allow restoring the bank to the full
+         snapshot's state. */
+      if( FD_LIKELY( ctx->banks ) ) {
+        fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+        if( FD_LIKELY( bank ) ) {
+          ctx->recovery.bank_f = bank->f;
+          ctx->recovery.txncache_fork_id = bank->txncache_fork_id;
+          fd_memcpy( ctx->recovery.top_votes_t_1, bank->top_votes_t_1_mem, FD_TOP_VOTES_MAX_FOOTPRINT );
+          fd_memcpy( ctx->recovery.top_votes_t_2, bank->top_votes_t_2_mem, FD_TOP_VOTES_MAX_FOOTPRINT );
+          ctx->recovery.epoch_credits_len = *fd_bank_epoch_credits_len( bank );
+          ctx->recovery.snapshot_commission_t_3_len = *fd_bank_snapshot_commission_t_3_len( bank );
+        }
       }
 
       /* Backup metric counters */
@@ -988,6 +1209,28 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       if( !ctx->full ) {
         fd_accdb_cancel( ctx->accdb_admin, ctx->xid );
         fd_funk_txn_xid_copy( ctx->xid, fd_funk_last_publish( ctx->funk ) );
+
+        /* Restore the bank to the full snapshot's state.  Stake
+           delegations and epoch stakes (vote_stakes, top_votes,
+           epoch_credits, commissions) do not need explicit restore:
+           stake delegations are unconditionally reset at the next
+           CTRL_INIT, and epoch stakes structures are re-initialized
+           during manifest parsing.  However, epoch_credits_len and
+           snapshot_commission_t_3_len must be restored since the lazy
+           init only zeroes them on first entry, which won't re-trigger
+           after a CTRL_FAIL + CTRL_INIT_INCR cycle resets
+           epoch_stakes_initialized. */
+        if( FD_LIKELY( ctx->banks ) ) {
+          fd_bank_t * bank = fd_banks_bank_query( ctx->banks, 0UL );
+          if( FD_LIKELY( bank ) ) {
+            bank->f = ctx->recovery.bank_f;
+            bank->txncache_fork_id = ctx->recovery.txncache_fork_id;
+            fd_memcpy( bank->top_votes_t_1_mem, ctx->recovery.top_votes_t_1, FD_TOP_VOTES_MAX_FOOTPRINT );
+            fd_memcpy( bank->top_votes_t_2_mem, ctx->recovery.top_votes_t_2, FD_TOP_VOTES_MAX_FOOTPRINT );
+            *fd_bank_epoch_credits_len( bank ) = ctx->recovery.epoch_credits_len;
+            *fd_bank_snapshot_commission_t_3_len( bank ) = ctx->recovery.snapshot_commission_t_3_len;
+          }
+        }
       }
       break;
     }
@@ -1139,6 +1382,14 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( txncache_shmem );
   ctx->txncache = fd_txncache_join( fd_txncache_new( _txncache, txncache_shmem ) );
   FD_TEST( ctx->txncache );
+
+  ulong banks_obj_id = fd_pod_query_ulong( topo->props, "banks", ULONG_MAX );
+  if( FD_LIKELY( banks_obj_id!=ULONG_MAX ) ) {
+    ctx->banks = fd_banks_join( fd_topo_obj_laddr( topo, banks_obj_id ) );
+    FD_TEST( ctx->banks );
+  } else {
+    ctx->banks = NULL;
+  }
 
   ctx->txncache_entries_len = 0UL;
   ctx->blockhash_offsets_len = 0UL;

--- a/src/discof/restore/fd_snapin_tile_private.h
+++ b/src/discof/restore/fd_snapin_tile_private.h
@@ -12,6 +12,7 @@
 #include "../../flamenco/accdb/fd_accdb_admin.h"
 #include "../../flamenco/accdb/fd_accdb_user.h"
 #include "../../flamenco/runtime/fd_txncache.h"
+#include "../../flamenco/runtime/fd_bank.h"
 #include "../../disco/stem/fd_stem.h"
 #include "../../vinyl/meta/fd_vinyl_meta.h"
 
@@ -55,6 +56,8 @@ struct fd_snapin_tile {
   ulong seed;
   long boot_timestamp;
 
+  fd_banks_t *     banks;
+
   fd_accdb_admin_t accdb_admin[1];
   fd_accdb_user_t  accdb[1];
   fd_funk_t *      funk;
@@ -82,6 +85,16 @@ struct fd_snapin_tile {
   ulong bank_slot;
   ulong epoch;
 
+  /* Epoch stakes index mapping for on-the-fly processing.
+     T-1, T-2, T-3 refer to which epoch's stakes are being processed,
+     mapped to the parser's epoch_idx (0, 1, or 2).  ULONG_MAX means
+     that epoch index is not present. */
+  ulong t_1_epoch_idx;
+  ulong t_2_epoch_idx;
+  ulong t_3_epoch_idx;
+  int   epoch_stakes_initialized;
+  ulong epoch_stakes_vote_cnt[3]; /* count of drained vote_stakes per epoch_idx */
+
   ulong full_genesis_creation_time_seconds;
   uchar advertised_hash[ FD_HASH_FOOTPRINT ];
 
@@ -93,7 +106,19 @@ struct fd_snapin_tile {
 
   struct {
     ulong capitalization;
-  } recovery; /* stores the capitalization value from the last full snapshot */
+
+    /* Backup of bank fields populated at CTRL_NEXT (full snapshot
+       completion) for rollback during incremental snapshot CTRL_FAIL.
+       This ensures the bank state can be properly reverted to the full
+       snapshot's values if an incremental snapshot fails at any point
+       after its manifest has been processed. */
+    fd_bank_fixed_t bank_f;
+    fd_txncache_fork_id_t txncache_fork_id;
+    uchar top_votes_t_1[ FD_TOP_VOTES_MAX_FOOTPRINT ];
+    uchar top_votes_t_2[ FD_TOP_VOTES_MAX_FOOTPRINT ];
+    ulong epoch_credits_len;
+    ulong snapshot_commission_t_3_len;
+  } recovery;
 
   ulong blockhash_offsets_len;
   blockhash_group_t * blockhash_offsets;

--- a/src/discof/restore/fd_snapla_tile.c
+++ b/src/discof/restore/fd_snapla_tile.c
@@ -176,15 +176,40 @@ handle_data_frag( fd_snapla_tile_t *  ctx,
         /* ignore */
         break;
       case FD_SSPARSE_ADVANCE_MANIFEST: {
-        int res = fd_ssmanifest_parser_consume( ctx->manifest_parser,
-          result->manifest.data,
-          result->manifest.data_sz,
-          result->manifest.acc_vec_map,
-          result->manifest.acc_vec_pool );
-        if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_ERROR ) ) {
-          FD_LOG_WARNING(( "error while parsing snapshot manifest" ));
-          transition_malformed( ctx, stem );
-          return 0;
+        uchar const * manifest_data    = result->manifest.data;
+        ulong         manifest_data_sz = result->manifest.data_sz;
+
+        for(;;) {
+          ulong bytes_consumed = 0UL;
+          int res = fd_ssmanifest_parser_consume( ctx->manifest_parser,
+            manifest_data,
+            manifest_data_sz,
+            result->manifest.acc_vec_map,
+            result->manifest.acc_vec_pool,
+            &bytes_consumed );
+          manifest_data    += bytes_consumed;
+          manifest_data_sz -= bytes_consumed;
+
+          if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_ERROR ) ) {
+            FD_LOG_WARNING(( "error while parsing snapshot manifest" ));
+            transition_malformed( ctx, stem );
+            return 0;
+          }
+
+          int drained = 0;
+
+          if( FD_UNLIKELY( fd_ssmanifest_parser_delegation_ready( ctx->manifest_parser ) ) ) {
+            drained = 1;
+            fd_ssmanifest_parser_delegation_done( ctx->manifest_parser );
+          }
+
+          if( FD_UNLIKELY( fd_ssmanifest_parser_vote_stakes_ready( ctx->manifest_parser ) ) ) {
+            drained = 1;
+            fd_ssmanifest_parser_vote_stakes_done( ctx->manifest_parser );
+          }
+
+          if( FD_LIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) break;
+          if( !drained ) break;
         }
         break;
       }

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -2,6 +2,7 @@
 
 #include "../../../disco/genesis/fd_genesis_cluster.h"
 #include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../../flamenco/runtime/fd_bank.h"
 #include "fd_ssmsg.h"
 
 void
@@ -59,9 +60,7 @@ blockhashes_recover( fd_blockhashes_t *                       blockhashes,
 
 void
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
-                   fd_banks_t *             banks,
-                   fd_bank_t *              bank,
-                   int                      is_incremental ) {
+                   fd_bank_t *              bank ) {
   /* Slot */
 
   bank->f.slot = manifest->slot;
@@ -179,132 +178,21 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
     }
   }
 
-  /* Stake delegations for the current epoch. */
-  fd_stake_delegations_t * stake_delegations = fd_banks_stake_delegations_root_query( banks );
-  if( is_incremental ) fd_stake_delegations_reset( stake_delegations );
-  for( ulong i=0UL; i<manifest->stake_delegations_len; i++ ) {
-    fd_snapshot_manifest_stake_delegation_t const * elem = &manifest->stake_delegations[ i ];
-    if( FD_UNLIKELY( elem->stake_delegation==0UL ) ) {
-      continue;
-    }
-    fd_stake_delegations_root_update(
-        stake_delegations,
-        (fd_pubkey_t *)elem->stake_pubkey,
-        (fd_pubkey_t *)elem->vote_pubkey,
-        elem->stake_delegation,
-        elem->activation_epoch,
-        elem->deactivation_epoch,
-        elem->credits_observed,
-        FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025
-    );
-  }
-
+  /* Seed new_votes with zero-stake vote accounts from the manifest.
+     These represent vote accounts that exist but have no delegated
+     stake, which need to be tracked for vote seeding on boot. */
   fd_new_votes_t * new_votes = fd_bank_new_votes( bank );
-  if( is_incremental ) fd_new_votes_reset_root( new_votes );
+  fd_new_votes_reset_root( new_votes );
   for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
     fd_snapshot_manifest_vote_account_t const * elem = &manifest->vote_accounts[ i ];
     if( FD_UNLIKELY( elem->stake==0UL ) ) fd_new_votes_root_insert( new_votes, (fd_pubkey_t *)elem->vote_account_pubkey );
   }
 
-  /* We also want to set the total stake to be the total amount of stake
-     at the end of the previous epoch. This value is used for the
-     get_epoch_stake syscall.
-
-     A note on Agave's indexing scheme for their epoch_stakes
-     structure:
-
-     https://github.com/anza-xyz/agave/blob/v2.2.14/runtime/src/bank.rs#L6175
-
-     If we are loading a snapshot and replaying in the middle of
-     epoch 7, the syscall is supposed to return the total stake at
-     the end of epoch 6.  The epoch_stakes structure is indexed in
-     Agave by the epoch number of the leader schedule that the
-     stakes are meant to determine.  For instance, to get the
-     stakes at the end of epoch 6, we should query by 8, because
-     the leader schedule for epoch 8 is determined based on the
-     stakes at the end of epoch 6.  Therefore, we save the total
-     epoch stake by querying for epoch+1.  This logic is encapsulated
-     in fd_ssmanifest_parser.c. */
-
-  fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
-  if( is_incremental ) fd_vote_stakes_reset( vote_stakes );
-
-  fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
-  fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
-  fd_top_votes_init( top_votes_t_1 );
-  fd_top_votes_init( top_votes_t_2 );
-
-  ulong leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( epoch_schedule, manifest->slot );
-  ulong epoch_stakes_base     = epoch > 0UL ? epoch - 1UL : 0UL;
-
-  FD_TEST( leader_schedule_epoch >= epoch_stakes_base );
-  ulong t_1_idx = leader_schedule_epoch - epoch_stakes_base;
-  FD_TEST( t_1_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
-
-  int   has_t_2 = (t_1_idx > 0UL);
-  ulong t_2_idx = has_t_2 ? t_1_idx - 1UL : 0UL;
-
-  bank->f.total_epoch_stake = manifest->epoch_stakes[t_1_idx].total_stake;
-
-  ulong epoch_credits_len = 0UL;
-
-  /* Populate the vote stakes for the end of the T-1 epoch if the
-     snapshot is in epoch T. */
-  for( ulong i=0UL; i<manifest->epoch_stakes[t_1_idx].vote_stakes_len; i++ ) {
-    fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[t_1_idx].vote_stakes[i];
-    fd_vote_stakes_root_insert_key(
-        vote_stakes,
-        (fd_pubkey_t *)elem->vote,
-        (fd_pubkey_t *)elem->identity,
-        elem->stake,
-        (uchar)elem->commission,
-        bank->f.epoch );
-
-    fd_top_votes_insert( top_votes_t_1, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, (uchar)elem->commission );
-
-    fd_epoch_credits_t * ec = &fd_bank_epoch_credits( bank )[epoch_credits_len];
-    fd_memcpy( ec->pubkey, elem->vote, 32UL );
-    ec->cnt          = elem->epoch_credits_history_len;
-    ec->base_credits = ec->cnt > 0UL ? elem->epoch_credits[0].prev_credits : 0UL;
-    for( ulong j=0UL; j<elem->epoch_credits_history_len; j++ ) {
-      ec->epoch[ j ]              = (ushort)elem->epoch_credits[ j ].epoch;
-      ec->credits_delta[ j ]      = (uint)( elem->epoch_credits[ j ].credits      - ec->base_credits );
-      ec->prev_credits_delta[ j ] = (uint)( elem->epoch_credits[ j ].prev_credits - ec->base_credits );
-    }
-    epoch_credits_len++;
-  }
-  *fd_bank_epoch_credits_len( bank ) = epoch_credits_len;
-
-  /* Populate the vote stakes for the end of the T-2 epoch if the
-     snapshot is in epoch T. */
-  if( has_t_2 ) {
-    for( ulong i=0UL; i<manifest->epoch_stakes[t_2_idx].vote_stakes_len; i++ ) {
-      fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[t_2_idx].vote_stakes[i];
-
-      fd_top_votes_insert( top_votes_t_2, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, (uchar)elem->commission );
-      fd_vote_stakes_root_update_meta(
-          vote_stakes,
-          (fd_pubkey_t *)elem->vote,
-          (fd_pubkey_t *)elem->identity,
-          elem->stake,
-          (uchar)elem->commission,
-          bank->f.epoch );
-    }
-  }
-
-  /* Store commissions in the banks for the end of the T-3 epoch if the
-     snapshot is in epoch T. */
-  if( manifest->epoch_stakes[0].vote_stakes_len > 0UL ) {
-    *fd_bank_snapshot_commission_t_3_len( bank ) = manifest->epoch_stakes[0].vote_stakes_len;
-    fd_stashed_commission_t * snapshot_commission = fd_bank_snapshot_commission_t_3( bank );
-    for( ulong i=0UL; i<manifest->epoch_stakes[0].vote_stakes_len; i++ ) {
-      fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[0].vote_stakes[i];
-      fd_memcpy( snapshot_commission[i].pubkey, elem->vote, 32UL );
-      snapshot_commission[i].commission = (uchar)elem->commission;
-    }
-  } else {
-    *fd_bank_snapshot_commission_t_3_len( bank ) = 0UL;
-  }
+  /* Stake delegations and epoch stakes (vote_stakes, top_votes,
+     epoch_credits, commissions) are processed on-the-fly by the
+     snapin tile during manifest parsing.  See the polling interfaces
+     in fd_ssmanifest_parser.h.  total_epoch_stake is set by the
+     snapin tile after all epoch stakes entries have been drained. */
 
   bank->txncache_fork_id = (fd_txncache_fork_id_t){ .val = manifest->txncache_fork_id };
 }

--- a/src/discof/restore/utils/fd_ssload.h
+++ b/src/discof/restore/utils/fd_ssload.h
@@ -14,9 +14,7 @@ blockhashes_recover( fd_blockhashes_t *                       blockhashes,
 
 void
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
-                   fd_banks_t *             banks,
-                   fd_bank_t *              bank,
-                   int                      is_incremental );
+                   fd_bank_t *              bank );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -402,6 +402,25 @@ struct fd_ssmanifest_parser_private {
 
   ulong   account_data_start;
 
+  /* Staging for vote_account epoch_credits_history_len (field removed
+     from struct but parser needs it to compute EPOCH_CREDITS size). */
+  ulong   va_epoch_credits_history_len;
+
+  /* Staging for stake delegation entries processed on-the-fly.
+     After each complete delegation entry is parsed, delegation_ready
+     is set to 1.  The consumer (snapin) checks this flag after each
+     fd_ssmanifest_parser_consume() call and drains the entry. */
+  fd_snapshot_manifest_stake_delegation_t staging_delegation;
+  int    delegation_ready;
+
+  /* Staging for epoch stakes vote_stakes entries processed on-the-fly.
+     After each complete vote_stakes entry is parsed, vote_stakes_ready
+     is set to 1.  vote_stakes_epoch_idx identifies which epoch_stakes
+     array index (0, 1, or 2) the entry belongs to. */
+  fd_snapshot_manifest_vote_stakes_t staging_vote_stakes;
+  int    vote_stakes_ready;
+  ulong  vote_stakes_epoch_idx;
+
   ulong acc_vec_slot;
   ulong acc_vec_id;
   ulong acc_vec_file_sz;
@@ -504,7 +523,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                          return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return 24UL*parser->va_epoch_credits_history_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                                return 32UL        ;
@@ -518,7 +537,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                          return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                               return 9UL+48UL*32UL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return 24UL*parser->va_epoch_credits_history_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                            return 32UL        ;
@@ -532,7 +551,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                      return 40UL*length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                           return 9UL+48UL*32UL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return 24UL*parser->va_epoch_credits_history_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                             return 32UL        ;
@@ -546,7 +565,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                        return 1UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                               return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return 8UL         ;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return 24UL*parser->manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return 24UL*parser->va_epoch_credits_history_len;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return 8UL         ;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                         return parser->length2-(parser->off-parser->account_data_start);
@@ -594,7 +613,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                    return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return 32UL        ;
@@ -608,7 +627,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                    return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                         return 9UL+48UL*32UL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return 32UL        ;
@@ -622,7 +641,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                return 40UL*length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                     return 9UL+48UL*32UL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return 32UL        ;
@@ -636,7 +655,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                  return 1UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                         return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return 8UL         ;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return 8UL         ;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                   return parser->length3-(parser->off-parser->account_data_start);
@@ -716,7 +735,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                   return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return 32UL        ;
@@ -730,7 +749,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                   return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                        return 9UL+48UL*32UL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return 32UL        ;
@@ -744,7 +763,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:               return 40UL*length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                    return 9UL+48UL*32UL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return 32UL        ;
@@ -758,7 +777,7 @@ state_size( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                 return 1UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                        return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return 8UL         ;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : length4 );;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return 24UL*(parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : length4);;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return 8UL         ;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                  return parser->length3-(parser->off-parser->account_data_start);
@@ -795,7 +814,6 @@ state_size( fd_ssmanifest_parser_t * parser ) {
 static inline uchar *
 state_dst( fd_ssmanifest_parser_t * parser ) {
   ulong idx1 = parser->idx1;
-  ulong idx2 = parser->idx2;
   fd_snapshot_manifest_t * manifest = parser->manifest;
 
   switch( parser->state ) {
@@ -872,7 +890,7 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:                                return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:                                    return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                           return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                           return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:                               return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:                               return &parser->option;
@@ -883,13 +901,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                                   return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                          return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&parser->va_epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                              return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                        return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                                return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:                                      return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                                 return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                                 return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                                               return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                                           return &parser->option;
@@ -897,13 +915,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:                                   return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                          return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                               return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                       return (uchar*)&parser->va_epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                              return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                        return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                            return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:                                  return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                             return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                             return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                                           return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                                       return &parser->option;
@@ -911,35 +929,35 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:                               return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                      return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                           return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                                   return (uchar*)&parser->va_epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                          return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                                    return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                               return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                             return (uchar*)&manifest->vote_accounts[ idx1 ].node_account_pubkey;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                                        return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:                                  return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                                            return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:                                   return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                              return (uchar*)&manifest->vote_accounts[ idx1 ].commission;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                              return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                                            return (uchar*)&parser->length3;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                                                   return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                        return &parser->option;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                               return NULL;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return (uchar*)&manifest->vote_accounts[ idx1 ].epoch_credits_history_len;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return (uchar*)manifest->vote_accounts[ idx1 ].epoch_credits;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return (uchar*)&manifest->vote_accounts[ idx1 ].last_slot;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return (uchar*)&manifest->vote_accounts[ idx1 ].last_timestamp;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                                    return (uchar*)&parser->va_epoch_credits_history_len;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                           return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                                     return NULL;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                                return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                         return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                                              return NULL;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                                         return (uchar*)&parser->option;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                                                         return NULL;
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH:                                                               return (uchar*)&manifest->stake_delegations_len;
-    case STATE_STAKES_STAKE_DELEGATIONS_KEY:                                                                  return (uchar*)&manifest->stake_delegations[ idx1 ].stake_pubkey;
-    case STATE_STAKES_STAKE_DELEGATIONS_VOTER_PUBKEY:                                                         return (uchar*)&manifest->stake_delegations[ idx1 ].vote_pubkey;
-    case STATE_STAKES_STAKE_DELEGATIONS_STAKE:                                                                return (uchar*)&manifest->stake_delegations[ idx1 ].stake_delegation;
-    case STATE_STAKES_STAKE_DELEGATIONS_ACTIVATION_EPOCH:                                                     return (uchar*)&manifest->stake_delegations[ idx1 ].activation_epoch;
-    case STATE_STAKES_STAKE_DELEGATIONS_DEACTIVATION_EPOCH:                                                   return (uchar*)&manifest->stake_delegations[ idx1 ].deactivation_epoch;
-    case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                                                 return (uchar*)&manifest->stake_delegations[ idx1 ].warmup_cooldown_rate;
+    case STATE_STAKES_STAKE_DELEGATIONS_KEY:                                                                  return (uchar*)&parser->staging_delegation.stake_pubkey;
+    case STATE_STAKES_STAKE_DELEGATIONS_VOTER_PUBKEY:                                                         return (uchar*)&parser->staging_delegation.vote_pubkey;
+    case STATE_STAKES_STAKE_DELEGATIONS_STAKE:                                                                return (uchar*)&parser->staging_delegation.stake_delegation;
+    case STATE_STAKES_STAKE_DELEGATIONS_ACTIVATION_EPOCH:                                                     return (uchar*)&parser->staging_delegation.activation_epoch;
+    case STATE_STAKES_STAKE_DELEGATIONS_DEACTIVATION_EPOCH:                                                   return (uchar*)&parser->staging_delegation.deactivation_epoch;
+    case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                                                 return (uchar*)&parser->staging_delegation.warmup_cooldown_rate;
     case STATE_STAKES_UNUSED:                                                                                 return NULL;
     case STATE_STAKES_EPOCH:                                                                                  return NULL;
     case STATE_STAKES_STAKE_HISTORY_LENGTH:                                                                   return (uchar*)&parser->length1;
@@ -952,34 +970,34 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_UNUSED_ACCOUNTS3_UNUSED:                                                                       return NULL;
     case STATE_EPOCH_STAKES_LENGTH:                                                                           return (uchar*)&parser->epoch_stakes_len;
     case STATE_EPOCH_STAKES_KEY:                                                                              return (uchar*)&parser->epoch_stakes_epoch;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                                                             return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : (uchar*)&parser->length2;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_KEY:                                                                return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].vote : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_STAKE:                                                              return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].stake : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                                                             return (uchar*)&parser->length2;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_KEY:                                                                return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.vote : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_STAKE:                                                              return parser->epoch_idx!=ULONG_MAX ? (uchar*)&parser->staging_vote_stakes.stake : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_LAMPORTS:                                                     return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                                                  return (uchar*)&parser->length3;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_VARIANT:                                                 return (uchar*)&parser->variant;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:                          return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:                              return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:                         return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:                         return &parser->option;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:                                return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity_bls : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES_LENGTH:                                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES:                                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION:                                     return &parser->option;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:                             return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                                    return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                                  return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:                             return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                                          return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:                                return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                           return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                                           return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                                     return &parser->option;
@@ -987,13 +1005,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:                             return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                                    return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                                         return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                                  return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:                             return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                                      return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:                            return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                                     return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                                 return &parser->option;
@@ -1001,24 +1019,24 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:                         return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:                                return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                                     return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:                             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:                              return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:                         return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                                       return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                                  return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:                            return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                                      return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:                             return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                                        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                                      return (uchar*)&parser->length4;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                                             return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                                  return &parser->option;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                                         return NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:                              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                                     return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:                               return NULL;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:                          return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                                   return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                                        return NULL;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                                   return NULL;
@@ -1074,34 +1092,34 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_LENGTH:                                                                 return (uchar*)&parser->epoch_stakes_len;
     case STATE_VERSIONED_EPOCH_STAKES_EPOCH:                                                                  return (uchar*)&parser->epoch_stakes_epoch;
     case STATE_VERSIONED_EPOCH_STAKES_VARIANT:                                                                return (uchar*)&parser->variant;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:                                            return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : (uchar*)&parser->length2;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_KEY:                                               return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].vote : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_STAKE:                                             return parser->epoch_idx!=ULONG_MAX ? (uchar*)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].stake : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:                                            return (uchar*)&parser->length2;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_KEY:                                               return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.vote : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_STAKE:                                             return parser->epoch_idx!=ULONG_MAX ? (uchar*)&parser->staging_vote_stakes.stake : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_LAMPORTS:                                    return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                                 return (uchar*)&parser->length3;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_VARIANT:                                return (uchar*)&parser->variant;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_WITHDRAWER:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COLLECTOR:         return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COLLECTOR:             return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS:    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLOCK_REVENUE_COMMISSION_BPS:        return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_PENDING_DELEGATOR_REWARDS:           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION:        return &parser->option;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:               return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity_bls : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES_LENGTH:                        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_VOTES:                               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION:                    return &parser->option;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT:                           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS_LENGTH:            return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_AUTHORIZED_VOTERS:                   return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_SLOT:                 return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_LAST_TIMESTAMP_TIMESTAMP:            return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_NODE_PUBKEY:                         return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_WITHDRAWER:               return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                          return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION:                          return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES_LENGTH:                        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_VOTES:                               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION:                    return &parser->option;
@@ -1109,13 +1127,13 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:            return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS:                   return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_PRIOR_VOTERS:                        return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:                return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_SLOT:                 return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_LAST_TIMESTAMP_TIMESTAMP:            return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_NODE_PUBKEY:                     return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_WITHDRAWER:           return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                      return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION:                      return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES_LENGTH:                    return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_VOTES:                           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION:                return &parser->option;
@@ -1123,24 +1141,24 @@ state_dst( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:        return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS:               return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_PRIOR_VOTERS:                    return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].identity : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:            return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS:                   return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:             return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:        return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_NODE_PUBKEY:                      return parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.identity : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER:                 return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_VOTER_EPOCH:           return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_PRIOR_VOTERS:                     return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_AUTHORIZED_WITHDRAWER:            return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].commission : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION:                       return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.commission : NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES_LENGTH:                     return (uchar*)&parser->length4;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_VOTES:                            return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION:                 return &parser->option;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT:                        return NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits_history_len : (uchar*)&parser->length4;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].epoch_credits : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].slot : NULL;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return parser->epoch_idx!=ULONG_MAX ? (uchar *)&manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ idx2 ].timestamp : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH:             return parser->epoch_idx!=ULONG_MAX ? (uchar *)&parser->staging_vote_stakes.epoch_credits_history_len : (uchar*)&parser->length4;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS:                    return parser->epoch_idx!=ULONG_MAX ? (uchar *)parser->staging_vote_stakes.epoch_credits : NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_SLOT:              return NULL;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_LAST_TIMESTAMP_TIMESTAMP:         return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_DUMMY:                                  return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_OWNER:                                       return NULL;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_EXECUTABLE:                                  return NULL;
@@ -1215,9 +1233,9 @@ state_log( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                           FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH:                           %lu", parser->length2 ));                                             break;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:      FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_AUTHORIZED_VOTERS_LENGTH:      %lu", parser->length3 ));                                             break;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:  FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_AUTHORIZED_VOTERS_LENGTH:  %lu", parser->length3 ));                                             break;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:      FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:      %lu", manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len )); break;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:       FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:       %lu", manifest->vote_accounts[ parser->idx1 ].last_slot ));           break;
-    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:  FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:  %ld", manifest->vote_accounts[ parser->idx1 ].last_timestamp ));      break;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:      FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:      %lu", parser->va_epoch_credits_history_len )); break;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:       FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_SLOT:       (discarded)" )); break;
+    case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:  FD_LOG_NOTICE(( "STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_LAST_TIMESTAMP_TIMESTAMP:  (discarded)" )); break;
     default: break;
   }
 }
@@ -1394,15 +1412,15 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH: {
-      if( FD_UNLIKELY( manifest->stake_delegations_len>sizeof(manifest->stake_delegations)/sizeof(manifest->stake_delegations[0]) ) ) {
+      if( FD_UNLIKELY( manifest->stake_delegations_len>FD_RUNTIME_MAX_STAKE_ACCOUNTS ) ) {
         FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu", manifest->stake_delegations_len ));
         return -1;
       }
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE: {
-      if( FD_UNLIKELY( manifest->stake_delegations[ parser->idx1 ].warmup_cooldown_rate>1.0 ) ) {
-        FD_LOG_WARNING(( "invalid stakes_stake_delegations warmup cooldown rate %f", manifest->stake_delegations[ parser->idx1 ].warmup_cooldown_rate ));
+      if( FD_UNLIKELY( parser->staging_delegation.warmup_cooldown_rate>1.0 ) ) {
+        FD_LOG_WARNING(( "invalid stakes_stake_delegations warmup cooldown rate %f", parser->staging_delegation.warmup_cooldown_rate ));
         return -1;
       }
       break;
@@ -1411,8 +1429,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
-      if( FD_UNLIKELY( manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len>64UL ) ) {
-        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu", manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len ));
+      if( FD_UNLIKELY( parser->va_epoch_credits_history_len>64UL ) ) {
+        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu", parser->va_epoch_credits_history_len ));
         return -1;
       }
       break;
@@ -1477,9 +1495,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     }
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH: {
-      ulong stakes_len = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2;
-      ulong stakes_cap = sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes)/sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes[ 0UL ]);
-      if( FD_UNLIKELY( stakes_len>stakes_cap ) ) {
+      ulong stakes_len = parser->length2;
+      if( FD_UNLIKELY( stakes_len>FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ) ) {
         FD_LOG_WARNING(( "invalid versioned epoch stakes vote accounts length %lu", stakes_len ));
         return -1;
       }
@@ -1515,7 +1532,7 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
-      ulong length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : parser->length4;
+      ulong length = parser->epoch_idx!=ULONG_MAX ? parser->staging_vote_stakes.epoch_credits_history_len : parser->length4;
       if( FD_UNLIKELY( length>64UL ) ) {
         FD_LOG_WARNING(( "invalid version_epoch_stakes.vote_accounts value data current epoch credits length %lu", length ));
         return -1;
@@ -1651,23 +1668,15 @@ state_process( fd_ssmanifest_parser_t * parser,
 
   /* Vote state v4 commission is stored in bps, and needs to be
      converted to a percentage for commission calculations. */
-  if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->vote_accounts[ parser->idx1 ].commission /= 100;
-  }
   if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX && parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission /= 100;
+    parser->staging_vote_stakes.commission /= 100;
   }
   if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX && parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_INFLATION_REWARDS_COMMISSION_BPS ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission /= 100;
+    parser->staging_vote_stakes.commission /= 100;
   }
 
   /* Older vote states only populate bottom 8 bytes of the commission
      field, upper bytes should be cleared */
-  if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
-                || parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
-                || parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION) ) {
-    parser->manifest->vote_accounts[ parser->idx1 ].commission &= 0xFF;
-  }
   if( FD_UNLIKELY( parser->epoch_idx!=ULONG_MAX &&
       (  parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
       || parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
@@ -1675,7 +1684,7 @@ state_process( fd_ssmanifest_parser_t * parser,
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_COMMISSION
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_COMMISSION
       || parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_COMMISSION ) ) ) {
-    parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].commission &= 0xFF;
+    parser->staging_vote_stakes.commission &= 0xFF;
   }
 
   if( FD_UNLIKELY( parser->state==STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH ) ) parser->account_data_start = parser->off;
@@ -1710,14 +1719,11 @@ state_process( fd_ssmanifest_parser_t * parser,
 
 
   if( FD_UNLIKELY( parser->state==STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_OWNER && parser->epoch_idx!=ULONG_MAX ) ) {
-    /* We're only interested in vote accounts with stakes>0 that have
-       valid epoch credits.  If these conditions are not met, we
-       decrement the counters so that we store all vote/stakes in a
-       compact array. */
-    fd_snapshot_manifest_vote_stakes_t * vote_stakes = &parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ];
-    if( vote_stakes->stake==0UL && vote_stakes->epoch_credits_history_len==0UL ) {
-      parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len--;
-      parser->idx2--;
+    /* Signal that a complete vote_stakes entry has been parsed.
+       Skip entries with zero stake and no epoch credits history. */
+    if( parser->staging_vote_stakes.stake!=0UL || parser->staging_vote_stakes.epoch_credits_history_len!=0UL ) {
+      parser->vote_stakes_ready     = 1;
+      parser->vote_stakes_epoch_idx = parser->epoch_idx;
     }
   }
 
@@ -1750,13 +1756,11 @@ state_process( fd_ssmanifest_parser_t * parser,
   if( FD_UNLIKELY( parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_LENGTH ) ) parser->account_data_start = parser->off;
 
   if( FD_UNLIKELY( parser->state==STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_OWNER && parser->epoch_idx!=ULONG_MAX ) ) {
-    /* We're only interested in vote accounts with stakes>0. When
-       stakes==0 and there is no epoch credit history, we decrement the
-       counters so that we store all vote/stakes in a compact array. */
-    fd_snapshot_manifest_vote_stakes_t * vote_stakes = &parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ];
-    if( vote_stakes->stake==0UL && vote_stakes->epoch_credits_history_len==0UL ) {
-      parser->manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len--;
-      parser->idx2--;
+    /* Signal that a complete vote_stakes entry has been parsed.
+       Skip entries with zero stake and no epoch credits history. */
+    if( parser->staging_vote_stakes.stake!=0UL || parser->staging_vote_stakes.epoch_credits_history_len!=0UL ) {
+      parser->vote_stakes_ready     = 1;
+      parser->vote_stakes_epoch_idx = parser->epoch_idx;
     }
   }
 
@@ -1784,13 +1788,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_LTHASH_OPTION:             manifest->has_accounts_lthash    = !!parser->option; parser->state += 2-!!parser->option; return 0;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) parser->staging_vote_stakes.has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
 
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_BLS_PUBKEY_COMPRESSED_OPTION: if( parser->epoch_idx!=ULONG_MAX ) parser->staging_vote_stakes.has_identity_bls = !!parser->option; parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V4_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_ROOT_SLOT_OPTION: parser->state += 2-!!parser->option; return 0;
@@ -1808,13 +1812,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_STAKES_VOTE_ACCOUNTS_LENGTH:                            length = manifest->vote_accounts_len; idx = &parser->idx1; next_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH;                        break;
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH:                        length = manifest->stake_delegations_len;        idx = &parser->idx1; next_target = STATE_STAKES_UNUSED;                                          break;
     case STATE_EPOCH_STAKES_LENGTH:                                    length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_IS_DELTA;                                               break;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                      length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  break;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:                      length = parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  break;
     case STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH:                  length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_UNUSED;                                    break;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH:           length = parser->length2;             idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;            break;
     case STATE_ACCOUNTS_DB_STORAGES_LENGTH:                            length = parser->length1;             idx = &parser->idx1; next_target = STATE_ACCOUNTS_DB_VERSION;                                    break;
     case STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_LENGTH:               length = parser->length2;             idx = &parser->idx2; next_target = STATE_ACCOUNTS_DB_STORAGES_DUMMY;                             break;
     case STATE_VERSIONED_EPOCH_STAKES_LENGTH:                          length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_LTHASH_OPTION;                                          break;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:     length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; break;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH:     length = parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; break;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_UNUSED;                   break;
     case STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;  break;
     default: break;
@@ -1835,13 +1839,13 @@ state_process( fd_ssmanifest_parser_t * parser,
     case STATE_HARD_FORKS_VAL:                                                   length = manifest->hard_forks_len;        idx = &parser->idx1; next_target = STATE_TRANSACTION_COUNT;                                      iter_target = STATE_HARD_FORKS_LENGTH+1UL;                                      break;
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                            length = manifest->vote_accounts_len;     idx = &parser->idx1; next_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH;                        iter_target = STATE_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                            break;
     case STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:                    length = manifest->stake_delegations_len; idx = &parser->idx1; next_target = STATE_STAKES_UNUSED;                                          iter_target = STATE_STAKES_STAKE_DELEGATIONS_LENGTH+1UL;                        break;
-    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                      length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  iter_target = STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                      break;
+    case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:                      length = parser->length2; idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH;                  iter_target = STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;                      break;
     case STATE_EPOCH_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE:              length = parser->length2;                 idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_UNUSED;                                    iter_target = STATE_EPOCH_STAKES_STAKE_DELEGATIONS_LENGTH+1UL;                  break;
     case STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_TOTAL_STAKE:                length = parser->length2;                 idx = &parser->idx2; next_target = STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;            iter_target = STATE_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH+1UL;           break;
     case STATE_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS:                             length = parser->epoch_stakes_len;        idx = &parser->idx1; next_target = STATE_IS_DELTA;                                               iter_target = STATE_EPOCH_STAKES_LENGTH+1UL;                                    break;
     case STATE_ACCOUNTS_DB_STORAGES_DUMMY:                                       length = parser->length1;                 idx = &parser->idx1; next_target = STATE_ACCOUNTS_DB_VERSION;                                    iter_target = STATE_ACCOUNTS_DB_STORAGES_LENGTH+1UL;                            break;
     case STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_FILE_SZ:                        length = parser->length2;                 idx = &parser->idx2; next_target = STATE_ACCOUNTS_DB_STORAGES_DUMMY;                             iter_target = STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_LENGTH+1UL;               break;
-    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:     length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;     break;
+    case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_RENT_EPOCH:     length = parser->length2; idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH; iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH+1UL;     break;
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_CREDITS_OBSERVED: length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_UNUSED;                   iter_target = STATE_VERSIONED_EPOCH_STAKES_STAKES_STAKE_DELEGATIONS_LENGTH+1UL; break;
     case STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_TOTAL_STAKE:      length = parser->length2;             idx = &parser->idx2; next_target = STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS_LENGTH;  iter_target = STATE_VERSIONED_EPOCH_STAKES_NODE_ID_TO_VOTE_ACCOUNTS_LENGTH+1UL; break;
     case STATE_VERSIONED_EPOCH_STAKES_EPOCH_AUTHORIZED_VOTERS:                   length = parser->epoch_stakes_len;    idx = &parser->idx1; next_target = STATE_LTHASH_OPTION;                                          iter_target = STATE_VERSIONED_EPOCH_STAKES_LENGTH+1UL;                          break;
@@ -1849,6 +1853,11 @@ state_process( fd_ssmanifest_parser_t * parser,
   }
 
   if( FD_UNLIKELY( iter_target!=INT_MAX ) ) {
+    /* Signal that a complete stake delegation entry has been parsed
+       and is ready for on-the-fly processing by the consumer. */
+    if( FD_UNLIKELY( parser->state==STATE_STAKES_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE ) ) {
+      parser->delegation_ready = 1;
+    }
     *idx += 1UL;
     if( FD_LIKELY( *idx<length ) ) parser->state = iter_target;
     else                           parser->state = next_target;
@@ -1909,6 +1918,11 @@ fd_ssmanifest_parser_init( fd_ssmanifest_parser_t * parser,
     manifest->epoch_stakes[i].total_stake     = 0UL;
     manifest->epoch_stakes[i].vote_stakes_len = 0UL;
   }
+  parser->delegation_ready = 0;
+  fd_memset( &parser->staging_delegation, 0, sizeof(parser->staging_delegation) );
+  parser->vote_stakes_ready = 0;
+  parser->vote_stakes_epoch_idx = ULONG_MAX;
+  fd_memset( &parser->staging_vote_stakes, 0, sizeof(parser->staging_vote_stakes) );
 
   FD_SCRATCH_ALLOC_INIT( l, parser );
                          FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_ssmanifest_parser_t), sizeof(fd_ssmanifest_parser_t)                 );
@@ -1919,7 +1933,9 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
                               uchar const *            buf,
                               ulong                    bufsz,
                               acc_vec_map_t *          acc_vec_map,
-                              acc_vec_t *              acc_vec_pool ) {
+                              acc_vec_t *              acc_vec_pool,
+                              ulong *                  opt_bytes_consumed ) {
+  uchar const * buf0 = buf;
 #if SSMANIFEST_DEBUG
   int state = parser->state;
 #endif
@@ -1951,10 +1967,12 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
 #endif
       if( FD_UNLIKELY( -1==state_validate( parser ) ) ) {
         FD_LOG_WARNING(("state_validate failed"));
+        if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
         return FD_SSMANIFEST_PARSER_ADVANCE_ERROR;
       }
       if( FD_UNLIKELY( -1==state_process( parser, acc_vec_map, acc_vec_pool ) ) ) {
         FD_LOG_WARNING(("state_process failed"));
+        if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
         return FD_SSMANIFEST_PARSER_ADVANCE_ERROR;
       }
       parser->dst     = state_dst( parser );
@@ -1963,14 +1981,77 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
     }
 
     if( FD_UNLIKELY( parser->state==STATE_DONE ) ) break;
-    if( FD_UNLIKELY( !bufsz ) ) return FD_SSMANIFEST_PARSER_ADVANCE_AGAIN;
+
+    /* Yield back to the caller when a staged entry is ready for
+       on-the-fly processing.  This ensures the caller can drain the
+       entry before the parser overwrites staging with the next entry.
+       The caller must re-invoke consume with the remaining bytes. */
+    if( FD_UNLIKELY( parser->delegation_ready || parser->vote_stakes_ready ) ) {
+      if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
+      return FD_SSMANIFEST_PARSER_ADVANCE_AGAIN;
+    }
+
+    if( FD_UNLIKELY( !bufsz ) ) {
+      if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
+      return FD_SSMANIFEST_PARSER_ADVANCE_AGAIN;
+    }
   }
 
   if( FD_UNLIKELY( bufsz ) ) {
     FD_LOG_WARNING(( "excess data in buffer" ));
+    if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
     return FD_SSMANIFEST_PARSER_ADVANCE_ERROR;
   }
 
+  if( opt_bytes_consumed ) *opt_bytes_consumed = (ulong)(buf - buf0);
+  if( FD_UNLIKELY( parser->state!=STATE_DONE ) ) return FD_SSMANIFEST_PARSER_ADVANCE_AGAIN;
   return FD_SSMANIFEST_PARSER_ADVANCE_DONE;
+}
+
+int
+fd_ssmanifest_parser_delegation_ready( fd_ssmanifest_parser_t const * parser ) {
+  return parser->delegation_ready;
+}
+
+fd_snapshot_manifest_stake_delegation_t const *
+fd_ssmanifest_parser_delegation_peek( fd_ssmanifest_parser_t const * parser ) {
+  return &parser->staging_delegation;
+}
+
+void
+fd_ssmanifest_parser_delegation_done( fd_ssmanifest_parser_t * parser ) {
+  parser->delegation_ready = 0;
+  fd_memset( &parser->staging_delegation, 0, sizeof(parser->staging_delegation) );
+}
+
+int
+fd_ssmanifest_parser_vote_stakes_ready( fd_ssmanifest_parser_t const * parser ) {
+  return parser->vote_stakes_ready;
+}
+
+fd_snapshot_manifest_vote_stakes_t const *
+fd_ssmanifest_parser_vote_stakes_peek( fd_ssmanifest_parser_t const * parser ) {
+  return &parser->staging_vote_stakes;
+}
+
+ulong
+fd_ssmanifest_parser_vote_stakes_epoch_idx( fd_ssmanifest_parser_t const * parser ) {
+  return parser->vote_stakes_epoch_idx;
+}
+
+void
+fd_ssmanifest_parser_vote_stakes_done( fd_ssmanifest_parser_t * parser ) {
+  parser->vote_stakes_ready = 0;
+  fd_memset( &parser->staging_vote_stakes, 0, sizeof(parser->staging_vote_stakes) );
+}
+
+ulong
+fd_ssmanifest_parser_epoch( fd_ssmanifest_parser_t const * parser ) {
+  return parser->epoch;
+}
+
+ulong
+fd_ssmanifest_parser_leader_schedule_epoch( fd_ssmanifest_parser_t const * parser ) {
+  return parser->leader_schedule_epoch;
 }
 

--- a/src/discof/restore/utils/fd_ssmanifest_parser.h
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.h
@@ -33,7 +33,57 @@ fd_ssmanifest_parser_consume( fd_ssmanifest_parser_t * parser,
                               uchar const *            buf,
                               ulong                    bufsz,
                               acc_vec_map_t *          acc_vec_map,
-                              acc_vec_t *              acc_vec_pool );
+                              acc_vec_t *              acc_vec_pool,
+                              ulong *                  opt_bytes_consumed );
+
+/* On-the-fly stake delegation polling interface.  After each
+   fd_ssmanifest_parser_consume() call, the consumer checks
+   fd_ssmanifest_parser_delegation_ready().  If it returns non-zero,
+   a complete stake delegation entry is available in staging and should
+   be drained.  The consumer must call
+   fd_ssmanifest_parser_delegation_done() after processing. */
+
+int
+fd_ssmanifest_parser_delegation_ready( fd_ssmanifest_parser_t const * parser );
+
+fd_snapshot_manifest_stake_delegation_t const *
+fd_ssmanifest_parser_delegation_peek( fd_ssmanifest_parser_t const * parser );
+
+void
+fd_ssmanifest_parser_delegation_done( fd_ssmanifest_parser_t * parser );
+
+/* On-the-fly epoch stakes vote_stakes polling interface.  After each
+   fd_ssmanifest_parser_consume() call, the consumer checks
+   fd_ssmanifest_parser_vote_stakes_ready().  If it returns non-zero,
+   a complete vote_stakes entry is available in staging and should
+   be drained.  epoch_idx identifies which epoch_stakes array index
+   (0, 1, or 2) the entry belongs to.  The consumer must call
+   fd_ssmanifest_parser_vote_stakes_done() after processing. */
+
+int
+fd_ssmanifest_parser_vote_stakes_ready( fd_ssmanifest_parser_t const * parser );
+
+fd_snapshot_manifest_vote_stakes_t const *
+fd_ssmanifest_parser_vote_stakes_peek( fd_ssmanifest_parser_t const * parser );
+
+ulong
+fd_ssmanifest_parser_vote_stakes_epoch_idx( fd_ssmanifest_parser_t const * parser );
+
+void
+fd_ssmanifest_parser_vote_stakes_done( fd_ssmanifest_parser_t * parser );
+
+/* Returns the epoch derived from the snapshot slot and epoch schedule.
+   Available after state_validate has run (i.e. before any vote_stakes
+   entry is signalled). */
+
+ulong
+fd_ssmanifest_parser_epoch( fd_ssmanifest_parser_t const * parser );
+
+/* Returns the leader schedule epoch derived from the snapshot slot and
+   epoch schedule.  Available after state_validate has run. */
+
+ulong
+fd_ssmanifest_parser_leader_schedule_epoch( fd_ssmanifest_parser_t const * parser );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/fd_ssmsg.h
+++ b/src/discof/restore/utils/fd_ssmsg.h
@@ -9,6 +9,9 @@
 #define FD_SSMSG_DONE                 (2) /* Indicates the snapshot is fully loaded and tiles are shutting down */
 #define FD_SSMSG_EXPECTED_SLOT        (3) /* Expected rooted slot from incremental snapshot */
 
+/* Maximum number of vote accounts in snapshot manifest arrays. */
+#define FD_SNAPSHOT_MAX_VOTE_ACCOUNTS FD_RUNTIME_MAX_VOTE_ACCOUNTS
+
 FD_FN_CONST static inline ulong
 fd_ssmsg_sig( ulong message ) {
   return (message & 0x3UL);
@@ -49,24 +52,6 @@ struct fd_snapshot_manifest_vote_account {
   uchar node_account_pubkey[ 32UL ];
 
   ulong stake;
-  ulong last_slot;
-  long  last_timestamp;
-
-  /* The percent of inflation rewards earned by the validator and
-     deposited into the validator's vote account, from 0 to 100%.
-     The remaning percentage of inflation rewards is distributed to
-     all delegated stake accounts by stake weight. */
-  ushort commission;
-
-  /* The epoch credits array tracks the history of how many credits the
-     provided vote account earned in each of the past epochs.  The
-     entry at epoch_credits[0] is for the current epoch,
-     epoch_credits[1] is for the previous epoch, and so on.  In cases of
-     booting a new chain from genesis, or for new vote accounts the
-     epoch credits history may be short.  The maximum number of entries
-     in the epoch credits history is 64. */
-  ulong epoch_credits_history_len;
-  epoch_credits_t epoch_credits[ FD_EPOCH_CREDITS_MAX ];
 };
 
 typedef struct fd_snapshot_manifest_vote_account fd_snapshot_manifest_vote_account_t;
@@ -106,25 +91,11 @@ struct fd_snapshot_manifest_vote_stakes {
   /* The validator identity pubkey, aka node pubkey */
   uchar identity[ 32UL ];
 
-  /* The commission account for inflation rewards (vote, before SIMD-0232) */
-  uchar commission_inflation[ 32UL ];
-
-  /* The commission account for block revenue (identity, before SIMD-0232) */
-  uchar commission_block[ 32UL ];
-
   /* Whether this vote account has a BLS pubkey set */
   uchar has_identity_bls;
 
-  /* The validator BLS pubkey (used after SIMD-0326: Alpenglow) */
-  uchar identity_bls[ 48UL ];
-
   /* The total amount of active stake for the vote account */
   ulong stake;
-
-  /* The latest slot and timestmap that the vote account voted on in
-     the given epoch. */
-  ulong slot;
-  long  timestamp;
 
   /* The validator's commission rate as of the given epoch. */
   ushort commission;
@@ -150,10 +121,10 @@ struct fd_snapshot_manifest_epoch_stakes {
   /* The total amount of active stake at the end of the given epoch.*/
   ulong                              total_stake;
 
-  /* The vote accounts and their stakes for a given epoch.
-     FIXME: Snapshot manifest has to support a much larger bound. */
+  /* The number of vote_stakes entries for this epoch.  The actual
+     entries are processed on-the-fly during parsing and are not stored
+     in this struct. */
   ulong                              vote_stakes_len;
-  fd_snapshot_manifest_vote_stakes_t vote_stakes[ 40200UL ];
 };
 
 typedef struct fd_snapshot_manifest_epoch_stakes fd_snapshot_manifest_epoch_stakes_t;
@@ -461,11 +432,12 @@ struct fd_snapshot_manifest {
      uptime, which is measured by vote account vote credits.
      FIXME: Make this unbounded or support a much larger bound. */
   ulong                               vote_accounts_len;
-  fd_snapshot_manifest_vote_account_t vote_accounts[ 40200UL ];
+  fd_snapshot_manifest_vote_account_t vote_accounts[ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
 
-  /* FIXME: Make this unbounded or support a much larger bound. */
+  /* Stake delegations are processed on-the-fly by the snapin tile
+     during parsing (via the parser's staging_delegation + polling
+     interface).  Only the count is stored here for reference. */
   ulong stake_delegations_len;
-  fd_snapshot_manifest_stake_delegation_t stake_delegations[ 3000000UL ];
 
   /* Epoch stakes represent the exact amount staked to each vote
      account at the beginning of a previous epoch.  They are primarily

--- a/src/discof/restore/utils/fuzz_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fuzz_ssmanifest_parser.c
@@ -36,6 +36,6 @@ int
 LLVMFuzzerTestOneInput( uchar const * data_,
                         ulong         size ) {
   fd_ssmanifest_parser_init( parser, output_mem );
-  fd_ssmanifest_parser_consume( parser, data_, size, NULL, NULL );
+  fd_ssmanifest_parser_consume( parser, data_, size, NULL, NULL, NULL );
   return 0;
 }

--- a/src/discof/restore/utils/test_ssmanifest_parser.c
+++ b/src/discof/restore/utils/test_ssmanifest_parser.c
@@ -61,7 +61,7 @@ main( int     argc,
 
   long ts = -fd_log_wallclock();
 
-  int result = fd_ssmanifest_parser_consume( parser, buffer, size, NULL, NULL );
+  int result = fd_ssmanifest_parser_consume( parser, buffer, size, NULL, NULL, NULL );
   if( FD_UNLIKELY( result ) ) FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed (%d)", result ));
 
   long elapsed = fd_log_wallclock() + ts;

--- a/src/discof/shredcap/fd_shredcap_tile.c
+++ b/src/discof/shredcap/fd_shredcap_tile.c
@@ -13,6 +13,7 @@
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../discof/restore/utils/fd_ssmanifest_parser.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../flamenco/leaders/fd_leaders_base.h"
 #include "../../disco/fd_disco.h"
 #include "../../util/pod/fd_pod_format.h"
 
@@ -73,6 +74,17 @@ struct out_link {
 };
 typedef struct out_link out_link_t;
 
+/* Slim vote_stakes entry holding only the fields needed for epoch
+   info messages (vote pubkey, identity pubkey, and stake amount).
+   This avoids storing the full fd_snapshot_manifest_vote_stakes_t
+   which contains large epoch_credits arrays. */
+struct fd_snapshot_vote_stakes_slim {
+  uchar vote    [ 32UL ];
+  uchar identity[ 32UL ];
+  ulong stake;
+};
+typedef struct fd_snapshot_vote_stakes_slim fd_snapshot_vote_stakes_slim_t;
+
 struct fd_capture_tile_ctx {
   uchar               in_kind[ 32 ];
   fd_capture_in_ctx_t in_links[ 32 ];
@@ -128,6 +140,17 @@ struct fd_capture_tile_ctx {
 
   fd_alloc_t * alloc;
   uchar contact_info_buffer[ MAX_BUFFER_SIZE ];
+
+  /* Slim vote_stakes buffers for epoch info message publishing.
+     vote_stakes_slim[0] holds entries for epoch_idx 1 (epoch E,
+     used for the current epoch's leader schedule).
+     vote_stakes_slim[1] holds entries for epoch_idx 2 (epoch E+1,
+     used for the next epoch's leader schedule).
+     Populated during manifest parsing via the parser's polling
+     interface.  Entries with zero stake are filtered during
+     accumulation. */
+  fd_snapshot_vote_stakes_slim_t vote_stakes_slim[2][ FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ];
+  ulong                         vote_stakes_slim_len[2];
 };
 typedef struct fd_capture_tile_ctx fd_capture_tile_ctx_t;
 
@@ -249,10 +272,11 @@ verify_epoch_stakes( fd_snapshot_manifest_t const * manifest ) {
 }
 
 static inline ulong
-generate_epoch_info_msg_manifest( ulong                                       epoch,
-                                  fd_epoch_schedule_t const *                 epoch_schedule,
-                                  fd_snapshot_manifest_epoch_stakes_t const * epoch_stakes,
-                                  ulong *                                     epoch_info_msg_out ) {
+generate_epoch_info_msg_slim( ulong                                    epoch,
+                              fd_epoch_schedule_t const *              epoch_schedule,
+                              fd_snapshot_vote_stakes_slim_t const *   entries,
+                              ulong                                    entries_len,
+                              ulong *                                  epoch_info_msg_out ) {
   fd_epoch_info_msg_t *    epoch_info_msg = (fd_epoch_info_msg_t *)fd_type_pun( epoch_info_msg_out );
   fd_vote_stake_weight_t * stake_weights  = fd_epoch_info_msg_stake_weights( epoch_info_msg );
 
@@ -264,21 +288,19 @@ generate_epoch_info_msg_manifest( ulong                                       ep
   /* Set all features as deactivated as we don't have available feature info from manifest. */
   fd_memset( &epoch_info_msg->features, 0xFF, sizeof(fd_features_t) );
 
-  /* Filter zero-stake entries (match replay: wsample and leader schedule reject zero weight). */
   ulong idx = 0UL;
-  for( ulong i=0UL; i<epoch_stakes->vote_stakes_len; i++ ) {
-    ulong stake = epoch_stakes->vote_stakes[ i ].stake;
+  for( ulong i=0UL; i<entries_len; i++ ) {
+    ulong stake = entries[ i ].stake;
     if( FD_UNLIKELY( !stake ) ) continue;
     stake_weights[ idx ].stake = stake;
-    memcpy( stake_weights[ idx ].id_key.uc, epoch_stakes->vote_stakes[ i ].identity, sizeof(fd_pubkey_t) );
-    memcpy( stake_weights[ idx ].vote_key.uc, epoch_stakes->vote_stakes[ i ].vote, sizeof(fd_pubkey_t) );
+    memcpy( stake_weights[ idx ].id_key.uc,   entries[ i ].identity, sizeof(fd_pubkey_t) );
+    memcpy( stake_weights[ idx ].vote_key.uc, entries[ i ].vote,     sizeof(fd_pubkey_t) );
     idx++;
   }
   epoch_info_msg->staked_vote_cnt = idx;
   sort_vote_weights_by_stake_vote_inplace( stake_weights, idx );
 
   fd_stake_weight_t * id_weights = fd_epoch_info_msg_id_weights( epoch_info_msg );
-
   epoch_info_msg->staked_id_cnt = compute_id_weights_from_vote_weights( id_weights, stake_weights, epoch_info_msg->staked_vote_cnt );
 
   FD_TEST( idx<=MAX_SHRED_DESTS );
@@ -290,36 +312,28 @@ generate_epoch_info_msg_manifest( ulong                                       ep
 
 static void
 publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
-                                fd_stem_context_t *    stem,
+                                fd_stem_context_t *     stem,
                                 fd_snapshot_manifest_t const * manifest ) {
   fd_epoch_schedule_t const * schedule = fd_type_pun_const( &manifest->epoch_schedule_params );
   ulong epoch = fd_slot_to_epoch( schedule, manifest->slot, NULL );
 
-  ulong epoch_stakes_base = epoch > 0UL ? epoch - 1UL : 0UL;
-  ulong leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( schedule, manifest->slot );
-  ulong cur_idx = epoch - epoch_stakes_base;
-  FD_TEST( cur_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
-
   /* current epoch */
   ulong * stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
-  ulong stake_weights_sz = generate_epoch_info_msg_manifest( epoch, schedule, &manifest->epoch_stakes[cur_idx], stake_weights_msg );
-  ulong stake_weights_sig = 4UL;
-  fd_stem_publish( stem, 0UL, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
+  ulong stake_weights_sz = generate_epoch_info_msg_slim( epoch, schedule,
+      ctx->vote_stakes_slim[0], ctx->vote_stakes_slim_len[0], stake_weights_msg );
+  ulong stake_weights_sig = FD_EPOCH_OUT_SIG;
+  fd_stem_publish( stem, ctx->stake_out->idx, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->stake_out->chunk = fd_dcache_compact_next( ctx->stake_out->chunk, stake_weights_sz, ctx->stake_out->chunk0, ctx->stake_out->wmark );
-  FD_LOG_NOTICE(("sending current epoch stake weights - epoch: %lu, stake_weight_cnt: %lu, start_slot: %lu, slot_cnt: %lu", stake_weights_msg[0], stake_weights_msg[1], stake_weights_msg[2], stake_weights_msg[3]));
+  FD_LOG_NOTICE(("sending current epoch stake weights - epoch: %lu, stake_weight_cnt: %lu, start_slot: %lu, slot_cnt: %lu", stake_weights_msg[0], stake_weights_msg[1], stake_weights_msg[3], stake_weights_msg[4]));
 
   /* next epoch */
-  if( leader_schedule_epoch >= epoch + 1UL ) {
-    ulong next_idx = epoch + 1UL - epoch_stakes_base;
-    FD_TEST( next_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
-
-    stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
-    stake_weights_sz = generate_epoch_info_msg_manifest( epoch + 1, schedule, &manifest->epoch_stakes[next_idx], stake_weights_msg );
-    stake_weights_sig = 4UL;
-    fd_stem_publish( stem, 0UL, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
-    ctx->stake_out->chunk = fd_dcache_compact_next( ctx->stake_out->chunk, stake_weights_sz, ctx->stake_out->chunk0, ctx->stake_out->wmark );
-    FD_LOG_NOTICE(("sending next epoch stake weights - epoch: %lu, stake_weight_cnt: %lu, start_slot: %lu, slot_cnt: %lu", stake_weights_msg[0], stake_weights_msg[1], stake_weights_msg[2], stake_weights_msg[3]));
-  }
+  stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
+  stake_weights_sz = generate_epoch_info_msg_slim( epoch + 1, schedule,
+      ctx->vote_stakes_slim[1], ctx->vote_stakes_slim_len[1], stake_weights_msg );
+  stake_weights_sig = FD_EPOCH_OUT_SIG;
+  fd_stem_publish( stem, ctx->stake_out->idx, stake_weights_sig, ctx->stake_out->chunk, stake_weights_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
+  ctx->stake_out->chunk = fd_dcache_compact_next( ctx->stake_out->chunk, stake_weights_sz, ctx->stake_out->chunk0, ctx->stake_out->wmark );
+  FD_LOG_NOTICE(("sending next epoch stake weights - epoch: %lu, stake_weight_cnt: %lu, start_slot: %lu, slot_cnt: %lu", stake_weights_msg[0], stake_weights_msg[1], stake_weights_msg[3], stake_weights_msg[4]));
 }
 
 static inline int
@@ -512,13 +526,60 @@ after_credit( fd_capture_tile_ctx_t * ctx,
         ulong   buf_sz = 0;
         FD_TEST( !fd_io_read( fd, buf/*dst*/, 0/*dst_min*/, manifest_load_footprint()-1UL /*dst_max*/, &buf_sz ) );
 
-        fd_ssmanifest_parser_t * parser = fd_ssmanifest_parser_join( fd_ssmanifest_parser_new( aligned_alloc(
-                fd_ssmanifest_parser_align(), fd_ssmanifest_parser_footprint() ) ) );
+        void * parser_mem = aligned_alloc( fd_ssmanifest_parser_align(), fd_ssmanifest_parser_footprint() );
+        fd_ssmanifest_parser_t * parser = fd_ssmanifest_parser_join( fd_ssmanifest_parser_new( parser_mem ) );
         FD_TEST( parser );
         fd_ssmanifest_parser_init( parser, manifest );
-        int parser_err = fd_ssmanifest_parser_consume( parser, buf, buf_sz, NULL, NULL );
-        FD_TEST( parser_err==1 );
-        // if( FD_UNLIKELY( parser_err ) ) FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed (%d)", parser_err ));
+
+        /* Parse the manifest, draining vote_stakes entries on-the-fly
+           into slim buffers for later epoch info message publishing. */
+        ctx->vote_stakes_slim_len[0] = 0UL;
+        ctx->vote_stakes_slim_len[1] = 0UL;
+
+        uchar const * parse_buf = buf;
+        ulong         parse_rem = buf_sz;
+        for(;;) {
+          ulong bytes_consumed = 0UL;
+          int res = fd_ssmanifest_parser_consume( parser, parse_buf, parse_rem, NULL, NULL, &bytes_consumed );
+          parse_buf += bytes_consumed;
+          parse_rem -= bytes_consumed;
+
+          /* Drain any ready delegation (shredcap doesn't use delegations
+             but must drain them to unblock the parser). */
+          if( FD_UNLIKELY( fd_ssmanifest_parser_delegation_ready( parser ) ) ) {
+            fd_ssmanifest_parser_delegation_done( parser );
+          }
+
+          /* Drain any ready vote_stakes entry into slim buffers */
+          if( fd_ssmanifest_parser_vote_stakes_ready( parser ) ) {
+            fd_snapshot_manifest_vote_stakes_t const * vs = fd_ssmanifest_parser_vote_stakes_peek( parser );
+            ulong eidx = fd_ssmanifest_parser_vote_stakes_epoch_idx( parser );
+
+            /* Buffer entries for epoch_idx 1 and 2 only.  epoch_idx 1
+               (epoch E) provides the current epoch's leader schedule,
+               epoch_idx 2 (epoch E+1) provides the next epoch's.
+               epoch_idx 0 (epoch E-1) is not needed. */
+            if( eidx>=1UL && eidx<=2UL && vs->stake!=0UL ) {
+              ulong * len = &ctx->vote_stakes_slim_len[ eidx-1UL ];
+              if( *len < FD_SNAPSHOT_MAX_VOTE_ACCOUNTS ) {
+                fd_snapshot_vote_stakes_slim_t * dst = &ctx->vote_stakes_slim[ eidx-1UL ][ *len ];
+                fd_memcpy( dst->vote,     vs->vote,     32UL );
+                fd_memcpy( dst->identity, vs->identity,  32UL );
+                dst->stake = vs->stake;
+                (*len)++;
+              } else {
+                FD_LOG_WARNING(( "vote_stakes_slim[%lu] overflow, dropping entry", eidx-1UL ));
+              }
+            }
+            fd_ssmanifest_parser_vote_stakes_done( parser );
+          }
+
+          if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) break;
+          if( FD_UNLIKELY( res==FD_SSMANIFEST_PARSER_ADVANCE_ERROR ) ) {
+            FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed" ));
+          }
+        }
+        free( parser_mem );
       } FD_SPAD_FRAME_END;
       FD_LOG_NOTICE(( "manifest bank slot %lu", manifest->slot ));
 

--- a/src/flamenco/leaders/fd_leaders_base.h
+++ b/src/flamenco/leaders/fd_leaders_base.h
@@ -94,6 +94,7 @@ typedef struct fd_epoch_info_msg_t fd_epoch_info_msg_t;
 #define FD_EPOCH_INFO_MSG_HEADER_SZ (sizeof(fd_epoch_info_msg_t))
 #define FD_EPOCH_INFO_MAX_MSG_SZ    (FD_EPOCH_INFO_MSG_HEADER_SZ + MAX_COMPRESSED_STAKE_WEIGHTS * sizeof(fd_vote_stake_weight_t) + MAX_SHRED_DESTS * sizeof(fd_stake_weight_t))
 #define FD_EPOCH_OUT_MTU            FD_EPOCH_INFO_MAX_MSG_SZ
+#define FD_EPOCH_OUT_SIG            (4UL)
 
 static inline ulong fd_epoch_info_msg_sz( ulong vote_cnt,
                                           ulong id_weight_cnt ) {

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -235,6 +235,60 @@ typedef struct fd_bank_cost_tracker fd_bank_cost_tracker_t;
 #define FD_BANK_STATE_FROZEN     (3UL)
 #define FD_BANK_STATE_DEAD       (4UL)
 
+/* fd_bank_fixed_t contains the "simple" (non-CoW, non-locked) fields
+   of a bank that are laid out contiguously and can be copied as a unit
+   (e.g. for backup/restore during snapshot rollback). */
+
+struct fd_bank_fixed {
+  fd_lthash_value_t      lthash;
+  fd_blockhashes_t       block_hash_queue;
+  fd_fee_rate_governor_t fee_rate_governor;
+  ulong                  rbh_lamports_per_sig;
+  ulong                  slot;
+  ulong                  parent_slot;
+  ulong                  capitalization;
+  ulong                  transaction_count;
+  ulong                  parent_signature_cnt;
+  ulong                  tick_height;
+  ulong                  max_tick_height;
+  ulong                  hashes_per_tick;
+  fd_w_u128_t            ns_per_slot;
+  ulong                  ticks_per_slot;
+  ulong                  genesis_creation_time;
+  double                 slots_per_year;
+  fd_inflation_t         inflation;
+  ulong                  cluster_type;
+  ulong                  total_epoch_stake; /* total staked to active vote accounts */
+  ulong                  total_effective_stake; /* effective stake from stake delegations */
+  ulong                  total_activating_stake;
+  ulong                  total_deactivating_stake;
+  ulong                  warmup_cooldown_rate_epoch; /* epoch when reduce_stake_warmup_cooldown */
+  ulong                  block_height;
+  ulong                  execution_fees;
+  ulong                  priority_fees;
+  ulong                  tips;
+  ulong                  signature_count;
+  fd_hash_t              poh;
+  ulong                  last_restart_slot;
+  fd_hash_t              bank_hash;
+  fd_hash_t              prev_bank_hash;
+  fd_hash_t              genesis_hash;
+  fd_epoch_schedule_t    epoch_schedule;
+  fd_rent_t              rent;
+  fd_sysvar_cache_t      sysvar_cache;
+  fd_features_t          features;
+  ulong                  txn_count;
+  ulong                  nonvote_txn_count;
+  ulong                  failed_txn_count;
+  ulong                  nonvote_failed_txn_count;
+  ulong                  total_compute_units_used;
+  ulong                  slots_per_epoch;
+  ulong                  shred_cnt;
+  ulong                  epoch;
+  ulong                  identity_vote_idx;
+};
+typedef struct fd_bank_fixed fd_bank_fixed_t;
+
 /* As mentioned above, the overall layout of the bank struct:
    - Fields used for internal pool/bank management
    - Non-Cow fields
@@ -283,54 +337,7 @@ struct fd_bank {
      tiles. */
   fd_rwlock_t lthash_lock;
 
-  struct {
-    fd_lthash_value_t      lthash;
-    fd_blockhashes_t       block_hash_queue;
-    fd_fee_rate_governor_t fee_rate_governor;
-    ulong                  rbh_lamports_per_sig;
-    ulong                  slot;
-    ulong                  parent_slot;
-    ulong                  capitalization;
-    ulong                  transaction_count;
-    ulong                  parent_signature_cnt;
-    ulong                  tick_height;
-    ulong                  max_tick_height;
-    ulong                  hashes_per_tick;
-    fd_w_u128_t            ns_per_slot;
-    ulong                  ticks_per_slot;
-    ulong                  genesis_creation_time;
-    double                 slots_per_year;
-    fd_inflation_t         inflation;
-    ulong                  cluster_type;
-    ulong                  total_epoch_stake; /* total staked to active vote accounts */
-    ulong                  total_effective_stake; /* effective stake from stake delegations */
-    ulong                  total_activating_stake;
-    ulong                  total_deactivating_stake;
-    ulong                  warmup_cooldown_rate_epoch; /* epoch when reduce_stake_warmup_cooldown */
-    ulong                  block_height;
-    ulong                  execution_fees;
-    ulong                  priority_fees;
-    ulong                  tips;
-    ulong                  signature_count;
-    fd_hash_t              poh;
-    ulong                  last_restart_slot;
-    fd_hash_t              bank_hash;
-    fd_hash_t              prev_bank_hash;
-    fd_hash_t              genesis_hash;
-    fd_epoch_schedule_t    epoch_schedule;
-    fd_rent_t              rent;
-    fd_sysvar_cache_t      sysvar_cache;
-    fd_features_t          features;
-    ulong                  txn_count;
-    ulong                  nonvote_txn_count;
-    ulong                  failed_txn_count;
-    ulong                  nonvote_failed_txn_count;
-    ulong                  total_compute_units_used;
-    ulong                  slots_per_epoch;
-    ulong                  shred_cnt;
-    ulong                  epoch;
-    ulong                  identity_vote_idx;
-  } f;
+  fd_bank_fixed_t f;
 
   uchar top_votes_t_1_mem[FD_TOP_VOTES_MAX_FOOTPRINT] __attribute__((aligned(FD_TOP_VOTES_ALIGN)));
   uchar top_votes_t_2_mem[FD_TOP_VOTES_MAX_FOOTPRINT] __attribute__((aligned(FD_TOP_VOTES_ALIGN)));


### PR DESCRIPTION
This PR decouples the size of `fd_snapshot_manifest_t` from the max amount of `vote_stakes` and `stake_delegations`, and streamlines `vote_accounts` to just 72B (the array of `vote_accounts` is still required in `fd_snapshot_manifest_t` by downstream consumers).
To make this possible
- former `fd_ssload_recover()` is relocated from `replay` to `snapin`.
- `snapin` now needs to process the manifest data `on-the-fly`,
- while still being able to recover from manifest / snapshot load failures,
- including recovering the bank.

Closes https://github.com/firedancer-io/firedancer/issues/8682.

Supersedes https://github.com/firedancer-io/firedancer/pull/9224.

Update: It no longer addresses points 20, 21 and 22 in https://github.com/firedancer-io/firedancer/issues/9176 (those issues have been handled separately).
