### PR TITLE
execle: remove OOB/UB in hash_transactions

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -169,8 +169,14 @@ hash_transactions( void *       mem,
       fd_bmtree_commit_append( bmtree, node, 1UL );
     }
   }
-  uchar * root = fd_bmtree_commit_fini( bmtree );
-  fd_memcpy( mixin, root, 32UL );
+  if( FD_LIKELY( fd_bmtree_commit_leaf_cnt( bmtree ) ) ) {
+    uchar * root = fd_bmtree_commit_fini( bmtree );
+    fd_memcpy( mixin, root, 32UL );
+  } else {
+    fd_memset( mixin, 0, 32UL );
+    /* Poison so we can detect if this is ever accessed upstream, even though it should never be. */
+    fd_msan_poison( mixin, 32UL );
+  }
 }
 
 static inline void

--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -174,7 +174,7 @@ hash_transactions( void *       mem,
     fd_memcpy( mixin, root, 32UL );
   } else {
     fd_memset( mixin, 0, 32UL );
-    /* Poison so we can detect if this is ever accessed upstream, even though it should never be. */
+    /* If FD_HAS_MSAN, poison so we can detect if this is ever accessed upstream, even though it should never be.  In production, this is a no-op. */
     fd_msan_poison( mixin, 32UL );
   }
 }

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -157,8 +157,14 @@ hash_transactions( void *       mem,
       fd_bmtree_commit_append( bmtree, node, 1UL );
     }
   }
-  uchar * root = fd_bmtree_commit_fini( bmtree );
-  fd_memcpy( mixin, root, 32UL );
+  if( FD_LIKELY( fd_bmtree_commit_leaf_cnt( bmtree ) ) ) {
+    uchar * root = fd_bmtree_commit_fini( bmtree );
+    fd_memcpy( mixin, root, 32UL );
+  } else {
+    fd_memset( mixin, 0, 32UL );
+    /* Poison so we can detect if this is ever accessed upstream, even though it should never be. */
+    fd_msan_poison( mixin, 32UL );
+  }
 }
 
 static inline void


### PR DESCRIPTION
fd_bmtree_commit_fini requires that at least one leaf has been added, but if all TXN don't succeed, no leaf will be added.

fd_bmtree_commit_fini would then compute
`fd_bmtree_node_t * root = node_buf + (fd_bmtree_depth( leaf_cnt ) - 1UL);` which effectively accesses node_buf OOB, because depth is 0. Then we'd read some garbage values as hash.

This is no problem in practice as downstream would never look at the computed hash if no TXN succeeded, but this might unnecessarily trip ASAN/UBSAN-enabled test validators.

Fixes https://github.com/firedancer-io/auditor-internal/issues/479