### PR TITLE
pack, poh/pohh: microblocks as a rebatable resource

### DIFF
--- a/contrib/tango.lua
+++ b/contrib/tango.lua
@@ -540,13 +540,13 @@ end
 -- Define a new protocol
 local fd_done_packing = Proto("fd_done_packing_t", "FD Pack to PoH Done Packing Message")
 
-local f_microblocks_in_slot = ProtoField.uint64("fd_done_packing_t.microblocks_in_slot", "Microblocks in slot")
+local f_max_pack_idx = ProtoField.uint32("fd_done_packing_t.max_pack_idx", "Max pack idx")
 
-fd_done_packing.fields = { f_microblocks_in_slot }
+fd_done_packing.fields = { f_max_pack_idx }
 
 function fd_done_packing.dissector(buffer, pinfo, tree)
   local subtree = tree:add(fd_done_packing, buffer(), "fd_done_packing_t")
-  subtree:add_le(f_microblocks_in_slot, buffer(0, 8))
+  subtree:add_le(f_max_pack_idx, buffer(0, 4))
 end
 
 

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -3100,7 +3100,7 @@ fd_gui_unbecame_leader( fd_gui_t *                gui,
   if( FD_UNLIKELY( !slot ) ) slot = fd_gui_clear_slot( gui, _slot, ULONG_MAX );
   fd_gui_leader_slot_t * lslot = fd_gui_get_leader_slot( gui, _slot );
   if( FD_LIKELY( !lslot ) ) return;
-  lslot->txs.microblocks_upper_bound = (uint)done_packing->microblocks_in_slot;
+  lslot->txs.microblocks_upper_bound = (uint)done_packing->max_pack_idx;
   fd_memcpy( lslot->scheduler_stats, done_packing, sizeof(fd_done_packing_t) );
 
   /* fd_gui_handle_slot_end may have already been called in response to

--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -2706,18 +2706,7 @@ fd_pack_rebate_cus( fd_pack_t              * pack,
   pack->data_bytes_consumed    -= rebate->data_bytes_rebate;
   pack->alloc_consumed         -= rebate->alloc_rebate;
   pack->cumulative_rebated_cus += rebate->total_cost_rebate;
-  /* For now, we want to ignore the microblock count rebate.  There are
-     3 places the microblock count is kept (here, in the pack tile, and
-     in the PoH tile), and they all need to count microblocks that end
-     up being empty in the same way.  It would be better from a
-     DoS-resistance perspective for them all not to count empty
-     microblocks towards the total, but there's a race condition:
-     suppose pack schedules a microblock containing one transaction that
-     doesn't land on chain, the slot ends, and then pack informs PoH of
-     the number of microblocks before the final rebate comes through.
-     This isn't unsolvable, but it's pretty gross, so it's probably
-     better to just not apply the rebate for now. */
-  (void)rebate->microblock_cnt_rebate;
+  pack->microblock_cnt         -= rebate->microblock_cnt_rebate;
 
   fd_pack_addr_use_t * writer_costs = pack->writer_costs;
   for( ulong i=0UL; i<rebate->writer_cnt; i++ ) {

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -151,10 +151,9 @@ typedef struct {
 
   fd_became_leader_t _became_leader[1];
 
-  /* The number of microblocks we have packed for the current leader
-     slot.  Will always be <= slot_max_microblocks.  We must track
-     this so that when we are done we can tell the PoH tile how many
-     microblocks to expect in the slot. */
+  /* The net number of microblocks packed for the current leader slot
+     (incremented on schedule, decremented on microblock rebate).
+     Used for the dynamic microblock cap and end-of-slot detection. */
   ulong slot_microblock_cnt;
 
   /* Counter which increments when we've finished packing for a slot */
@@ -414,7 +413,7 @@ log_end_block_metrics( fd_pack_ctx_t * ctx,
 
 static inline void
 get_done_packing( fd_pack_ctx_t * ctx, fd_done_packing_t * done_packing, int reason ) {
-    done_packing->microblocks_in_slot = ctx->slot_microblock_cnt;
+    done_packing->max_pack_idx = ctx->pack_idx;
     done_packing->end_slot_reason = reason;
     fd_pack_get_block_limits( ctx->pack, done_packing->limits_usage, done_packing->limits );
 
@@ -843,7 +842,7 @@ after_credit( fd_pack_ctx_t *     ctx,
       fd_microblock_execle_trailer_t * trailer = (fd_microblock_execle_trailer_t*)(microblock_dst+schedule_cnt);
       trailer->bank = ctx->leader_bank;
       trailer->bank_idx = ctx->leader_bank_idx;
-      trailer->microblock_idx = ctx->slot_microblock_cnt;
+      trailer->microblock_idx = ctx->pack_idx;
       trailer->pack_idx = ctx->pack_idx;
       trailer->pack_txn_idx = ctx->pack_txn_cnt;
       trailer->is_bundle = !!(microblock_dst->txnp->flags & FD_TXN_P_FLAGS_BUNDLE);
@@ -1202,6 +1201,7 @@ after_frag( fd_pack_ctx_t *     ctx,
     /* For a previous slot */
     if( FD_UNLIKELY( sig!=ctx->leader_slot ) ) return;
 
+    ctx->slot_microblock_cnt -= ctx->rebate->rebate->microblock_cnt_rebate;
     fd_pack_rebate_cus( ctx->pack, ctx->rebate->rebate );
     ctx->pending_rebate_sz = 0UL;
     fd_pack_pacing_update_consumed_cus( ctx->pacer, fd_pack_current_block_cost( ctx->pack ), now );

--- a/src/disco/tiles.h
+++ b/src/disco/tiles.h
@@ -136,7 +136,7 @@ typedef struct fd_microblock_trailer fd_microblock_trailer_t;
 #define FD_PACK_END_SLOT_REASON_LEADER_SWITCH (3)
 
 struct fd_done_packing {
-  ulong microblocks_in_slot;
+  uint max_pack_idx;
 
   fd_pack_limits_usage_t limits_usage[ 1 ];
   fd_pack_limits_t limits[ 1 ];

--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -211,7 +211,7 @@ fd_poh_reset( fd_poh_t *          poh,
      than being constrained.  If we are leader after the reset, this
      is OK because we won't tick until we get a bank, and the lower
      bound will be reset with the value from the bank. */
-  poh->microblocks_lower_bound = poh->max_microblocks_per_slot;
+  poh->microblocks_mixed_in = poh->max_microblocks_per_slot;
 
   if( FD_UNLIKELY( poh->state!=STATE_FOLLOWER ) ) transition_to_follower( poh, stem, 0 );
   if( FD_UNLIKELY( poh->slot==poh->next_leader_slot ) ) poh->state = STATE_WAITING_FOR_BANK;
@@ -240,7 +240,7 @@ fd_poh_begin_leader( fd_poh_t * poh,
   if( FD_LIKELY( poh->state==STATE_FOLLOWER ) ) poh->state = STATE_WAITING_FOR_SLOT;
   else                                          poh->state = STATE_LEADER;
 
-  poh->microblocks_lower_bound = 0UL;
+  poh->microblocks_mixed_in = 0UL;
 
   FD_LOG_INFO(( "begin_leader(slot=%lu, last_slot=%lu, last_hashcnt=%lu)", slot, poh->last_slot, poh->last_hashcnt ));
 }
@@ -274,24 +274,21 @@ fd_poh_update_max_microblocks( fd_poh_t * poh,
   /* Guaranteed to be monotonically decreasing. */
   FD_TEST( inflated <= poh->max_microblocks_per_slot );
   poh->max_microblocks_per_slot = inflated;
-  FD_TEST( poh->max_microblocks_per_slot >= poh->microblocks_lower_bound );
+  FD_TEST( poh->max_microblocks_per_slot >= poh->microblocks_mixed_in );
 }
 
 void
-fd_poh_done_packing( fd_poh_t * poh,
-                     ulong      microblocks_in_slot ) {
+fd_poh_done_packing( fd_poh_t * poh ) {
   FD_TEST( poh->state==STATE_LEADER );
-  FD_LOG_INFO(( "done_packing(slot=%lu,seen_microblocks=%lu,microblocks_in_slot=%lu)",
+  FD_LOG_INFO(( "done_packing(slot=%lu,microblocks_mixed_in=%lu)",
                 poh->slot,
-                poh->microblocks_lower_bound,
-                microblocks_in_slot ));
-  FD_TEST( poh->microblocks_lower_bound==microblocks_in_slot );
-  FD_TEST( poh->microblocks_lower_bound<=poh->max_microblocks_per_slot );
+                poh->microblocks_mixed_in ));
+  FD_TEST( poh->microblocks_mixed_in<=poh->max_microblocks_per_slot );
 
-  poh->microblocks_lower_bound += 1UL /* done_packing as a phantom "microblock"*/
-                                + (poh->max_microblocks_per_slot-1UL) /* the canonical microblock limit */
-                                - microblocks_in_slot /* the actual microblock count */;
-  FD_TEST( poh->microblocks_lower_bound==poh->max_microblocks_per_slot );
+  /* pack_idx ordering guarantees all microblocks have been processed
+     before done_packing arrives.  Fill the counter to max so no more
+     microblocks can be mixed in. */
+  poh->microblocks_mixed_in = poh->max_microblocks_per_slot;
 }
 
 static void
@@ -380,7 +377,7 @@ fd_poh_advance( fd_poh_t *          poh,
   /* If we are the leader, always leave enough capacity in the slot so
      that we can mixin any potential microblocks still coming from the
      pack tile for this slot. */
-  ulong max_remaining_microblocks = poh->max_microblocks_per_slot - poh->microblocks_lower_bound;
+  ulong max_remaining_microblocks = poh->max_microblocks_per_slot - poh->microblocks_mixed_in;
 
   /* With hashcnt_per_tick hashes per tick, we actually get
      hashcnt_per_tick-1 chances to mixin a microblock.  For each tick
@@ -679,15 +676,9 @@ fd_poh1_mixin( fd_poh_t *          poh,
   if( FD_UNLIKELY( (poh->hashcnt%poh->hashcnt_per_tick)==(poh->hashcnt_per_tick-1UL) ) ) FD_LOG_CRIT(( "a tick will be skipped due to hashcnt %lu hashcnt_per_tick %lu", poh->hashcnt, poh->hashcnt_per_tick ));
 
   FD_TEST( poh->state==STATE_LEADER );
-  FD_TEST( poh->microblocks_lower_bound<poh->max_microblocks_per_slot );
-  poh->microblocks_lower_bound += 1UL;
 
   ulong executed_txn_cnt = 0UL;
   for( ulong i=0UL; i<txn_cnt; i++ ) {
-    /* It's important that we check if a transaction is included in the
-       block with FD_TXN_P_FLAGS_EXECUTE_SUCCESS since
-       actual_consumed_cus may have a nonzero value for excluded
-       transactions used for monitoring purposes */
     if( FD_LIKELY( txns[ i ].flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS ) ) {
       executed_txn_cnt++;
     }
@@ -696,8 +687,15 @@ fd_poh1_mixin( fd_poh_t *          poh,
   /* We don't publish transactions that fail to execute.  If all the
      transactions failed to execute, the microblock would be empty,
      causing agave to think it's a tick and complain.  Instead, we just
-     skip the microblock and don't hash or update the hashcnt. */
+     skip the microblock and don't hash or update the hashcnt.
+
+     Empty microblocks (failed bundles, unincludable non-bundles) don't
+     count toward the microblock limit.  Pack rebates their microblock
+     slots so it can schedule replacements. */
   if( FD_UNLIKELY( !executed_txn_cnt ) ) return;
+
+  FD_TEST( poh->microblocks_mixed_in<poh->max_microblocks_per_slot );
+  poh->microblocks_mixed_in += 1UL;
 
   uchar data[ 64 ];
   fd_memcpy( data, poh->hash, 32UL );

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -320,18 +320,8 @@
 #define FD_POH_MAGIC (0xF17EDA2CE580A000) /* FIREDANCE POH V0 */
 
 /* The maximum number of microblocks that pack is allowed to pack into a
-   single slot.  This is not consensus critical, and pack could, if we
-   let it, produce as many microblocks as it wants, and the slot would
-   still be valid.
-
-   We have this here instead so that PoH can estimate slot completion,
-   and keep the hashcnt up to date as pack progresses through packing
-   the slot.  If this upper bound was not enforced, PoH could tick to
-   the last hash of the slot and have no hashes left to mixin incoming
-   microblocks from pack, so this upper bound is a coordination
-   mechanism so that PoH can progress hashcnts while the slot is active,
-   and know that pack will not need those hashcnts later to do mixins. */
-#define MAX_MICROBLOCKS_PER_SLOT (131072UL)
+   single slot  */
+#define MAX_MICROBLOCKS_PER_SLOT FD_MAX_TXN_PER_SLOT_CU
 
 /* When we are hashing in the background in case a prior leader skips
    their slot, we need to store the result of each tick hash so we can
@@ -423,9 +413,13 @@ struct __attribute__((aligned(FD_POH_ALIGN))) fd_poh_private {
      mixin whatever future microblocks pack might produce for it.
 
      This value tracks that.  At any time, max_microblocks_per_slot
-     - microblocks_lower_bound is an upper bound on the maximum number
-     of microblocks that might still be received in this slot. */
-  ulong microblocks_lower_bound;
+     - microblocks_mixed_in is an upper bound on the maximum number
+     of microblocks that might still be received in this slot.
+
+     Only microblocks with at least one successfully executed
+     transaction count toward this limit.  Empty microblocks (failed
+     bundles, unincludable non-bundles) are not counted. */
+  ulong microblocks_mixed_in;
 
   uchar __attribute__((aligned(32UL))) reset_hash[ 32 ];
   uchar __attribute__((aligned(32UL))) hash[ 32 ];
@@ -504,8 +498,7 @@ fd_poh_begin_leader( fd_poh_t * poh,
                      ulong      max_microblocks_in_slot );
 
 void
-fd_poh_done_packing( fd_poh_t * poh,
-                     ulong      microblocks_in_slot );
+fd_poh_done_packing( fd_poh_t * poh );
 
 void
 fd_poh_advance( fd_poh_t *          poh,

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -177,8 +177,7 @@ returnable_frag( fd_poh_tile_t *     ctx,
 
   switch( ctx->in_kind[ in_idx ] ) {
     case IN_KIND_PACK: {
-      fd_done_packing_t const * done_packing = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
-      fd_poh_done_packing( ctx->poh, done_packing->microblocks_in_slot );
+      fd_poh_done_packing( ctx->poh );
       break;
     }
     case IN_KIND_REPLAY: {

--- a/src/discoh/pohh/fd_pohh_tile.c
+++ b/src/discoh/pohh/fd_pohh_tile.c
@@ -323,18 +323,8 @@
 #include <string.h>
 
 /* The maximum number of microblocks that pack is allowed to pack into a
-   single slot.  This is not consensus critical, and pack could, if we
-   let it, produce as many microblocks as it wants, and the slot would
-   still be valid.
-
-   We have this here instead so that PoH can estimate slot completion,
-   and keep the hashcnt up to date as pack progresses through packing
-   the slot.  If this upper bound was not enforced, PoH could tick to
-   the last hash of the slot and have no hashes left to mixin incoming
-   microblocks from pack, so this upper bound is a coordination
-   mechanism so that PoH can progress hashcnts while the slot is active,
-   and know that pack will not need those hashcnts later to do mixins. */
-#define MAX_MICROBLOCKS_PER_SLOT (131072UL)
+   single slot. */
+#define MAX_MICROBLOCKS_PER_SLOT FD_MAX_TXN_PER_SLOT_CU
 
 /* When we are hashing in the background in case a prior leader skips
    their slot, we need to store the result of each tick hash so we can
@@ -477,9 +467,13 @@ struct fd_pohh_tile {
      mixin whatever future microblocks pack might produce for it.
 
      This value tracks that.  At any time, max_microblocks_per_slot
-     - microblocks_lower_bound is an upper bound on the maximum number
-     of microblocks that might still be received in this slot. */
-  ulong microblocks_lower_bound;
+     - microblocks_mixed_in is an upper bound on the maximum number
+     of microblocks that might still be received in this slot.
+
+     Only microblocks with at least one successfully executed
+     transaction count toward this limit.  Empty microblocks (failed
+     bundles, unincludable non-bundles) are not counted. */
+  ulong microblocks_mixed_in;
 
   uchar __attribute__((aligned(32UL))) reset_hash[ 32 ];
   uchar __attribute__((aligned(32UL))) hash[ 32 ];
@@ -1157,7 +1151,7 @@ fd_ext_poh_begin_leader( void const * bank,
   }
 
   ctx->current_leader_bank     = bank;
-  ctx->microblocks_lower_bound = 0UL;
+  ctx->microblocks_mixed_in    = 0UL;
   ctx->cus_used                = 0UL;
 
   ctx->limits.slot_max_cost                = cus_block_limit;
@@ -1357,7 +1351,7 @@ fd_ext_poh_reset( ulong         completed_bank_slot, /* The slot that successful
      than being constrained.  If we are leader after the reset, this
      is OK because we won't tick until we get a bank, and the lower
      bound will be reset with the value from the bank. */
-  ctx->microblocks_lower_bound = ctx->max_microblocks_per_slot;
+  ctx->microblocks_mixed_in = ctx->max_microblocks_per_slot;
 
   if( FD_UNLIKELY( leader_before_reset ) ) {
     /* No longer have a leader bank if we are reset. Replay stage will
@@ -1572,7 +1566,7 @@ after_credit( fd_pohh_tile_t *    ctx,
   /* If we are the leader, always leave enough capacity in the slot so
      that we can mixin any potential microblocks still coming from the
      pack tile for this slot. */
-  ulong max_remaining_microblocks = ctx->max_microblocks_per_slot - ctx->microblocks_lower_bound;
+  ulong max_remaining_microblocks = ctx->max_microblocks_per_slot - ctx->microblocks_mixed_in;
 
   /* With hashcnt_per_tick hashes per tick, we actually get
      hashcnt_per_tick-1 chances to mixin a microblock.  For each tick
@@ -1918,22 +1912,18 @@ during_frag( fd_pohh_tile_t * ctx,
   int is_frag_for_prior_leader_slot = slot<ctx->highwater_leader_slot;
 
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_PACK ) ) {
-    /* We now know the real amount of microblocks published, so set an
-       exact bound for once we receive them. */
     ctx->skip_frag = 1;
     if( FD_UNLIKELY( is_frag_for_prior_leader_slot ) ) return;
-    fd_done_packing_t const * done_packing = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
 
-    FD_TEST( ctx->microblocks_lower_bound<=ctx->max_microblocks_per_slot );
-    FD_TEST( done_packing->microblocks_in_slot<=ctx->max_microblocks_per_slot-1UL );
-    FD_LOG_INFO(( "done_packing(slot=%lu,seen_microblocks=%lu,microblocks_in_slot=%lu)",
+    FD_TEST( ctx->microblocks_mixed_in<=ctx->max_microblocks_per_slot );
+    FD_LOG_INFO(( "done_packing(slot=%lu,microblocks_mixed_in=%lu)",
                   ctx->slot,
-                  ctx->microblocks_lower_bound,
-                  done_packing->microblocks_in_slot ));
+                  ctx->microblocks_mixed_in ));
 
-    ctx->microblocks_lower_bound += 1UL /* done_packing as a phantom "microblock"*/
-                                  + (ctx->max_microblocks_per_slot-1UL) /* the canonical microblock limit */
-                                  - done_packing->microblocks_in_slot /* the actual microblock count */;
+    /* pack_idx ordering guarantees all microblocks have been processed
+       before done_packing arrives.  Fill the counter to max so no more
+       microblocks can be mixed in. */
+    ctx->microblocks_mixed_in = ctx->max_microblocks_per_slot;
     return;
   } else {
     if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz>USHORT_MAX ) )
@@ -2051,7 +2041,7 @@ after_frag( fd_pohh_tile_t *    ctx,
     return;
   }
 
-  if( FD_UNLIKELY( !ctx->microblocks_lower_bound ) ) {
+  if( FD_UNLIKELY( !ctx->microblocks_mixed_in ) ) {
     double tick_per_ns = fd_tempo_tick_per_ns( NULL );
     fd_histf_sample( ctx->first_microblock_delay, (ulong)((double)(fd_log_wallclock()-ctx->reset_slot_start_ns)/tick_per_ns) );
   }
@@ -2064,18 +2054,12 @@ after_frag( fd_pohh_tile_t *    ctx,
   }
 
   FD_TEST( ctx->current_leader_bank );
-  FD_TEST( ctx->microblocks_lower_bound<ctx->max_microblocks_per_slot );
-  ctx->microblocks_lower_bound += 1UL;
 
   ulong txn_cnt = (sz-sizeof(fd_microblock_trailer_t))/sizeof(fd_txn_p_t);
   fd_txn_p_t * txns = (fd_txn_p_t *)(ctx->_txns);
   ulong executed_txn_cnt = 0UL;
   ulong cus_used         = 0UL;
   for( ulong i=0UL; i<txn_cnt; i++ ) {
-    /* It's important that we check if a transaction is included in the
-       block with FD_TXN_P_FLAGS_EXECUTE_SUCCESS since
-       actual_consumed_cus may have a nonzero value for excluded
-       transactions used for monitoring purposes */
     if( FD_LIKELY( txns[ i ].flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS ) ) {
       executed_txn_cnt++;
       cus_used += txns[ i ].execle_cu.actual_consumed_cus;
@@ -2085,8 +2069,15 @@ after_frag( fd_pohh_tile_t *    ctx,
   /* We don't publish transactions that fail to execute.  If all the
      transactions failed to execute, the microblock would be empty,
      causing agave to think it's a tick and complain.  Instead, we just
-     skip the microblock and don't hash or update the hashcnt. */
+     skip the microblock and don't hash or update the hashcnt.
+
+     Empty microblocks (failed bundles, unincludable non-bundles) don't
+     count toward the microblock limit.  Pack rebates their microblock
+     slots so it can schedule replacements. */
   if( FD_UNLIKELY( !executed_txn_cnt ) ) return;
+
+  FD_TEST( ctx->microblocks_mixed_in<ctx->max_microblocks_per_slot );
+  ctx->microblocks_mixed_in += 1UL;
 
   uchar data[ 64 ];
   fd_memcpy( data, ctx->hash, 32UL );
@@ -2330,7 +2321,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->expect_sequential_leader_slot = ULONG_MAX;
 
   ctx->expect_pack_idx         = 0U;
-  ctx->microblocks_lower_bound = 0UL;
+  ctx->microblocks_mixed_in    = 0UL;
 
   ctx->max_active_descendant = 0UL;
 


### PR DESCRIPTION
treat microblocks as a rebatable resource, just like block cost and byte limits. pack now applies `microblock_cnt_rebate` (previously ignored bc @ptaffet-jump didn't want to deal with a race) to free up slots from failed bundles and unincludable non-bundles.

notes: 
1. the race is sidestepped by sending `max_pack_idx` in `done_packing` instead of the net microblock count. since poh enforces strict pack_idx ordering, all microblocks are guaranteed processed before `done_packing`, so poh just saturates its counter directly.
2. `microblocks_lower_bound` is renamed to `microblocks_mixed_in` and only incremented for non-empty microblocks.
3. `trailer->microblock_idx` now uses `pack_idx` to stay unique after rebates (perhaps we should rename this one? it's only used by the gui).
4. discoh/discof `MAX_MICROBLOCKS_PER_SLOT` is tightened from 131072 to `FD_MAX_TXN_PER_SLOT_CU` (98039) since that's the actual ceiling. (this partially addresses the slot time issue that we tried to address with the recent dynamic microblock bound change in pack/poh/pohh)

