### PR TITLE
Clean up pool_para

### DIFF
--- a/src/disco/store/fd_store.c
+++ b/src/disco/store/fd_store.c
@@ -1,7 +1,5 @@
 #include "fd_store.h"
 
-#define BLOCKING 1
-
 static inline fd_store_map_t *
 map_laddr( fd_store_t * store ) {
   return fd_wksp_laddr_fast( fd_store_wksp( store ), store->map_gaddr );
@@ -84,7 +82,7 @@ fd_store_new( void * shmem,
     return NULL;
   }
   fd_store_pool_t pool_ljoin;
-  fd_store_pool_reset( fd_store_pool_join( &pool_ljoin, shpool, shele, fec_max ), 0 );
+  fd_store_pool_reset( fd_store_pool_join( &pool_ljoin, shpool, shele, fec_max ) );
 
   /* Set each element's data_gaddr to point to its slice of the
      contiguous data buffer region. */
@@ -201,8 +199,8 @@ fd_store_insert( fd_store_t * store,
     if( FD_UNLIKELY( fec ) ) return fec;
   }
 
-  int err; fd_store_fec_t * fec = fd_store_pool_acquire( &pool, NULL, BLOCKING, &err );
-  if( FD_UNLIKELY( err!=FD_POOL_SUCCESS ) ) FD_LOG_CRIT(( "store pool: %s", fd_store_pool_strerror( err ) ));
+  fd_store_fec_t * fec = fd_store_pool_acquire( &pool );
+  if( FD_UNLIKELY( !fec ) ) FD_LOG_CRIT(( "fd_store_pool_acquire failed" ));
   fec->key.merkle_root = *merkle_root;
   fec->key.part_idx    = part_idx;
   fec->cmr             = (fd_hash_t){ 0 };
@@ -230,8 +228,7 @@ fd_store_remove( fd_store_t      * store,
     } FD_STORE_XLOCK_END;
     if( FD_UNLIKELY( !fec ) ) continue;
 
-    int err = fd_store_pool_release( &pool, fec, BLOCKING );
-    if( FD_UNLIKELY( err!=FD_POOL_SUCCESS ) ) FD_LOG_CRIT(( "store pool: %s", fd_store_pool_strerror( err ) ));
+    fd_store_pool_release( &pool, fec );
     return;
   }
 

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1392,8 +1392,8 @@ store_xinsert( fd_store_t      * store,
       .ele     = fd_wksp_laddr_fast( fd_store_wksp( store ), store->pool_ele_gaddr ),
       .ele_max = store->fec_max
   };
-  int err; fd_store_fec_t * fec = fd_store_pool_acquire( &pool, NULL, 1 /* blocking */, &err );
-  if( FD_UNLIKELY( err!=FD_POOL_SUCCESS ) ) FD_LOG_CRIT(( "store pool: %s", fd_store_pool_strerror( err ) ));
+  fd_store_fec_t * fec = fd_store_pool_acquire( &pool );
+  if( FD_UNLIKELY( !fec ) ) FD_LOG_CRIT(( "fd_store_pool_acquire failed" ));
   fec->key.merkle_root = *merkle_root;
   fec->key.part_idx    = 0;
   fec->cmr             = (fd_hash_t){ 0 };

--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -195,7 +195,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     ctx->metrics.accounts_loaded++;
     fd_funk_rec_t * r = rec[ i ];
     if( FD_LIKELY( !r ) ) {  /* optimize for new account */
-      r = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 0, NULL );
+      r = fd_funk_rec_pool_acquire( funk->rec_pool );
       FD_TEST( r );
       ulong rec_idx = (ulong)( r - rec_tbl );
 

--- a/src/flamenco/accdb/fd_accdb_admin_v1.c
+++ b/src/flamenco/accdb/fd_accdb_admin_v1.c
@@ -138,7 +138,7 @@ fd_accdb_txn_cancel_one( fd_accdb_admin_v1_t * admin,
     rec->next_idx = FD_FUNK_REC_IDX_NULL;
     rec->prev_idx = FD_FUNK_REC_IDX_NULL;
     funk->rec_lock[ rec_idx ] = fd_funk_rec_ver_lock( fd_funk_rec_ver_inc( fd_funk_rec_ver_bits( funk->rec_lock[ rec_idx ] ) ), 0UL );
-    fd_funk_rec_pool_release( funk->rec_pool, rec, 1 );
+    fd_funk_rec_pool_release( funk->rec_pool, rec );
     rec_idx = next_idx;
     rec_cnt++;
   }
@@ -183,7 +183,7 @@ fd_accdb_txn_cancel_one( fd_accdb_admin_v1_t * admin,
   txn->sibling_next_cidx = UINT_MAX;
   fd_rwlock_unwrite( &funk->txn_lock[ txn_idx ] );
   FD_VOLATILE( txn->state ) = FD_FUNK_TXN_STATE_FREE;
-  fd_funk_txn_pool_release( funk->txn_pool, txn, 1 );
+  fd_funk_txn_pool_release( funk->txn_pool, txn );
 }
 
 /* Cancels txn and all children */
@@ -282,7 +282,7 @@ fd_accdb_chain_reclaim( fd_accdb_admin_v1_t * accdb,
 
   old_rec->map_next = FD_FUNK_REC_IDX_NULL;
   fd_funk_val_flush( old_rec, funk->alloc, funk->wksp );
-  fd_funk_rec_pool_release( funk->rec_pool, old_rec, 1 );
+  fd_funk_rec_pool_release( funk->rec_pool, old_rec );
   accdb->base.reclaim_cnt++;
 }
 
@@ -312,7 +312,7 @@ fd_accdb_chain_gc_root( fd_accdb_admin_v1_t *          accdb,
 
   old_rec->map_next = FD_FUNK_REC_IDX_NULL;
   fd_funk_val_flush( old_rec, funk->alloc, funk->wksp );
-  fd_funk_rec_pool_release( funk->rec_pool, old_rec, 1 );
+  fd_funk_rec_pool_release( funk->rec_pool, old_rec );
   accdb->base.gc_root_cnt++;
 }
 
@@ -423,7 +423,7 @@ fd_accdb_txn_publish_one( fd_accdb_admin_v1_t * accdb,
   txn->sibling_next_cidx = UINT_MAX;
   txn->child_head_cidx   = UINT_MAX;
   txn->child_tail_cidx   = UINT_MAX;
-  fd_funk_txn_pool_release( funk->txn_pool, txn, 1 );
+  fd_funk_txn_pool_release( funk->txn_pool, txn );
 }
 
 void
@@ -494,7 +494,7 @@ reset_rec_map( fd_funk_t * funk ) {
       rec->prev_idx = FD_FUNK_REC_IDX_NULL;
       memset( &rec->pair, 0, sizeof(fd_funk_xid_key_pair_t) );
       fd_funk_val_flush( rec, alloc, wksp );
-      fd_funk_rec_pool_release( rec_pool, rec, 1 );
+      fd_funk_rec_pool_release( rec_pool, rec );
       iter.ele_idx = next;
     }
   }
@@ -527,8 +527,7 @@ clear_txn_list( fd_funk_t * funk,
     int rm_err = fd_funk_txn_map_remove( txn_map, &txn->xid, NULL, query, FD_MAP_FLAG_BLOCKING );
     if( FD_UNLIKELY( rm_err!=FD_MAP_SUCCESS ) ) FD_LOG_CRIT(( "fd_funk_txn_map_remove failed (%i-%s)", rm_err, fd_map_strerror( rm_err ) ));
     txn->state = FD_FUNK_TXN_STATE_FREE;
-    int free_err = fd_funk_txn_pool_release( txn_pool, txn, 1 );
-    if( FD_UNLIKELY( free_err!=FD_POOL_SUCCESS ) ) FD_LOG_CRIT(( "fd_funk_txn_pool_release failed (%i)", free_err ));
+    fd_funk_txn_pool_release( txn_pool, txn );
     idx = next_idx;
   }
 }

--- a/src/flamenco/accdb/fd_accdb_admin_v2.c
+++ b/src/flamenco/accdb/fd_accdb_admin_v2.c
@@ -129,7 +129,7 @@ txn_free( fd_funk_t *     funk,
   txn->sibling_next_cidx = UINT_MAX;
   txn->child_head_cidx   = UINT_MAX;
   txn->child_tail_cidx   = UINT_MAX;
-  fd_funk_txn_pool_release( funk->txn_pool, txn, 1 );
+  fd_funk_txn_pool_release( funk->txn_pool, txn );
 }
 
 static void

--- a/src/flamenco/accdb/fd_accdb_admin_v2_root.c
+++ b/src/flamenco/accdb/fd_accdb_admin_v2_root.c
@@ -109,7 +109,7 @@ funk_free_rec( fd_funk_t *     funk,
   rec->map_next = FD_FUNK_REC_IDX_NULL;
   fd_funk_val_flush( rec, funk->alloc, funk->wksp );
   fd_funk_rec_admin_unlock( funk, rec, ver_lock );
-  fd_funk_rec_pool_release( funk->rec_pool, rec, 1 );
+  fd_funk_rec_pool_release( funk->rec_pool, rec );
 }
 
 /* funk_gc_chain optimistically deletes all but the newest rooted

--- a/src/flamenco/accdb/fd_accdb_funk.c
+++ b/src/flamenco/accdb/fd_accdb_funk.c
@@ -44,7 +44,7 @@ fd_accdb_funk_prep_create( fd_accdb_rw_t *       rw,
   FD_CRIT( val_sz<=val_max, "invalid val_max" );
   fd_account_meta_t * meta = val;
 
-  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 1, NULL );
+  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( funk->rec_pool );
   if( FD_UNLIKELY( !rec ) ) FD_LOG_CRIT(( "Failed to modify account: DB record pool is out of memory" ));
   ulong rec_idx = (ulong)( rec - funk->rec_pool->ele );
   funk->rec_lock[ rec_idx ] = fd_funk_rec_ver_lock( fd_funk_rec_ver_inc( fd_funk_rec_ver_bits( funk->rec_lock[ rec_idx ] ) ), FD_FUNK_REC_LOCK_MASK );

--- a/src/flamenco/accdb/test_accdb_v1.c
+++ b/src/flamenco/accdb/test_accdb_v1.c
@@ -268,7 +268,7 @@ add_account_funk( fd_accdb_user_t * accdb_,
   fd_funk_rec_map_t *  rec_map  = funk->rec_map;
   fd_funk_rec_pool_t * rec_pool = funk->rec_pool;
 
-  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( rec_pool, NULL, 1, NULL );
+  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( rec_pool );
   FD_TEST( rec );
   *rec = (fd_funk_rec_t) {
     .next_idx = UINT_MAX,
@@ -434,8 +434,7 @@ test_random_ops( fd_wksp_t * wksp,
     uint op = fd_rng_uint_roll( rng, 1U+2U+8U );
     if( op>=3U ) { /* insert (2x as frequent as attach_child) */
 
-      if( FD_UNLIKELY( fd_funk_rec_is_full( funk ) ) ) continue;
-      if( FD_UNLIKELY( !ref->txn_cnt               ) ) continue;
+      if( FD_UNLIKELY( !ref->txn_cnt ) ) continue;
 
       ulong idx = fd_rng_ulong_roll( rng, ref->txn_cnt );
       txn_t * rtxn = ref->txn_map_head; for( ulong rem=idx; rem; rem-- ) rtxn = rtxn->map_next;
@@ -455,7 +454,10 @@ test_random_ops( fd_wksp_t * wksp,
       int err;
       fd_funk_rec_prepare_t prepare[1];
       fd_funk_rec_t * trec = fd_funk_rec_prepare( funk, xid_set( txid, rxid ), key_set( tkey, rkey ), prepare, &err );
-      FD_TEST( trec );
+      if( FD_UNLIKELY( !trec ) ) {
+        FD_TEST( err==FD_FUNK_ERR_REC );
+        continue;
+      }
       ulong val_sz = sizeof(fd_account_meta_t);
       fd_account_meta_t * meta = fd_funk_val_truncate( trec, funk->alloc, funk->wksp, 1UL, val_sz, NULL );
       FD_TEST( meta );
@@ -468,7 +470,7 @@ test_random_ops( fd_wksp_t * wksp,
 
     } else if( op>=1U ) { /* attach_child (2x as frequent as advance_root) */
 
-      if( FD_UNLIKELY( fd_funk_txn_is_full( funk ) ) ) continue;
+      if( FD_UNLIKELY( fd_funk_txn_pool_idx_is_null( fd_funk_txn_pool_private_vidx_idx( funk->txn_pool->pool->ver_top ) ) ) ) continue;
 
       txn_t *           rparent;
       fd_funk_txn_xid_t tparent;

--- a/src/flamenco/accdb/test_accdb_v2.c
+++ b/src/flamenco/accdb/test_accdb_v2.c
@@ -110,7 +110,7 @@ add_account_funk( fd_accdb_user_t * accdb_,
   fd_funk_rec_map_t *  rec_map  = funk->rec_map;
   fd_funk_rec_pool_t * rec_pool = funk->rec_pool;
 
-  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( rec_pool, NULL, 1, NULL );
+  fd_funk_rec_t * rec = fd_funk_rec_pool_acquire( rec_pool );
   FD_TEST( rec );
   ulong rec_idx = (ulong)( rec - rec_pool->ele );
   *rec = (fd_funk_rec_t) {

--- a/src/flamenco/progcache/fd_progcache.c
+++ b/src/flamenco/progcache/fd_progcache.c
@@ -160,7 +160,7 @@ fd_progcache_shmem_new( void * shmem,
   pc->rec.pool_gaddr = fd_wksp_gaddr_fast( wksp, rec_pool2 );
   fd_prog_recp_t rec_join[1];
   fd_prog_recp_join( rec_join, rec_pool2, rec_ele, rec_max );
-  fd_prog_recp_reset( rec_join, 0UL );
+  fd_prog_recp_reset( rec_join );
   pc->rec.ele_gaddr = fd_wksp_gaddr_fast( wksp, rec_ele );
   pc->rec.max = (uint)rec_max;
   fd_prog_recp_leave( rec_join );

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -437,7 +437,7 @@ reset_rec_map( fd_progcache_join_t * cache ) {
 
       rec->exists = 0;
       fd_prog_clock_remove( cache->clock.bits, (ulong)( rec-rec0 ) );
-      fd_prog_recp_release( cache->rec.pool, rec, 1 );
+      fd_prog_recp_release( cache->rec.pool, rec );
       iter.ele_idx = next;
     }
   }

--- a/src/flamenco/progcache/fd_progcache_reclaim.c
+++ b/src/flamenco/progcache/fd_progcache_reclaim.c
@@ -55,7 +55,7 @@ rec_reclaim( fd_progcache_join_t * join,
   fd_progcache_val_free( rec, join );
   rec->exists = 0;
   fd_prog_clock_remove( join->clock.bits, (ulong)( rec - join->rec.pool->ele ) );
-  fd_prog_recp_release( join->rec.pool, rec, 1 );
+  fd_prog_recp_release( join->rec.pool, rec );
   return 1;
 }
 

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -285,7 +285,7 @@ fd_progcache_push( fd_progcache_join_t * cache,
       fd_progcache_val_free( prev_rec, cache );
       fd_rwlock_unwrite( &prev_rec->lock );
       fd_prog_clock_remove( cache->clock.bits, (ulong)( prev_rec - cache->rec.pool->ele ) );
-      fd_prog_recp_release( cache->rec.pool, prev_rec, 1 );
+      fd_prog_recp_release( cache->rec.pool, prev_rec );
     } else {
       fd_prog_recm_txn_test( map_txn );
       fd_prog_recm_txn_fini( map_txn );
@@ -472,11 +472,11 @@ fd_progcache_insert( fd_progcache_t *        cache,
 
   /* Allocate record and heap space */
 
-  fd_progcache_rec_t * rec = fd_prog_recp_acquire( ljoin->rec.pool, NULL, 1, NULL );
+  fd_progcache_rec_t * rec = fd_prog_recp_acquire( ljoin->rec.pool );
   if( FD_UNLIKELY( !rec ) ) {
     cache->metrics->oom_desc_cnt++;
     fd_prog_clock_evict( cache, 4UL, 0UL );
-    rec = fd_prog_recp_acquire( ljoin->rec.pool, NULL, 1, NULL );
+    rec = fd_prog_recp_acquire( ljoin->rec.pool );
     if( FD_UNLIKELY( !rec ) ) {
       /* Out of memory (record table) */
       return fd_progcache_spill_open( cache, params );
@@ -497,7 +497,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
       if( FD_UNLIKELY( !fd_progcache_val_alloc( rec, ljoin, val_align, val_footprint ) ) ) {
         /* Out of memory (heap) */
         rec->exists = 0;
-        fd_prog_recp_release( ljoin->rec.pool, rec, 1 );
+        fd_prog_recp_release( ljoin->rec.pool, rec );
         return fd_progcache_spill_open( cache, params );
       }
     }
@@ -523,7 +523,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
     fd_rwlock_unread( &ljoin->shmem->txn.rwlock );
     fd_rwlock_unwrite( &rec->lock );
     fd_progcache_val_free( rec, ljoin );
-    fd_prog_recp_release( ljoin->rec.pool, rec, 1 );
+    fd_prog_recp_release( ljoin->rec.pool, rec );
     return NULL;
   }
   fd_rwlock_unread( &ljoin->shmem->txn.rwlock );

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -652,7 +652,7 @@ fd_svm_mini_put_account_rooted( fd_svm_mini_t *       mini,
     memset( &old_rec->pair, 0, sizeof(fd_funk_xid_key_pair_t) );
     old_rec->map_next = FD_FUNK_REC_IDX_NULL;
     fd_funk_val_flush( old_rec, funk->alloc, funk->wksp );
-    fd_funk_rec_pool_release( funk->rec_pool, old_rec, 1 );
+    fd_funk_rec_pool_release( funk->rec_pool, old_rec );
   }
 
   fd_accdb_rw_t rw[1];

--- a/src/funk/fd_funk.c
+++ b/src/funk/fd_funk.c
@@ -111,7 +111,7 @@ fd_funk_shmem_new( void * shmem,
   funk->txn_pool_gaddr = fd_wksp_gaddr_fast( wksp, txn_pool2 );
   fd_funk_txn_pool_t txn_join[1];
   fd_funk_txn_pool_join( txn_join, txn_pool2, txn_ele, txn_max );
-  fd_funk_txn_pool_reset( txn_join, 0UL );
+  fd_funk_txn_pool_reset( txn_join );
   funk->txn_ele_gaddr = fd_wksp_gaddr_fast( wksp, txn_ele );
   funk->txn_max = txn_max;
   funk->child_head_cidx = fd_funk_txn_cidx( FD_FUNK_TXN_IDX_NULL );
@@ -129,7 +129,7 @@ fd_funk_shmem_new( void * shmem,
   funk->rec_pool_gaddr = fd_wksp_gaddr_fast( wksp, rec_pool2 );
   fd_funk_rec_pool_t rec_join[1];
   fd_funk_rec_pool_join( rec_join, rec_pool2, rec_ele, rec_max );
-  fd_funk_rec_pool_reset( rec_join, 0UL );
+  fd_funk_rec_pool_reset( rec_join );
   funk->rec_ele_gaddr = fd_wksp_gaddr_fast( wksp, rec_ele );
   funk->rec_max = (uint)rec_max;
 

--- a/src/funk/fd_funk.h
+++ b/src/funk/fd_funk.h
@@ -459,22 +459,6 @@ FD_FN_PURE static inline fd_funk_rec_pool_t * fd_funk_rec_pool( fd_funk_t * funk
 
 FD_FN_PURE static inline fd_alloc_t * fd_funk_alloc( fd_funk_t * funk ) { return funk->alloc; }
 
-/* fd_funk_rec_is_full returns 1 if no more records can be allocated
-   and 0 otherwise. */
-
-static inline int
-fd_funk_rec_is_full( fd_funk_t * funk ) {
-  return fd_funk_rec_pool_is_empty( funk->rec_pool );
-}
-
-/* fd_funk_txn_is_full returns true if the transaction map is
-   full. No more in-preparation transactions are allowed. */
-
-static inline int
-fd_funk_txn_is_full( fd_funk_t * funk ) {
-  return fd_funk_txn_pool_is_empty( funk->txn_pool );
-}
-
 /* Misc */
 
 /* fd_funk_verify verifies the integrity of funk.  Returns

--- a/src/funk/fd_funk_rec.c
+++ b/src/funk/fd_funk_rec.c
@@ -118,10 +118,7 @@ fd_funk_rec_prepare( fd_funk_t *               funk,
     }
   }
 
-  fd_funk_rec_t * rec = prepare->rec = fd_funk_rec_pool_acquire( funk->rec_pool, NULL, 1, opt_err );
-  if( opt_err && *opt_err == FD_POOL_ERR_CORRUPT ) {
-    FD_LOG_CRIT(( "corrupt element returned from funk rec pool" ));
-  }
+  fd_funk_rec_t * rec = prepare->rec = fd_funk_rec_pool_acquire( funk->rec_pool );
   if( FD_UNLIKELY( !rec ) ) {
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_ERR_REC );
     fd_funk_rec_txn_release( txn_query );

--- a/src/funk/fd_funk_txn.c
+++ b/src/funk/fd_funk_txn.c
@@ -100,7 +100,7 @@ fd_funk_txn_prepare( fd_funk_t *               funk,
 
   /* Get a new transaction from the map */
 
-  fd_funk_txn_t * txn = fd_funk_txn_pool_acquire( funk->txn_pool, NULL, 1, NULL );
+  fd_funk_txn_t * txn = fd_funk_txn_pool_acquire( funk->txn_pool );
   if( FD_UNLIKELY( !txn ) ) FD_LOG_ERR(( "fd_funk_txn_prepare failed: transaction object pool out of memory" ));
   fd_funk_txn_xid_copy( &txn->xid, xid );
   ulong txn_idx = (ulong)(txn - funk->txn_pool->ele);

--- a/src/groove/fd_groove_data.c
+++ b/src/groove/fd_groove_data.c
@@ -323,16 +323,8 @@ fd_groove_data_private_alloc_obj( fd_groove_data_t * data,
 
       if( FD_UNLIKELY( parent_szc==FD_GROOVE_DATA_SZC_CNT ) ) { /* Acquire a volume to use for the new superblock */
 
-        int err;
-        fd_groove_volume_t * _volume = fd_groove_volume_pool_acquire( data->volume_pool, NULL, 1 /* blocking */, &err );
-
-        if( FD_UNLIKELY( !_volume ) ) {
-          if( FD_UNLIKELY( err!=FD_POOL_ERR_EMPTY ) ) {
-            FD_LOG_WARNING(( "fd_groove_volume_pool_acquire failed (%i-%s)", err, fd_groove_volume_pool_strerror( err ) ));
-            return FD_GROOVE_ERR_CORRUPT;
-          }
-          return FD_GROOVE_ERR_FULL;
-        }
+        fd_groove_volume_t * _volume = fd_groove_volume_pool_acquire( data->volume_pool );
+        if( FD_UNLIKELY( !_volume ) ) return FD_GROOVE_ERR_FULL;
 
 #       if FD_GROOVE_PARANOID
         ulong volume_off = (ulong)_volume - (ulong)_volume0;
@@ -759,11 +751,7 @@ fd_groove_data_private_free( fd_groove_data_t * data,
         _volume->magic = ~FD_GROOVE_VOLUME_MAGIC; /* mark volume as containing no groove data allocations */
         FD_COMPILER_MFENCE();
 
-        int err = fd_groove_volume_pool_release( data->volume_pool, _volume, 1 /* blocking */ );
-        if( FD_UNLIKELY( err ) ) {
-          FD_LOG_WARNING(( "fd_groove_volume_pool_release failed (%i-%s)", err, fd_groove_volume_pool_strerror( err ) ));
-          return FD_GROOVE_ERR_CORRUPT;
-        }
+        fd_groove_volume_pool_release( data->volume_pool, _volume );
 
       }
     }

--- a/src/groove/fd_groove_volume.c
+++ b/src/groove/fd_groove_volume.c
@@ -57,11 +57,7 @@ fd_groove_volume_pool_add( fd_groove_volume_pool_t * pool,
     _volume->magic = ~FD_GROOVE_VOLUME_MAGIC; /* Mark groove volume as containing no data allocations */
     FD_COMPILER_MFENCE();
 
-    int err = fd_groove_volume_pool_release( pool, _volume, 1 /* blocking */ );
-    if( FD_UNLIKELY( err ) ) {
-      FD_LOG_WARNING(( "fd_groove_volume_pool_release failed (%i-%s)", err, fd_groove_volume_pool_strerror( err ) ));
-      return err;
-    }
+    fd_groove_volume_pool_release( pool, _volume );
 
   } while( _volume>_va );
 
@@ -76,8 +72,7 @@ fd_groove_volume_pool_remove( fd_groove_volume_pool_t * pool ) {
     return NULL;
   }
 
-  int err;
-  fd_groove_volume_t * _volume = fd_groove_volume_pool_acquire( pool, NULL, 1 /* blocking */, &err );
+  fd_groove_volume_t * _volume = fd_groove_volume_pool_acquire( pool );
 
   if( FD_LIKELY( _volume ) ) {
 
@@ -104,10 +99,6 @@ fd_groove_volume_pool_remove( fd_groove_volume_pool_t * pool ) {
     FD_COMPILER_MFENCE();
     _volume->magic = 0UL; /* mark as no longer a groove volume */
     FD_COMPILER_MFENCE();
-
-  } else if( FD_UNLIKELY( err!=FD_POOL_ERR_EMPTY ) ) {
-
-    FD_LOG_WARNING(( "fd_groove_volume_pool_acquire failed (%i-%s)", err, fd_groove_volume_pool_strerror( err ) ));
 
   }
 

--- a/src/util/tmpl/fd_pool_para.c
+++ b/src/util/tmpl/fd_pool_para.c
@@ -158,53 +158,21 @@
      myele_t *       mypool_peek      ( mypool_t       * join );
 
      // mypool_acquire acquires an element from a mypool.  Assumes join
-     // is a current local join.  If the mypool is empty or an error
-     // occurs, returns sentinel (arbitrary).  A non-zero / zero value
-     // for blocking indicates locked operations on the mypool are / are
-     // not allowed to block the caller.  If opt_err is not NULL, on
-     // return, *_opt_err will indicate FD_POOL_SUCCESS (zero) or an
-     // FD_POOL_ERR code (negative).  On success, the returned value
-     // will be a pointer in the caller's address space to the element
-     // store element acquired from the mypool.  On failure for any
-     // reason, the value returned will be sentinel and the mypool will
-     // be unchanged.  Reasons for failure:
-     //
-     // FD_POOL_ERR_EMPTY: the mypool contained no elements at some
-     // point during the call.
-     //
-     // FD_POOL_ERR_AGAIN: the mypool was locked at some point during
-     // the call.  Never returned for a blocking call (but then locking
-     // operations can then potentially block the caller indefinitely).
-     //
-     // FD_POOL_ERR_CORRUPT: memory corruption was detected during the
-     // call.
+     // is a current local join.  If the mypool is empty returns NULL
+     // On success, the returned value will be a pointer in the caller's
+     // address space to the element store element acquired from the
+     // mypool.  On failure, the value returned will be NULL and the
+     // mypool will be unchanged.  Failure can occur if the mypool
+     // contained no elements at some point during the call.
 
-     myele_t * mypool_acquire( mypool_t * join, myele_t * sentinel, int blocking, int * _opt_err );
+     myele_t * mypool_acquire( mypool_t * join );
 
      // mypool_release releases an element to a mypoool.  Assumes join
      // is a current local join, ele is a pointer in the caller's
      // address space to the element, and the element is currently not
-     // in the mypool.  Returns FD_POOL_SUCCESS (zero) on success (the
-     // element will be in the mypool on return) and an FD_POOL_ERR code
-     // (negative) on failure (the element will not be in the mypool on
-     // return).  Reasons for failure:
-     //
-     // FD_POOL_ERR_INVAL: ele does not point to an element in mypool's
-     // element store.
-     //
-     // FD_POOL_ERR_AGAIN: the mypool was locked at some point during
-     // the call.  Never returned for a blocking call (but locking
-     // operations can then potentially block the caller indefinitely).
-     //
-     // FD_POOL_ERR_CORRUPT: memory corruption was detected during the
-     // call.
+     // in the mypool.
 
-     int mypool_release( mypool_t * join, myele_t * ele, int blocking );
-
-     // mypool_is_locked returns whether or not a mypool is locked.
-     // Assumes join is a current local join.
-
-     int mypool_is_locked( mypool_t const * join );
+     void mypool_release( mypool_t * join, myele_t * ele );
 
      // mypool_lock will lock a mypool (e.g. pausing concurrent acquire
      // / release operations).  A non-zero / zero value for blocking
@@ -224,18 +192,12 @@
 
      void mypool_unlock( mypool_t * join );
 
-     // mypool_reset resets the mypool.  On return, it will hold all but
-     // the leading sentinel_cnt elements in the element store (e.g.
-     // initialization after creation) in ascending order.  If
-     // sentinel_cnt is greater than or equal to the element store
-     // capacity, the mypool will be empty on return.  Thus, on return,
-     // if sentinel_cnt is zero, every element in the element store will
-     // be in the mypool and, if sentinel_cnt is ele_max or greater
-     // (e.g. ULONG_MAX), every element will be removed from the mypool.
-     // Assumes join is a current local join and the mypool is locked or
-     // otherwise idle.
+     // mypool_reset resets the mypool.  On return, it will hold all
+     // elements in the element store (e.g. initialization after
+     // creation) in ascending order.  Assumes join is a current local
+     // join and the mypool is locked or otherwise idle.
 
-     void mypool_reset( mypool_t * join, ulong sentinel_cnt );
+     void mypool_reset( mypool_t * join );
 
      // mypool_verify returns FD_POOL_SUCCESS if join appears to be
      // current local join to a valid mypool and FD_POOL_ERR_CORRUPT
@@ -336,12 +298,8 @@
    we don't have to do this in the generator itself) */
 
 #define FD_POOL_SUCCESS     ( 0)
-#define FD_POOL_ERR_INVAL   (-1)
-#define FD_POOL_ERR_AGAIN   (-2)
-#define FD_POOL_ERR_CORRUPT (-3)
-#define FD_POOL_ERR_EMPTY   (-4)
-//#define FD_POOL_ERR_FULL    (-5)
-//#define FD_POOL_ERR_KEY     (-6)
+#define FD_POOL_ERR_AGAIN   (-1)
+#define FD_POOL_ERR_CORRUPT (-2)
 
 /* Implementation *****************************************************/
 
@@ -504,23 +462,6 @@ POOL_(peek_const)( POOL_(t) const * join ) {
 
 static inline POOL_ELE_T * POOL_(peek)( POOL_(t) * join ) { return (POOL_ELE_T *)POOL_(peek_const)( join ); }
 
-static inline int
-POOL_(is_locked)( POOL_(t) const * join ) {
-  POOL_(shmem_t) const * pool = join->pool;
-  FD_COMPILER_MFENCE();
-  ulong ver_top  = pool->ver_top;
-# if POOL_LAZY
-  ulong ver_lazy = pool->ver_lazy;
-# endif
-  FD_COMPILER_MFENCE();
-  return
-      (int)(POOL_(private_vidx_ver)( ver_top  ) & 1UL)
-# if POOL_LAZY
-    | (int)(POOL_(private_vidx_ver)( ver_lazy ) & 1UL)
-# endif
-  ;
-}
-
 static inline void
 POOL_(unlock)( POOL_(t) * join ) {
   POOL_(shmem_t) * pool = join->pool;
@@ -537,15 +478,13 @@ POOL_STATIC POOL_(t) * POOL_(join)  ( void *     ljoin, void * shpool, void * sh
 POOL_STATIC void *     POOL_(leave) ( POOL_(t) * join );
 POOL_STATIC void *     POOL_(delete)( void *     shpool );
 
-POOL_STATIC POOL_ELE_T * POOL_(acquire)( POOL_(t) * join, POOL_ELE_T * sentinel, int blocking, int * _opt_err );
+POOL_STATIC POOL_ELE_T * POOL_(acquire)( POOL_(t) * join );
 
-POOL_STATIC int POOL_(release)( POOL_(t) * join, POOL_ELE_T * ele, int blocking );
-
-POOL_STATIC int POOL_(is_empty)( POOL_(t) * join );
+POOL_STATIC void POOL_(release)( POOL_(t) * join, POOL_ELE_T * ele );
 
 POOL_STATIC int POOL_(lock)( POOL_(t) * join, int blocking );
 
-POOL_STATIC void POOL_(reset)( POOL_(t) * join, ulong sentinel_cnt );
+POOL_STATIC void POOL_(reset)( POOL_(t) * join );
 
 POOL_STATIC int POOL_(verify)( POOL_(t) const * join );
 
@@ -681,16 +620,12 @@ POOL_(delete)( void * shpool ) {
 #if POOL_LAZY
 
 static inline POOL_ELE_T *
-POOL_(acquire_lazy)( POOL_(t) *   join,
-                     POOL_ELE_T * sentinel,
-                     int          blocking,
-                     int *        _opt_err ) {
+POOL_(acquire_lazy)( POOL_(t) * join ) {
   POOL_ELE_T *     ele0    = join->ele;
   ulong            ele_max = join->ele_max;
   ulong volatile * _l      = (ulong volatile *)&join->pool->ver_lazy;
 
-  POOL_ELE_T * ele = sentinel;
-  int          err = FD_POOL_SUCCESS;
+  POOL_ELE_T * ele = NULL;
 
   FD_COMPILER_MFENCE();
 
@@ -703,13 +638,11 @@ POOL_(acquire_lazy)( POOL_(t) *   join,
     if( FD_LIKELY( !(ver & 1UL) ) ) { /* opt for unlocked */
 
       if( FD_UNLIKELY( POOL_(idx_is_null)( ele_idx ) ) ) { /* opt for not empty */
-        err = FD_POOL_ERR_EMPTY;
         break;
       }
 
-      if( FD_UNLIKELY( ele_idx>=ele_max ) ) { /* opt for not corrupt */
-        err = FD_POOL_ERR_CORRUPT;
-        break;
+      if( FD_UNLIKELY( ele_idx>=ele_max ) ) {
+        FD_LOG_CRIT(( "corruption detected (ele_idx=%lu ele_max=%lu)", ele_idx, ele_max ));
       }
 
       ulong ele_nxt = ele_idx+1UL;
@@ -720,11 +653,6 @@ POOL_(acquire_lazy)( POOL_(t) *   join,
         ele = ele0 + ele_idx;
         break;
       }
-    } else if( FD_UNLIKELY( !blocking ) ) { /* opt for blocking */
-
-      err = FD_POOL_ERR_AGAIN;
-      break; /* opt for blocking */
-
     }
 
     FD_SPIN_PAUSE();
@@ -732,23 +660,18 @@ POOL_(acquire_lazy)( POOL_(t) *   join,
 
   FD_COMPILER_MFENCE();
 
-  fd_int_store_if( !!_opt_err, _opt_err, err );
   return ele;
 }
 
 #endif /* POOL_LAZY */
 
 POOL_STATIC POOL_ELE_T *
-POOL_(acquire)( POOL_(t) *   join,
-                POOL_ELE_T * sentinel,
-                int          blocking,
-                int *        _opt_err ) {
+POOL_(acquire)( POOL_(t) * join ) {
   POOL_ELE_T *     ele0    = join->ele;
   ulong            ele_max = join->ele_max;
   ulong volatile * _v      = (ulong volatile *)&join->pool->ver_top;
 
-  POOL_ELE_T * ele = sentinel;
-  int          err = FD_POOL_SUCCESS;
+  POOL_ELE_T * ele = NULL;
 
   FD_COMPILER_MFENCE();
 
@@ -762,15 +685,13 @@ POOL_(acquire)( POOL_(t) *   join,
 
       if( FD_UNLIKELY( POOL_(idx_is_null)( ele_idx ) ) ) { /* opt for not empty */
 #       if POOL_LAZY
-        return POOL_(acquire_lazy)( join, sentinel, blocking, _opt_err );
+        return POOL_(acquire_lazy)( join );
 #       endif
-        err = FD_POOL_ERR_EMPTY;
         break;
       }
 
-      if( FD_UNLIKELY( ele_idx>=ele_max ) ) { /* opt for not corrupt */
-        err = FD_POOL_ERR_CORRUPT;
-        break;
+      if( FD_UNLIKELY( ele_idx>=ele_max ) ) {
+        FD_LOG_CRIT(( "corruption detected (ele_idx=%lu ele_max=%lu)", ele_idx, ele_max ));
       }
 
       ulong ele_nxt = POOL_(private_idx)( ele0[ ele_idx ].POOL_NEXT );
@@ -785,8 +706,7 @@ POOL_(acquire)( POOL_(t) *   join,
            since we read it. */
 
         if( FD_UNLIKELY( POOL_(private_vidx_ver)( *_v )==ver ) ) {
-          err = FD_POOL_ERR_CORRUPT;
-          break;
+          FD_LOG_CRIT(( "corruption detected (ele_nxt=%lu ele_max=%lu)", ele_nxt, ele_max ));
         }
       } else { /* ele_nxt is valid */
         ulong new_ver_top = POOL_(private_vidx)( ver+2UL, ele_nxt );
@@ -796,11 +716,6 @@ POOL_(acquire)( POOL_(t) *   join,
           break;
         }
       }
-    } else if( FD_UNLIKELY( !blocking ) ) { /* opt for blocking */
-
-      err = FD_POOL_ERR_AGAIN;
-      break; /* opt for blocking */
-
     }
 
     FD_SPIN_PAUSE();
@@ -808,21 +723,17 @@ POOL_(acquire)( POOL_(t) *   join,
 
   FD_COMPILER_MFENCE();
 
-  fd_int_store_if( !!_opt_err, _opt_err, err );
   return ele;
 }
 
-POOL_STATIC int
+POOL_STATIC void
 POOL_(release)( POOL_(t) *   join,
-                POOL_ELE_T * ele,
-                int          blocking ) {
+                POOL_ELE_T * ele ) {
   ulong            ele_max = join->ele_max;
   ulong volatile * _v      = (ulong volatile *)&join->pool->ver_top;
 
   ulong ele_idx = (ulong)(ele - join->ele);
-  if( FD_UNLIKELY( ele_idx>=ele_max ) ) return FD_POOL_ERR_INVAL; /* opt for valid call */
-
-  int err = FD_POOL_SUCCESS;
+  if( FD_UNLIKELY( ele_idx>=ele_max ) ) FD_LOG_CRIT(( "corruption detected: ele=%p is not in bounds", (void *)ele ));
 
   FD_COMPILER_MFENCE();
 
@@ -835,8 +746,7 @@ POOL_(release)( POOL_(t) *   join,
     if( FD_LIKELY( !(ver & 1UL) ) ) { /* opt for unlocked */
 
       if( FD_UNLIKELY( (ele_nxt>=ele_max) & (!POOL_(idx_is_null)( ele_nxt )) ) ) { /* opt for not corrupt */
-        err = FD_POOL_ERR_CORRUPT;
-        break;
+        FD_LOG_CRIT(( "corruption detected (ele_nxt=%lu ele_max=%lu)", ele_nxt, ele_max ));
       }
 
       ele->POOL_NEXT = POOL_(private_cidx)( ele_nxt );
@@ -845,40 +755,12 @@ POOL_(release)( POOL_(t) *   join,
 
       if( FD_LIKELY( POOL_(private_cas)( _v, ver_top, new_ver_top )==ver_top ) ) break; /* opt for low contention */
 
-    } else if( FD_UNLIKELY( !blocking ) ) { /* opt for blocking */
-
-      err = FD_POOL_ERR_AGAIN;
-      break;
-
     }
 
     FD_SPIN_PAUSE();
   }
 
   FD_COMPILER_MFENCE();
-
-  return err;
-}
-
-POOL_STATIC int
-POOL_(is_empty)( POOL_(t) * join ) {
-  POOL_(shmem_t) const * pool = join->pool;
-  FD_COMPILER_MFENCE();
-  ulong ver_top  = pool->ver_top;
-# if POOL_LAZY
-  ulong ver_lazy = pool->ver_lazy;
-# endif
-  FD_COMPILER_MFENCE();
-
-  ulong top_idx = POOL_(private_vidx_idx)( ver_top );
-# if POOL_LAZY
-  ulong  ele_max = join->ele_max;
-  if( FD_LIKELY( top_idx<ele_max ) ) return 0;  /* explicit stack non-empty */
-  ulong lazy_idx = POOL_(private_vidx_idx)( ver_lazy );
-  return !(lazy_idx<ele_max);                   /* empty only if lazy also empty */
-# else
-  return POOL_(idx_is_null)( top_idx );
-# endif
 }
 
 POOL_STATIC int
@@ -946,20 +828,16 @@ fail:
 #if !POOL_LAZY
 
 POOL_STATIC void
-POOL_(reset)( POOL_(t) * join,
-              ulong      sentinel_cnt ) {
+POOL_(reset)( POOL_(t) * join ) {
   POOL_(shmem_t) * pool    = join->pool;
   POOL_ELE_T *     ele     = join->ele;
   ulong            ele_max = join->ele_max;
 
-  /* Insert all but the leading sentinel_cnt elements in increasing
-     order */
+  /* Insert all elements in increasing order */
 
-  ulong ele_top;
-
-  if( FD_UNLIKELY( sentinel_cnt>=ele_max ) ) ele_top = POOL_(idx_null)(); /* All items are sentinels */
-  else { /* Note: ele_max at least 1 here */
-    ele_top = sentinel_cnt;
+  ulong ele_top = 0UL;
+  if( FD_UNLIKELY( !ele_max ) ) ele_top = POOL_(idx_null)();
+  else {
     for( ulong ele_idx=ele_top; ele_idx<(ele_max-1UL); ele_idx++ ) {
       ele[ ele_idx ].POOL_NEXT = POOL_(private_cidx)( ele_idx+1UL );
     }
@@ -974,16 +852,13 @@ POOL_(reset)( POOL_(t) * join,
 #else
 
 POOL_STATIC void
-POOL_(reset)( POOL_(t) * join,
-              ulong      sentinel_cnt ) {
+POOL_(reset)( POOL_(t) * join ) {
   POOL_(shmem_t) * pool    = join->pool;
-  ulong            ele_max = join->ele_max;
 
-  /* Assign all but the leading sentinel_cnt elements to the bump
-     allocator */
+  /* Assign all elements to the bump allocator */
 
   ulong ele_top  = POOL_(idx_null)();
-  ulong ele_lazy = sentinel_cnt<ele_max ? sentinel_cnt : POOL_(idx_null)();
+  ulong ele_lazy = 0UL;
 
   ulong ver_top  = pool->ver_top;
   ulong ver_lazy = pool->ver_lazy;
@@ -1052,10 +927,8 @@ POOL_STATIC char const *
 POOL_(strerror)( int err ) {
   switch( err ) {
   case FD_POOL_SUCCESS:     return "success";
-  case FD_POOL_ERR_INVAL:   return "bad input";
   case FD_POOL_ERR_AGAIN:   return "try again";
   case FD_POOL_ERR_CORRUPT: return "corruption detected";
-  case FD_POOL_ERR_EMPTY:   return "pool empty";
   default: break;
   }
   return "unknown";

--- a/src/util/tmpl/test_map_chain_para.c
+++ b/src/util/tmpl/test_map_chain_para.c
@@ -165,13 +165,8 @@ tile_main( int     argc,
     }
 
     case 1: { /* good insert */
-      int       acq_err;
-      myele_t * ele = mypool_acquire( pool, NULL, 0, &acq_err ); /* non-blocking acquire */
-      if( FD_UNLIKELY( !ele ) ) {
-        if( acq_err==FD_POOL_ERR_AGAIN ) FD_TEST( tile_cnt>1UL );
-        else                             FD_TEST( acq_err==FD_POOL_ERR_EMPTY );
-        break;
-      }
+      myele_t * ele = mypool_acquire( pool );
+      if( FD_UNLIKELY( !ele ) ) break;
       uint key = (uint)(local_prefix | local_key);
       uint mod = 0U;
 
@@ -185,7 +180,7 @@ tile_main( int     argc,
         FD_TEST( !(flags & FD_MAP_FLAG_BLOCKING) );
         FD_TEST( err==FD_MAP_ERR_AGAIN           );
         FD_TEST( tile_cnt>1UL                    );
-        FD_TEST( !mypool_release( pool, ele, 1 ) ); /* blocking release */
+        mypool_release( pool, ele );
       } else {
         map_key[ map_cnt++ ] = key;
         local_key++;
@@ -242,7 +237,7 @@ tile_main( int     argc,
       } else {
         FD_TEST( ele->mykey== key                                               );
         FD_TEST( ele->val  ==((key ^ ele->mod) ^ (uint)mypool_idx( pool, ele )) );
-        FD_TEST( !mypool_release( pool, ele, 1 ) ); /* blocking release */
+        mypool_release( pool, ele );
         map_key[ idx ] = map_key[ --map_cnt ];
       }
       break;
@@ -472,13 +467,9 @@ tile_main( int     argc,
             FD_TEST( mymap_txn_insert( map, sentinel )==FD_MAP_ERR_INVAL ); /* not in ele store */
             FD_TEST( mymap_txn_insert( map, ele_stop )==FD_MAP_ERR_INVAL ); /* not in ele store */
 
-            int       err;
-            myele_t * ele = mypool_acquire( pool, NULL, 0, &err ); /* non-blocking acquire */
-            if( FD_UNLIKELY( !ele ) ) {
-              if( err==FD_POOL_ERR_AGAIN ) FD_TEST( tile_cnt>1UL );
-              else                         FD_TEST( err==FD_POOL_ERR_EMPTY );
-              break;
-            }
+            myele_t * ele = mypool_acquire( pool ); /* non-blocking acquire */
+            if( FD_UNLIKELY( !ele ) ) break;
+
             uint mod = 0U;
 
             ele->mykey = key;
@@ -510,7 +501,7 @@ tile_main( int     argc,
             } else {
               FD_TEST( ele->mykey== key                                               );
               FD_TEST( ele->val  ==((key ^ ele->mod) ^ (uint)mypool_idx( pool, ele )) );
-              FD_TEST( !mypool_release( pool, ele, 1 ) ); /* blocking release */
+              mypool_release( pool, ele );
               ulong idx;
               for( idx=0UL; idx<map_cnt; idx++ ) if( map_key[ idx ]==key ) break;
               map_key[ idx ] = map_key[ --map_cnt ];
@@ -625,7 +616,7 @@ tile_main( int     argc,
   for( ulong map_idx=0UL; map_idx<map_cnt; map_idx++ ) {
     mymap_query_t query[1];
     FD_TEST( !mymap_remove( map, map_key + map_idx, NULL, query, 1 ) );
-    FD_TEST( !mypool_release( pool, mymap_query_ele( query ), 1 ) );
+    mypool_release( pool, mymap_query_ele( query ) );
   }
 
   shmem_cnt = save;
@@ -657,7 +648,7 @@ main( int     argc,
 
   void * shpool = mypool_new( shmem_alloc( mypool_align(), mypool_footprint() ) );
   mypool_t pool[1]; FD_TEST( mypool_join( pool, shpool, shele, ele_max )==pool );
-  mypool_reset( pool, 0UL );
+  mypool_reset( pool );
 
   FD_LOG_NOTICE(( "Testing misc" ));
 

--- a/src/util/tmpl/test_pool_para.c
+++ b/src/util/tmpl/test_pool_para.c
@@ -16,10 +16,8 @@ typedef struct myele myele_t;
 #include "fd_pool_para.c"
 
 FD_STATIC_ASSERT( FD_POOL_SUCCESS    == 0, unit_test );
-FD_STATIC_ASSERT( FD_POOL_ERR_INVAL  ==-1, unit_test );
-FD_STATIC_ASSERT( FD_POOL_ERR_AGAIN  ==-2, unit_test );
-FD_STATIC_ASSERT( FD_POOL_ERR_CORRUPT==-3, unit_test );
-FD_STATIC_ASSERT( FD_POOL_ERR_EMPTY  ==-4, unit_test );
+FD_STATIC_ASSERT( FD_POOL_ERR_AGAIN  ==-1, unit_test );
+FD_STATIC_ASSERT( FD_POOL_ERR_CORRUPT==-2, unit_test );
 
 #define SHMEM_MAX (131072UL)
 
@@ -56,8 +54,6 @@ tile_main( int     argc,
   myele_t **  acq_ele = shmem_alloc( alignof(myele_t *), ele_max*sizeof(myele_t *) );
   ulong       acq_cnt = 0UL;
 
-  myele_t sentinel[1];
-
   while( !FD_VOLATILE_CONST( tile_go ) ) FD_SPIN_PAUSE();
 
   ulong diag_rem = 0UL;
@@ -70,34 +66,29 @@ tile_main( int     argc,
 
     uint r = fd_rng_uint( rng );
 
-    int op       = (int)(r & 1U); r>>=1;
-    int blocking = (int)(r & 1U); r>>=1;
+    int op = (int)(r & 1U); r>>=1;
 
-    int       err;
     myele_t * ele;
 
     switch( op ) {
 
     case 0: { /* acquire */
-      ele = mypool_acquire( pool, sentinel, blocking, &err );
-      if( ele!=sentinel ) {
-        FD_TEST( !err );
+      ele = mypool_acquire( pool );
+      if( ele ) {
         FD_TEST( mypool_idx( pool, ele )<ele_max );
         /* FIXME: Ideally would check unique cross thread */
         for( ulong acq_idx=0UL; acq_idx<acq_cnt; acq_idx++ ) FD_TEST( ele!=acq_ele[ acq_idx ] );
         acq_ele[ acq_cnt++ ] = ele;
       } else {
-        FD_TEST( err==FD_POOL_ERR_EMPTY );
         if( tile_cnt==1UL ) FD_TEST( acq_cnt==ele_max );
       }
       break;
     }
 
     case 1: { /* release */
-      if( !acq_cnt ) FD_TEST( mypool_release( pool, sentinel, blocking )==FD_POOL_ERR_INVAL );
-      else {
+      if( acq_cnt ) {
         ulong acq_idx = fd_rng_ulong_roll( rng, acq_cnt );
-        FD_TEST( !mypool_release( pool, acq_ele[ acq_idx ], blocking ) );
+        mypool_release( pool, acq_ele[ acq_idx ] );
         acq_ele[ acq_idx ] = acq_ele[ --acq_cnt ];
       }
       break;
@@ -108,7 +99,7 @@ tile_main( int     argc,
     }
   }
 
-  for( ulong acq_idx=0UL; acq_idx<acq_cnt; acq_idx++ ) FD_TEST( !mypool_release( pool, acq_ele[ acq_idx ], 1 ) );
+  for( ulong acq_idx=0UL; acq_idx<acq_cnt; acq_idx++ ) mypool_release( pool, acq_ele[ acq_idx ] );
   shmem_cnt = save;
 
   fd_rng_delete( fd_rng_leave( rng ) );
@@ -186,39 +177,20 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Testing initialization" ));
 
-  FD_TEST( !mypool_is_locked( pool ) );
   FD_TEST( !mypool_lock( pool, 1 ) );
   FD_TEST(  mypool_lock( pool, 0 )==FD_POOL_ERR_AGAIN ); /* non-blocking on a locked pool */
-  FD_TEST(  mypool_is_locked( pool )==1 );
 
   FD_TEST( !mypool_verify    ( pool ) );
   FD_TEST( !mypool_peek_const( pool ) );
   FD_TEST( !mypool_peek      ( pool ) );
 
-  mypool_reset( pool, ULONG_MAX ); /* empty pool */
-  FD_TEST( !mypool_verify    ( pool ) );
-  FD_TEST( !mypool_peek_const( pool ) );
-  FD_TEST( !mypool_peek      ( pool ) );
-
-  mypool_reset( pool, ele_max ); /* empty pool */
-  FD_TEST( !mypool_verify    ( pool ) );
-  FD_TEST( !mypool_peek_const( pool ) );
-  FD_TEST( !mypool_peek      ( pool ) );
-
-  mypool_reset( pool, 1UL ); /* all but first in pool in increasing order */
-  FD_TEST( !mypool_verify    ( pool ) );
-  FD_TEST(  mypool_peek_const( pool )==((ele_max>1UL) ? (shele+1) : NULL) );
-  FD_TEST(  mypool_peek      ( pool )==((ele_max>1UL) ? (shele+1) : NULL) );
-
-  mypool_reset( pool, 0UL ); /* all in pool in increasing order */
+  mypool_reset( pool ); /* all in pool in increasing order */
   FD_TEST(  mypool_peek_const( pool )==(ele_max ? shele : NULL) );
   FD_TEST(  mypool_peek      ( pool )==(ele_max ? shele : NULL) );
 
   FD_TEST( !mypool_verify  ( pool ) );
-  FD_TEST( !mypool_is_empty( pool ) );
 
   mypool_unlock( pool );
-  FD_TEST( !mypool_is_locked( pool ) );
 
   /* FIXME: use tpool here */
 
@@ -262,10 +234,8 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "bad error code      (%i-%s)", 1,                   mypool_strerror( 1                   ) ));
   FD_LOG_NOTICE(( "FD_POOL_SUCCESS     (%i-%s)", FD_POOL_SUCCESS,     mypool_strerror( FD_POOL_SUCCESS     ) ));
-  FD_LOG_NOTICE(( "FD_POOL_ERR_INVAL   (%i-%s)", FD_POOL_ERR_INVAL,   mypool_strerror( FD_POOL_ERR_INVAL   ) ));
   FD_LOG_NOTICE(( "FD_POOL_ERR_AGAIN   (%i-%s)", FD_POOL_ERR_AGAIN,   mypool_strerror( FD_POOL_ERR_AGAIN   ) ));
   FD_LOG_NOTICE(( "FD_POOL_ERR_CORRUPT (%i-%s)", FD_POOL_ERR_CORRUPT, mypool_strerror( FD_POOL_ERR_CORRUPT ) ));
-  FD_LOG_NOTICE(( "FD_POOL_ERR_EMPTY   (%i-%s)", FD_POOL_ERR_EMPTY,   mypool_strerror( FD_POOL_ERR_EMPTY   ) ));
 
   fd_rng_delete( fd_rng_leave( rng ) );
 


### PR DESCRIPTION
Remove a large amount of boilerplate, mostly redundant function
parameters. Also remove methods that are unsafe by design.
Makes pool_para easier to use and defends against programmer
error.

- treat 'ERR_INVAL' and 'ERR_CORRUPT' as critical errors (all
  callers crash on these errors, thus we can just crash in the
  template)
- acquire takes 3 redundant arguments
  - sentinel: all callers pass it as NULL, return NULL on err
  - blocking: all callers use blocking mode, remove non-blocking
  - opt_err: after cleanup, only err is 'pool empty', thus remove
    error code
- release takes 1 redundant argument
  - blocking: all callers use blocking mode, remove non-blocking
- release now crashes if called with an invalid element
- is_locked is useless, remove it (TOCTOU)
- is_empty is useless, remove it (TOCTOU)
- remove sentinel_cnt from reset: no callers use sentinel elems
