### PR TITLE
gossip: reclassify unstaked->stake crds entries after boot

### DIFF
--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -835,7 +835,7 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
   uchar failed[ FD_GOSSIP_MESSAGE_MAX_CRDS ] = {0};
 
   if( FD_UNLIKELY( message->tag==FD_GOSSIP_MESSAGE_PULL_RESPONSE ) ) {
-    int has_staked_node = ctx->stake.count>0UL;
+    int stakes_loaded = ctx->stake.count>0UL;
     for( ulong i=0UL; i<message->pull_response->values_len; i++ ) {
       fd_gossip_value_t const * value = &message->pull_response->values[ i ];
 
@@ -850,7 +850,7 @@ handle_net( fd_gossvf_tile_ctx_t * ctx,
       } else {
         stake_t const * entry = stake_map_ele_query_const( ctx->stake.map, (fd_pubkey_t const *)value->origin, NULL, ctx->stake.pool );
         ulong origin_stake = entry ? entry->stake : 0UL;
-        if( !origin_stake && has_staked_node ) accept_after_nanos = now-15L*1000L*1000L*1000L;
+        if( !origin_stake && stakes_loaded ) accept_after_nanos = now-15L*1000L*1000L*1000L;
         else                                   accept_after_nanos = now-432000L*400L*1000L*1000L;
       }
 

--- a/src/flamenco/gossip/Local.mk
+++ b/src/flamenco/gossip/Local.mk
@@ -10,6 +10,9 @@ $(call run-unit-test,test_bloom)
 $(call make-unit-test,test_active_set,test_active_set,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_active_set)
 
+$(call make-unit-test,test_crds,test_crds,fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_crds)
+
 $(call make-unit-test,test_ping_tracker,test_ping_tracker,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_ping_tracker)
 

--- a/src/flamenco/gossip/fd_crds.c
+++ b/src/flamenco/gossip/fd_crds.c
@@ -64,7 +64,7 @@ typedef struct fd_crds_contact_info_entry fd_crds_contact_info_entry_t;
 
 struct fd_crds_key {
   uchar tag;
-  uchar pubkey[ 32UL ];
+  fd_pubkey_t pubkey;
   union {
     uchar  vote_index;
     uchar  epoch_slots_index;
@@ -270,6 +270,12 @@ struct fd_crds_entry_private {
 #define TREAP_PRIO      hash.prio
 #include "../../util/tmpl/fd_treap.c"
 
+struct expire_sort_ele {
+  ulong pool_idx;
+  long  wallclock_nanos;
+};
+typedef struct expire_sort_ele expire_sort_ele_t;
+
 static inline ulong
 lookup_hash( fd_crds_key_t const * key,
              ulong                 seed ) {
@@ -287,14 +293,14 @@ lookup_hash( fd_crds_key_t const * key,
   default:
     break;
   }
-  return fd_accdb_hash( key->pubkey, seed^hash_fn );
+  return fd_accdb_hash( key->pubkey.uc, seed^hash_fn );
 }
 
 static inline int
 lookup_eq( fd_crds_key_t const * key0,
            fd_crds_key_t const * key1 ) {
   if( FD_UNLIKELY( key0->tag!=key1->tag ) ) return 0;
-  if( FD_UNLIKELY( !!memcmp( key0->pubkey, key1->pubkey, 32UL ) ) ) return 0;
+  if( FD_UNLIKELY( !fd_pubkey_eq( &key0->pubkey, &key1->pubkey ) ) ) return 0;
   switch( key0->tag ) {
     case FD_GOSSIP_VALUE_VOTE:
       return key0->vote_index==key1->vote_index;
@@ -329,7 +335,12 @@ struct fd_crds_private {
 
   fd_sha256_t sha256[1];
 
-  int has_staked_node;
+  /* stakes_loaded is set when any CRDS entry is inserted with nonzero
+     stake, or when epoch stakes are loaded.  Before this flag is set,
+     unstaked entries use the long (~2 day) expiration duration instead
+     of 15 seconds, preventing the table from being flushed before epoch
+     stakes are known. */
+  int stakes_loaded;
 
   fd_ip4_port_t entrypoints[ 16UL ];
   ulong         entrypoints_cnt;
@@ -354,6 +365,9 @@ struct fd_crds_private {
 
   fd_crds_metrics_t metrics[1];
 
+  ulong               ele_max;
+  expire_sort_ele_t * sort_scratch;
+
   ulong magic;
 };
 
@@ -377,6 +391,7 @@ fd_crds_footprint( ulong ele_max ) {
   l = FD_LAYOUT_APPEND( l, crds_contact_info_pool_align(),        crds_contact_info_pool_footprint( FD_CONTACT_INFO_TABLE_SIZE ) );
   l = FD_LAYOUT_APPEND( l, crds_contact_info_fresh_list_align(),  crds_contact_info_fresh_list_footprint()                       );
   l = FD_LAYOUT_APPEND( l, ci_evict_treap_align(),                ci_evict_treap_footprint( FD_CONTACT_INFO_TABLE_SIZE )         );
+  l = FD_LAYOUT_APPEND( l, alignof(expire_sort_ele_t),            ele_max*sizeof(expire_sort_ele_t)                              );
   return FD_LAYOUT_FINI( l, FD_CRDS_ALIGN );
 }
 
@@ -434,6 +449,7 @@ fd_crds_new( void *                       shmem,
   void * _ci_pool               = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_pool_align(),        crds_contact_info_pool_footprint( FD_CONTACT_INFO_TABLE_SIZE ) );
   void * _ci_dlist              = FD_SCRATCH_ALLOC_APPEND( l, crds_contact_info_fresh_list_align(),  crds_contact_info_fresh_list_footprint()                       );
   void * _ci_evict_treap        = FD_SCRATCH_ALLOC_APPEND( l, ci_evict_treap_align(),                ci_evict_treap_footprint( FD_CONTACT_INFO_TABLE_SIZE )         );
+  void * _sort_scratch          = FD_SCRATCH_ALLOC_APPEND( l, alignof(expire_sort_ele_t),            ele_max*sizeof(expire_sort_ele_t)                              );
 
   crds->activity_update_fn = activity_update_fn;
   FD_TEST( crds->activity_update_fn );
@@ -487,7 +503,10 @@ fd_crds_new( void *                       shmem,
   memset( crds->metrics, 0, sizeof(fd_crds_metrics_t) );
 
   crds->gossip_update   = gossip_update_out;
-  crds->has_staked_node = 0;
+  crds->stakes_loaded = 0;
+
+  crds->ele_max      = ele_max;
+  crds->sort_scratch = (expire_sort_ele_t *)_sort_scratch;
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( crds->magic ) = FD_CRDS_MAGIC;
@@ -546,7 +565,7 @@ crds_unindex( fd_crds_t *       crds,
     if( FD_LIKELY( entry->ci->fresh_dlist.in_list ) ) crds_contact_info_fresh_list_ele_remove( crds->ci_fresh_dlist, entry->ci, crds->ci_pool );
     if( FD_LIKELY( entry->ci->fresh_15s_dlist.in_list ) ) {
       ci_fresh_15s_dlist_ele_remove( crds->ci_fresh_15s_dlist, entry->ci, crds->ci_pool );
-      crds->activity_update_fn( crds->activity_update_fn_ctx, (fd_pubkey_t const *)entry->key.pubkey, entry->ci->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_INACTIVE );
+      crds->activity_update_fn( crds->activity_update_fn_ctx, &entry->key.pubkey, entry->ci->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_INACTIVE );
     }
     ci_evict_treap_ele_remove( crds->ci_evict_treap, entry->ci, crds->ci_pool );
   }
@@ -574,7 +593,7 @@ crds_index( fd_crds_t *       crds,
     ci_fresh_15s_dlist_ele_push_tail( crds->ci_fresh_15s_dlist, entry->ci, crds->ci_pool );
     entry->ci->fresh_dlist.in_list = 1;
     entry->ci->fresh_15s_dlist.in_list = 1;
-    crds->activity_update_fn( crds->activity_update_fn_ctx, (fd_pubkey_t const *)entry->key.pubkey, entry->ci->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_ACTIVE );
+    crds->activity_update_fn( crds->activity_update_fn_ctx, &entry->key.pubkey, entry->ci->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_ACTIVE );
   }
 
   crds->metrics->count[ entry->key.tag ]++;
@@ -596,7 +615,7 @@ crds_release( fd_crds_t *         crds,
     msg->tag = FD_GOSSIP_UPDATE_TAG_CONTACT_INFO_REMOVE;
     msg->wallclock = (ulong)FD_NANOSEC_TO_MILLI( now );
     msg->contact_info_remove->idx = crds_contact_info_pool_idx( crds->ci_pool, entry->ci );
-    fd_memcpy( msg->origin, entry->key.pubkey, 32UL );
+    fd_memcpy( msg->origin, entry->key.pubkey.uc, 32UL );
     fd_gossip_tx_publish_chunk( crds->gossip_update, stem, (ulong)msg->tag, FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE, now );
 
     ulong ci_idx = crds_contact_info_pool_idx( crds->ci_pool, entry->ci );
@@ -660,7 +679,7 @@ expire( fd_crds_t *         crds,
     if( charge_busy ) *charge_busy = 1;
   }
 
-  long unstaked_expire_duration_nanos = fd_long_if( crds->has_staked_node,
+  long unstaked_expire_duration_nanos = fd_long_if( crds->stakes_loaded,
                                                     UNSTAKED_EXPIRE_DURATION_NANOS,
                                                     STAKED_EXPIRE_DURATION_NANOS );
 
@@ -698,7 +717,7 @@ unfresh( fd_crds_t * crds,
 
     FD_TEST( head->fresh_15s_dlist.in_list );
     head->fresh_15s_dlist.in_list = 0U;
-    crds->activity_update_fn( crds->activity_update_fn_ctx, (fd_pubkey_t const *)head->crds_entry->key.pubkey, head->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_INACTIVE );
+    crds->activity_update_fn( crds->activity_update_fn_ctx, &head->crds_entry->key.pubkey, head->contact_info, FD_GOSSIP_ACTIVITY_CHANGE_TYPE_INACTIVE );
     if( charge_busy ) *charge_busy = 1;
   }
 }
@@ -728,7 +747,7 @@ publish_update_msg( fd_crds_t *               crds,
 
   fd_gossip_update_message_t * msg = fd_gossip_out_get_chunk( crds->gossip_update );
   msg->wallclock = entry->wallclock;
-  fd_memcpy( msg->origin, entry->key.pubkey, 32UL );
+  fd_memcpy( msg->origin, entry->key.pubkey.uc, 32UL );
 
   ulong sz;
   switch( entry->key.tag ) {
@@ -744,7 +763,7 @@ publish_update_msg( fd_crds_t *               crds,
       sz = FD_GOSSIP_UPDATE_SZ_VOTE;
       fd_crds_key_t lookup_ci;
       lookup_ci.tag = FD_GOSSIP_VALUE_CONTACT_INFO;
-      fd_memcpy( &lookup_ci.pubkey, entry->key.pubkey, sizeof(fd_pubkey_t) );
+      lookup_ci.pubkey = entry->key.pubkey;
       fd_crds_entry_t * ci = lookup_map_ele_query( crds->lookup_map, &lookup_ci, NULL, crds->pool );
 
       if( FD_LIKELY( ci && ci->key.tag == FD_GOSSIP_VALUE_CONTACT_INFO ) ) {
@@ -849,7 +868,7 @@ fd_crds_insert( fd_crds_t *               crds,
     case FD_GOSSIP_VALUE_DUPLICATE_SHRED: candidate_key.duplicate_shred_index = value->duplicate_shred->index; break;
     default: break;
   }
-  fd_memcpy( candidate_key.pubkey, value->origin, 32UL );
+  fd_memcpy( candidate_key.pubkey.uc, value->origin, 32UL );
 
   fd_crds_entry_t * incumbent = lookup_map_ele_query( crds->lookup_map, &candidate_key, NULL, crds->pool );
   int replacing = !!incumbent;
@@ -915,7 +934,7 @@ fd_crds_insert( fd_crds_t *               crds,
 
   crds_index( crds, incumbent );
 
-  crds->has_staked_node |= incumbent->stake ? 1 : 0;
+  crds->stakes_loaded |= incumbent->stake ? 1 : 0;
 
   publish_update_msg( crds, incumbent, value, now, stem );
 
@@ -953,12 +972,83 @@ fd_crds_ci( fd_crds_t const * crds,
   return ci->contact_info;
 }
 
+#define SORT_NAME        expire_sort
+#define SORT_KEY_T       expire_sort_ele_t
+#define SORT_BEFORE(a,b) ((a).wallclock_nanos<(b).wallclock_nanos)
+#include "../../util/tmpl/fd_sort.c"
+
+void
+fd_crds_refresh_stakes( fd_crds_t *               crds,
+                        fd_stake_weight_t const * sorted_stakes,
+                        ulong                     sorted_stakes_cnt ) {
+  FD_TEST( sorted_stakes || !sorted_stakes_cnt );
+  crds->stakes_loaded = 1;
+
+  for( hash_treap_fwd_iter_t iter = hash_treap_fwd_iter_init( crds->hash_treap, crds->pool );
+       !hash_treap_fwd_iter_done( iter );
+       iter = hash_treap_fwd_iter_next( iter, crds->pool ) ) {
+    fd_crds_entry_t * entry = hash_treap_fwd_iter_ele( iter, crds->pool );
+
+    ulong stake = 0UL;
+    ulong idx   = fd_stake_weight_key_sort_split( sorted_stakes, sorted_stakes_cnt, (fd_stake_weight_t){ .key = entry->key.pubkey } );
+    if( FD_LIKELY( idx<sorted_stakes_cnt && fd_pubkey_eq( &sorted_stakes[ idx ].key, &entry->key.pubkey ) ) ) {
+      stake = sorted_stakes[ idx ].stake;
+    }
+
+    if( FD_LIKELY( entry->stake==stake ) ) continue;
+
+    evict_treap_ele_remove( crds->evict_treap, entry, crds->pool );
+    if( entry->key.tag==FD_GOSSIP_VALUE_CONTACT_INFO ) ci_evict_treap_ele_remove( crds->ci_evict_treap, entry->ci, crds->ci_pool );
+    ulong old_stake = entry->stake;
+    entry->stake = stake;
+    evict_treap_ele_insert( crds->evict_treap, entry, crds->pool );
+    if( entry->key.tag==FD_GOSSIP_VALUE_CONTACT_INFO ) ci_evict_treap_ele_insert( crds->ci_evict_treap, entry->ci, crds->ci_pool );
+
+    int became_staked   = (!old_stake) & (!!stake);
+    int became_unstaked = (!!old_stake) & (!stake);
+
+    if( FD_LIKELY( became_staked ) ) {
+      unstaked_expire_dlist_ele_remove( crds->unstaked_expire_dlist, entry, crds->pool );
+      staked_expire_dlist_ele_push_tail( crds->staked_expire_dlist, entry, crds->pool );
+    }
+    if( FD_LIKELY( became_unstaked ) ) {
+      staked_expire_dlist_ele_remove( crds->staked_expire_dlist, entry, crds->pool );
+      unstaked_expire_dlist_ele_push_tail( crds->unstaked_expire_dlist, entry, crds->pool );
+    }
+
+    if( entry->key.tag==FD_GOSSIP_VALUE_CONTACT_INFO ) {
+      fd_gossip_wsample_stake( crds->wsample, crds_contact_info_pool_idx( crds->ci_pool, entry->ci ), stake );
+
+      crds->metrics->peer_staked_cnt    += (ulong)became_staked;
+      crds->metrics->peer_staked_cnt    -= (ulong)became_unstaked;
+      crds->metrics->peer_unstaked_cnt  += (ulong)became_unstaked;
+      crds->metrics->peer_unstaked_cnt  -= (ulong)became_staked;
+      crds->metrics->peer_visible_stake += fd_ulong_if( stake>=old_stake, stake - old_stake, 0UL );
+      crds->metrics->peer_visible_stake -= fd_ulong_if( stake< old_stake, old_stake - stake, 0UL );
+    }
+  }
+
+#define EXPIRE_DLIST_SORT(PREFIX) do { \
+  ulong cnt = 0UL; \
+  while( !PREFIX##_is_empty( crds->PREFIX, crds->pool ) ) { \
+    ulong idx = PREFIX##_idx_pop_head( crds->PREFIX, crds->pool ); \
+    crds->sort_scratch[ cnt++ ] = (expire_sort_ele_t){ .pool_idx = idx, .wallclock_nanos = crds->pool[ idx ].expire.wallclock_nanos }; \
+  } \
+  expire_sort_inplace( crds->sort_scratch, cnt ); \
+  for( ulong i=0UL; i<cnt; i++ ) PREFIX##_idx_push_tail( crds->PREFIX, crds->sort_scratch[ i ].pool_idx, crds->pool ); } while(0)
+
+  /* Restore "oldest-at-head" ordering. */
+  EXPIRE_DLIST_SORT( staked_expire_dlist   );
+  EXPIRE_DLIST_SORT( unstaked_expire_dlist );
+#undef EXPIRE_DLIST_SORT
+}
+
 uchar const *
 fd_crds_ci_pubkey( fd_crds_t const * crds,
                    ulong             ci_idx ) {
   fd_crds_contact_info_entry_t const * ci = crds_contact_info_pool_ele_const( crds->ci_pool, ci_idx );
   FD_TEST( ci );
-  return ci->crds_entry->key.pubkey;
+  return ci->crds_entry->key.pubkey.uc;
 }
 
 ulong
@@ -967,7 +1057,7 @@ fd_crds_ci_idx( fd_crds_t const * crds,
   fd_crds_key_t lookup_ci = {
     .tag = FD_GOSSIP_VALUE_CONTACT_INFO,
   };
-  fd_memcpy( lookup_ci.pubkey, pubkey, 32UL );
+  fd_memcpy( lookup_ci.pubkey.uc, pubkey, 32UL );
 
   fd_crds_entry_t const * ci_entry = lookup_map_ele_query( crds->lookup_map, &lookup_ci, NULL, crds->pool );
   if( FD_UNLIKELY( !ci_entry ) ) return ULONG_MAX;

--- a/src/flamenco/gossip/fd_crds.h
+++ b/src/flamenco/gossip/fd_crds.h
@@ -5,6 +5,7 @@
 #include "fd_gossip_message.h"
 #include "fd_gossip_out.h"
 #include "fd_gossip_purged.h"
+#include "../stakes/fd_stake_weight.h"
 
 #include "../../util/net/fd_net_headers.h"
 #include "../../disco/metrics/generated/fd_metrics_enums.h"
@@ -208,6 +209,17 @@ fd_crds_mask_iter_done( fd_crds_mask_iter_t * it,
 fd_crds_entry_t const *
 fd_crds_mask_iter_entry( fd_crds_mask_iter_t * it,
                          fd_crds_t const * crds );
+
+/* fd_crds_refresh_stakes iterates all CRDS entries and updates each
+   entry's stake using the provided sorted_stakes array.  sorted_stakes
+   must be sorted by key (ascending memcmp order) so that binary search
+   can be used.  Entries whose origin pubkey is not found in
+   sorted_stakes are set to zero stake. */
+
+void
+fd_crds_refresh_stakes( fd_crds_t *               crds,
+                        fd_stake_weight_t const * sorted_stakes,
+                        ulong                     sorted_stakes_cnt );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1,4 +1,5 @@
 #include "fd_gossip.h"
+#include "fd_crds.h"
 #include "fd_bloom.h"
 #include "fd_gossip_message.h"
 #include "fd_gossip_txbuild.h"
@@ -121,6 +122,10 @@ struct fd_gossip_private {
     ulong             crds_val_sz;
     fd_gossip_value_t ci[1];
   } my_contact_info;
+
+  union {
+    fd_stake_weight_t epoch_stakes[ MAX_SHRED_DESTS ];
+  } scratch;
 
   fd_gossip_out_ctx_t * gossip_net_out;
 };
@@ -409,12 +414,23 @@ fd_gossip_stakes_update( fd_gossip_t *             gossip,
   stake_map_reset( gossip->stake.map );
   stake_pool_reset( gossip->stake.pool );
 
-  for( ulong i=0UL; i<stake_weights_cnt; i++ ) {
+  if( FD_UNLIKELY( stake_weights_cnt>MAX_SHRED_DESTS ) ) {
+    FD_LOG_WARNING(( "stake_weights_cnt %lu exceeds scratch capacity %lu; clamping", stake_weights_cnt, MAX_SHRED_DESTS ));
+  }
+  ulong cnt = fd_ulong_min( stake_weights_cnt, MAX_SHRED_DESTS );
+  if( FD_LIKELY( cnt ) ) {
+    fd_memcpy( gossip->scratch.epoch_stakes, stake_weights, cnt*sizeof(fd_stake_weight_t) );
+    fd_stake_weight_key_sort_inplace( gossip->scratch.epoch_stakes, cnt );
+  }
+
+  for( ulong i=0UL; i<cnt; i++ ) {
     stake_t * entry = stake_pool_ele_acquire( gossip->stake.pool );
-    entry->pubkey = stake_weights[i].key;
-    entry->stake  = stake_weights[i].stake;
+    entry->pubkey = gossip->scratch.epoch_stakes[i].key;
+    entry->stake  = gossip->scratch.epoch_stakes[i].stake;
     stake_map_ele_insert( gossip->stake.map, entry, gossip->stake.pool );
   }
+
+  fd_crds_refresh_stakes( gossip->crds, gossip->scratch.epoch_stakes, cnt );
 
   gossip->identity_stake = get_stake( gossip, gossip->identity_pubkey );
   fd_gossip_wsample_self_stake( gossip->wsample, gossip->identity_stake );

--- a/src/flamenco/gossip/test_crds.c
+++ b/src/flamenco/gossip/test_crds.c
@@ -1,0 +1,216 @@
+#include "../../util/fd_util.h"
+
+#include "fd_crds.h"
+#include "fd_active_set.h"
+#include "fd_gossip_wsample.h"
+#include "fd_gossip_purged.h"
+#include "fd_gossip_out.h"
+#include "../stakes/fd_stake_weight.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define ELE_MAX (1024UL)
+
+static const long STAKED_EXPIRE_DURATION_NANOS   = 432000L*400L*1000L*1000L;
+static const long UNSTAKED_EXPIRE_DURATION_NANOS = 15L*1000L*1000L*1000L;
+
+/* The test avoids CONTACT_INFO crds which triggers stem/publish codepaths. */
+static fd_stem_context_t stem[ 1 ] = {0};
+static fd_gossip_out_ctx_t gossip_out[ 1 ] = {0};
+
+static void
+noop_activity_update( void *                           ctx,
+                      fd_pubkey_t const *              identity,
+                      fd_gossip_contact_info_t const * ci,
+                      int                              change_type ) {
+  (void)ctx; (void)identity; (void)ci; (void)change_type;
+}
+
+typedef struct {
+  fd_crds_t * crds;
+  void *      purged_mem;
+  void *      wsample_mem;
+  void *      crds_mem;
+  void *      as_mem;
+} test_crds_env_t;
+
+static fd_crds_t *
+make_crds( fd_rng_t * rng,
+           test_crds_env_t * env ) {
+  void * purged_mem = aligned_alloc( fd_gossip_purged_align(), fd_gossip_purged_footprint( ELE_MAX ) );
+  FD_TEST( purged_mem );
+  fd_gossip_purged_t * purged = fd_gossip_purged_join( fd_gossip_purged_new( purged_mem, rng, ELE_MAX ) );
+  FD_TEST( purged );
+
+  void * wsample_mem = aligned_alloc( fd_gossip_wsample_align(), fd_gossip_wsample_footprint( FD_CONTACT_INFO_TABLE_SIZE ) );
+  FD_TEST( wsample_mem );
+  fd_gossip_wsample_t * wsample = fd_gossip_wsample_join( fd_gossip_wsample_new( wsample_mem, rng, FD_CONTACT_INFO_TABLE_SIZE ) );
+  FD_TEST( wsample );
+
+  void * crds_mem = aligned_alloc( fd_crds_align(),       fd_crds_footprint( ELE_MAX ) );
+  FD_TEST( crds_mem );
+  void * as_mem   = aligned_alloc( fd_active_set_align(), fd_active_set_footprint()    );
+  FD_TEST( as_mem );
+
+  uchar identity[ 32UL ] = {0};
+
+  fd_crds_t * crds = fd_crds_join( fd_crds_new( crds_mem, NULL, 0UL, wsample, (fd_active_set_t *)as_mem, rng, ELE_MAX, purged, noop_activity_update, NULL, gossip_out ) );
+  FD_TEST( crds );
+
+  FD_TEST( fd_active_set_join( fd_active_set_new( as_mem, wsample, crds, rng, identity, 0UL, NULL, NULL ) ) );
+
+  env->crds        = crds;
+  env->purged_mem  = purged_mem;
+  env->wsample_mem = wsample_mem;
+  env->crds_mem    = crds_mem;
+  env->as_mem      = as_mem;
+
+  return crds;
+}
+
+static void
+teardown_crds( test_crds_env_t * env ) {
+  free( env->purged_mem );
+  free( env->wsample_mem );
+  free( env->crds_mem );
+  free( env->as_mem );
+}
+
+static void
+insert_node_instance( fd_crds_t * crds,
+                      uchar       origin_byte,
+                      ulong       token,
+                      ulong       origin_stake,
+                      long        now ) {
+  fd_gossip_value_t value[ 1 ];
+  memset( value, 0, sizeof(fd_gossip_value_t) );
+  value->tag       = FD_GOSSIP_VALUE_NODE_INSTANCE;
+  value->wallclock = 100UL;
+  memset( value->origin, origin_byte, 32UL );
+  value->node_instance->token = token;
+
+  uchar value_bytes[ 128UL ];
+  memset( value_bytes, 0, sizeof(value_bytes) );
+  value_bytes[ 0 ] = origin_byte;
+  memcpy( value_bytes+1UL, &token, sizeof(ulong) );
+
+  FD_TEST( fd_crds_insert( crds, value, value_bytes, sizeof(value_bytes), origin_stake, 0, 0, now, stem )==0L );
+}
+
+static fd_stake_weight_t
+mk_stake( uchar byte,
+          ulong stake ) {
+  fd_stake_weight_t sw;
+  memset( &sw, 0, sizeof(sw) );
+  memset( sw.key.uc, byte, 32UL );
+  sw.stake = stake;
+  return sw;
+}
+
+/* Before stakes are loaded, unstaked entries use the long expiry
+   duration, so they are not flushed at 15s. */
+
+static void
+test_unstaked_no_expire_before_stakes( fd_rng_t * rng ) {
+  test_crds_env_t env[ 1 ] = { 0 };
+  fd_crds_t * crds = make_crds( rng, env );
+
+  long t0 = 1000L*1000L*1000L;
+  insert_node_instance( crds, 0x44, 1UL, 0UL, t0 );
+  FD_TEST( fd_crds_len( crds )==1UL );
+
+  fd_crds_advance( crds, t0+UNSTAKED_EXPIRE_DURATION_NANOS+1000L*1000L*1000L, stem, NULL );
+  FD_TEST( fd_crds_len( crds )==1UL );
+
+  teardown_crds( env );
+}
+
+/* Loading stakes reclassifies entries: newly-staked entries move to the
+   long-lived staked list, still-unstaked ones expire at 15s. */
+
+static void
+test_reclassify( fd_rng_t * rng ) {
+  test_crds_env_t env[ 1 ] = { 0 };
+  fd_crds_t * crds = make_crds( rng, env );
+
+  long t0 = 1000L*1000L*1000L;
+  insert_node_instance( crds, 0x11, 1UL, 0UL, t0 );
+  insert_node_instance( crds, 0x22, 2UL, 0UL, t0 );
+  insert_node_instance( crds, 0x33, 3UL, 0UL, t0 );
+  FD_TEST( fd_crds_len( crds )==3UL );
+
+  fd_stake_weight_t stakes[ 1 ] = { mk_stake( 0x22, 500UL ) };
+  fd_stake_weight_key_sort_inplace( stakes, 1UL );
+  fd_crds_refresh_stakes( crds, stakes, 1UL );
+  FD_TEST( fd_crds_len( crds )==3UL );
+
+  int charge_busy = 0;
+  fd_crds_advance( crds, t0+UNSTAKED_EXPIRE_DURATION_NANOS+1000L*1000L*1000L, stem, &charge_busy );
+  FD_TEST( fd_crds_len( crds )==1UL );
+  FD_TEST( charge_busy==1 );
+
+  fd_crds_advance( crds, t0+STAKED_EXPIRE_DURATION_NANOS-1L, stem, NULL );
+  FD_TEST( fd_crds_len( crds )==1UL );
+
+  fd_crds_advance( crds, t0+STAKED_EXPIRE_DURATION_NANOS+1L, stem, NULL );
+  FD_TEST( fd_crds_len( crds )==0UL );
+
+  teardown_crds( env );
+}
+
+/* refresh_stakes re-sorts the expiry lists, so the oldest entry must
+   still expire first afterwards. */
+
+static void
+test_ordering_preserved( fd_rng_t * rng ) {
+  test_crds_env_t env[ 1 ] = { 0 };
+  fd_crds_t * crds = make_crds( rng, env );
+
+  long t_bb = 1000L*1000L*1000L;
+  long t_aa = t_bb + 5L*1000L*1000L*1000L;
+  insert_node_instance( crds, 0xBB, 1UL, 0UL, t_bb );
+  insert_node_instance( crds, 0xAA, 2UL, 0UL, t_aa );
+
+  fd_crds_refresh_stakes( crds, NULL, 0UL );
+  FD_TEST( fd_crds_len( crds )==2UL );
+
+  long t1 = t_bb + UNSTAKED_EXPIRE_DURATION_NANOS + 1000L*1000L*1000L;
+  FD_TEST( t1 < t_aa+UNSTAKED_EXPIRE_DURATION_NANOS );
+  fd_crds_advance( crds, t1, stem, NULL );
+  FD_TEST( fd_crds_len( crds )==1UL );
+
+  fd_crds_advance( crds, t_aa+UNSTAKED_EXPIRE_DURATION_NANOS+1000L*1000L*1000L, stem, NULL );
+  FD_TEST( fd_crds_len( crds )==0UL );
+
+  teardown_crds( env );
+}
+
+static void
+test_empty_refresh( fd_rng_t * rng ) {
+  test_crds_env_t env[ 1 ] = { 0 };
+  fd_crds_t * crds = make_crds( rng, env );
+  fd_crds_refresh_stakes( crds, NULL, 0UL );
+  FD_TEST( fd_crds_len( crds )==0UL );
+  teardown_crds( env );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  fd_rng_t _rng[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  test_empty_refresh( rng );
+  test_unstaked_no_expire_before_stakes( rng );
+  test_reclassify( rng );
+  test_ordering_preserved( rng );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
closes https://github.com/firedancer-io/firedancer/issues/8673

Problem
----
When a node boots, CRDS entries arrive via gossip before epoch stakes are known, so everything is classified as unstaked. Once `fd_gossip_stakes_update` loads stakes, `has_staked_node` flips, the unstaked TTL drops from ~2 days to 15s, and every misclassified entry from a staked validator gets expired and re-fetched.

Scraped Prometheus metrics at 1s intervals on testnet, same node, with and without the fix:

| Metric | Without fix | With fix |
|---|---|---|
| `crds_expired_count` at t+25s | **196,948** | 156 |
| `crds_peer_staked_count` at stakes load | Ramps 0→33→141→…→617 over ~8s | Jumps 0→**610** in one interval |
| `crds_peer_total_stake` | Takes ~8s to converge to 3.13e17 | Converges to 3.12e17 **instantly** |
| `crds_count::epoch_slots` | Peaks at 59K, crashes to **434** | Peaks at 55K, **stays at 55K