### PR TITLE
flamenco: mark stake_minimum_delegation_for_rewards as reverted

### DIFF
--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -632,7 +632,8 @@ fd_feature_id_t const ids[] = {
     .id                        = {"\xe0\x31\xcd\xc7\x1c\xf7\x58\x54\x9d\x9f\x58\x3b\xa5\xe4\x94\xf7\xc8\x74\xb1\xab\xcf\xed\xe9\x3b\x3b\xce\x1c\xc0\xeb\x2d\xda\xe1"},
                                  /* G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ */
     .name                      = "stake_minimum_delegation_for_rewards",
-    .cleaned_up                = 0 },
+    .cleaned_up                = 0,
+    .reverted                  = 1 },
 
   { .index                     = offsetof(fd_features_t, add_set_compute_unit_price_ix)>>3,
     .id                        = {"\x78\xe2\x1a\x43\xc1\x90\x64\x60\x36\x9e\x01\x54\xad\x41\x14\x72\x2f\x6b\x2a\x43\xe7\x9b\x9a\x61\xcb\x4b\x37\xa1\x0c\x7f\x4b\xd1"},

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -89,7 +89,7 @@
   {"name":"stake_allow_zero_undelegated_amount","pubkey":"sTKz343FM8mqtyGvYWvbLpTThw3ixRM4Xk8QvZ985mw","cleaned_up":1,"hardcode_for_fuzzing":1},
   {"name":"require_static_program_ids_in_transaction","pubkey":"8FdwgyHFEjhAdjWfV2vfqk7wA1g9X3fQpKH7SBpEv3kC","cleaned_up":1,"hardcode_for_fuzzing":1},
   {"name":"stake_raise_minimum_delegation_to_1_sol","pubkey":"9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i"},
-  {"name":"stake_minimum_delegation_for_rewards","pubkey":"G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ","comment":"not ready for activation as in flux in Agave"},
+  {"name":"stake_minimum_delegation_for_rewards","pubkey":"G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ","comment":"not ready for activation as in flux in Agave","reverted":1},
   {"name":"add_set_compute_unit_price_ix","pubkey":"98std1NSHqXi9WYvFShfVepRdCoq1qvsp8fsR2XZtG8g","cleaned_up":1,"hardcode_for_fuzzing":1},
   {"name":"disable_deploy_of_alloc_free_syscall","pubkey":"79HWsX9rpnnJBPcdNURVqygpMAfxdrAirzAGAVmf92im","cleaned_up":1,"hardcode_for_fuzzing":1},
   {"name":"include_account_index_in_rent_error","pubkey":"2R72wpcQ7qV7aTJWUumdn8u5wmmTyXbK7qzEy7YSAgyY","cleaned_up":1,"hardcode_for_fuzzing":1},


### PR DESCRIPTION
It is unclear what Agave's plan is with this feature gate, and we explicitly do not implement it:
https://github.com/firedancer-io/firedancer/blob/881335e95bcf2987042a28a7106a76cb11b7e8f9/src/flamenco/rewards/fd_rewards.c#L360-L364
so we just remove it from the map, to indicate that we do not support it.