### PR TITLE
forest: reject incorrect merkles on fec_insert and tighten fec_chain_verify

### DIFF
--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -1259,33 +1259,36 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
 # endif
 
   uint fec_idx = fec_set_idx / 32UL; /* index into merkle root array */
-  if( FD_UNLIKELY( merkle_recvd( ele, fec_idx )
-                   && !fd_hash_eq( &ele->merkle_roots[fec_idx].mr, mr ) ) ) {
-    FD_BASE58_ENCODE_32_BYTES( ele->merkle_roots[fec_idx].mr.key, mr_b58 );
-    FD_BASE58_ENCODE_32_BYTES( mr->key, mr_recv_b58 );
-    FD_LOG_WARNING(( "fd_forest_fec_insert: fec_resolver inserted a version of slot %lu fec_set_idx %u we dont have recorded. current_mr %s, received_mr %s", slot, fec_set_idx, mr_b58, mr_recv_b58 ));
-    /* there are two cases:
 
-       (1) the first and common case is that we've received a mix of
-           shreds from equivocating FEC siblings A & B.  In forest we
-           have recorded hash = { 0 } for this fec set because we've
-           received a mix of merkle roots, so we nulled the FEC set.
-           Let's say fec_resolver then completes version B, and delivers
-           it.  We can safely overwrite our null merkle root with B
-           because we know we must've received all the data for version
-           B!
-       (2) the second case is that we get two FEC completion msgs:
-           one for both version B and A. They get completed, one after
-           the other. In this case we've first overwritten from { 0 } to
-           B.  But if version A arrives, what should we do?  If B
-           is the correct version, but we choose to overwrite the fec
-           when A arrive, then we need to ask ask shred to
-           re-deliver the FEC set.  Since we don't know at this time if
-           B or A is correct, we optimize for case 1, and overwrite the
-           merkle root with the new one. */
-    // overwrite the merkle root with the new one
-    ele->merkle_roots[fec_idx].mr  = *mr;
-    ele->merkle_roots[fec_idx].cmr = *cmr;
+  if( FD_UNLIKELY( merkle_recvd( ele, fec_idx ) && !fd_hash_eq( &ele->merkle_roots[fec_idx].mr, mr ) ) ) {
+    if( FD_UNLIKELY( merkle_verified( ele, fec_idx + 1 ) && !fd_hash_eq( &ele->merkle_roots[fec_idx + 1].cmr, mr ) ) ) {
+      /* reject if the fec is verified and the merkle root doesn't match */
+      return ele;
+    } else {
+      /* overwrite the merkle root with the new one */
+      FD_BASE58_ENCODE_32_BYTES( ele->merkle_roots[fec_idx].mr.key, mr_b58 );
+      FD_BASE58_ENCODE_32_BYTES( mr->key, mr_recv_b58 );
+      FD_LOG_WARNING(( "fd_forest_fec_insert: fec_resolver inserted a version of slot %lu fec_set_idx %u we dont have recorded. current_mr %s, received_mr %s", slot, fec_set_idx, mr_b58, mr_recv_b58 ));
+      /* there are two cases:
+         (1) the first and common case is that we've received a mix of
+         shreds from equivocating FEC siblings A & B.  In forest we have
+         recorded hash = { invalid_mr } for this fec set because we've
+         received a mix of merkle roots, so we nulled the FEC set. Let's
+         say fec_resolver then completes version B, and delivers it.  We
+         can safely overwrite our null merkle root with B because we know
+         we must've received all the data for version B!
+
+         (2) the second case is that we get two FEC completion msgs: one
+         for both version B and A. They get completed, one after the
+         other.  We first overwriten from { invalid_mr } to B.  But if
+         version A arrives, what should we do?  If B is the correct
+         version, but we choose to overwrite the fec when A arrive, then
+         we need to ask ask shred to re-deliver the FEC set. Since we
+         don't know at this time if B or A is correct, we optimize for
+         case 1, and overwrite the merkle root with the new one. */
+      ele->merkle_roots[fec_idx].mr  = *mr;
+      ele->merkle_roots[fec_idx].cmr = *cmr;
+    }
   }
 
   if( FD_UNLIKELY( slot_complete && ele->child != ULONG_MAX ) ) {

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -1390,6 +1390,7 @@ fd_forest_fec_chain_verify( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash
   fd_hash_t const * expected_mr = bid;
 
   while( FD_UNLIKELY( !ele->chain_confirmed ) ) {
+    if( FD_UNLIKELY(  fd_hash_eq( &ele->merkle_roots[fec_idx].mr, &empty_mr   ) ) ) return NULL; /* can't verify the chain further */
     if( FD_UNLIKELY( !fd_hash_eq( expected_mr, &ele->merkle_roots[fec_idx].mr ) ) ) return ele;
 
     /* This FEC merkle is correct, and the chained merkle is correct. */
@@ -1406,7 +1407,7 @@ fd_forest_fec_chain_verify( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash
       if( FD_UNLIKELY( !ele ) ) return NULL; /* can't verify the chain further */
 
       ele->confirmed_bid = *expected_mr; /* CMR of child slot */
-      if( FD_UNLIKELY( ele->complete_idx == UINT_MAX || ele->buffered_idx != ele->complete_idx ) ) return NULL; /* can't verify the chain further */
+      if( FD_UNLIKELY( ele->complete_idx == UINT_MAX ) ) return NULL; /* can't verify the chain further */
 
       fec_idx = ele->complete_idx / 32UL;
       continue;

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -1220,16 +1220,10 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
      occurring.  What if this shred is part of the canonical chain
      though?  When the duplicate confirmation arrives from tower, the
      false complete_idx will be cleared, and shreds higher than the
-     false complete_idx will be accepted.  It is always beneficial for
-     us to take the minimum slot complete index because this triggers
-     the chain verification to start. */
+     false complete_idx will be accepted. */
 
   if( FD_UNLIKELY( shred_idx > ele->complete_idx ) ) {
     FD_LOG_WARNING(( "[%s] slot %lu shred index %u is greater than known complete_idx %u. rejecting shred", __func__, slot, shred_idx, ele->complete_idx ));
-    return NULL;
-  }
-  if( FD_UNLIKELY( slot_complete && ele->complete_idx < shred_idx ) ) {
-    FD_LOG_WARNING(( "[%s] slot %lu slot_complete received, but new complete_idx %u > complete_idx %u. rejecting shred", __func__, slot, ele->complete_idx, shred_idx ));
     return NULL;
   }
 
@@ -1272,7 +1266,14 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
     }
   }
 
-  /* Shred accepted, merkle root verified (as much as possible) */
+  /* Shred accepted, merkle root verified (as much as possible). */
+
+  if( FD_UNLIKELY( slot_complete && ele->complete_idx != UINT_MAX && shred_idx != ele->complete_idx ) ) {
+    /* It is always beneficial for us to take the minimum slot complete
+       index because this enables the chain verification to start
+       earlier. */
+    FD_LOG_WARNING(( "[%s] slot %lu shred_idx %u is slot_complete, but recorded complete_idx is %u. Updating complete_idx to %u", __func__, slot, shred_idx, ele->complete_idx, shred_idx ));
+  }
   ele->complete_idx = fd_uint_if( slot_complete, shred_idx, ele->complete_idx );
 
   if( !fd_forest_blk_idxs_test( ele->idxs, shred_idx ) ) { /* newly seen shred */

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -1140,16 +1140,41 @@ merkle_recvd( fd_forest_blk_t * ele, uint fec_idx ) {
   return memcmp( &ele->merkle_roots[fec_idx].mr, &empty_mr, sizeof(fd_hash_t) ) != 0;
 }
 
+/* returns 1 if the FEC set after the given FEC set has been confirmed */
 static inline int
-merkle_verified( fd_forest_blk_t * ele, uint fec_idx ) {
+next_merkle_confirmed( fd_forest_blk_t * ele, uint fec_idx ) {
   // not possible for anything to be verified if the slot doesn't know the last index
   if( ele->complete_idx == UINT_MAX ) return 0;
   /* if we are asking about the block_id, it's stored in the confirmed_bid field */
-  if( FD_UNLIKELY( fec_idx == (ele->complete_idx / 32UL + 1) ) ) {
+  if( FD_UNLIKELY( fec_idx == (ele->complete_idx / 32UL) ) ) {
     return !fd_hash_eq( &ele->confirmed_bid, &empty_mr );
   }
-  return ele->lowest_verified_fec <= fec_idx;
+  return ele->lowest_verified_fec <= (fec_idx + 1UL);
 }
+
+/* Returns the chained merkle root that commits to the given FEC set.
+   Only meaningful when next_merkle_confirmed() is true; otherwise the
+   returned cmr may be uninitialized. For most FEC sets this is
+   merkle_roots[fec_idx+1].cmr.  For the last FEC in the slot (fec_idx
+   == complete_idx/32) it is confirmed_bid.
+
+   Guard against OOB read: an attacker can send a fec_idx beyond
+   complete_idx. The shred gets filtered upstream, so we don't need to
+   guard against it here. */
+
+static inline fd_hash_t *
+next_chained_merkle( fd_forest_blk_t * ele, uint fec_idx ) {
+  if( FD_UNLIKELY( fec_idx == ele->complete_idx / 32UL ) ) {
+    return &ele->confirmed_bid;
+  }
+  return &ele->merkle_roots[fec_idx + 1].cmr;
+}
+
+/* data_shred_insert accepts the first complete_idx it sees while
+   complete_idx is UINT_MAX, and rejects any subsequent shreds that are
+   greater than the complete_idx.  This is applies for the very first
+   slot_complete seen (could be incorrect), or after the complete_idx has
+   been cleared by fec_clear due to an incorrect FEC. */
 
 fd_forest_blk_t *
 fd_forest_data_shred_insert( fd_forest_t * forest,
@@ -1190,13 +1215,29 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
     ele->merkle_roots[fec_idx].cmr = *cmr;
   }
 
+  /* We can automatically reject if the shred index is greater than the
+     complete index, as it clearly signifies some duplicity is
+     occurring.  What if this shred is part of the canonical chain
+     though?  When the duplicate confirmation arrives from tower, the
+     false complete_idx will be cleared, and shreds higher than the
+     false complete_idx will be accepted.  It is always beneficial for
+     us to take the minimum slot complete index because this triggers
+     the chain verification to start. */
+
+  if( FD_UNLIKELY( shred_idx > ele->complete_idx ) ) {
+    FD_LOG_WARNING(( "[%s] slot %lu shred index %u is greater than known complete_idx %u. rejecting shred", __func__, slot, shred_idx, ele->complete_idx ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( slot_complete && ele->complete_idx < shred_idx ) ) {
+    FD_LOG_WARNING(( "[%s] slot %lu slot_complete received, but new complete_idx %u > complete_idx %u. rejecting shred", __func__, slot, ele->complete_idx, shred_idx ));
+    return NULL;
+  }
+
   /* Otherwise if this is any other shred and we know the verification
      status, we can immediately verify or reject. */
 
-  if( FD_UNLIKELY( merkle_verified( ele, fec_idx + 1 ) ) ) { /* if the cmr pointing to this FEC has been verified, then... */
-    if( FD_UNLIKELY(
-         ( fec_idx == (ele->complete_idx / 32UL) && !fd_hash_eq( &ele->confirmed_bid, mr ) ) ||
-         ( fec_idx != (ele->complete_idx / 32UL) && !fd_hash_eq( &ele->merkle_roots[fec_idx + 1].cmr, mr ) ) ) ) {
+  if( FD_UNLIKELY( next_merkle_confirmed( ele, fec_idx ) ) ) { /* if the cmr pointing to this FEC has been confirmed, then... */
+    if( FD_UNLIKELY( !fd_hash_eq( next_chained_merkle( ele, fec_idx ), mr ) ) ) {
       /* merkle root doesn't match the verified CMR  */
       return NULL; /* do not accept this shred. */
     } else {
@@ -1263,31 +1304,38 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
 # endif
 
   uint fec_idx = fec_set_idx / 32UL; /* index into merkle root array */
-  if( FD_UNLIKELY( merkle_recvd( ele, fec_idx )
-                   && !fd_hash_eq( &ele->merkle_roots[fec_idx].mr, mr ) ) ) {
+
+  /* if the FEC set is beyond the complete_idx, then we reject the FEC */
+  if( FD_UNLIKELY( fec_set_idx > ele->complete_idx ) ) {
+    FD_LOG_WARNING(( "[%s] slot %lu fec set %u is greater than known complete_idx %u. rejecting FEC", __func__, slot, fec_set_idx, ele->complete_idx ));
+    return NULL;
+  }
+
+  /* reject if the fec is confirmed and the merkle root doesn't match */
+  if( FD_UNLIKELY( next_merkle_confirmed( ele, fec_idx ) && !fd_hash_eq( next_chained_merkle( ele, fec_idx ), mr ) ) ) return NULL;
+
+  if( FD_UNLIKELY( merkle_recvd( ele, fec_idx ) && !fd_hash_eq( &ele->merkle_roots[fec_idx].mr, mr ) ) ) {
+    /* overwrite the merkle root with the new one */
     FD_BASE58_ENCODE_32_BYTES( ele->merkle_roots[fec_idx].mr.key, mr_b58 );
     FD_BASE58_ENCODE_32_BYTES( mr->key, mr_recv_b58 );
-    FD_LOG_WARNING(( "[%s] received a version of slot %lu fec set %u we dont have recorded. current_mr %s, received_mr %s", __func__, slot, fec_set_idx, mr_b58, mr_recv_b58 ));
+    FD_LOG_WARNING(( "[%s] received a version of slot %lu fec_set_idx %u that isn't recorded. current_mr %s, received_mr %s", __func__, slot, fec_set_idx, mr_b58, mr_recv_b58 ));
     /* there are two cases:
+        (1) the first and common case is that we've received a mix of
+        shreds from equivocating FEC siblings A & B.  In forest we have
+        recorded hash = { invalid_mr } for this fec set because we've
+        received a mix of merkle roots, so we nulled the FEC set. Let's
+        say fec_resolver then completes version B, and delivers it.  We
+        can safely overwrite our null merkle root with B because we know
+        we must've received all the data for version B!
 
-       (1) the first and common case is that we've received a mix of
-           shreds from equivocating FEC siblings A & B.  In forest we
-           have recorded hash = { 0 } for this fec set because we've
-           received a mix of merkle roots, so we nulled the FEC set.
-           Let's say fec_resolver then completes version B, and delivers
-           it.  We can safely overwrite our null merkle root with B
-           because we know we must've received all the data for version
-           B!
-       (2) the second case is that we get two FEC completion msgs:
-           one for both version B and A. They get completed, one after
-           the other. In this case we've first overwritten from { 0 } to
-           B.  But if version A arrives, what should we do?  If B
-           is the correct version, but we choose to overwrite the fec
-           when A arrive, then we need to ask ask shred to
-           re-deliver the FEC set.  Since we don't know at this time if
-           B or A is correct, we optimize for case 1, and overwrite the
-           merkle root with the new one. */
-    // overwrite the merkle root with the new one
+        (2) the second case is that we get two FEC completion msgs: one
+        for both version B and A. They get completed, one after the
+        other.  We first overwrite from { invalid_mr } to B.  But if
+        version A arrives, what should we do?  If B is the correct
+        version, but we choose to overwrite the fec when A arrive, then
+        we need to ask shred to re-deliver the FEC set. Since we
+        don't know at this time if B or A is correct, we optimize for
+        case 1, and overwrite the merkle root with the new one. */
     ele->merkle_roots[fec_idx].mr  = *mr;
     ele->merkle_roots[fec_idx].cmr = *cmr;
   }

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -1644,6 +1644,71 @@ test_eqvoc_different_slot_size( fd_wksp_t * wksp ) {
   fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
 }
 
+void
+test_fec_complete_no_poison_verified( fd_wksp_t * wksp ) {
+  /* A conflicting FEC_COMPLETE arrives for an FEC index that has
+     already been chain-verified.  The merkle root metadata doesn't get
+     overwritten. */
+  ulong ele_max = 16;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_init( forest, 0 );
+
+  fd_hash_t mr_0   = (fd_hash_t){ .key = { 0 } };
+  fd_hash_t mr_1   = (fd_hash_t){ .key = { 1 } };
+  fd_hash_t mr_2   = (fd_hash_t){ .key = { 2 } };
+  fd_hash_t mr_3_0 = (fd_hash_t){ .key = { 30 } }; /* correct FEC 0 mr */
+  fd_hash_t mr_3_1 = (fd_hash_t){ .key = { 31 } }; /* correct FEC 1 mr = block_id */
+
+  /* Conflicting FEC 1 merkle roots */
+  fd_hash_t mr_3_1_bad = (fd_hash_t){ .key = { 99 } };
+  fd_hash_t cmr_bad    = (fd_hash_t){ .key = { 98 } };
+
+  /* Set up ancestry: root=0 -> slot 1 -> slot 2 -> slot 3 */
+  fd_forest_blk_insert( forest, 1, 0, NULL );
+  fd_forest_data_shred_insert( forest, 1, 0, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_1, &mr_0 );
+  fd_forest_blk_insert( forest, 2, 1, NULL );
+  fd_forest_data_shred_insert( forest, 2, 1, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_2, &mr_1 );
+
+  /* Insert correct version of slot 3: 2 FEC sets, parent=2 */
+  fd_forest_blk_insert( forest, 3, 2, NULL );
+  /* FEC 0: shreds 0-31 */
+  fd_forest_fec_insert( forest, 3, 2, 31, 0, 0, 0, &mr_3_0, &mr_2 );
+  /* FEC 1: shreds 32-63, slot_complete=1 */
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1, &mr_3_0 );
+
+  fd_forest_blk_t * ele = fd_forest_query( forest, 3 );
+  FD_TEST( ele->complete_idx == 63 );
+
+  /* Chain-verify with the correct block_id.  Both FEC 1 and FEC 0
+     should be verified, and chain_confirmed should be set. */
+  fd_forest_blk_t * fail = fd_forest_fec_chain_verify( forest, ele, &mr_3_1 );
+  FD_TEST( !fail ); /* NULL means full success */
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  fd_hash_t saved_mr  = ele->merkle_roots[1].mr;
+  fd_hash_t saved_cmr = ele->merkle_roots[1].cmr;
+  FD_TEST( fd_hash_eq( &saved_mr, &mr_3_1 ) );
+
+  /* Now a conflicting FEC_COMPLETE arrives for FEC 1 (fec_set_idx=32)
+     with a different merkle root.  This is the bug scenario: without
+     the fix, this would overwrite the verified merkle entry. */
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1_bad, &cmr_bad );
+
+  /* The verified merkle root must NOT have been overwritten */
+  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].mr,  &saved_mr  ) );
+  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].cmr, &saved_cmr ) );
+
+  /* The block should still be chain-confirmed */
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
+}
 
 
 int
@@ -1680,6 +1745,7 @@ main( int argc, char ** argv ) {
   test_eqvoc_blk_wrong_parent( wksp );
   test_parent_update( wksp );
   test_eqvoc_different_slot_size( wksp );
+  test_fec_complete_no_poison_verified( wksp );
 
   fd_halt();
   return 0;

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -1644,6 +1644,71 @@ test_eqvoc_different_slot_size( fd_wksp_t * wksp ) {
   fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
 }
 
+void
+test_fec_complete_no_poison_verified( fd_wksp_t * wksp ) {
+  /* A conflicting FEC_COMPLETE arrives for an FEC index that has
+     already been chain-verified.  The merkle root metadata doesn't get
+     overwritten. */
+  ulong ele_max = 16;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_init( forest, 0 );
+
+  fd_hash_t mr_0   = (fd_hash_t){ .key = { 0 } };
+  fd_hash_t mr_1   = (fd_hash_t){ .key = { 1 } };
+  fd_hash_t mr_2   = (fd_hash_t){ .key = { 2 } };
+  fd_hash_t mr_3_0 = (fd_hash_t){ .key = { 30 } }; /* correct FEC 0 mr */
+  fd_hash_t mr_3_1 = (fd_hash_t){ .key = { 31 } }; /* correct FEC 1 mr = block_id */
+
+  /* Conflicting FEC 1 merkle roots */
+  fd_hash_t mr_3_1_bad = (fd_hash_t){ .key = { 99 } };
+  fd_hash_t cmr_bad    = (fd_hash_t){ .key = { 98 } };
+
+  /* Set up ancestry: root=0 -> slot 1 -> slot 2 -> slot 3 */
+  fd_forest_blk_insert( forest, 1, 0, NULL );
+  fd_forest_data_shred_insert( forest, 1, 0, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_1, &mr_0 );
+  fd_forest_blk_insert( forest, 2, 1, NULL );
+  fd_forest_data_shred_insert( forest, 2, 1, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_2, &mr_1 );
+
+  /* Insert correct version of slot 3: 2 FEC sets, parent=2 */
+  fd_forest_blk_insert( forest, 3, 2, NULL );
+  /* FEC 0: shreds 0-31 */
+  fd_forest_fec_insert( forest, 3, 2, 31, 0, 0, 0, &mr_3_0, &mr_2 );
+  /* FEC 1: shreds 32-63, slot_complete=1 */
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1, &mr_3_0 );
+
+  fd_forest_blk_t * ele = fd_forest_query( forest, 3 );
+  FD_TEST( ele->complete_idx == 63 );
+
+  /* Chain-verify with the correct block_id.  Both FEC 1 and FEC 0
+     should be verified, and chain_confirmed should be set. */
+  fd_forest_blk_t * fail = fd_forest_fec_chain_verify( forest, ele, &mr_3_1 );
+  FD_TEST( !fail ); /* NULL means full success */
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  fd_hash_t saved_mr  = ele->merkle_roots[1].mr;
+  fd_hash_t saved_cmr = ele->merkle_roots[1].cmr;
+  FD_TEST( fd_hash_eq( &saved_mr, &mr_3_1 ) );
+
+  /* Now a conflicting FEC_COMPLETE arrives for FEC 1 (fec_set_idx=32)
+     with a different merkle root.  This is the bug scenario: without
+     the fix, this would overwrite the verified merkle entry. */
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1_bad, &cmr_bad );
+
+  /* The verified merkle root must NOT have been overwritten */
+  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].mr,  &saved_mr  ) );
+  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].cmr, &saved_cmr ) );
+
+  /* The block should still be chain-confirmed */
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
+}
 
 
 /* test_buffered_idx_oob
@@ -1729,6 +1794,132 @@ test_buffered_idx_oob( fd_wksp_t * wksp ) {
 }
 
 
+void
+test_fec_insert_reject_oob_after_verify( fd_wksp_t * wksp ) {
+  /* After a slot is fully received and chain-verified, an attacker
+     sends a FEC set with the maximum possible fec_set_idx (well beyond
+     complete_idx).  The FEC is rejected because fec_set_idx > complete_idx. */
+  ulong ele_max = 16;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_init( forest, 0 );
+
+  fd_hash_t mr_0   = (fd_hash_t){ .key = { 0 } };
+  fd_hash_t mr_1   = (fd_hash_t){ .key = { 1 } };
+  fd_hash_t mr_2   = (fd_hash_t){ .key = { 2 } };
+  fd_hash_t mr_3_0 = (fd_hash_t){ .key = { 30 } };
+  fd_hash_t mr_3_1 = (fd_hash_t){ .key = { 31 } };
+
+  /* Build chain: root=0 -> slot 1 -> slot 2 -> slot 3 (2 FEC sets) */
+  fd_forest_blk_insert( forest, 1, 0, NULL );
+  fd_forest_data_shred_insert( forest, 1, 0, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_1, &mr_0 );
+  fd_forest_blk_insert( forest, 2, 1, NULL );
+  fd_forest_data_shred_insert( forest, 2, 1, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_2, &mr_1 );
+
+  fd_forest_blk_insert( forest, 3, 2, NULL );
+  fd_forest_fec_insert( forest, 3, 2, 31, 0, 0, 0, &mr_3_0, &mr_2 );
+  fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1, &mr_3_0 );
+
+  fd_forest_blk_t * ele = fd_forest_query( forest, 3 );
+  FD_TEST( ele->complete_idx == 63 );
+
+  /* Chain-verify slot 3 all the way back. */
+  FD_TEST( !fd_forest_fec_chain_verify( forest, ele, &mr_3_1 ) );
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  /* Attacker sends a FEC with the max possible fec_set_idx.
+     complete_idx == 63, attacker's fec_set_idx == (1023*32) >> 63.
+     This must be rejected (return NULL). */
+  uint    attack_fec_set_idx = (FD_FEC_BLK_MAX - 1) * 32;
+  uint    attack_last_shred  = attack_fec_set_idx + 31;
+  fd_hash_t mr_bad  = (fd_hash_t){ .key = { 0xBA } };
+  fd_hash_t cmr_bad = (fd_hash_t){ .key = { 0xBB } };
+
+  fd_forest_blk_t * result = fd_forest_fec_insert( forest, 3, 2, attack_last_shred, attack_fec_set_idx, 0, 0, &mr_bad, &cmr_bad );
+  FD_TEST( !result );
+
+  /* Slot 3 state must be untouched. */
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+  FD_TEST( ele->complete_idx == 63 );
+
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
+}
+
+void
+test_fec_insert_dup_confirm_larger_complete_idx( fd_wksp_t * wksp ) {
+  /* Attacker sends a false slot_complete shred at shred 31 (1 FEC set),
+     so complete_idx == 31.  Later, duplicate confirmation arrives and
+     we fec_clear the bad FEC.  The canonical version has 2 FEC sets
+     (complete_idx == 63).  After clearing, we must be able to receive
+     the canonical FEC sets that extend beyond the old complete_idx.
+
+         0
+         |
+         2
+         |
+         3  (attacker: complete_idx=31, canonical: complete_idx=63)
+  */
+
+  ulong ele_max = 16;
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  FD_TEST( mem );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_init( forest, 0 );
+
+  fd_hash_t mr_0    = (fd_hash_t){ .key = { 0 } };
+  fd_hash_t mr_2    = (fd_hash_t){ .key = { 2 } };
+
+  /* Attacker's version of slot 3: 1 FEC set, slot_complete at shred 31 */
+  fd_hash_t mr_3_bad = (fd_hash_t){ .key = { 99 } };
+
+  /* Canonical version of slot 3: 2 FEC sets */
+  fd_hash_t mr_3_0  = (fd_hash_t){ .key = { 30 } };
+  fd_hash_t mr_3_1  = (fd_hash_t){ .key = { 31 } };
+
+  /* Build ancestry: root=0 -> slot 2 (1 FEC) */
+  fd_forest_blk_insert( forest, 2, 0, NULL );
+  fd_forest_data_shred_insert( forest, 2, 0, 31, 0, 1, 0, SHRED_SRC_REPAIR, &mr_2, &mr_0 );
+
+  /* Receive the attacker's version of slot 3: complete at shred 31 */
+  fd_forest_blk_insert( forest, 3, 2, NULL );
+  fd_forest_fec_insert( forest, 3, 2, 31, 0, 1, 0, &mr_3_bad, &mr_2 );
+
+  fd_forest_blk_t * ele = fd_forest_query( forest, 3 );
+  FD_TEST( ele->complete_idx == 31 );
+
+  /* Canonical FEC 1 (fec_set_idx=32) should be rejected because
+     fec_set_idx 32 > complete_idx 31. */
+  FD_TEST( !fd_forest_fec_insert( forest, 3, 2, 63, 32, 0, 0, &mr_3_1, &mr_3_0 ) );
+
+  /* Duplicate confirmation arrives: clear the bad FEC (shreds 0-31).
+     This resets complete_idx to UINT_MAX. */
+  FD_TEST( fd_forest_fec_chain_verify( forest, ele, &mr_3_1 ) == ele );
+  FD_TEST( fd_forest_merkle_last_incorrect_idx( ele ) == 0 );
+  fd_forest_fec_clear( forest, 3, 0, 31 );
+  FD_TEST( ele->complete_idx == UINT_MAX );
+
+  /* Try inserting the bad version again.  It should be rejected. */
+  FD_TEST( !fd_forest_fec_insert( forest, 3, 2, 31, 0, 1, 0, &mr_3_bad, &mr_2 ) );
+  /* Now we can receive the canonical version: 2 FEC sets */
+  FD_TEST( fd_forest_fec_insert( forest, 3, 2, 31, 0,  0, 0, &mr_3_0, &mr_2 ) );
+  FD_TEST( fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1, &mr_3_0 ) );
+  FD_TEST( ele->complete_idx == 63 );
+
+  /* Chain-verify succeeds */
+  FD_TEST( !fd_forest_fec_chain_verify( forest, ele, &mr_3_1 ) );
+  FD_TEST( ele->chain_confirmed );
+  FD_TEST( ele->lowest_verified_fec == 0 );
+
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( fd_forest_fini( forest ) ) ) );
+}
+
 int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
@@ -1764,6 +1955,9 @@ main( int argc, char ** argv ) {
   test_eqvoc_blk_wrong_parent( wksp );
   test_parent_update( wksp );
   test_eqvoc_different_slot_size( wksp );
+  test_fec_complete_no_poison_verified( wksp );
+  test_fec_insert_reject_oob_after_verify( wksp );
+  test_fec_insert_dup_confirm_larger_complete_idx( wksp );
 
   fd_halt();
   return 0;

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -806,7 +806,7 @@ check_confirmed( ctx_t           * ctx,
                  fd_forest_blk_t * blk,
                  fd_hash_t const * confirmed_bid ) {
 
-  if( FD_LIKELY( !blk->chain_confirmed && blk->complete_idx != UINT_MAX && blk->buffered_idx == blk->complete_idx ) ) {
+  if( FD_LIKELY( !blk->chain_confirmed && blk->complete_idx != UINT_MAX ) ) {
     /* The above conditions say that all the shreds of the block have arrived. */
     fd_forest_blk_t * bad_blk = fd_forest_fec_chain_verify( ctx->forest, blk, confirmed_bid );
     if( FD_LIKELY( !bad_blk ) ) {
@@ -890,10 +890,10 @@ after_fec( ctx_t      * ctx,
                     block_id ));
   }
 
-  /* re-trigger continuation of chained merkle verification if this FEC
-     set enables it  TODO MOVE TO AFTER_SHRED? */
-  if( FD_UNLIKELY( ele->lowest_verified_fec == (shred->fec_set_idx / 32UL) + 1 ) &&
-                   ele->buffered_idx == ele->complete_idx ) {
+  /* re-trigger continuation of chained merkle verification if slot is
+     complete. TODO MOVE TO AFTER_SHRED? */
+  fd_hash_t empty_mr = (fd_hash_t){ .ul = { 0, 0, 0, 0 } };
+  if( FD_UNLIKELY( ele->buffered_idx == ele->complete_idx && !fd_hash_eq( &ele->confirmed_bid, &empty_mr ) ) ) {
     check_confirmed( ctx, ele, &ele->confirmed_bid /* if lowest_verified_fec is not UINT_MAX, confirmed_bid must be populated */ );
   }
 }

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -635,6 +635,121 @@ test_after_tower_confirmed_eviction( fd_wksp_t * wksp ) {
 }
 
 
+/* test_after_fec_dup_confirm_larger_slot
+
+   An attacker sends us a non-canonical version of slot 3 that can never
+   complete contiguously:
+
+     1. We receive 64 contiguous shreds (FEC 0 and FEC 1, shreds 0-63),
+        no slot_complete.
+     2. The attacker sends the maximum FEC set (fec_set_idx=1023*32)
+        with slot_complete.  complete_idx is now at a very high shred
+        index, but buffered_idx stays at 63 because there's a huge gap.
+
+   Then tower sends a duplicate confirmation with the correct block_id.
+   fec_chain_verify detects the wrong last FEC and fec_clears it,
+   resetting complete_idx to UINT_MAX.
+
+   Finally, the canonical FEC 1 (shreds 32-63, slot_complete) arrives
+   via after_fec.  This sets complete_idx=63 and buffered_idx==63,
+   triggering check_confirmed which chain-verifies the whole slot. */
+
+static void
+test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
+
+  static ctx_t ctx[1];
+  setup_ctx( ctx, wksp, 512 );
+
+  fd_forest_init( ctx->forest, 0 );
+
+  fd_hash_t mr_root   = (fd_hash_t){ .ul = { 100 } };
+  fd_hash_t mr_2_0    = (fd_hash_t){ .ul = { 200 } };
+  fd_hash_t mr_2_32   = (fd_hash_t){ .ul = { 201 } };
+  fd_hash_t mr_3_0    = (fd_hash_t){ .ul = { 300 } };
+  fd_hash_t mr_3_1    = (fd_hash_t){ .ul = { 301 } };  /* correct block_id for slot 3 */
+  fd_hash_t mr_3_1_bad = (fd_hash_t){ .ul = { 997 } };  /* attacker's  FEC 1 mr */
+
+  fd_hash_t mr_3_bad  = (fd_hash_t){ .ul = { 999 } };  /* attacker's max FEC mr */
+  fd_hash_t cmr_3_bad = (fd_hash_t){ .ul = { 998 } };
+
+  /* Set up ancestry: root=0 -> slot 2 (2 correct FEC sets) */
+  fd_forest_blk_insert( ctx->forest, 2, 0, NULL );
+  fd_forest_fec_insert( ctx->forest, 2, 0, 31, 0,  0, 0, &mr_2_0,  &mr_root );
+  fd_forest_fec_insert( ctx->forest, 2, 0, 63, 32, 1, 0, &mr_2_32, &mr_2_0  );
+
+  /* Slot 3: receive FEC 0 and FEC 1 (shreds 0-63), no slot_complete */
+  fd_forest_blk_insert( ctx->forest, 3, 2, NULL );
+  fd_forest_fec_insert( ctx->forest, 3, 2, 31, 0,  0, 0, &mr_3_0, &mr_2_32 );
+  fd_forest_fec_insert( ctx->forest, 3, 2, 63, 32, 0, 0, &mr_3_1_bad, &mr_3_0  );
+
+  fd_forest_blk_t * blk3 = fd_forest_query( ctx->forest, 3 );
+  FD_TEST( blk3->complete_idx == UINT_MAX );
+  FD_TEST( blk3->buffered_idx == 63 );
+
+  /* Attacker sends the max FEC set with slot_complete.
+     complete_idx jumps to a very high value, but buffered_idx stays 63
+     because there's a gap between shred 63 and the max FEC. */
+  uint max_fec_set_idx = (FD_FEC_BLK_MAX - 1) * 32;
+  uint max_last_shred  = max_fec_set_idx + 31;
+  fd_forest_fec_insert( ctx->forest, 3, 2, max_last_shred, max_fec_set_idx, 1, 0, &mr_3_bad, &cmr_3_bad );
+
+  blk3 = fd_forest_query( ctx->forest, 3 );
+  FD_TEST( blk3->complete_idx == max_last_shred );
+  FD_TEST( blk3->buffered_idx == 63 );  /* gap prevents contiguous buffering */
+  FD_TEST( blk3->chain_confirmed == 0 );
+
+  /* Tower sends duplicate confirmation with the correct block_id.
+     check_confirmed -> fec_chain_verify should fail because the last
+     FEC (at max index) has mr_3_bad != mr_3_1 (the correct block_id).
+     fec_clear should remove the bad max FEC. */
+
+  fd_tower_slot_confirmed_t confirmed_msg[1];
+  memset( confirmed_msg, 0, sizeof(*confirmed_msg) );
+  confirmed_msg->level    = FD_TOWER_SLOT_CONFIRMED_DUPLICATE;
+  confirmed_msg->fwd      = 0;
+  confirmed_msg->slot     = 3;
+  confirmed_msg->block_id = mr_3_1;
+
+  after_tower( ctx, FD_TOWER_SIG_SLOT_CONFIRMED, (uchar *)confirmed_msg );
+
+  blk3 = fd_forest_query( ctx->forest, 3 );
+  FD_TEST( blk3 );
+
+  /* fec_clear should have reset complete_idx since it cleared the last FEC */
+  FD_TEST( blk3->complete_idx == UINT_MAX );
+  FD_TEST( blk3->chain_confirmed == 0 );
+
+  /* Now the canonical FEC 1 arrives via after_fec with slot_complete.
+     This is the correct version with complete_idx=63.
+     after_fec should set complete_idx=63, and since buffered_idx==63
+     and lowest_verified_fec was set by fec_chain_verify, it should
+     trigger check_confirmed and chain-verify the whole slot. */
+
+  fd_shred_t shred_hdr[1];
+  memset( shred_hdr, 0, sizeof(fd_shred_t) );
+  shred_hdr->variant     = fd_shred_variant( FD_SHRED_TYPE_MERKLE_DATA, 5 );
+  shred_hdr->slot        = 3;
+  shred_hdr->idx         = 63;
+  shred_hdr->fec_set_idx = 32;
+  shred_hdr->data.parent_off = 1;  /* parent = slot 2 */
+  shred_hdr->data.flags      = FD_SHRED_DATA_FLAG_SLOT_COMPLETE;
+
+  after_fec( ctx, shred_hdr, &mr_3_1, &mr_3_0 );
+
+  blk3 = fd_forest_query( ctx->forest, 3 );
+  FD_TEST( blk3->complete_idx == 63 );
+  FD_TEST( blk3->buffered_idx == 63 );
+  FD_TEST( blk3->chain_confirmed == 1 );
+
+  /* Slot 2 should also be chain_confirmed (chain verify walks parents) */
+  fd_forest_blk_t * blk2 = fd_forest_query( ctx->forest, 2 );
+  FD_TEST( blk2->chain_confirmed == 1 );
+
+  FD_TEST( !fd_forest_verify( ctx->forest ) );
+
+  FD_LOG_NOTICE(( "pass: test_after_fec_dup_confirm_larger_slot" ));
+}
+
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
@@ -654,6 +769,9 @@ int main( int argc, char ** argv ) {
 
   fd_wksp_reset( wksp, 1UL );
   test_after_tower_confirmed_eviction( wksp );
+
+  fd_wksp_reset( wksp, 1UL );
+  test_after_fec_dup_confirm_larger_slot( wksp );
 
   fd_halt();
   return 0;


### PR DESCRIPTION
closes https://github.com/firedancer-io/firedancer/issues/9481

Main changes:
- rejects shreds that are greater than the complete_idx
- defense against "far ahead shred" attack
- rejecting FEC sets that are known to be non-canonical
- Loosening conditions to `chain_verify` (can now verify even when all shreds have not been buffered), i.e. decoupling completion with verification.  
