### PR TITLE
repair: simplify rnonce_ss setup

### DIFF
--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -13,7 +13,6 @@ Constructed using a full topology which is pruned down. */
 #include "../../../../discof/tower/fd_tower_tile.h"
 #include "../../../../discof/replay/fd_replay_tile.h"
 #include "../../../../disco/shred/fd_shred_tile.h"
-#include "../../../../disco/shred/fd_rnonce_ss.h"
 #include "../../../../disco/net/fd_net_tile.h"
 #include "../../../../disco/pack/fd_pack_cost.h"
 #include "../../../../disco/topo/fd_topob.h"
@@ -499,14 +498,6 @@ forktest_fn( args_t *   args,
 
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );
   fd_topo_fill( &config->topo );
-
-  ulong rnonce_ss_id = fd_pod_queryf_ulong( config->topo.props, ULONG_MAX, "rnonce_ss" );
-  FD_TEST( rnonce_ss_id!=ULONG_MAX );
-  void * shared_rnonce = fd_topo_obj_laddr( &config->topo, rnonce_ss_id );
-  ulong * nonce_initialized = (ulong *)(sizeof(fd_rnonce_ss_t)+(uchar *)shared_rnonce);
-  FD_TEST( fd_rng_secure( shared_rnonce, sizeof(fd_rnonce_ss_t) ) );
-  FD_COMPILER_MFENCE();
-  FD_VOLATILE( *nonce_initialized ) = 1UL;
 
   args_t watch_args;
   int pipefd[2];

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -294,7 +294,7 @@ repair_topo( config_t * config ) {
   if( 1 /* just restrict the scope for these variables in this big function */ ) {
     fd_topo_obj_t * rnonce_ss_obj = fd_topob_obj( topo, "rnonce_ss", "rnonce" );
     fd_topo_tile_t * repair_tile = &topo->tiles[ fd_topo_find_tile( topo, "repair", 0UL ) ];
-    fd_topob_tile_uses( topo, repair_tile, rnonce_ss_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, repair_tile, rnonce_ss_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
     for( ulong i=0UL; i<shred_tile_cnt; i++ ) {
       fd_topo_tile_t * shred_tile = &topo->tiles[ fd_topo_find_tile( topo, "shred", i ) ];
       fd_topob_tile_uses( topo, shred_tile, rnonce_ss_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );

--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -262,7 +262,7 @@ fd_topo_obj_callbacks_t fd_obj_cb_acc_pool = {
 static ulong
 rnonce_ss_footprint( fd_topo_t const *     topo FD_FN_UNUSED,
                      fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
-  return sizeof(fd_rnonce_ss_t) + sizeof(ulong);
+  return sizeof(fd_rnonce_ss_t);
 }
 
 static ulong
@@ -273,8 +273,8 @@ rnonce_ss_align( fd_topo_t const *     topo FD_FN_UNUSED,
 
 static void
 rnonce_ss_new( fd_topo_t const *     topo,
-              fd_topo_obj_t const * obj ) {
-  memset( fd_topo_obj_laddr( topo, obj->id ), '\0', sizeof(fd_rnonce_ss_t)+sizeof(ulong) );
+               fd_topo_obj_t const * obj ) {
+  FD_TEST( fd_rng_secure( fd_topo_obj_laddr( topo, obj->id ), sizeof(fd_rnonce_ss_t) ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss = {

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -1257,19 +1257,9 @@ unprivileged_init( fd_topo_t *      topo,
     }
     fec_sets_shmem = (uchar *)fd_topo_obj_laddr( topo, fec_sets_obj_id ) + (ctx->round_robin_id * fec_sets_required_sz);
 
-    /* Initialize the rnonce.  The repair tile sets it, so we can only
-       do this in firedancer mode.  In frankendancer mode, we initialize
-       it randomly in privileged_init just so that an attacker can't
-       guess it. */
-    FD_LOG_DEBUG(( "Loading rnonce_ss" ));
     ulong rnonce_ss_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "rnonce_ss" );
     FD_TEST( rnonce_ss_id!=ULONG_MAX );
-    void const * shared_rnonce = fd_topo_obj_laddr( topo, rnonce_ss_id );
-    ulong * nonce_initialized = (ulong *)(sizeof(fd_rnonce_ss_t)+(uchar const *)shared_rnonce);
-    while( !FD_VOLATILE_CONST( *nonce_initialized ) ) FD_SPIN_PAUSE();
-    FD_COMPILER_MFENCE();
-    memcpy( ctx->repair_nonce_ss, shared_rnonce, sizeof(fd_rnonce_ss_t) );
-    FD_LOG_DEBUG(( "Loaded rnonce_ss" ));
+    memcpy( ctx->repair_nonce_ss, fd_topo_obj_laddr( topo, rnonce_ss_id ), sizeof(fd_rnonce_ss_t) );
 
   } else if ( FD_LIKELY( ctx->store_out_idx!=ULONG_MAX ) ) { /* frankendancer-only */
     FD_TEST( 0==strcmp( topo->links[tile->out_link_id[ ctx->store_out_idx ]].name, "shred_store" ) );

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -1260,19 +1260,9 @@ unprivileged_init( fd_topo_t *      topo,
     }
     fec_sets_shmem = (uchar *)fd_topo_obj_laddr( topo, fec_sets_obj_id ) + (ctx->round_robin_id * fec_sets_required_sz);
 
-    /* Initialize the rnonce.  The repair tile sets it, so we can only
-       do this in firedancer mode.  In frankendancer mode, we initialize
-       it randomly in privileged_init just so that an attacker can't
-       guess it. */
-    FD_LOG_DEBUG(( "Loading rnonce_ss" ));
     ulong rnonce_ss_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "rnonce_ss" );
     FD_TEST( rnonce_ss_id!=ULONG_MAX );
-    void const * shared_rnonce = fd_topo_obj_laddr( topo, rnonce_ss_id );
-    ulong * nonce_initialized = (ulong *)(sizeof(fd_rnonce_ss_t)+(uchar const *)shared_rnonce);
-    while( !FD_VOLATILE_CONST( *nonce_initialized ) ) FD_SPIN_PAUSE();
-    FD_COMPILER_MFENCE();
-    memcpy( ctx->repair_nonce_ss, shared_rnonce, sizeof(fd_rnonce_ss_t) );
-    FD_LOG_DEBUG(( "Loaded rnonce_ss" ));
+    memcpy( ctx->repair_nonce_ss, fd_topo_obj_laddr( topo, rnonce_ss_id ), sizeof(fd_rnonce_ss_t) );
 
   } else if ( FD_LIKELY( ctx->store_out_idx!=ULONG_MAX ) ) { /* frankendancer-only */
     FD_TEST( 0==strcmp( topo->links[tile->out_link_id[ ctx->store_out_idx ]].name, "shred_store" ) );

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -1165,15 +1165,9 @@ privileged_init( fd_topo_t *      topo,
 
   FD_TEST( fd_rng_secure( &ctx->repair_seed, sizeof(ulong) ) );
 
-  FD_LOG_DEBUG(( "Generating rnonce_ss" ));
   ulong rnonce_ss_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "rnonce_ss" );
   FD_TEST( rnonce_ss_id!=ULONG_MAX );
-  void * shared_rnonce = fd_topo_obj_laddr( topo, rnonce_ss_id );
-  ulong * nonce_initialized = (ulong *)(sizeof(fd_rnonce_ss_t)+(uchar *)shared_rnonce);
-  FD_TEST( fd_rng_secure( shared_rnonce, sizeof(fd_rnonce_ss_t) ) );
-  memcpy( ctx->repair_nonce_ss, shared_rnonce, sizeof(fd_rnonce_ss_t) );
-  FD_COMPILER_MFENCE();
-  FD_VOLATILE( *nonce_initialized ) = 1UL;
+  memcpy( ctx->repair_nonce_ss, fd_topo_obj_laddr( topo, rnonce_ss_id ), sizeof(fd_rnonce_ss_t) );
 }
 
 static void

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -1244,15 +1244,9 @@ privileged_init( fd_topo_t *      topo,
 
   FD_TEST( fd_rng_secure( &ctx->repair_seed, sizeof(ulong) ) );
 
-  FD_LOG_DEBUG(( "Generating rnonce_ss" ));
   ulong rnonce_ss_id = fd_pod_queryf_ulong( topo->props, ULONG_MAX, "rnonce_ss" );
   FD_TEST( rnonce_ss_id!=ULONG_MAX );
-  void * shared_rnonce = fd_topo_obj_laddr( topo, rnonce_ss_id );
-  ulong * nonce_initialized = (ulong *)(sizeof(fd_rnonce_ss_t)+(uchar *)shared_rnonce);
-  FD_TEST( fd_rng_secure( shared_rnonce, sizeof(fd_rnonce_ss_t) ) );
-  memcpy( ctx->repair_nonce_ss, shared_rnonce, sizeof(fd_rnonce_ss_t) );
-  FD_COMPILER_MFENCE();
-  FD_VOLATILE( *nonce_initialized ) = 1UL;
+  memcpy( ctx->repair_nonce_ss, fd_topo_obj_laddr( topo, rnonce_ss_id ), sizeof(fd_rnonce_ss_t) );
 }
 
 static void


### PR DESCRIPTION
The full Firedancer rnonce_ss setup uses an unnecessary spinlock
on startup.
