### PR TITLE
topo: support operation without huge pages

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -64,6 +64,7 @@ backtest_topo( config_t * config ) {
   fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
   topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
+  topo->lazy_paging = config->development.lazy_paging;
 
   ulong cpu_idx = 0;
 

--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -148,6 +148,7 @@ forktest_topo( config_t * config ) {
 
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
   topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
+  topo->lazy_paging = config->development.lazy_paging;
 
   /*             topo, name */
   fd_topob_wksp( topo, "metric" );

--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -45,6 +45,7 @@ gossip_cmd_topo( config_t * config ) {
   fd_topo_t * topo = &config->topo;
   fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging = config->development.lazy_paging;
 
   fd_core_subtopo(   config, tile_to_cpu );
   fd_gossip_subtopo( config, tile_to_cpu );

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -78,6 +78,7 @@ repair_topo( config_t * config ) {
   fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
   topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
+  topo->lazy_paging = config->development.lazy_paging;
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   ushort parsed_tile_to_cpu[ FD_TILE_MAX ];

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -52,6 +52,7 @@ send_test_topo( config_t * config ) {
   /* Setup topology */
   fd_topo_t * topo    = fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   ushort parsed_tile_to_cpu[ FD_TILE_MAX ];

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -38,6 +38,7 @@ snapshot_load_topo( config_t * config ) {
   fd_topo_t * topo = &config->topo;
   fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
 
   fd_topob_wksp( topo, "txncache" );
   fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache",

--- a/src/app/firedancer-dev/config/minimal.toml
+++ b/src/app/firedancer-dev/config/minimal.toml
@@ -1,15 +1,14 @@
+telemetry = false
+
 [hugetlbfs]
-max_page_size = "huge"
+max_page_size = "normal"
 
-[accounts]
-max_accounts = 1048576
-file_size_gib = 20
-
-[runtime.limits]
+[runtime]
 max_live_slots = 512
 max_fork_width = 16
 
 [layout]
+enable_block_production = false
 verify_tile_count = 1
 execrp_tile_count = 1
 
@@ -21,3 +20,6 @@ enabled = false
 max_http_connections = 16
 max_websocket_connections = 16
 send_buffer_size_mb = 128
+
+[development]
+lazy_paging = true

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1700,6 +1700,14 @@ telemetry = true
     # log the hard fork event and continue running.
     hard_fork_fatal = false
 
+    # If enabled, do not mlock workspaces.
+    # When combined with [hugetlbfs.max_page_size] "normal", causes the
+    # kernel to defer memory reservation to runtime via page faults.
+    # Greatly reduces production performance and but allows for instant
+    # startup.  Because memory is no longer reserved on startup, reduces
+    # apparent RSS usage until load increases, which risks OOM kills.
+    lazy_paging = false
+
     [development.gossip]
         # Under normal operating conditions, a validator should always
         # reach out to a host located on the public internet.  If this

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -968,9 +968,9 @@ telemetry = true
     mount_path = "/mnt/.fd"
 
     # The largest supported page size on the system.  Possible values
-    # are either "huge" (2 MiB) or "gigantic" (1 GiB).  Larger sizes
-    # yield better performance.  Smaller values may be required on
-    # virtualized environments like cloud providers.
+    # are "normal" (4 KiB), "huge" (2 MiB), or "gigantic" (1 GiB).
+    # Larger sizes yield better performance.  "normal" or "huge" may
+    # be required on virtualized environments like cloud providers.
     max_page_size = "gigantic"
 
     # Workspaces are either fully backed by "huge" or "gigantic" pages.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -395,6 +395,7 @@ fd_topo_initialize( config_t * config ) {
 
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
   topo->gigantic_page_threshold = config->hugetlbfs.gigantic_page_threshold_mib << 20;
+  topo->lazy_paging = config->development.lazy_paging;
 
   int solcap_enabled = strlen( config->capture.solcap_capture ) > 0;
 

--- a/src/app/shared/commands/configure/hugetlbfs.c
+++ b/src/app/shared/commands/configure/hugetlbfs.c
@@ -46,8 +46,51 @@ static char const * PAGE_NAMES[ 2 ] = {
   "gigantic"
 };
 
+static ulong
+normal_tmpfs_sz( config_t const * config ) {
+  ulong total_sz = 0UL;
+  for( ulong i=0UL; i<config->topo.wksp_cnt; i++ ) {
+    if( FD_LIKELY( config->topo.workspaces[ i ].page_sz==FD_SHMEM_NORMAL_PAGE_SZ ) )
+      total_sz += config->topo.workspaces[ i ].page_cnt * FD_SHMEM_NORMAL_PAGE_SZ;
+  }
+  total_sz += config->topo.tile_cnt * (12UL<<20); /* stacks */
+  return total_sz;
+}
+
+static void
+init_normal( config_t const * config ) {
+  char const * normal_path = config->hugetlbfs.normal_page_mount_path;
+
+  FD_LOG_NOTICE(( "RUN: `mkdir -p %s`", config->hugetlbfs.mount_path ));
+  if( FD_UNLIKELY( -1==fd_file_util_mkdir_all( config->hugetlbfs.mount_path, config->uid, config->gid, 1 ) ) )
+    FD_LOG_ERR(( "could not create mount directory `%s` (%i-%s)", config->hugetlbfs.mount_path, errno, fd_io_strerror( errno ) ));
+
+  FD_LOG_NOTICE(( "RUN: `mkdir -p %s`", normal_path ));
+  if( FD_UNLIKELY( -1==fd_file_util_mkdir_all( normal_path, config->uid, config->gid, 1 ) ) )
+    FD_LOG_ERR(( "could not create tmpfs mount directory `%s` (%i-%s)", normal_path, errno, fd_io_strerror( errno ) ));
+
+  ulong total_sz = normal_tmpfs_sz( config );
+
+  char options[ 256 ];
+  FD_TEST( fd_cstr_printf_check( options, sizeof(options), NULL, "size=%lu", total_sz ) );
+  FD_LOG_NOTICE(( "RUN: `mount -t tmpfs tmpfs %s -o %s`", normal_path, options ));
+  if( FD_UNLIKELY( mount( "tmpfs", normal_path, "tmpfs", 0, options ) ) )
+    FD_LOG_ERR(( "mount of tmpfs at `%s` failed (%i-%s)", normal_path, errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( chown( normal_path, config->uid, config->gid ) ) )
+    FD_LOG_ERR(( "chown of tmpfs at `%s` failed (%i-%s)", normal_path, errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( chmod( normal_path, S_IRUSR | S_IWUSR | S_IXUSR ) ) )
+    FD_LOG_ERR(( "chmod of tmpfs at `%s` failed (%i-%s)", normal_path, errno, fd_io_strerror( errno ) ));
+}
+
 static void
 init( config_t const * config ) {
+
+  ulong max_page_sz = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  if( FD_UNLIKELY( max_page_sz==FD_SHMEM_NORMAL_PAGE_SZ ) ) {
+    init_normal( config );
+    return;
+  }
+
   char const * mount_path[ 2 ] = {
     config->hugetlbfs.huge_page_mount_path,
     config->hugetlbfs.gigantic_page_mount_path,
@@ -56,7 +99,7 @@ init( config_t const * config ) {
   ulong numa_node_cnt = fd_shmem_numa_cnt();
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
     ulong required_pages[ 2 ] = {
-      fd_topo_huge_page_cnt( &config->topo, i, 0 ),
+      fd_topo_huge_page_cnt( &config->topo, i ),
       fd_topo_gigantic_page_cnt( &config->topo, i ),
     };
 
@@ -153,7 +196,7 @@ init( config_t const * config ) {
 
   ulong min_size[ 2 ] = {0};
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
-    min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
+    min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i );
     min_size[ 1 ] += PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
   }
 
@@ -288,8 +331,98 @@ fini( config_t const * config,
 }
 
 static configure_result_t
+check_normal( config_t const * config ) {
+  char const * normal_path = config->hugetlbfs.normal_page_mount_path;
+
+  struct stat st;
+  if( FD_UNLIKELY( stat( normal_path, &st ) ) ) {
+    if( FD_LIKELY( errno==ENOENT ) )
+      NOT_CONFIGURED( "mount `%s` does not exist", normal_path );
+    PARTIALLY_CONFIGURED( "failed to stat `%s` (%i-%s)", normal_path, errno, fd_io_strerror( errno ) );
+  }
+
+  CHECK( check_dir( config->hugetlbfs.mount_path, config->uid, config->gid, S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR ) );
+  CHECK( check_dir( normal_path, config->uid, config->gid, S_IFDIR | S_IRUSR | S_IWUSR | S_IXUSR ) );
+
+  FILE * fp = fopen( "/proc/self/mounts", "r" );
+  if( FD_UNLIKELY( !fp ) ) FD_LOG_ERR(( "failed to open `/proc/self/mounts`" ));
+
+  char line[ 4096 ];
+  int found = 0;
+  while( FD_LIKELY( fgets( line, 4096UL, fp ) ) ) {
+    if( FD_UNLIKELY( strlen( line )==4095UL ) ) FD_LOG_ERR(( "line too long in `/proc/self/mounts`" ));
+    if( FD_UNLIKELY( strstr( line, normal_path ) ) ) {
+      found = 1;
+
+      char * saveptr;
+      char * device = strtok_r( line, " ", &saveptr );
+      if( FD_UNLIKELY( !device ) ) FD_LOG_ERR(( "error parsing `/proc/self/mounts`, line `%s`", line ));
+      if( FD_UNLIKELY( strcmp( device, "tmpfs" ) ) ) {
+        if( FD_UNLIKELY( fclose( fp ) ) )
+          FD_LOG_ERR(( "error closing `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+        PARTIALLY_CONFIGURED( "mount `%s` is on unrecognized device, expected `tmpfs`", normal_path );
+      }
+
+      char * path1 = strtok_r( NULL, " ", &saveptr );
+      if( FD_UNLIKELY( !path1 ) ) FD_LOG_ERR(( "error parsing `/proc/self/mounts`, line `%s`", line ));
+      if( FD_UNLIKELY( strcmp( path1, normal_path ) ) ) {
+        if( FD_UNLIKELY( fclose( fp ) ) )
+          FD_LOG_ERR(( "error closing `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+        PARTIALLY_CONFIGURED( "mount `%s` is on unrecognized path, expected `%s`", path1, normal_path );
+      }
+
+      char * type = strtok_r( NULL, " ", &saveptr );
+      if( FD_UNLIKELY( !type ) ) FD_LOG_ERR(( "error parsing `/proc/self/mounts`, line `%s`", line ));
+      if( FD_UNLIKELY( strcmp( type, "tmpfs" ) ) ) {
+        if( FD_UNLIKELY( fclose( fp ) ) )
+          FD_LOG_ERR(( "error closing `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+        PARTIALLY_CONFIGURED( "mount `%s` has unrecognized type, expected `tmpfs`", normal_path );
+      }
+
+      char * options = strtok_r( NULL, " ", &saveptr );
+      if( FD_UNLIKELY( !options ) ) FD_LOG_ERR(( "error parsing `/proc/self/mounts`" ));
+
+      /* Find size= in the comma-separated options.  The kernel
+         displays tmpfs size in kilobytes (e.g. size=1024k). */
+      ulong mounted_sz = 0UL;
+      char * saveptr2;
+      for( char * opt=strtok_r( options, ",", &saveptr2 ); opt; opt=strtok_r( NULL, ",", &saveptr2 ) ) {
+        if( !strncmp( opt, "size=", 5UL ) ) {
+          char * endptr;
+          mounted_sz = strtoul( opt+5, &endptr, 10 );
+          if( *endptr=='k' || *endptr=='K' ) mounted_sz *= 1024UL;
+          break;
+        }
+      }
+
+      ulong required_sz = normal_tmpfs_sz( config );
+      if( FD_UNLIKELY( mounted_sz<required_sz ) ) {
+        if( FD_UNLIKELY( fclose( fp ) ) )
+          FD_LOG_ERR(( "error closing `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+        PARTIALLY_CONFIGURED( "tmpfs at `%s` has size %lu but need at least %lu", normal_path, mounted_sz, required_sz );
+      }
+
+      break;
+    }
+  }
+
+  if( FD_UNLIKELY( ferror( fp ) ) )
+    FD_LOG_ERR(( "error reading `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_LIKELY( fclose( fp ) ) )
+    FD_LOG_ERR(( "error closing `/proc/self/mounts` (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  if( FD_UNLIKELY( !found ) )
+    PARTIALLY_CONFIGURED( "mount `%s` not found in `/proc/self/mounts`", normal_path );
+
+  CONFIGURE_OK();
+}
+
+static configure_result_t
 check( config_t const * config,
        int              check_type FD_PARAM_UNUSED ) {
+  ulong max_page_sz = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  if( FD_UNLIKELY( max_page_sz==FD_SHMEM_NORMAL_PAGE_SZ ) ) return check_normal( config );
+
   char const * mount_path[ 2 ] = {
     config->hugetlbfs.huge_page_mount_path,
     config->hugetlbfs.gigantic_page_mount_path,
@@ -303,7 +436,7 @@ check( config_t const * config,
   ulong numa_node_cnt = fd_shmem_numa_cnt();
   ulong required_min_size[ 2 ] = {0};
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
-    required_min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
+    required_min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i );
     required_min_size[ 1 ] += PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
   }
 

--- a/src/app/shared/commands/mem.c
+++ b/src/app/shared/commands/mem.c
@@ -101,7 +101,7 @@ mem_cmd_fn( args_t *   args,
     }
 
     /* Extra normal pages (private keys, XSK rings, log locks, etc.) */
-    ulong extra_normal = fd_topo_normal_page_cnt( topo );
+    ulong extra_normal = fd_topo_extra_normal_page_cnt( topo );
     if( extra_normal ) {
       entries[ cnt ].footprint = extra_normal * FD_SHMEM_NORMAL_PAGE_SZ;
       fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( entries[ cnt ].wksp ), "", 0 ) );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -11,7 +11,6 @@
 
 #include "../../../platform/fd_sys_util.h"
 #include "../../../platform/fd_file_util.h"
-#include "../../../platform/fd_net_util.h"
 #include "../../../../disco/net/fd_net_tile.h"
 
 #include "../configure/configure.h"
@@ -42,7 +41,9 @@ run_cmd_perm( args_t *         args,
               config_t const * config ) {
   (void)args;
 
-  ulong mlock_limit = fd_topo_mlock_max_tile( &config->topo );
+  ulong mlock_limit;
+  if( config->development.no_clone ) mlock_limit = fd_topo_mlock( &config->topo );
+  else                               mlock_limit = fd_topo_mlock_max_tile( &config->topo );
 
   fd_cap_chk_raise_rlimit( chk, NAME, RLIMIT_MEMLOCK, mlock_limit, "call `rlimit(2)` to increase `RLIMIT_MEMLOCK` so all memory can be locked with `mlock(2)`" );
   fd_cap_chk_raise_rlimit( chk, NAME, RLIMIT_NICE,    40,          "call `setpriority(2)` to increase thread priorities" );
@@ -489,17 +490,14 @@ workspace_path( config_t const *       config,
 
 static void
 warn_unknown_files( config_t const * config,
-                    ulong            mount_type ) {
+                    ulong            page_sz ) {
   char const * mount_path;
-  switch( mount_type ) {
-    case 0UL:
-      mount_path = config->hugetlbfs.huge_page_mount_path;
-      break;
-    case 1UL:
-      mount_path = config->hugetlbfs.gigantic_page_mount_path;
-      break;
-    default:
-      FD_LOG_ERR(( "invalid mount type %lu", mount_type ));
+  switch( page_sz ) {
+  case FD_SHMEM_HUGE_PAGE_SZ:     mount_path = config->hugetlbfs.huge_page_mount_path;     break;
+  case FD_SHMEM_GIGANTIC_PAGE_SZ: mount_path = config->hugetlbfs.gigantic_page_mount_path; break;
+  case FD_SHMEM_NORMAL_PAGE_SZ:   mount_path = config->hugetlbfs.normal_page_mount_path;   break;
+  default:
+    FD_LOG_ERR(( "invalid page_sz %lu", page_sz ));
   }
 
   /* Check if there are any files in mount_path */
@@ -532,12 +530,13 @@ warn_unknown_files( config_t const * config,
       }
     }
 
-    if( mount_type==0UL ) {
+    ulong stack_sz = fd_ulong_min( config->topo.max_page_size, FD_SHMEM_HUGE_PAGE_SZ );
+    if( page_sz==stack_sz ) {
       for( ulong i=0UL; i<config->topo.tile_cnt; i++ ) {
-        fd_topo_tile_t const * tile = &config->topo.tiles [ i ];
+        fd_topo_tile_t const * tile = &config->topo.tiles[ i ];
 
         char expected_path[ PATH_MAX ];
-        FD_TEST( fd_cstr_printf_check( expected_path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", config->hugetlbfs.huge_page_mount_path, config->name, tile->name, tile->kind_id ) );
+        FD_TEST( fd_cstr_printf_check( expected_path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", mount_path, config->name, tile->name, tile->kind_id ) );
 
         if( !strcmp( entry_path, expected_path ) ) {
           known_file = 1;
@@ -600,7 +599,7 @@ initialize_workspaces( config_t * config ) {
     if( FD_UNLIKELY( -1==fd_topo_create_workspace( &config->topo, wksp, update_existing ) ) ) {
       FD_TEST( errno==ENOMEM );
 
-      warn_unknown_files( config, wksp->page_sz!=FD_SHMEM_HUGE_PAGE_SZ );
+      warn_unknown_files( config, wksp->page_sz );
 
       char path[ PATH_MAX ];
       workspace_path( config, wksp, path );
@@ -638,11 +637,20 @@ initialize_stacks( config_t const * config ) {
   if( FD_LIKELY( uid!=config->uid && -1==seteuid( config->uid ) ) )
     FD_LOG_ERR(( "seteuid() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
+  ulong stack_page_sz = fd_ulong_min( config->topo.max_page_size, FD_SHMEM_HUGE_PAGE_SZ );
+  char const * stack_mount;
+  switch( stack_page_sz ) {
+  case FD_SHMEM_HUGE_PAGE_SZ:   stack_mount = config->hugetlbfs.huge_page_mount_path;   break;
+  case FD_SHMEM_NORMAL_PAGE_SZ: stack_mount = config->hugetlbfs.normal_page_mount_path; break;
+  default:
+    FD_LOG_ERR(( "invalid stack_page_sz %lu", stack_page_sz ));
+  }
+
   for( ulong i=0UL; i<config->topo.tile_cnt; i++ ) {
     fd_topo_tile_t const * tile = &config->topo.tiles[ i ];
 
     char path[ PATH_MAX ];
-    FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", config->hugetlbfs.huge_page_mount_path, config->name, tile->name, tile->kind_id ) );
+    FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", stack_mount, config->name, tile->name, tile->kind_id ) );
 
     struct stat st;
     int result = stat( path, &st );
@@ -667,20 +675,20 @@ initialize_stacks( config_t const * config ) {
     char name[ PATH_MAX ];
     FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_stack_%s%lu", config->name, tile->name, tile->kind_id ) );
 
-    ulong sub_page_cnt[ 1 ] = { 6 };
+    ulong sub_page_cnt[ 1 ] = { (12UL<<20) / stack_page_sz };
     ulong sub_cpu_idx [ 1 ] = { stack_cpu_idx };
     int err;
     if( FD_UNLIKELY( update_existing ) ) {
-      err = fd_shmem_update_multi( name, FD_SHMEM_HUGE_PAGE_SZ, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR ); /* logs details */
+      err = fd_shmem_update_multi( name, stack_page_sz, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR ); /* logs details */
     } else {
-      err = fd_shmem_create_multi( name, FD_SHMEM_HUGE_PAGE_SZ, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR ); /* logs details */
+      err = fd_shmem_create_multi( name, stack_page_sz, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR ); /* logs details */
     }
     if( FD_UNLIKELY( err && errno==ENOMEM ) ) {
-      warn_unknown_files( config, 0UL );
+      warn_unknown_files( config, stack_page_sz );
 
       char path[ PATH_MAX ];
-      FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", config->hugetlbfs.huge_page_mount_path, config->name, tile->name, tile->kind_id ) );
-      FD_LOG_ERR(( "ENOMEM-Out of memory when trying to create huge page stack for tile `%s` at `%s`. "
+      FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "%s/%s_stack_%s%lu", stack_mount, config->name, tile->name, tile->kind_id ) );
+      FD_LOG_ERR(( "ENOMEM-Out of memory when trying to create stack for tile `%s` at `%s`. "
                    "Firedancer reserves enough memory for all of its stacks during the `hugetlbfs` configure "
                    "step, so it is likely you have unknown files left over in this directory which are "
                    "consuming memory, or another program on the system is using pages from the same mount.",

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -390,6 +390,7 @@ fd_config_fill( fd_config_t * config,
     if( FD_UNLIKELY( config->development.bench.larger_shred_limits_per_block ) ) FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.larger_shred_limits_per_block] which is a development only feature" ));
     if( FD_UNLIKELY( config->development.bench.disable_blockstore_from_slot ) )  FD_LOG_ERR(( "trying to join a live cluster, but configuration has a non-zero value for [development.bench.disable_blockstore_from_slot] which is a development only feature" ));
     if( FD_UNLIKELY( config->development.bench.disable_status_cache ) )          FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.disable_status_cache] which is a development only feature" ));
+    if( FD_UNLIKELY( config->development.lazy_paging ) )                         FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.lazy_paging] which is a development only feature" ));
   }
 
   /* When running a local cluster, some options are overriden by default

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -286,9 +286,16 @@ fd_config_fill( fd_config_t * config,
     NULL,
     "%s/.huge",
     config->hugetlbfs.mount_path ) );
+  FD_TEST( fd_cstr_printf_check( config->hugetlbfs.normal_page_mount_path,
+    sizeof(config->hugetlbfs.normal_page_mount_path),
+    NULL,
+    "%s/.normal",
+    config->hugetlbfs.mount_path ) );
 
   ulong max_page_sz = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
-  if( FD_UNLIKELY( max_page_sz!=FD_SHMEM_HUGE_PAGE_SZ && max_page_sz!=FD_SHMEM_GIGANTIC_PAGE_SZ ) ) FD_LOG_ERR(( "[hugetlbfs.max_page_size] must be \"huge\" or \"gigantic\"" ));
+  if( FD_UNLIKELY( !fd_shmem_is_page_sz( max_page_sz ) ) ) {
+    FD_LOG_ERR(( "[hugetlbfs.max_page_size] must be \"normal\", \"huge\", or \"gigantic\"" ));
+  }
 
   replace( config->log.path, "{user}", config->user );
   replace( config->log.path, "{name}", config->name );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -314,6 +314,7 @@ struct fd_config {
     int no_clone;
     int no_agave;
     int bootstrap;
+    int lazy_paging;
 
     char core_dump[ 16 ];
     int core_dump_level;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -296,6 +296,7 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( cstr,   development.core_dump                            );
   CFG_POP      ( bool,   development.no_agave                             );
   CFG_POP      ( bool,   development.bootstrap                            );
+  CFG_POP      ( bool,   development.lazy_paging                          );
 
   CFG_POP      ( bool,   development.gossip.allow_private_address         );
 

--- a/src/app/shared_dev/commands/bundle_client.c
+++ b/src/app/shared_dev/commands/bundle_client.c
@@ -15,6 +15,7 @@ bundle_client_topo( config_t *   config ) {
   fd_topo_t * topo = &config->topo;
   fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
 
   fd_topob_wksp( topo, "metric_in" );
 

--- a/src/app/shared_dev/commands/load.c
+++ b/src/app/shared_dev/commands/load.c
@@ -105,6 +105,7 @@ load_cmd_fn( args_t *   args,
 
   fd_topo_t * topo = { fd_topob_new( &config->topo, config->name ) };
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
   add_bench_topo( topo,
                   args->load.affinity,
                   args->load.benchg,

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -50,6 +50,7 @@ pktgen_topo( config_t * config ) {
   fd_topo_t * topo = &config->topo;
   fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
 
   fd_topob_wksp( topo, "metric" );
   fd_topob_wksp( topo, "metric_in" );

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -46,6 +46,7 @@ udpecho_topo( config_t * config ) {
   fd_topo_t * topo = &config->topo;
   fd_topob_new( &config->topo, config->name );
   topo->max_page_size = fd_cstr_to_shmem_page_sz( config->hugetlbfs.max_page_size );
+  topo->lazy_paging   = config->development.lazy_paging;
 
   fd_topob_wksp( topo, "metric" );
   fd_topob_wksp( topo, "metric_in" );

--- a/src/disco/topo/Local.mk
+++ b/src/disco/topo/Local.mk
@@ -2,7 +2,7 @@ ifdef FD_HAS_HOSTED
 ifdef FD_HAS_THREADS
 ifdef FD_HAS_LINUX
 $(call add-hdrs,fd_topo.h)
-$(call add-objs,fd_topo fd_topob fd_cpu_topo fd_topo_run,fd_disco)
+$(call add-objs,fd_topo fd_topob fd_cpu_topo fd_topo_run fd_topo_lazy,fd_disco)
 $(call make-unit-test,test_topob,test_topob,fd_disco fd_ballet fd_tango fd_waltz fd_util)
 $(call run-unit-test,test_topob)
 endif

--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -211,14 +211,24 @@ fd_topo_fill( fd_topo_t * topo ) {
 }
 
 FD_FN_CONST static ulong
-fd_topo_tile_extra_huge_pages( fd_topo_tile_t const * tile ) {
+fd_topo_tile_stack_sz( void ) {
   /* Every tile maps an additional set of pages for the stack. */
-  (void)tile;
-  return (FD_TILE_PRIVATE_STACK_SZ/FD_SHMEM_HUGE_PAGE_SZ)+2UL;
+  return FD_TILE_PRIVATE_STACK_SZ + (2UL*FD_SHMEM_HUGE_PAGE_SZ);
 }
 
 FD_FN_PURE static ulong
-fd_topo_tile_extra_normal_pages( fd_topo_tile_t const * tile ) {
+fd_topo_tile_extra_huge_pages( fd_topo_t const *      topo,
+                               fd_topo_tile_t const * tile ) {
+  (void)tile;
+  if( topo->max_page_size >= FD_SHMEM_HUGE_PAGE_SZ ) {
+    return fd_topo_tile_stack_sz() / FD_SHMEM_HUGE_PAGE_SZ;
+  }
+  return 0UL;
+}
+
+FD_FN_PURE static ulong
+fd_topo_tile_extra_normal_pages( fd_topo_t const *      topo,
+                                 fd_topo_tile_t const * tile ) {
   ulong key_pages = 0UL;
   if( FD_UNLIKELY( tile->id_keyswitch_obj_id!=ULONG_MAX ) ) {
     /* Certain tiles using fd_keyload_load need normal pages to hold
@@ -232,31 +242,35 @@ fd_topo_tile_extra_normal_pages( fd_topo_tile_t const * tile ) {
   }
 
   if( !strcmp( tile->name, "net" ) ) {
-      /* net tile uses normal pages to hold xsk rings */
+    /* net tile uses normal pages to hold xsk rings */
 
-      /* xdp_desc struct is in linux UAPI so its size can be
-         safely assumed */
-      ulong xdp_desc_sz_bytes    = 16UL;
-      ulong xsk_rings_sz_bytes   = 0UL;
-      ulong xdp_address_sz_bytes = sizeof(ulong);
+    /* xdp_desc struct is in linux UAPI so its size can be
+        safely assumed */
+    ulong xdp_desc_sz_bytes    = 16UL;
+    ulong xsk_rings_sz_bytes   = 0UL;
+    ulong xdp_address_sz_bytes = sizeof(ulong);
 
-      /* rx ring */
-      xsk_rings_sz_bytes += tile->xdp.xdp_rx_queue_size * xdp_desc_sz_bytes;
-      /* tx ring */
-      xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_desc_sz_bytes;
+    /* rx ring */
+    xsk_rings_sz_bytes += tile->xdp.xdp_rx_queue_size * xdp_desc_sz_bytes;
+    /* tx ring */
+    xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_desc_sz_bytes;
 
-      /* completion ring */
-      xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_address_sz_bytes;
-      /* free ring */
-      xsk_rings_sz_bytes += tile->xdp.free_ring_depth   * xdp_address_sz_bytes;
+    /* completion ring */
+    xsk_rings_sz_bytes += tile->xdp.xdp_tx_queue_size * xdp_address_sz_bytes;
+    /* free ring */
+    xsk_rings_sz_bytes += tile->xdp.free_ring_depth   * xdp_address_sz_bytes;
 
-      key_pages += fd_ulong_align_up( xsk_rings_sz_bytes, FD_SHMEM_NORMAL_PAGE_SZ ) / FD_SHMEM_NORMAL_PAGE_SZ;
+    key_pages += fd_ulong_align_up( xsk_rings_sz_bytes, FD_SHMEM_NORMAL_PAGE_SZ ) / FD_SHMEM_NORMAL_PAGE_SZ;
 
-      /* All 4 rings must store a ring header. This is 320 bytes
-         per ring as of linux v6.18.3, however could change in
-         the future so allow up to a full 4KB page per ring to
-         be safe. */
-      key_pages += 4UL;
+    /* All 4 rings must store a ring header. This is 320 bytes
+       per ring as of linux v6.18.3, however could change in
+       the future so allow up to a full 4KB page per ring to
+       be safe. */
+    key_pages += 4UL;
+  }
+
+  if( topo->max_page_size == FD_SHMEM_NORMAL_PAGE_SZ ) {
+    key_pages += fd_topo_tile_stack_sz() / FD_SHMEM_NORMAL_PAGE_SZ;
   }
 
   return key_pages;
@@ -273,8 +287,8 @@ fd_topo_mlock_max_tile1( fd_topo_t const *      topo,
   }
 
   return tile_mem +
-      fd_topo_tile_extra_huge_pages( tile ) * FD_SHMEM_HUGE_PAGE_SZ +
-      fd_topo_tile_extra_normal_pages( tile ) * FD_SHMEM_NORMAL_PAGE_SZ;
+      fd_topo_tile_extra_huge_pages  ( topo, tile ) * FD_SHMEM_HUGE_PAGE_SZ +
+      fd_topo_tile_extra_normal_pages( topo, tile ) * FD_SHMEM_NORMAL_PAGE_SZ;
 }
 
 FD_FN_PURE ulong
@@ -305,8 +319,7 @@ fd_topo_gigantic_page_cnt( fd_topo_t const * topo,
 
 FD_FN_PURE ulong
 fd_topo_huge_page_cnt( fd_topo_t const * topo,
-                       ulong             numa_idx,
-                       int               include_anonymous ) {
+                       ulong             numa_idx ) {
   ulong result = 0UL;
   for( ulong i=0UL; i<topo->wksp_cnt; i++ ) {
     fd_topo_wksp_t const * wksp = &topo->workspaces[ i ];
@@ -317,22 +330,41 @@ fd_topo_huge_page_cnt( fd_topo_t const * topo,
     }
   }
 
-  /* The stack huge pages are also placed in the hugetlbfs. */
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
-    result += fd_topo_tile_extra_huge_pages( &topo->tiles[ i ] );
+    result += fd_topo_tile_extra_huge_pages( topo, &topo->tiles[ i ] );
   }
-
-  /* No anonymous huge pages in use yet. */
-  (void)include_anonymous;
 
   return result;
 }
 
 FD_FN_PURE ulong
-fd_topo_normal_page_cnt( fd_topo_t const * topo ) {
+fd_topo_normal_page_cnt( fd_topo_t const * topo,
+                         ulong             numa_idx ) {
+  ulong result = 0UL;
+  for( ulong i=0UL; i<topo->wksp_cnt; i++ ) {
+    fd_topo_wksp_t const * wksp = &topo->workspaces[ i ];
+    if( FD_LIKELY( wksp->numa_idx!=numa_idx ) ) continue;
+    if( FD_LIKELY( wksp->page_sz==FD_SHMEM_NORMAL_PAGE_SZ ) ) {
+      result += wksp->page_cnt;
+    }
+  }
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    fd_topo_tile_t const * tile = &topo->tiles[ i ];
+    ulong tile_numa_idx = 0UL;
+    if( tile->cpu_idx<FD_TILE_MAX ) {
+      tile_numa_idx = fd_shmem_numa_idx( tile->cpu_idx );
+    }
+    if( tile_numa_idx!=numa_idx ) continue;
+    result += fd_topo_tile_extra_normal_pages( topo, tile );
+  }
+  return result;
+}
+
+FD_FN_PURE ulong
+fd_topo_extra_normal_page_cnt( fd_topo_t const * topo ) {
   ulong result = 0UL;
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
-    result += fd_topo_tile_extra_normal_pages( &topo->tiles[ i ] );
+    result += fd_topo_tile_extra_normal_pages( topo, &topo->tiles[ i ] );
   }
   return result;
 }
@@ -343,6 +375,10 @@ fd_topo_mlock( fd_topo_t const * topo ) {
   for( ulong i=0UL; i<topo->wksp_cnt; i++ ) {
     result += topo->workspaces[ i ].page_cnt * topo->workspaces[ i ].page_sz;
   }
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    result += fd_topo_tile_extra_huge_pages( topo, &topo->tiles[ i ] ) * FD_SHMEM_HUGE_PAGE_SZ;
+  }
+  result += fd_topo_extra_normal_page_cnt( topo ) * FD_SHMEM_NORMAL_PAGE_SZ;
   return result;
 }
 
@@ -377,16 +413,7 @@ fd_topo_print_log( int         stdout,
 
   PRINT( "\nSUMMARY\n" );
 
-  /* The logic to compute number of stack pages is taken from
-     fd_tile_thread.cxx, in function fd_topo_tile_stack_join, and this
-     should match that. */
-  ulong stack_pages = topo->tile_cnt * FD_SHMEM_HUGE_PAGE_SZ * ((FD_TILE_PRIVATE_STACK_SZ/FD_SHMEM_HUGE_PAGE_SZ)+2UL);
-
-  /* The logic to map these private pages into memory is in utility.c,
-     under fd_keyload_load, and the amount of pages should be kept in
-     sync. */
-  ulong private_key_pages = 5UL * FD_SHMEM_NORMAL_PAGE_SZ;
-  ulong total_bytes = fd_topo_mlock( topo ) + stack_pages + private_key_pages;
+  ulong total_bytes = fd_topo_mlock( topo );
 
   PRINT("  %23s: %lu\n", "Total Tiles", topo->tile_cnt );
   PRINT("  %23s: %lu bytes (%lu GiB + %lu MiB + %lu KiB)\n",
@@ -398,18 +425,21 @@ fd_topo_print_log( int         stdout,
 
   ulong required_gigantic_pages = 0UL;
   ulong required_huge_pages = 0UL;
+  ulong required_normal_pages = 0UL;
 
   ulong numa_node_cnt = fd_shmem_numa_cnt();
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
     required_gigantic_pages += fd_topo_gigantic_page_cnt( topo, i );
-    required_huge_pages += fd_topo_huge_page_cnt( topo, i, 0 );
+    required_huge_pages += fd_topo_huge_page_cnt( topo, i );
+    required_normal_pages += fd_topo_normal_page_cnt( topo, i );
   }
   PRINT("  %23s: %lu\n", "Required Gigantic Pages", required_gigantic_pages );
   PRINT("  %23s: %lu\n", "Required Huge Pages", required_huge_pages );
-  PRINT("  %23s: %lu\n", "Required Normal Pages", fd_topo_normal_page_cnt( topo ) );
+  if( required_normal_pages ) PRINT("  %23s: %lu\n", "Required Normal Pages", required_normal_pages );
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
     PRINT("  %23s (NUMA node %lu): %lu\n", "Required Gigantic Pages", i, fd_topo_gigantic_page_cnt( topo, i ) );
-    PRINT("  %23s (NUMA node %lu): %lu\n", "Required Huge Pages", i, fd_topo_huge_page_cnt( topo, i, 0 ) );
+    PRINT("  %23s (NUMA node %lu): %lu\n", "Required Huge Pages", i, fd_topo_huge_page_cnt( topo, i ) );
+    if( required_normal_pages ) PRINT("  %23s (NUMA node %lu): %lu\n", "Required Normal Pages", i, fd_topo_normal_page_cnt( topo, i ) );
   }
 
   if( FD_UNLIKELY( topo->agave_affinity_cnt>0UL ) ) {

--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -26,6 +26,11 @@ fd_topo_join_workspace( fd_topo_t *      topo,
                         fd_topo_wksp_t * wksp,
                         int              mode,
                         int              dump ) {
+  if( FD_UNLIKELY( topo->lazy_paging ) ) {
+    fd_topo_join_workspace_lazy_paged( topo, wksp, mode, dump );
+    return;
+  }
+
   char name[ PATH_MAX ];
   FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_%s.wksp", topo->app_name, wksp->name ) );
 
@@ -91,6 +96,10 @@ int
 fd_topo_create_workspace( fd_topo_t *      topo,
                           fd_topo_wksp_t * wksp,
                           int              update_existing ) {
+  if( FD_UNLIKELY( topo->lazy_paging ) ) {
+    return fd_topo_create_workspace_lazy_paged( topo, wksp, update_existing );
+  }
+
   char name[ PATH_MAX ];
   FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_%s.wksp", topo->app_name, wksp->name ) );
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -725,6 +725,7 @@ struct fd_topo {
 
   ulong          max_page_size; /* 2^21 or 2^30 */
   ulong          gigantic_page_threshold; /* see [hugetlbfs.gigantic_page_threshold_mib]*/
+  int            lazy_paging; /* see [development.lazy_paging] */
 };
 typedef struct fd_topo fd_topo_t;
 
@@ -1073,6 +1074,20 @@ int
 fd_topo_create_workspace( fd_topo_t *      topo,
                           fd_topo_wksp_t * wksp,
                           int              update_existing );
+
+/* Lazy-paged variants of workspace create/join.  Skip mlock, mbind, and
+   NUMA validation so pages are demand-faulted.  Development only. */
+
+int
+fd_topo_create_workspace_lazy_paged( fd_topo_t *      topo,
+                                     fd_topo_wksp_t * wksp,
+                                     int              update_existing );
+
+void
+fd_topo_join_workspace_lazy_paged( fd_topo_t *      topo,
+                                   fd_topo_wksp_t * wksp,
+                                   int              mode,
+                                   int              dump );
 
 /* Join the standard IPC objects needed by the topology of this particular
    tile */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -1229,20 +1229,24 @@ fd_topo_gigantic_page_cnt( fd_topo_t const * topo,
 
 /* This returns the number of huge pages in the application needed by
    the topology on the provided numa node.  It includes pages needed by
-   things placed in the hugetlbfs (workspaces, process stacks).  If
-   include_anonymous is true, it also includes anonymous hugepages which
-   are needed but are not placed in the hugetlbfs. */
+   things placed in the hugetlbfs (workspaces, process stacks). */
 
 FD_FN_PURE ulong
 fd_topo_huge_page_cnt( fd_topo_t const * topo,
-                       ulong             numa_idx,
-                       int               include_anonymous );
+                       ulong             numa_idx );
+
+/* Returns the number of normal pages in the application needed by the
+   topology on the provided NUMA node.  Includes extra pages. */
+
+FD_FN_PURE ulong
+fd_topo_normal_page_cnt( fd_topo_t const * topo,
+                         ulong             numa_idx );
 
 /* Returns the number of normal (4 KiB) pages needed by the topology
    for extra allocations like private key storage and XSK rings. */
 
 FD_FN_PURE ulong
-fd_topo_normal_page_cnt( fd_topo_t const * topo );
+fd_topo_extra_normal_page_cnt( fd_topo_t const * topo );
 
 /* Prints a message describing the topology to an output stream.  If
    stdout is true, will be written to stdout, otherwise will be written

--- a/src/disco/topo/fd_topo_lazy.c
+++ b/src/disco/topo/fd_topo_lazy.c
@@ -1,0 +1,278 @@
+#define _GNU_SOURCE
+#include "fd_topo.h"
+
+#include "../../util/shmem/fd_shmem_private.h"
+#include "../../util/wksp/fd_wksp_private.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+/* Lazy-paged workspace creation.  Same as fd_shmem_create_multi /
+   fd_shmem_update_multi but skips mlock, mbind, and NUMA validation so
+   that pages are demand-faulted rather than pre-allocated.  This
+   greatly reduces startup time at the cost of production performance
+   and reliability. */
+
+static int
+fd_shmem_create_multi_lazy_paged( char const *  name,
+                                  ulong         page_sz,
+                                  ulong         sub_cnt,
+                                  ulong const * _sub_page_cnt,
+                                  ulong const * _sub_cpu_idx,
+                                  ulong         mode,
+                                  int           open_flags ) {
+
+  if( FD_UNLIKELY( !fd_shmem_name_len( name ) ) ) { FD_LOG_WARNING(( "bad name (%s)", name ? name : "NULL" )); return EINVAL; }
+  if( FD_UNLIKELY( !fd_shmem_is_page_sz( page_sz ) ) ) { FD_LOG_WARNING(( "bad page_sz (%lu)", page_sz )); return EINVAL; }
+  if( FD_UNLIKELY( !sub_cnt       ) ) { FD_LOG_WARNING(( "zero sub_cnt"      )); return EINVAL; }
+  if( FD_UNLIKELY( !_sub_page_cnt ) ) { FD_LOG_WARNING(( "NULL sub_page_cnt" )); return EINVAL; }
+  if( FD_UNLIKELY( !_sub_cpu_idx  ) ) { FD_LOG_WARNING(( "NULL sub_cpu_idx"  )); return EINVAL; }
+
+  ulong cpu_cnt = fd_shmem_cpu_cnt();
+
+  ulong page_cnt = 0UL;
+  for( ulong sub_idx=0UL; sub_idx<sub_cnt; sub_idx++ ) {
+    ulong sub_page_cnt = _sub_page_cnt[ sub_idx ];
+    if( FD_UNLIKELY( !sub_page_cnt ) ) continue;
+
+    page_cnt += sub_page_cnt;
+    if( FD_UNLIKELY( page_cnt<sub_page_cnt ) ) {
+      FD_LOG_WARNING(( "sub[%lu] sub page_cnt overflow (page_cnt %lu, sub_page_cnt %lu)",
+                       sub_idx, page_cnt-sub_page_cnt, sub_page_cnt ));
+      return EINVAL;
+    }
+
+    ulong sub_cpu_idx = _sub_cpu_idx[ sub_idx ];
+    if( FD_UNLIKELY( sub_cpu_idx>=cpu_cnt ) ) {
+      FD_LOG_WARNING(( "sub[%lu] bad cpu_idx (%lu)", sub_idx, sub_cpu_idx ));
+      return EINVAL;
+    }
+  }
+
+  if( FD_UNLIKELY( !((1UL<=page_cnt) & (page_cnt<=(((ulong)LONG_MAX)/page_sz))) ) ) {
+    FD_LOG_WARNING(( "bad total page_cnt (%lu)", page_cnt ));
+    return EINVAL;
+  }
+
+  if( FD_UNLIKELY( mode!=(ulong)(mode_t)mode ) ) { FD_LOG_WARNING(( "bad mode (0%03lo)", mode )); return EINVAL; }
+
+  FD_SHMEM_LOCK;
+
+  int err;
+
+# define ERROR( cleanup ) do { err = errno; goto cleanup; } while(0)
+
+  char   path[ FD_SHMEM_PRIVATE_PATH_BUF_MAX ];
+  int    fd;
+  void * shmem;
+
+  ulong  sz = page_cnt*page_sz;
+
+  fd = open( fd_shmem_private_path( name, page_sz, path ), open_flags, (mode_t)mode );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",%#x,0%03lo) failed (%i-%s)", path, (uint)open_flags, mode, errno, fd_io_strerror( errno ) ));
+    ERROR( done );
+  }
+
+  if( FD_UNLIKELY( ftruncate( fd, (off_t)sz ) ) ) {
+    FD_LOG_WARNING(( "ftruncate(\"%s\",%lu KiB) failed (%i-%s)", path, sz>>10, errno, fd_io_strerror( errno ) ));
+    ERROR( close );
+  }
+
+  shmem = mmap( NULL, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, (off_t)0);
+  if( FD_UNLIKELY( shmem==MAP_FAILED ) ) {
+    FD_LOG_WARNING(( "mmap(NULL,%lu KiB,PROT_READ|PROT_WRITE,MAP_SHARED,\"%s\",0) failed (%i-%s)",
+                     sz>>10, path, errno, fd_io_strerror( errno ) ));
+    ERROR( close );
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, page_sz ) ) ) {
+    FD_LOG_WARNING(( "misaligned memory mapping for \"%s\"\n\t"
+                     "This thread group's hugetlbfs mount path (--shmem-path / FD_SHMEM_PATH):\n\t"
+                     "\t%s\n\t"
+                     "has probably been corrupted and needs to be redone.\n\t"
+                     "See 'bin/fd_shmem_cfg help' for more information.",
+                     path, fd_shmem_private_base ));
+    errno = EFAULT;
+    ERROR( unmap );
+  }
+
+  err = 0;
+
+# undef ERROR
+
+unmap:
+  if( FD_UNLIKELY( munmap( shmem, sz ) ) )
+    FD_LOG_ERR(( "munmap(\"%s\",%lu KiB) failed (%i-%s)",
+                 path, sz>>10, errno, fd_io_strerror( errno ) ));
+
+close:
+  if( FD_UNLIKELY( err ) && FD_UNLIKELY( unlink( path ) ) )
+    FD_LOG_ERR(( "unlink(\"%s\") failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_ERR(( "close(\"%s\") failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+done:
+  FD_SHMEM_UNLOCK;
+  return err;
+}
+
+/* Lazy-paged workspace join.  Same as fd_shmem_join but skips mlock so
+   that pages are demand-faulted. */
+
+static void *
+fd_shmem_join_lazy_paged( char const *           name,
+                          int                    mode,
+                          int                    dump,
+                          fd_shmem_join_info_t * opt_info ) {
+
+  /* For regions already joined, defer to the normal join path (which
+     just bumps the refcount). */
+  fd_shmem_join_info_t existing;
+  if( !fd_shmem_join_query_by_name( name, &existing ) ) {
+    return fd_shmem_join( name, mode, dump, NULL, NULL, opt_info );
+  }
+
+  fd_shmem_info_t shmem_info[1];
+  if( FD_UNLIKELY( fd_shmem_info( name, 0UL, shmem_info ) ) ) {
+    FD_LOG_WARNING(( "unable to query region \"%s\"\n\tprobably does not exist or bad permissions", name ));
+    return NULL;
+  }
+  ulong page_sz  = shmem_info->page_sz;
+  ulong page_cnt = shmem_info->page_cnt;
+  ulong sz       = page_sz*page_cnt;
+  int   rw       = (mode==FD_SHMEM_JOIN_MODE_READ_WRITE);
+
+  char path[ FD_SHMEM_PRIVATE_PATH_BUF_MAX ];
+  int fd = open( fd_shmem_private_path( name, page_sz, path ), rw ? O_RDWR : O_RDONLY, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) ) {
+    FD_LOG_WARNING(( "open(\"%s\",%s,0) failed (%i-%s)", path, rw ? "O_RDWR" : "O_RDONLY", errno, fd_io_strerror( errno ) ));
+    return NULL;
+  }
+
+  void * const map_addr = fd_shmem_private_map_rand( sz, page_sz, PROT_READ );
+  if( FD_UNLIKELY( map_addr==MAP_FAILED ) ) FD_LOG_ERR(( "fd_shmem_private_map_rand failed" ));
+
+  void * shmem = mmap( map_addr, sz, PROT_READ|( rw?PROT_WRITE:0 ), MAP_SHARED|MAP_FIXED, fd, (off_t)0 );
+
+  int mmap_errno = errno;
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  if( FD_UNLIKELY( shmem==MAP_FAILED ) ) {
+    FD_LOG_WARNING(( "mmap(%p,%lu KiB,%s,MAP_SHARED,\"%s\",0) failed (%i-%s)",
+                     map_addr, sz>>10, rw ? "PROT_READ|PROT_WRITE" : "PROT_READ", path, mmap_errno, fd_io_strerror( mmap_errno ) ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, page_sz ) ) ) {
+    if( FD_UNLIKELY( munmap( shmem, sz ) ) )
+      FD_LOG_WARNING(( "munmap(\"%s\",%lu KiB) failed (%i-%s); attempting to continue",
+                       path, sz>>10, errno, fd_io_strerror( errno ) ));
+    FD_LOG_WARNING(( "misaligned memory mapping for \"%s\"\n\t"
+                     "This thread group's hugetlbfs mount path (--shmem-path / FD_SHMEM_PATH):\n\t"
+                     "\t%s\n\t"
+                     "has probably been corrupted and needs to be redone.\n\t"
+                     "See 'bin/fd_shmem_cfg help' for more information.",
+                     path, fd_shmem_private_base ));
+    return NULL;
+  }
+
+  if( FD_LIKELY( !dump ) ) {
+    if( FD_UNLIKELY( madvise( shmem, sz, MADV_DONTDUMP ) ) )
+      FD_LOG_WARNING(( "madvise(\"%s\",%lu KiB) failed (%i-%s); attempting to continue",
+                      path, sz>>10, errno, fd_io_strerror( errno ) ));
+  }
+
+  if( FD_UNLIKELY( fd_shmem_join_anonymous( name, mode, shmem, shmem, page_sz, page_cnt ) ) ) {
+    FD_LOG_WARNING(( "fd_shmem_join_anonymous(\"%s\") failed", name ));
+    munmap( shmem, sz );
+    return NULL;
+  }
+
+  if( opt_info ) {
+    fd_shmem_join_query_by_name( name, opt_info );
+  }
+
+  return shmem;
+}
+
+/* Public topo-level lazy-paged APIs */
+
+int
+fd_topo_create_workspace_lazy_paged( fd_topo_t *      topo,
+                                     fd_topo_wksp_t * wksp,
+                                     int              update_existing ) {
+  char name[ PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_%s.wksp", topo->app_name, wksp->name ) );
+
+  ulong sub_page_cnt[ 1 ] = { wksp->page_cnt };
+  ulong sub_cpu_idx [ 1 ] = { fd_shmem_cpu_idx( wksp->numa_idx ) };
+
+  int err;
+  if( FD_UNLIKELY( update_existing ) ) {
+    err = fd_shmem_create_multi_lazy_paged( name, wksp->page_sz, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR, O_RDWR );
+  } else {
+    err = fd_shmem_create_multi_lazy_paged( name, wksp->page_sz, 1, sub_page_cnt, sub_cpu_idx, S_IRUSR | S_IWUSR, O_RDWR | O_CREAT | O_EXCL );
+  }
+  if( FD_UNLIKELY( err && errno==ENOMEM ) ) return -1;
+  else if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "fd_shmem_create_multi_lazy_paged failed" ));
+
+  /* Temporarily mmap the region to initialize the workspace header.
+     No shmem join registration needed — this mapping is short-lived. */
+
+  ulong sz = wksp->page_cnt * wksp->page_sz;
+
+  fd_shmem_info_t shmem_info[1];
+  if( FD_UNLIKELY( fd_shmem_info( name, 0UL, shmem_info ) ) )
+    FD_LOG_ERR(( "fd_shmem_info(\"%s\") failed", name ));
+
+  char path[ FD_SHMEM_PRIVATE_PATH_BUF_MAX ];
+  int fd = open( fd_shmem_private_path( name, shmem_info->page_sz, path ), O_RDWR, (mode_t)0 );
+  if( FD_UNLIKELY( fd==-1 ) )
+    FD_LOG_ERR(( "open(\"%s\") failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  void * shmem = mmap( NULL, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, (off_t)0 );
+  if( FD_UNLIKELY( shmem==MAP_FAILED ) )
+    FD_LOG_ERR(( "mmap(\"%s\",%lu KiB) failed (%i-%s)", path, sz>>10, errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( close( fd ) ) )
+    FD_LOG_WARNING(( "close(\"%s\") failed (%i-%s); attempting to continue", path, errno, fd_io_strerror( errno ) ));
+
+  void * wkspmem = fd_wksp_new( shmem, name, 0U, wksp->part_max, wksp->total_footprint );
+  if( FD_UNLIKELY( !wkspmem ) ) FD_LOG_ERR(( "fd_wksp_new failed" ));
+
+  fd_wksp_t * join = fd_wksp_join( wkspmem );
+  if( FD_UNLIKELY( !join ) ) FD_LOG_ERR(( "fd_wksp_join failed" ));
+
+  if( FD_LIKELY( wksp->known_footprint ) ) {
+    ulong offset = fd_wksp_alloc( join, fd_topo_workspace_align(), wksp->known_footprint, 1UL );
+    if( FD_UNLIKELY( !offset ) ) FD_LOG_ERR(( "fd_wksp_alloc failed" ));
+
+    if( FD_UNLIKELY( fd_ulong_align_up( ((struct fd_wksp_private*)join)->gaddr_lo, fd_topo_workspace_align() ) != offset ) )
+      FD_LOG_ERR(( "wksp gaddr_lo %lu != offset %lu", fd_ulong_align_up( ((struct fd_wksp_private*)join)->gaddr_lo, fd_topo_workspace_align() ), offset ));
+  }
+
+  fd_wksp_leave( join );
+
+  if( FD_UNLIKELY( munmap( shmem, sz ) ) )
+    FD_LOG_ERR(( "munmap failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  return 0;
+}
+
+void
+fd_topo_join_workspace_lazy_paged( fd_topo_t *      topo,
+                                   fd_topo_wksp_t * wksp,
+                                   int              mode,
+                                   int              dump ) {
+  (void)dump;
+
+  char name[ PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_%s.wksp", topo->app_name, wksp->name ) );
+
+  wksp->wksp = fd_wksp_join( fd_shmem_join_lazy_paged( name, mode, dump, NULL ) );
+  if( FD_UNLIKELY( !wksp->wksp ) ) FD_LOG_ERR(( "fd_wksp_join failed" ));
+}

--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -218,14 +218,18 @@ fd_topo_tile_stack_join( char const * app_name,
   FD_TEST( fd_cstr_printf_check( name, PATH_MAX, NULL, "%s_stack_%s%lu", app_name, tile_name, tile_kind_id ) );
 
   int dump = strcmp( tile_name, "sign" ) ? 1 : 0; /* avoid core dumps of sign tile stacks */
-  uchar * stack = fd_shmem_join( name, FD_SHMEM_JOIN_MODE_READ_WRITE, dump, NULL, NULL, NULL );
+  fd_shmem_join_info_t info;
+  uchar * stack = fd_shmem_join( name, FD_SHMEM_JOIN_MODE_READ_WRITE, dump, NULL, NULL, &info );
   if( FD_UNLIKELY( !stack ) ) FD_LOG_ERR(( "fd_shmem_join failed" ));
 
+  ulong page_sz        = info.page_sz;
+  ulong guard_page_cnt = FD_SHMEM_HUGE_PAGE_SZ / page_sz;
+
   /* Make space for guard lo and guard hi */
-  if( FD_UNLIKELY( fd_shmem_release( stack, FD_SHMEM_HUGE_PAGE_SZ, 1UL ) ) )
+  if( FD_UNLIKELY( fd_shmem_release( stack, page_sz, guard_page_cnt ) ) )
     FD_LOG_ERR(( "fd_shmem_release (%d-%s)", errno, fd_io_strerror( errno ) ));
   stack += FD_SHMEM_HUGE_PAGE_SZ;
-  if( FD_UNLIKELY( fd_shmem_release( stack + FD_TILE_PRIVATE_STACK_SZ, FD_SHMEM_HUGE_PAGE_SZ, 1UL ) ) )
+  if( FD_UNLIKELY( fd_shmem_release( stack + FD_TILE_PRIVATE_STACK_SZ, page_sz, guard_page_cnt ) ) )
     FD_LOG_ERR(( "fd_shmem_release (%d-%s)", errno, fd_io_strerror( errno ) ));
 
   /* Create the guard regions in the extra space */

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -31,6 +31,7 @@ fd_topob_new( void * mem,
 
   topo->max_page_size           = FD_SHMEM_GIGANTIC_PAGE_SZ;
   topo->gigantic_page_threshold = 4 * FD_SHMEM_HUGE_PAGE_SZ;
+  topo->lazy_paging             = 0;
 
   topo->agave_affinity_cnt = 0;
   topo->blocklist_cores_cnt = 0;

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -809,8 +809,12 @@ fd_topob_finish( fd_topo_t *                topo,
     ulong total_wksp_footprint = fd_wksp_footprint( part_max, footprint + fd_topo_workspace_align() + loose_sz );
 
     ulong page_sz = topo->max_page_size;
-    if( total_wksp_footprint < topo->gigantic_page_threshold ) page_sz = FD_SHMEM_HUGE_PAGE_SZ;
-    if( FD_UNLIKELY( page_sz!=FD_SHMEM_HUGE_PAGE_SZ && page_sz!=FD_SHMEM_GIGANTIC_PAGE_SZ ) ) FD_LOG_ERR(( "invalid page_sz" ));
+    if( total_wksp_footprint < topo->gigantic_page_threshold ) {
+      page_sz = fd_ulong_min( page_sz, FD_SHMEM_HUGE_PAGE_SZ );
+    }
+    if( FD_UNLIKELY( !fd_shmem_is_page_sz( page_sz ) ) ) {
+      FD_LOG_ERR(( "invalid page_sz" ));
+    }
 
     ulong wksp_aligned_footprint = fd_ulong_align_up( total_wksp_footprint, page_sz );
 


### PR DESCRIPTION
Run Firedancer without hugepages or memory preallocation:

`sudo build/native/gcc/bin/firedancer-dev --config src/app/firedancer-dev/config/minimal.toml --testnet`