### PR TITLE
secp: add edge cases for k256 and align all cases in p256

### DIFF
--- a/src/ballet/secp256k1/fd_secp256k1.c
+++ b/src/ballet/secp256k1/fd_secp256k1.c
@@ -1,5 +1,12 @@
 #include "fd_secp256k1_private.h"
 
+/* Public wrapper for fp_sqrt (internal impl is static inline). */
+fd_uint256_t *
+fd_secp256k1_fp_sqrt( fd_uint256_t *       restrict r,
+                      fd_uint256_t const * restrict a ) {
+  return (fd_uint256_t *)fd_secp256k1_fp_sqrt_impl( (fd_secp256k1_fp_t *)r,
+                                                     (fd_secp256k1_fp_t const *)a );
+}
 
 /* Given the coordinate X and the odd-ness of the Y coordinate, recovers Y and
    returns the affine group element. Returns NULL if there is no valid pair. */
@@ -13,7 +20,7 @@ fd_secp256k1_recovery_y( fd_secp256k1_point_t *r, fd_secp256k1_fp_t const *x, in
   fd_secp256k1_fp_add( x3, x3, fd_secp256k1_const_b );
 
   /* y^2 = x^3 + b <=> y = sqrt(x^3 + b) */
-  if( FD_UNLIKELY( !fd_secp256k1_fp_sqrt( r->y, x3 ) ) ) {
+  if( FD_UNLIKELY( !fd_secp256k1_fp_sqrt_impl( r->y, x3 ) ) ) {
     return NULL;
   }
 

--- a/src/ballet/secp256k1/fd_secp256k1_private.h
+++ b/src/ballet/secp256k1/fd_secp256k1_private.h
@@ -20,19 +20,19 @@ struct fd_secp256k1_point {
 typedef struct fd_secp256k1_point fd_secp256k1_point_t;
 
 /* const 0 */
-fd_secp256k1_scalar_t const fd_secp256k1_const_zero[1] = {{{
+static const fd_secp256k1_scalar_t fd_secp256k1_const_zero[1] = {{{
   0, 0, 0, 0,
 }}};
 
 /* const n, used to validate a scalar element. NOT Montgomery.
    0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 */
-fd_secp256k1_scalar_t const fd_secp256k1_const_n[1] = {{{
+static const fd_secp256k1_scalar_t fd_secp256k1_const_n[1] = {{{
   0xbfd25e8cd0364141, 0xbaaedce6af48a03b, 0xfffffffffffffffe, 0xffffffffffffffff,
 }}};
 
 /* const p - n. NOT Montgomery.
    0x14551231950b75fc4402da1722fc9baee */
-fd_secp256k1_scalar_t const fd_secp256k1_const_p_minus_n[1] = {{{
+static const fd_secp256k1_scalar_t fd_secp256k1_const_p_minus_n[1] = {{{
   0x402da1722fc9baeeUL, 0x4551231950b75fc4UL, 0x1UL, 0x0UL
 }}};
 
@@ -42,29 +42,29 @@ fd_secp256k1_scalar_t const fd_secp256k1_const_p_minus_n[1] = {{{
    move into the montgomery domain by doing montmul(x, RR), where RR is R in the montgomery domain.
 
    TODO: In the future s2n-bignum might provide a tomont_n256k1 API, and we should migrate to it. */
-ulong const fd_secp256k1_const_scalar_rr_mont[4] = {
+static const ulong fd_secp256k1_const_scalar_rr_mont[4] = {
   0x896cf21467d7d140UL, 0x741496c20e7cf878UL, 0xe697f5e45bcd07c6UL, 0x9d671cd581c69bc5UL,
 };
 
 /* const 1 */
-fd_secp256k1_fp_t const fd_secp256k1_const_one[1] = {{{
+static const fd_secp256k1_fp_t fd_secp256k1_const_one[1] = {{{
   1UL, 0UL, 0UL, 0UL
 }}};
 
 /* const b = 7 */
-fd_secp256k1_fp_t const fd_secp256k1_const_b[1] = {{{
+static const fd_secp256k1_fp_t fd_secp256k1_const_b[1] = {{{
   7UL, 0UL, 0UL, 0UL
 }}};
 
 /* const n as a field element, used to bump r for recovery_id & 2.
    0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 */
-fd_secp256k1_fp_t const fd_secp256k1_const_n_fp[1] = {{{
+static const fd_secp256k1_fp_t fd_secp256k1_const_n_fp[1] = {{{
   0xbfd25e8cd0364141UL, 0xbaaedce6af48a03bUL, 0xfffffffffffffffeUL, 0xffffffffffffffffUL
 }}};
 
 /* const p, used for field operations.
    0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f */
-fd_secp256k1_fp_t const fd_secp256k1_const_p[1] = {{{
+static const fd_secp256k1_fp_t fd_secp256k1_const_p[1] = {{{
   0xfffffffefffffc2fUL, 0xffffffffffffffffUL, 0xffffffffffffffffUL, 0xffffffffffffffffUL
 }}};
 

--- a/src/ballet/secp256k1/fd_secp256k1_s2n.c
+++ b/src/ballet/secp256k1/fd_secp256k1_s2n.c
@@ -46,7 +46,7 @@ fd_secp256k1_scalar_frombytes( fd_secp256k1_scalar_t * r,
 /* r = 1 / a
    Operates on scalars NOT in the montgomery domain.
    a MUST not be 0. */
-fd_secp256k1_scalar_t *
+static inline fd_secp256k1_scalar_t *
 fd_secp256k1_scalar_invert( fd_secp256k1_scalar_t *       r,
                             fd_secp256k1_scalar_t const * a ) {
   ulong t[ 12 ];
@@ -211,9 +211,9 @@ fd_secp256k1_fp_tobytes( uchar                    r[ 32 ],
     a^((p-1)/2) = -1
   and the result will fail the final verification.
 */
-fd_secp256k1_fp_t *
-fd_secp256k1_fp_sqrt( fd_secp256k1_fp_t *       restrict r,
-                      fd_secp256k1_fp_t const * restrict a ) {
+static inline fd_secp256k1_fp_t *
+fd_secp256k1_fp_sqrt_impl( fd_secp256k1_fp_t *       restrict r,
+                           fd_secp256k1_fp_t const * restrict a ) {
   fd_secp256k1_fp_t x2;
   fd_secp256k1_fp_t x3;
 
@@ -279,12 +279,39 @@ fd_secp256k1_fp_sqrt( fd_secp256k1_fp_t *       restrict r,
 /* Point operations in plain (non-Montgomery) Jacobian coordinates.
    s2n-bignum's secp256k1 point ops work in this domain. */
 
-/* r = a + b */
+/* Returns 1 if two Jacobian points represent the same affine point, 0 otherwise. */
+static inline int
+fd_secp256k1_point_eq( fd_secp256k1_point_t const * a,
+                       fd_secp256k1_point_t const * b ) {
+  int a_zero = fd_secp256k1_fp_eq( a->z, fd_secp256k1_const_zero );
+  int b_zero = fd_secp256k1_fp_eq( b->z, fd_secp256k1_const_zero );
+  if( FD_UNLIKELY( a_zero | b_zero ) ) return a_zero & b_zero;
+  fd_secp256k1_fp_t az2[1], bz2[1], t1[1], t2[1];
+  bignum_sqr_p256k1( az2->limbs, (ulong *)a->z->limbs );
+  bignum_sqr_p256k1( bz2->limbs, (ulong *)b->z->limbs );
+  bignum_mul_p256k1( t1->limbs, (ulong *)a->x->limbs, bz2->limbs );
+  bignum_mul_p256k1( t2->limbs, (ulong *)b->x->limbs, az2->limbs );
+  if( FD_UNLIKELY( fd_secp256k1_fp_eq( t1, t2 ) ) ) {
+    bignum_mul_p256k1( t1->limbs, (ulong *)a->y->limbs, bz2->limbs );
+    bignum_mul_p256k1( t1->limbs, t1->limbs, (ulong *)b->z->limbs );
+    bignum_mul_p256k1( t2->limbs, (ulong *)b->y->limbs, az2->limbs );
+    bignum_mul_p256k1( t2->limbs, t2->limbs, (ulong *)a->z->limbs );
+    return fd_secp256k1_fp_eq( t1, t2 );
+  }
+  return 0;
+}
+
+/* r = a + b.
+   secp256k1_jadd handles identity and negation but NOT doubling. */
 static inline fd_secp256k1_point_t *
 fd_secp256k1_point_add( fd_secp256k1_point_t *       r,
                         fd_secp256k1_point_t const * a,
                         fd_secp256k1_point_t const * b ) {
-  secp256k1_jadd( (ulong *)r, (ulong const *)a, (ulong const *)b );
+  if( FD_UNLIKELY( fd_secp256k1_point_eq( a, b ) ) ) {
+    secp256k1_jdouble( (ulong *)r, (ulong const *)a );
+  } else {
+    secp256k1_jadd( (ulong *)r, (ulong const *)a, (ulong const *)b );
+  }
   return r;
 }
 
@@ -315,24 +342,54 @@ fd_secp256k1_point_sub( fd_secp256k1_point_t *       r,
   return fd_secp256k1_point_add( r, a, neg );
 }
 
-/* Mixed addition: a (Jacobian) + b (affine xy as 8 ulongs). */
+/* Returns 1 if Jacobian `a` and affine `b` represent the same point, 0 otherwise. */
+static inline int
+fd_secp256k1_point_eq_mixed( fd_secp256k1_point_t const * a,
+                             fd_secp256k1_point_t const * b ) {
+  if( FD_UNLIKELY( fd_secp256k1_fp_eq( a->z, fd_secp256k1_const_zero ) ) ) {
+    return fd_uint256_eq( b->x, fd_secp256k1_const_zero ) &
+           fd_uint256_eq( b->y, fd_secp256k1_const_zero );
+  }
+  fd_secp256k1_fp_t z1z1[1], temp[1];
+  bignum_sqr_p256k1( z1z1->limbs, (ulong *)a->z->limbs );
+  bignum_mul_p256k1( temp->limbs, (ulong *)b->x->limbs, z1z1->limbs );
+  if( FD_UNLIKELY( fd_secp256k1_fp_eq( a->x, temp ) ) ) {
+    bignum_mul_p256k1( temp->limbs, z1z1->limbs, (ulong *)a->z->limbs );
+    bignum_mul_p256k1( temp->limbs, temp->limbs, (ulong *)b->y->limbs );
+    return fd_secp256k1_fp_eq( a->y, temp );
+  }
+  return 0;
+}
+
+/* Mixed addition: a (Jacobian) + b (affine point, with z=1 or z=0).
+   secp256k1_jmixadd handles identity (a.z==0) and negation (a==-b)
+   but NOT b==0 or doubling (a==b). */
 static inline fd_secp256k1_point_t *
 fd_secp256k1_point_add_mixed( fd_secp256k1_point_t *       r,
                               fd_secp256k1_point_t const * a,
-                              ulong                const   b[ 8 ] ) {
-  secp256k1_jmixadd( (ulong *)r, (ulong const *)a, (ulong *)b );
+                              fd_secp256k1_point_t const * b ) {
+  int b_is_zero = fd_uint256_eq( b->x, fd_secp256k1_const_zero ) &
+                  fd_uint256_eq( b->y, fd_secp256k1_const_zero );
+  if( FD_UNLIKELY( b_is_zero ) ) {
+    if( r != a ) fd_memcpy( r, a, sizeof(fd_secp256k1_point_t) );
+    return r;
+  }
+  if( FD_UNLIKELY( fd_secp256k1_point_eq_mixed( a, b ) ) ) {
+    secp256k1_jdouble( (ulong *)r, (ulong const *)a );
+  } else {
+    secp256k1_jmixadd( (ulong *)r, (ulong const *)a, (ulong const *)b );
+  }
   return r;
 }
 
 static inline fd_secp256k1_point_t *
 fd_secp256k1_point_sub_mixed( fd_secp256k1_point_t *       r,
                               fd_secp256k1_point_t const * a,
-                              ulong                const   b[ 8 ] ) {
-  ulong neg[8];
-  fd_memcpy( neg, b, 64 );
-  bignum_neg_p256k1( neg+4, neg+4 );
-  secp256k1_jmixadd( (ulong *)r, (ulong const *)a, neg );
-  return r;
+                              fd_secp256k1_point_t const * b ) {
+  fd_secp256k1_point_t neg[1];
+  fd_memcpy( neg, b, sizeof(fd_secp256k1_point_t) );
+  bignum_neg_p256k1( neg->y->limbs, neg->y->limbs );
+  return fd_secp256k1_point_add_mixed( r, a, neg );
 }
 
 /* Double base multiplication */
@@ -392,9 +449,9 @@ fd_secp256k1_double_scalar_mul_base( fd_secp256k1_point_t *        r,
   for( int pos=64; ; pos-- ) {
     schar slot1 = e1[pos];
     if( slot1 > 0 ) {
-      fd_secp256k1_point_add_mixed( r, r, fd_secp256k1_base_point_table[ (ulong)slot1 ].x->limbs );
+      fd_secp256k1_point_add_mixed( r, r, &fd_secp256k1_base_point_table[ (ulong)slot1 ] );
     } else if( slot1 < 0 ) {
-      fd_secp256k1_point_sub_mixed( r, r, fd_secp256k1_base_point_table[ (ulong)(-slot1) ].x->limbs );
+      fd_secp256k1_point_sub_mixed( r, r, &fd_secp256k1_base_point_table[ (ulong)(-slot1) ] );
     }
 
     schar slot2 = e2[pos];

--- a/src/ballet/secp256k1/test_secp256k1.c
+++ b/src/ballet/secp256k1/test_secp256k1.c
@@ -1,5 +1,6 @@
 #include "../fd_ballet.h"
 #include "fd_secp256k1.h"
+#include "fd_secp256k1_private.h"
 #include "../hex/fd_hex.h"
 
 static void
@@ -502,6 +503,166 @@ test_recover_consistency( void ) {
 }
 
 /**********************************************************************/
+/* Test: point arithmetic edge cases                                  */
+/**********************************************************************/
+
+/* Helper: compare Jacobian result against a known affine point. */
+static int
+point_eq_affine( fd_secp256k1_point_t const * jac,
+                 fd_secp256k1_point_t const * affine ) {
+  fd_secp256k1_point_t aff[1];
+  fd_secp256k1_point_to_affine( aff, jac );
+  return fd_uint256_eq( aff->x, affine->x ) &
+         fd_uint256_eq( aff->y, affine->y );
+}
+
+static void
+test_point_add_edge_cases( void ) {
+  FD_LOG_NOTICE(( "Testing point_add edge cases" ));
+  fd_secp256k1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256k1_point_t) );
+  fd_secp256k1_point_t const * G  = &fd_secp256k1_base_point_table[1];
+  fd_secp256k1_point_t const * G2 = &fd_secp256k1_base_point_table[2];
+  fd_secp256k1_point_t r[1];
+
+  /* 0 + 0 = 0 */
+  fd_secp256k1_point_add( r, zero, zero );
+  FD_TEST( fd_secp256k1_point_is_identity( r ) );
+
+  /* G + 0 = G */
+  fd_secp256k1_point_add( r, G, zero );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* 0 + G = G */
+  fd_secp256k1_point_add( r, zero, G );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* G + G = 2G (doubling case) */
+  fd_secp256k1_point_add( r, G, G );
+  FD_TEST( point_eq_affine( r, G2 ) );
+
+  /* G + (-G) = 0 */
+  {
+    fd_secp256k1_point_t neg_g[1];
+    fd_secp256k1_point_neg( neg_g, G );
+    fd_secp256k1_point_add( r, G, neg_g );
+    FD_TEST( fd_secp256k1_point_is_identity( r ) );
+  }
+
+  FD_LOG_NOTICE(( "point_add edge cases passed" ));
+}
+
+static void
+test_point_sub_edge_cases( void ) {
+  FD_LOG_NOTICE(( "Testing point_sub edge cases" ));
+  fd_secp256k1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256k1_point_t) );
+  fd_secp256k1_point_t const * G = &fd_secp256k1_base_point_table[1];
+  fd_secp256k1_point_t r[1];
+
+  /* G - G = 0 */
+  fd_secp256k1_point_sub( r, G, G );
+  FD_TEST( fd_secp256k1_point_is_identity( r ) );
+
+  /* G - 0 = G */
+  fd_secp256k1_point_sub( r, G, zero );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* 0 - G = -G */
+  {
+    fd_secp256k1_point_t neg_g[1];
+    fd_secp256k1_point_neg( neg_g, G );
+    fd_secp256k1_point_sub( r, zero, G );
+    FD_TEST( point_eq_affine( r, neg_g ) );
+  }
+
+  FD_LOG_NOTICE(( "point_sub edge cases passed" ));
+}
+
+static void
+test_point_add_mixed_edge_cases( void ) {
+  FD_LOG_NOTICE(( "Testing point_add_mixed edge cases" ));
+  fd_secp256k1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256k1_point_t) );
+  fd_secp256k1_point_t const * G  = &fd_secp256k1_base_point_table[1];
+  fd_secp256k1_point_t const * G2 = &fd_secp256k1_base_point_table[2];
+  fd_secp256k1_point_t r[1];
+
+  /* 0 + 0 = 0 (both zero) */
+  fd_secp256k1_point_add_mixed( r, zero, zero );
+  FD_TEST( fd_secp256k1_point_is_identity( r ) );
+
+  /* G + 0 = G */
+  fd_secp256k1_point_add_mixed( r, G, zero );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* 0 + G = G */
+  fd_secp256k1_point_add_mixed( r, zero, G );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* G + G = 2G (doubling case) */
+  fd_secp256k1_point_add_mixed( r, G, G );
+  FD_TEST( point_eq_affine( r, G2 ) );
+
+  /* G + (-G) = 0 */
+  {
+    fd_secp256k1_point_t neg_g[1];
+    fd_secp256k1_point_neg( neg_g, G );
+    fd_secp256k1_point_add_mixed( r, G, neg_g );
+    FD_TEST( fd_secp256k1_point_is_identity( r ) );
+  }
+
+  FD_LOG_NOTICE(( "point_add_mixed edge cases passed" ));
+}
+
+static void
+test_point_sub_mixed_edge_cases( void ) {
+  FD_LOG_NOTICE(( "Testing point_sub_mixed edge cases" ));
+  fd_secp256k1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256k1_point_t) );
+  fd_secp256k1_point_t const * G = &fd_secp256k1_base_point_table[1];
+  fd_secp256k1_point_t r[1];
+
+  /* G - G = 0 */
+  fd_secp256k1_point_sub_mixed( r, G, G );
+  FD_TEST( fd_secp256k1_point_is_identity( r ) );
+
+  /* G - 0 = G */
+  fd_secp256k1_point_sub_mixed( r, G, zero );
+  FD_TEST( point_eq_affine( r, G ) );
+
+  /* 0 - G = -G */
+  {
+    fd_secp256k1_point_t neg_g[1];
+    fd_secp256k1_point_neg( neg_g, G );
+    fd_secp256k1_point_sub_mixed( r, zero, G );
+    FD_TEST( point_eq_affine( r, neg_g ) );
+  }
+
+  FD_LOG_NOTICE(( "point_sub_mixed edge cases passed" ));
+}
+
+static void
+test_point_eq( void ) {
+  FD_LOG_NOTICE(( "Testing point_eq" ));
+  fd_secp256k1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256k1_point_t) );
+  fd_secp256k1_point_t const * G  = &fd_secp256k1_base_point_table[1];
+  fd_secp256k1_point_t const * G2 = &fd_secp256k1_base_point_table[2];
+
+  FD_TEST( fd_secp256k1_point_eq( zero, zero ) == 1 );
+  FD_TEST( fd_secp256k1_point_eq( G, G ) == 1 );
+  FD_TEST( fd_secp256k1_point_eq( G, G2 ) == 0 );
+  FD_TEST( fd_secp256k1_point_eq( G, zero ) == 0 );
+  FD_TEST( fd_secp256k1_point_eq( zero, G ) == 0 );
+
+  /* Compare G in affine (z=1) with G in a different Jacobian representation (2G + G - 2G) */
+  {
+    fd_secp256k1_point_t g_jac[1];
+    fd_secp256k1_point_add( g_jac, G2, G );    /* 3G */
+    fd_secp256k1_point_sub( g_jac, g_jac, G2 );/* 3G - 2G = G, in non-affine Jacobian */
+    FD_TEST( fd_secp256k1_point_eq( G, g_jac ) == 1 );
+  }
+
+  FD_LOG_NOTICE(( "point_eq tests passed" ));
+}
+
+/**********************************************************************/
 /* Benches                                                            */
 /**********************************************************************/
 
@@ -512,7 +673,7 @@ bench_fp( void ) {
   a->limbs[0] = 8; a->limbs[1] = 0; a->limbs[2] = 0; a->limbs[3] = 0;
   /* No Montgomery conversion needed -- field is now plain */
 
-  FD_TEST( fd_secp256k1_fp_sqrt( r, a ) != NULL );
+  FD_TEST( fd_secp256k1_fp_sqrt_impl( r, a ) != NULL );
 
   fd_uint256_t * rp = r;
   fd_uint256_t * ap = a;
@@ -521,7 +682,7 @@ bench_fp( void ) {
   long dt = fd_log_wallclock();
   for( ulong rem=iter; rem; rem-- ) {
     FD_COMPILER_FORGET( rp ); FD_COMPILER_FORGET( ap );
-    fd_secp256k1_fp_sqrt( rp, ap );
+    fd_secp256k1_fp_sqrt_impl( rp, ap );
   }
   dt = fd_log_wallclock() - dt;
   char cstr[128];
@@ -575,6 +736,13 @@ main( int     argc,
   test_recover_extended ();
   test_recover_edge_cases();
   test_recover_consistency();
+
+  test_point_eq();
+  test_point_add_edge_cases();
+  test_point_sub_edge_cases();
+  test_point_add_mixed_edge_cases();
+  test_point_sub_mixed_edge_cases();
+
   bench_fp();
   bench_recover();
 

--- a/src/ballet/secp256r1/fd_secp256r1_s2n.c
+++ b/src/ballet/secp256r1/fd_secp256r1_s2n.c
@@ -193,12 +193,39 @@ fd_secp256r1_point_eq_x( fd_secp256r1_point_t const *  p,
 
 /* Point operations in Montgomery Jacobian coordinates. */
 
-/* r = a + b */
+/* Returns 1 if two Jacobian points represent the same affine point, 0 otherwise. */
+static inline int
+fd_secp256r1_point_eq( fd_secp256r1_point_t const * a,
+                       fd_secp256r1_point_t const * b ) {
+  int a_zero = fd_uint256_eq( a->z, fd_secp256r1_const_zero );
+  int b_zero = fd_uint256_eq( b->z, fd_secp256r1_const_zero );
+  if( FD_UNLIKELY( a_zero | b_zero ) ) return a_zero & b_zero;
+  fd_secp256r1_fp_t az2[1], bz2[1], t1[1], t2[1];
+  bignum_montsqr_p256( az2->limbs, (ulong *)a->z->limbs );
+  bignum_montsqr_p256( bz2->limbs, (ulong *)b->z->limbs );
+  bignum_montmul_p256( t1->limbs, (ulong *)a->x->limbs, bz2->limbs );
+  bignum_montmul_p256( t2->limbs, (ulong *)b->x->limbs, az2->limbs );
+  if( FD_UNLIKELY( fd_uint256_eq( t1, t2 ) ) ) {
+    bignum_montmul_p256( t1->limbs, (ulong *)a->y->limbs, bz2->limbs );
+    bignum_montmul_p256( t1->limbs, t1->limbs, (ulong *)b->z->limbs );
+    bignum_montmul_p256( t2->limbs, (ulong *)b->y->limbs, az2->limbs );
+    bignum_montmul_p256( t2->limbs, t2->limbs, (ulong *)a->z->limbs );
+    return fd_uint256_eq( t1, t2 );
+  }
+  return 0;
+}
+
+/* r = a + b.
+   p256_montjadd handles identity and negation but NOT the doubling case. */
 static inline fd_secp256r1_point_t *
 fd_secp256r1_point_add( fd_secp256r1_point_t *       r,
                         fd_secp256r1_point_t const * a,
                         fd_secp256r1_point_t const * b ) {
-  p256_montjadd( (ulong *)r, (ulong const *)a, (ulong const *)b );
+  if( FD_UNLIKELY( fd_secp256r1_point_eq( a, b ) ) ) {
+    p256_montjdouble( (ulong *)r, (ulong const *)a );
+  } else {
+    p256_montjadd( (ulong *)r, (ulong const *)a, (ulong const *)b );
+  }
   return r;
 }
 
@@ -251,7 +278,8 @@ fd_secp256r1_point_eq_mixed( fd_secp256r1_point_t const * a,
 }
 
 /* Mixed addition: a (Jacobian) + b (affine xy as 8 ulongs).
-   Handles identity elements and the equal-point (doubling) case. */
+   p256_montjmixadd handles identity (a.z==0) and negation (a==-b)
+   but NOT b==0 or doubling (a==b). */
 static inline void
 fd_secp256r1_point_add_mixed( fd_secp256r1_point_t *       r,
                               fd_secp256r1_point_t const * a,

--- a/src/ballet/secp256r1/test_secp256r1.c
+++ b/src/ballet/secp256r1/test_secp256r1.c
@@ -281,6 +281,67 @@ test_secp256r1_point_add_mixed( FD_FN_UNUSED fd_rng_t * rng ) {
 }
 
 static void
+test_secp256r1_point_add_edge_cases( FD_FN_UNUSED fd_rng_t * rng ) {
+  FD_LOG_NOTICE(( "Testing point_add edge cases" ));
+  fd_secp256r1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256r1_point_t) );
+  fd_secp256r1_point_t const * G  = &fd_secp256r1_base_point_table[1];
+  fd_secp256r1_point_t const * G2 = &fd_secp256r1_base_point_table[2];
+  fd_secp256r1_point_t r[1];
+
+  /* 0 + 0 = 0 */
+  fd_secp256r1_point_add( r, zero, zero );
+  FD_TEST( fd_uint256_eq( r->z, fd_secp256r1_const_zero ) );
+
+  /* G + 0 = G */
+  fd_secp256r1_point_add( r, G, zero );
+  FD_TEST( fd_secp256r1_point_eq_mixed( r, G->x->limbs ) );
+
+  /* 0 + G = G */
+  fd_secp256r1_point_add( r, zero, G );
+  FD_TEST( fd_secp256r1_point_eq_mixed( r, G->x->limbs ) );
+
+  /* G + G = 2G */
+  fd_secp256r1_point_add( r, G, G );
+  FD_TEST( fd_secp256r1_point_eq_mixed( r, G2->x->limbs ) );
+
+  /* G + (-G) = 0 */
+  {
+    fd_secp256r1_point_t neg_g[1];
+    fd_secp256r1_point_neg( neg_g, G );
+    fd_secp256r1_point_add( r, G, neg_g );
+    FD_TEST( fd_uint256_eq( r->z, fd_secp256r1_const_zero ) );
+  }
+
+  FD_LOG_NOTICE(( "point_add edge cases passed" ));
+}
+
+static void
+test_secp256r1_point_sub_edge_cases( FD_FN_UNUSED fd_rng_t * rng ) {
+  FD_LOG_NOTICE(( "Testing point_sub edge cases" ));
+  fd_secp256r1_point_t zero[1]; fd_memset( zero, 0, sizeof(fd_secp256r1_point_t) );
+  fd_secp256r1_point_t const * G = &fd_secp256r1_base_point_table[1];
+  fd_secp256r1_point_t r[1];
+
+  /* G - G = 0 */
+  fd_secp256r1_point_sub( r, G, G );
+  FD_TEST( fd_uint256_eq( r->z, fd_secp256r1_const_zero ) );
+
+  /* G - 0 = G */
+  fd_secp256r1_point_sub( r, G, zero );
+  FD_TEST( fd_secp256r1_point_eq_mixed( r, G->x->limbs ) );
+
+  /* 0 - G = -G */
+  {
+    fd_secp256r1_point_t neg_g[1];
+    fd_secp256r1_point_neg( neg_g, G );
+    fd_secp256r1_point_sub( r, zero, G );
+    FD_TEST( fd_secp256r1_point_eq_mixed( r, neg_g->x->limbs ) );
+  }
+
+  FD_LOG_NOTICE(( "point_sub edge cases passed" ));
+}
+
+static void
 test_secp256r1_double_scalar_mul_base_equal_points( FD_FN_UNUSED fd_rng_t * rng ) {
   /* edge case in fd_secp256r1_double_scalar_mul_base where the point
      addition at the end receives equal points. without special handling,
@@ -383,6 +444,8 @@ main( int     argc,
   test_secp256r1_point_eq_x      ( rng );
 
   test_secp256r1_point_add_mixed ( rng );
+  test_secp256r1_point_add_edge_cases( rng );
+  test_secp256r1_point_sub_edge_cases( rng );
   test_secp256r1_double_scalar_mul_base_equal_points( rng );
 
   test_secp256r1_verify          ( rng );


### PR DESCRIPTION
**E** = Explicit guard in our code, **I** = Implicit (handled correctly by s2n-bignum assembly)

### `point_add` (Jacobian + Jacobian)

| Case | k256 | p256 |
|---|---|---|
| `0 + 0 = 0` | I | I |
| `P + 0 = P` | I | I |
| `0 + P = P` | I | I |
| `P + P = 2P` (doubling) | **E** | **E** |
| `P + (-P) = 0` (negation) | I | I |

Both curves: `jadd` / `montjadd` handle identity and negation internally. Only the **doubling case** needs an explicit guard.

### `point_add_mixed` (Jacobian + affine)

| Case | k256 | p256 |
|---|---|---|
| `0 + 0 = 0` | **E** (b=0 check) | **E** (b=0 check) |
| `P + 0 = P` | **E** (b=0 check) | **E** (b=0 check) |
| `0 + P = P` | I | I |
| `P + P = 2P` (doubling) | **E** | **E** |
| `P + (-P) = 0` (negation) | I | I |

Both curves: `jmixadd` / `montjmixadd` handle `a.z==0` (identity first operand) and negation internally. The **b=0 guard** is needed because `(0,0)` is not a valid curve point — passing it to the assembly would give undefined behavior. The **doubling guard** is also needed.
