### PR TITLE
Fix replay-only topology

### DIFF
--- a/src/app/firedancer-dev/config/minimal.toml
+++ b/src/app/firedancer-dev/config/minimal.toml
@@ -5,12 +5,14 @@ max_page_size = "huge"
 max_accounts = 1048576
 file_size_gib = 20
 
-[runtime.limits]
+[runtime]
 max_live_slots = 512
 max_fork_width = 16
 
 [layout]
+enable_block_production = false
 verify_tile_count = 1
+resolv_tile_count = 1
 execrp_tile_count = 1
 
 [tiles.shred]

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -413,19 +413,17 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "txsend" );
   fd_topob_wksp( topo, "sign"   )->core_dump_level = FD_TOPO_CORE_DUMP_LEVEL_NEVER;
 
+  fd_topob_wksp( topo, "verify" );
+  fd_topob_wksp( topo, "dedup"  );
+  fd_topob_wksp( topo, "resolv" );
   if( leader_enabled ) {
     fd_topob_wksp( topo, "quic"   );
-    fd_topob_wksp( topo, "verify" );
-    fd_topob_wksp( topo, "dedup"  );
-    fd_topob_wksp( topo, "resolv" );
     fd_topob_wksp( topo, "pack"   );
     fd_topob_wksp( topo, "execle" );
     fd_topob_wksp( topo, "poh"    );
   } else {
     execle_tile_cnt = 0UL;
-    resolv_tile_cnt = 0UL;
     quic_tile_cnt   = 0UL;
-    verify_tile_cnt = 0UL;
     config->tiles.bundle.enabled = 0;
   }
 
@@ -451,14 +449,14 @@ fd_topo_initialize( config_t * config ) {
   fd_topob_wksp( topo, "tower_out"     );
   fd_topob_wksp( topo, "txsend_out"    );
 
+  fd_topob_wksp( topo, "verify_dedup"  );
+  fd_topob_wksp( topo, "dedup_resolv"  );
+  fd_topob_wksp( topo, "resolv_replay" );
   if( leader_enabled ) {
-    fd_topob_wksp( topo, "quic_verify"   );
-    fd_topob_wksp( topo, "verify_dedup"  );
-    fd_topob_wksp( topo, "dedup_resolv"  );
     fd_topob_wksp( topo, "resolv_pack"   );
+    fd_topob_wksp( topo, "quic_verify"   );
     fd_topob_wksp( topo, "pack_poh"      );
     fd_topob_wksp( topo, "pack_execle"   );
-    fd_topob_wksp( topo, "resolv_replay" );
     if( FD_LIKELY( config->tiles.pack.use_consumed_cus ) ) {
       fd_topob_wksp( topo, "execle_pack" );
     }
@@ -613,8 +611,8 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_link( topo, "replay_epoch",  "replay_epoch",  128UL,                                    FD_EPOCH_OUT_MTU,              1UL ); /* TODO: This should be 2 but requires fixing STEM_BURST */
   /**/                 fd_topob_link( topo, "replay_out",    "replay_out",    65536UL,                                  sizeof(fd_replay_message_t),   1UL );
                        fd_topob_link( topo, "replay_execrp", "replay_execrp", 16384UL,                                  sizeof(fd_execrp_task_msg_t),  1UL );
+  /**/                 fd_topob_link( topo, "dedup_resolv",  "dedup_resolv",  65536UL,                                  FD_TPU_PARSED_MTU,             1UL );
   if( leader_enabled ) {
-    /**/                   fd_topob_link( topo, "dedup_resolv",  "dedup_resolv",  65536UL,                                  FD_TPU_PARSED_MTU,             1UL );
     FOR(resolv_tile_cnt)   fd_topob_link( topo, "resolv_pack",   "resolv_pack",   65536UL,                                  FD_TPU_RESOLVED_MTU,           1UL );
     /**/                   fd_topob_link( topo, "pack_poh",      "pack_poh",      4096UL,                                   sizeof(fd_done_packing_t),     1UL );
     FOR(execle_tile_cnt)   fd_topob_link( topo, "execle_poh",    "execle_poh",    16384UL,                                  USHORT_MAX,                    1UL );
@@ -720,11 +718,11 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile( topo, "tower",   "tower",   "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        1,                 1 );
   /**/                 fd_topob_tile( topo, "txsend",  "txsend",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        1,                 0 );
 
+  FOR(verify_tile_cnt) fd_topob_tile( topo, "verify",  "verify",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
+  /**/                 fd_topob_tile( topo, "dedup",   "dedup",   "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
+  FOR(resolv_tile_cnt) fd_topob_tile( topo, "resolv",  "resolv",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
   if( leader_enabled ) {
     FOR(quic_tile_cnt)   fd_topob_tile( topo, "quic",    "quic",    "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
-    FOR(verify_tile_cnt) fd_topob_tile( topo, "verify",  "verify",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
-    /**/                 fd_topob_tile( topo, "dedup",   "dedup",   "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
-    FOR(resolv_tile_cnt) fd_topob_tile( topo, "resolv",  "resolv",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
     /**/                 fd_topob_tile( topo, "pack",    "pack",    "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        config->tiles.bundle.enabled, 0 );
     FOR(execle_tile_cnt) fd_topob_tile( topo, "execle",  "execle",  "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
     /**/                 fd_topob_tile( topo, "poh",     "poh",     "metric_in",  tile_to_cpu[ topo->tile_cnt ], 0,        0,               0 );
@@ -774,7 +772,7 @@ fd_topo_initialize( config_t * config ) {
     fd_topob_wksp( topo, "accdb_execrp" );
     if( leader_enabled ) fd_topob_wksp( topo, "accdb_execle" );
     fd_topob_wksp( topo, "accdb_tower"  );
-    if( leader_enabled ) fd_topob_wksp( topo, "accdb_resolv" );
+    fd_topob_wksp( topo, "accdb_resolv" );
     if( config->tiles.rpc.enabled ) fd_topob_wksp( topo, "accdb_rpc" );
   }
 
@@ -940,7 +938,7 @@ fd_topo_initialize( config_t * config ) {
   FOR(execrp_tile_cnt) fd_topob_tile_in (   topo, "execrp",  i,            "metric_in", "replay_execrp", 0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   FOR(execrp_tile_cnt) fd_topob_tile_out(   topo, "execrp",  i,                         "execrp_replay", i                                                  );
 
-  if(leader_enabled)  {fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );}
+  /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "dedup_resolv",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "replay_epoch",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   /**/                 fd_topob_tile_in (   topo, "tower",   0UL,          "metric_in", "ipecho_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
@@ -954,22 +952,25 @@ fd_topo_initialize( config_t * config ) {
   /**/                 fd_topob_tile_out(   topo, "txsend",  0UL,                       "txsend_net",    0UL                                                );
   /**/                 fd_topob_tile_out(   topo, "txsend",  0UL,                       "txsend_out",    0UL                                                );
 
+  FOR(verify_tile_cnt) fd_topob_tile_in(  topo, "verify",  i,            "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  FOR(verify_tile_cnt) fd_topob_tile_out( topo, "verify",  i,                         "verify_dedup",  i                                                  );
+  FOR(verify_tile_cnt) fd_topob_tile_in(  topo, "dedup",   0UL,          "metric_in", "verify_dedup",  i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_in(  topo, "dedup",   0UL,          "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  /**/                 fd_topob_tile_out( topo, "dedup",   0UL,                       "dedup_resolv",  0UL                                                );
+  FOR(resolv_tile_cnt) fd_topob_tile_in(  topo, "resolv",  i,            "metric_in", "dedup_resolv",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
+  FOR(resolv_tile_cnt) fd_topob_tile_in(  topo, "resolv",  i,            "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
   if( leader_enabled ) {
-    FOR(quic_tile_cnt)   fd_topob_tile_out( topo, "quic",    i,                         "quic_verify",   i                                                  );
-    FOR(quic_tile_cnt)   fd_topob_tile_out( topo, "quic",    i,                         "quic_net",      i                                                  );
+    FOR(resolv_tile_cnt) fd_topob_tile_out( topo, "resolv",  i,                         "resolv_pack",   i                                                  );
+  }
+  FOR(resolv_tile_cnt) fd_topob_tile_out( topo, "resolv",  i,                         "resolv_replay", i                                                  );
+
+  if( leader_enabled ) {
     /* All verify tiles read from all QUIC tiles, packets are round robin. */
     FOR(verify_tile_cnt) for( ulong j=0UL; j<quic_tile_cnt; j++ )
                          fd_topob_tile_in(  topo, "verify",  i,            "metric_in", "quic_verify",   j,            FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED ); /* No reliable consumers, verify tiles may be overrun */
-    FOR(verify_tile_cnt) fd_topob_tile_in(  topo, "verify",  i,            "metric_in", "gossip_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "verify",  0UL,          "metric_in", "txsend_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    FOR(verify_tile_cnt) fd_topob_tile_out( topo, "verify",  i,                         "verify_dedup",  i                                                  );
-    FOR(verify_tile_cnt) fd_topob_tile_in(  topo, "dedup",   0UL,          "metric_in", "verify_dedup",  i,            FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                 fd_topob_tile_in(  topo, "dedup",   0UL,          "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    /**/                 fd_topob_tile_out( topo, "dedup",   0UL,                       "dedup_resolv",  0UL                                                );
-    FOR(resolv_tile_cnt) fd_topob_tile_in(  topo, "resolv",  i,            "metric_in", "dedup_resolv",  0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    FOR(resolv_tile_cnt) fd_topob_tile_in(  topo, "resolv",  i,            "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
-    FOR(resolv_tile_cnt) fd_topob_tile_out( topo, "resolv",  i,                         "resolv_pack",   i                                                  );
-    FOR(resolv_tile_cnt) fd_topob_tile_out( topo, "resolv",  i,                         "resolv_replay", i                                                  );
+    FOR(quic_tile_cnt)   fd_topob_tile_out( topo, "quic",    i,                         "quic_verify",   i                                                  );
+    FOR(quic_tile_cnt)   fd_topob_tile_out( topo, "quic",    i,                         "quic_net",      i                                                  );
     /**/                 fd_topob_tile_in(  topo, "pack",    0UL,          "metric_in", "resolv_pack",   0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_in(  topo, "pack",    0UL,          "metric_in", "replay_out",    0UL,          FD_TOPOB_RELIABLE,   FD_TOPOB_POLLED );
     /**/                 fd_topob_tile_out(  topo, "pack",   0UL,                       "pack_execle",   0UL                                                );

--- a/src/discof/resolv/fd_resolv_tile.c
+++ b/src/discof/resolv/fd_resolv_tile.c
@@ -121,6 +121,7 @@ typedef struct {
 } fd_resolv_in_ctx_t;
 
 typedef struct {
+  ulong       out_idx;
   fd_wksp_t * mem;
   ulong       chunk0;
   ulong       wmark;
@@ -227,9 +228,11 @@ during_frag( fd_resolv_ctx_t * ctx,
 
   switch( ctx->in[in_idx].kind ) {
     case IN_KIND_DEDUP: {
-      uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
-      uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_pack->mem, ctx->out_pack->chunk );
-      fd_memcpy( dst, src, sz );
+      if( FD_LIKELY( ctx->out_pack->mem ) ) {
+        uchar * src = (uchar *)fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
+        uchar * dst = (uchar *)fd_chunk_to_laddr( ctx->out_pack->mem, ctx->out_pack->chunk );
+        fd_memcpy( dst, src, sz );
+      }
       break;
     }
     case IN_KIND_REPLAY: {
@@ -323,6 +326,8 @@ static int
 publish_txn( fd_resolv_ctx_t *          ctx,
              fd_stem_context_t *        stem,
              fd_stashed_txn_m_t const * stashed ) {
+  if( FD_UNLIKELY( !ctx->out_pack->mem ) ) return 0;
+
   fd_txn_m_t * txnm = fd_chunk_to_laddr( ctx->out_pack->mem, ctx->out_pack->chunk );
   fd_memcpy( txnm, stashed->_, fd_txn_m_realized_footprint( (fd_txn_m_t *)stashed->_, 1, 0 ) );
 
@@ -341,7 +346,7 @@ publish_txn( fd_resolv_ctx_t *          ctx,
 
   ulong realized_sz = fd_txn_m_realized_footprint( txnm, 1, 1 );
   ulong tspub = fd_frag_meta_ts_comp( fd_tickcount() );
-  fd_stem_publish( stem, 0UL, txnm->reference_slot, ctx->out_pack->chunk, realized_sz, 0UL, 0UL, tspub );
+  fd_stem_publish( stem, ctx->out_pack->out_idx, txnm->reference_slot, ctx->out_pack->chunk, realized_sz, 0UL, 0UL, tspub );
   ctx->out_pack->chunk = fd_dcache_compact_next( ctx->out_pack->chunk, realized_sz, ctx->out_pack->chunk0, ctx->out_pack->wmark );
 
   return 1;
@@ -450,7 +455,7 @@ after_frag( fd_resolv_ctx_t *   ctx,
           fd_resolv_slot_exchanged_t * slot_exchanged =
             fd_type_pun( fd_chunk_to_laddr( ctx->out_replay->mem, ctx->out_replay->chunk ) );
           slot_exchanged->bank_idx = prev_bank->idx;
-          fd_stem_publish( stem, 1UL, 0UL, ctx->out_replay->chunk, sizeof(fd_resolv_slot_exchanged_t), 0UL, tsorig, tspub );
+          fd_stem_publish( stem, ctx->out_replay->out_idx, 0UL, ctx->out_replay->chunk, sizeof(fd_resolv_slot_exchanged_t), 0UL, tsorig, tspub );
           ctx->out_replay->chunk = fd_dcache_compact_next( ctx->out_replay->chunk, sizeof(fd_resolv_slot_exchanged_t), ctx->out_replay->chunk0, ctx->out_replay->wmark );
         }
 
@@ -460,6 +465,8 @@ after_frag( fd_resolv_ctx_t *   ctx,
     }
     return;
   }
+
+  if( FD_UNLIKELY( !ctx->out_pack->mem ) ) return;
 
   fd_txn_m_t * txnm = (fd_txn_m_t *)fd_chunk_to_laddr( ctx->out_pack->mem, ctx->out_pack->chunk );
   FD_TEST( txnm->payload_sz<=FD_TPU_MTU );
@@ -611,15 +618,26 @@ unprivileged_init( fd_topo_t *      topo,
     ctx->in[i].mtu    = link->mtu;
   }
 
-  ctx->out_pack->mem    = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ 0 ] ].dcache_obj_id ].wksp_id ].wksp;
-  ctx->out_pack->chunk0 = fd_dcache_compact_chunk0( ctx->out_pack->mem, topo->links[ tile->out_link_id[ 0 ] ].dcache );
-  ctx->out_pack->wmark  = fd_dcache_compact_wmark ( ctx->out_pack->mem, topo->links[ tile->out_link_id[ 0 ] ].dcache, topo->links[ tile->out_link_id[ 0 ] ].mtu );
-  ctx->out_pack->chunk  = ctx->out_pack->chunk0;
-
-  ctx->out_replay->mem    = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ 1 ] ].dcache_obj_id ].wksp_id ].wksp;
-  ctx->out_replay->chunk0 = fd_dcache_compact_chunk0( ctx->out_replay->mem, topo->links[ tile->out_link_id[ 1 ] ].dcache );
-  ctx->out_replay->wmark  = fd_dcache_compact_wmark ( ctx->out_replay->mem, topo->links[ tile->out_link_id[ 1 ] ].dcache, topo->links[ tile->out_link_id[ 1 ] ].mtu );
-  ctx->out_replay->chunk  = ctx->out_replay->chunk0;
+  memset( ctx->out_pack,   0, sizeof( ctx->out_pack   ) );
+  memset( ctx->out_replay, 0, sizeof( ctx->out_replay ) );
+  for( ulong i=0UL; i<tile->out_cnt; i++ ) {
+    fd_topo_link_t const * link = &topo->links[ tile->out_link_id[ i ] ];
+    if( 0==strcmp( link->name, "resolv_replay" ) ) {
+      ctx->out_replay->out_idx = i;
+      ctx->out_replay->mem     = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ i ] ].dcache_obj_id ].wksp_id ].wksp;
+      ctx->out_replay->chunk0  = fd_dcache_compact_chunk0( ctx->out_replay->mem, topo->links[ tile->out_link_id[ i ] ].dcache );
+      ctx->out_replay->wmark   = fd_dcache_compact_wmark ( ctx->out_replay->mem, topo->links[ tile->out_link_id[ i ] ].dcache, topo->links[ tile->out_link_id[ i ] ].mtu );
+      ctx->out_replay->chunk   = ctx->out_replay->chunk0;
+    } else if( 0==strcmp( link->name, "resolv_pack" ) ) {
+      ctx->out_pack->out_idx = i;
+      ctx->out_pack->mem     = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ i ] ].dcache_obj_id ].wksp_id ].wksp;
+      ctx->out_pack->chunk0  = fd_dcache_compact_chunk0( ctx->out_pack->mem, topo->links[ tile->out_link_id[ i ] ].dcache );
+      ctx->out_pack->wmark   = fd_dcache_compact_wmark ( ctx->out_pack->mem, topo->links[ tile->out_link_id[ i ] ].dcache, topo->links[ tile->out_link_id[ i ] ].mtu );
+      ctx->out_pack->chunk   = ctx->out_pack->chunk0;
+    } else {
+      FD_LOG_ERR(( "unknown out link name '%s'", link->name ));
+    }
+  }
 
   fd_accdb_init_from_topo( ctx->accdb, topo, tile, tile->resolv.accdb_max_depth );
 


### PR DESCRIPTION
Nodes with enable_block_production=false are currently broken
because they fully rely on repair, but repair only works if tower
can observe votes.  Since the verify/dedup/resolv pipeline was
missing, gossip-observed votes were not relayed to repair, thus
repair never started.

Fixes RPC-only nodes by re-enabling the verify, dedup, and resolv
tiles.
