### PR TITLE
monitor: don't display links between dead tiles

### DIFF
--- a/src/app/shared/commands/monitor/monitor.c
+++ b/src/app/shared/commands/monitor/monitor.c
@@ -365,12 +365,18 @@ run_monitor( config_t const * config,
       ulong link_idx = 0UL;
       for( ulong tile_idx=0UL; tile_idx<topo->tile_cnt; tile_idx++ ) {
         for( ulong in_idx=0UL; in_idx<topo->tiles[ tile_idx ].in_cnt; in_idx++ ) {
-          link_snap_t * prv = &link_snap_prv[ link_idx ];
-          link_snap_t * cur = &link_snap_cur[ link_idx ];
-
           fd_topo_link_t link = topo->links[ topo->tiles[ tile_idx ].in_link_id[ in_idx ] ];
           ulong producer_tile_id = fd_topo_find_link_producer( topo, &link );
           FD_TEST( producer_tile_id != ULONG_MAX );
+
+          if( tile_snap_cur[ producer_tile_id ].status==2UL && tile_snap_cur[ tile_idx ].status==2UL ) {
+            link_idx++;
+            continue;
+          }
+
+          link_snap_t * prv = &link_snap_prv[ link_idx ];
+          link_snap_t * cur = &link_snap_cur[ link_idx ];
+
           char const * producer = topo->tiles[ producer_tile_id ].name;
           PRINT( " %7s->%-7s", producer, topo->tiles[ tile_idx ].name );
           ulong cur_raw_cnt = /* cur->cnc_diag_ha_filt_cnt + */ cur->fseq_diag_tot_cnt;


### PR DESCRIPTION
No need to display links where both the producer and consumer have
shut down, i.e. the snapshot pipeline.
