### PR TITLE
restore: stake delegation oob check

### DIFF
--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -1394,7 +1394,7 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH: {
-      if( FD_UNLIKELY( manifest->stake_delegations_len>( 1UL<<22UL ) ) ) { /* 2^21 needed, arbitrarily put 2^22 to have some margin */
+      if( FD_UNLIKELY( manifest->stake_delegations_len>sizeof(manifest->stake_delegations)/sizeof(manifest->stake_delegations[0]) ) ) {
         FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu", manifest->stake_delegations_len ));
         return -1;
       }


### PR DESCRIPTION
Correcting potential OOB access.

Addresses points 21 and 22 of https://github.com/firedancer-io/firedancer/issues/9176.