### PR TITLE
Fix wrong FD_FN_PURE annotations

### DIFF
--- a/src/ballet/shred/fd_shred.c
+++ b/src/ballet/shred/fd_shred.c
@@ -105,7 +105,7 @@ fd_shred_parse( uchar const * const buf,
   return shred;
 }
 
-FD_FN_PURE int
+int
 fd_shred_merkle_root( fd_shred_t const * shred, void * bmtree_mem, fd_bmtree_node_t * root_out ) {
   fd_bmtree_commit_t * tree = fd_bmtree_commit_init( bmtree_mem,
                                                      FD_SHRED_MERKLE_NODE_SZ,

--- a/src/ballet/shred/fd_shred.h
+++ b/src/ballet/shred/fd_shred.h
@@ -407,7 +407,7 @@ fd_shred_merkle_nodes( fd_shred_t const * shred ) {
    root_out.  Returns 1 on success, 0 on failure.  The output value must
    be ignored if a failure is returned.  U.B. if the shred is not a
    merkle variant. */
-FD_FN_PURE int
+int
 fd_shred_merkle_root( fd_shred_t const * shred, void * bmtree_mem, fd_bmtree_node_t * root_out );
 
 /* fd_shred_data_payload: Returns a pointer to a data shred payload.

--- a/src/choreo/tower/fd_tower_serdes.h
+++ b/src/choreo/tower/fd_tower_serdes.h
@@ -137,7 +137,7 @@ struct __attribute__((packed)) fd_vote_acc {
 };
 typedef struct fd_vote_acc fd_vote_acc_t;
 
-FD_FN_PURE ulong
+ulong
 fd_vote_acc_vote_cnt( uchar const * buf );
 
 /* fd_vote_acc_vote_slot takes a voter's vote account data and returns

--- a/src/discof/repair/fd_repair.h
+++ b/src/discof/repair/fd_repair.h
@@ -257,7 +257,7 @@ fd_repair_msg_t * fd_repair_orphan       ( fd_repair_t * repair, fd_pubkey_t con
 
 /* fd_repair_sz returns the bincode-serialized sz of msg. */
 
-FD_FN_PURE static inline ulong
+static inline ulong
 fd_repair_sz( fd_repair_msg_t const * msg ) {
    switch( msg->kind ) {
      case FD_REPAIR_KIND_PONG:          return sizeof(uint) + sizeof(fd_repair_pong_t);

--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -350,7 +350,7 @@ scratch_align( void ) {
   return a;
 }
 
-FD_FN_PURE static inline ulong
+static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   ulong http_fp = fd_http_server_footprint( derive_http_params( tile ) );
   if( FD_UNLIKELY( !http_fp ) ) FD_LOG_ERR(( "Invalid [tiles.rpc] config parameters" ));

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -312,7 +312,7 @@ calculate_non_vote_transaction_cost( fd_bank_t *          bank,
 }
 
 /* https://github.com/anza-xyz/agave/blob/v2.2.0/cost-model/src/transaction_cost.rs#L26-L42 */
-FD_FN_PURE static inline ulong
+static inline ulong
 transaction_cost_sum( fd_transaction_cost_t const * txn_cost ) {
   switch( txn_cost->type ) {
     case FD_TXN_COST_TYPE_SIMPLE_VOTE: {
@@ -338,7 +338,7 @@ transaction_cost_sum( fd_transaction_cost_t const * txn_cost ) {
   }
 }
 
-FD_FN_PURE static inline ulong
+static inline ulong
 get_allocated_accounts_data_size( fd_transaction_cost_t const * txn_cost ) {
   switch( txn_cost->type ) {
   case FD_TXN_COST_TYPE_SIMPLE_VOTE:

--- a/src/util/cstr/fd_cstr.h
+++ b/src/util/cstr/fd_cstr.h
@@ -34,17 +34,17 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_CONST char const * fd_cstr_to_cstr  ( char const * s );
 FD_FN_PURE  char         fd_cstr_to_char  ( char const * s );
-FD_FN_PURE  schar        fd_cstr_to_schar ( char const * s );
-FD_FN_PURE  short        fd_cstr_to_short ( char const * s );
-FD_FN_PURE  int          fd_cstr_to_int   ( char const * s );
-FD_FN_PURE  long         fd_cstr_to_long  ( char const * s );
-FD_FN_PURE  uchar        fd_cstr_to_uchar ( char const * s );
-FD_FN_PURE  ushort       fd_cstr_to_ushort( char const * s );
-FD_FN_PURE  uint         fd_cstr_to_uint  ( char const * s );
-FD_FN_PURE  ulong        fd_cstr_to_ulong ( char const * s );
-FD_FN_PURE  float        fd_cstr_to_float ( char const * s );
+            schar        fd_cstr_to_schar ( char const * s );
+            short        fd_cstr_to_short ( char const * s );
+            int          fd_cstr_to_int   ( char const * s );
+            long         fd_cstr_to_long  ( char const * s );
+            uchar        fd_cstr_to_uchar ( char const * s );
+            ushort       fd_cstr_to_ushort( char const * s );
+            uint         fd_cstr_to_uint  ( char const * s );
+            ulong        fd_cstr_to_ulong ( char const * s );
+            float        fd_cstr_to_float ( char const * s );
 #if FD_HAS_DOUBLE
-FD_FN_PURE  double       fd_cstr_to_double( char const * s );
+            double       fd_cstr_to_double( char const * s );
 #endif
 
 /* fd_cstr_to_ulong_octal is the same as fd_cstr_to_ulong but assumes s

--- a/src/util/log/fd_log.h
+++ b/src/util/log/fd_log.h
@@ -481,7 +481,7 @@ ulong fd_log_tid( void );
    typically something provided to the caller when the caller started.
    This is cheap after the first call. */
 
-FD_FN_PURE ulong fd_log_user_id( void );
+ulong fd_log_user_id( void );
 
 /* fd_log_user() returns a non-NULL pointer to a cstr describing the
    user that created the thread group to which the caller belongs.  In

--- a/src/util/pod/fd_pod.h
+++ b/src/util/pod/fd_pod.h
@@ -487,7 +487,7 @@ fd_pod_compact( uchar * pod,
    0:255) and on failure returns a negative value (an FD_POD_ERR_*
    code). */
 
-FD_FN_PURE int
+int
 fd_cstr_to_pod_val_type( char const * cstr );
 
 /* fd_pod_val_type_to_cstr:  Populate the buffer cstr (which has enough

--- a/src/util/shmem/fd_shmem.h
+++ b/src/util/shmem/fd_shmem.h
@@ -485,7 +485,7 @@ fd_shmem_is_page_sz( ulong page_sz ) {
    FD_SHMEM_UNKNOWN_LG_PAGE_SZ (-1 ... the only negative return
    possible) if it can't figure this out. */
 
-FD_FN_PURE int
+int
 fd_cstr_to_shmem_lg_page_sz( char const * cstr );
 
 /* fd_shmem_lg_page_sz_to_cstr:  Return a pointer to a cstr
@@ -506,7 +506,7 @@ fd_shmem_lg_page_sz_to_cstr( int lg_page_sz );
    (0UL, the only non-integral power of 2 return possible) if it can't
    figure this out. */
 
-FD_FN_PURE ulong
+ulong
 fd_cstr_to_shmem_page_sz( char const * cstr );
 
 /* fd_shmem_page_sz_to_cstr:  Return a pointer to a cstr corresponding

--- a/src/util/tmpl/fd_map_giant.c
+++ b/src/util/tmpl/fd_map_giant.c
@@ -734,7 +734,7 @@ MAP_(verify_key)( MAP_T *           join,
   return (long)cnt;;
 }
 
-FD_FN_PURE MAP_IMPL_STATIC MAP_T *
+MAP_IMPL_STATIC MAP_T *
 MAP_(query)( MAP_T *           join,
              MAP_KEY_T const * key,
              MAP_T *           sentinel ) {

--- a/src/vinyl/data/fd_vinyl_data.c
+++ b/src/vinyl/data/fd_vinyl_data.c
@@ -472,7 +472,7 @@ fd_vinyl_data_reset( fd_tpool_t * tpool, ulong t0, ulong t1, int level,
    and FD_VINYL_ERR_CORRUPT (negative) if memory corruption was detected
    (logs details). */
 
-FD_FN_PURE static int
+static int
 fd_vinyl_data_verify_superblock( fd_vinyl_data_t     const * data,
                                  fd_vinyl_data_obj_t const * superblock ) {
 

--- a/src/vinyl/data/fd_vinyl_data.h
+++ b/src/vinyl/data/fd_vinyl_data.h
@@ -470,7 +470,7 @@ fd_vinyl_data_reset( fd_tpool_t * tpool, ulong t0, ulong t1, int level,
    allocations for correctness (but could given access to the bstream,
    line and/or meta). */
 
-FD_FN_PURE int
+int
 fd_vinyl_data_verify( fd_vinyl_data_t const * data );
 
 FD_PROTOTYPES_END

--- a/src/waltz/h2/fd_h2_hdr_match.h
+++ b/src/waltz/h2/fd_h2_hdr_match.h
@@ -148,7 +148,7 @@ fd_h2_hdr_matcher_insert( fd_h2_hdr_matcher_t * matcher,
    - Positive if the entry matched a value previously added with
      fd_h2_hdr_matcher_add */
 
-FD_FN_PURE static inline int
+static inline int
 fd_h2_hdr_match( fd_h2_hdr_matcher_t const * matcher,
                  char const *                name,
                  ulong                       name_len,

--- a/src/waltz/quic/fd_quic_retry.h
+++ b/src/waltz/quic/fd_quic_retry.h
@@ -56,7 +56,7 @@ fd_quic_retry_integrity_tag_sign(
   fd_aes_gcm_encrypt( aes_gcm, NULL, NULL, 0UL, retry_pseudo_pkt, retry_pseudo_pkt_len, retry_integrity_tag );
 }
 
-FD_FN_PURE static inline int
+static inline int
 fd_quic_retry_integrity_tag_verify(
     fd_aes_gcm_t * aes_gcm,
     uchar const *  retry_pseudo_pkt,


### PR DESCRIPTION
While being a no-op currently, still worth a fix

- src/util/cstr/fd_cstr.h:37 declares the fd_cstr_to_* conversion helpers as pure, but the implementation uses strtol (and similar); those will set errno on error (that can happen under the contract), which is global state.
- src/util/shmem/fd_shmem.h:488 and src/util/shmem/fd_shmem.h:509 inherit the same issue through fd_cstr_to_int / fd_cstr_to_ulong.
- src/util/pod/fd_pod.h:490 inherits the same strtol issue for fd_cstr_to_pod_val_type.
- src/util/log/fd_log.h:484 (fd_log_user_id) is straight up writing to global state
- src/waltz/h2/fd_h2_hdr_match.h:151 (fd_h2_hdr_match) but src/waltz/h2/fd_h2_hdr_match.h:164 writes the TL fd_h2_hdr_match_seed variable
- src/waltz/quic/fd_quic_retry.h:59 (fd_quic_retry_integrity_tag_verify) but it writes aes_gcm argument
- src/ballet/shred/fd_shred.h:410 (fd_shred_merkle_root) but src/ballet/shred/fd_shred.c:108 mutates bmtree_mem and writes root_out.
- src/util/tmpl/fd_map_giant.c:737 marks MAP_(query) pure, but it mutates the map by moving a hit to the front of the chain.
- src/discof/rpc/fd_rpc_tile.c:353 (scratch_footprint) logs on error
- src/discof/repair/fd_repair.h:260 (fd_repair_sz) logs on error
- src/vinyl/data/fd_vinyl_data.c:475 (fd_vinyl_data_verify_superblock) logs on error (via FD_TEST)
- src/vinyl/data/fd_vinyl_data.c:504 (fd_vinyl_data_verify) logs on error (via FD_TEST)
- src/choreo/tower/fd_tower_serdes.c:148 (fd_vote_acc_vote_cnt) logs on error
- src/flamenco/runtime/fd_cost_tracker.c:315 (transaction_cost_sum)
- src/flamenco/runtime/fd_cost_tracker.c:341 (get_allocated_accounts_data_size)