### PR TITLE
firedancer-dev: bench rpc no delay startup

### DIFF
--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -125,6 +125,8 @@ fd_topo_initialize( config_t * config );
 
 void
 bench_topo( config_t * config ) {
+  config->tiles.rpc.delay_startup = 0;
+
   fd_topo_initialize( config );
 
   ushort rpc_port;

--- a/src/app/shared_dev/commands/bench/fd_bencho.c
+++ b/src/app/shared_dev/commands/bench/fd_bencho.c
@@ -69,8 +69,12 @@ service_block_hash( fd_bencho_ctx_t *   ctx,
   if( FD_UNLIKELY( ctx->blockhash_state==FD_BENCHO_STATE_SENT ) ) {
     fd_rpc_client_response_t * response = fd_rpc_client_status( ctx->rpc, ctx->blockhash_request, 0 );
     if( FD_UNLIKELY( response->status==FD_RPC_CLIENT_PENDING ) ) {
-      if( FD_UNLIKELY( fd_log_wallclock()>=ctx->blockhash_deadline ) )
+      if( FD_UNLIKELY( fd_log_wallclock()>=ctx->blockhash_deadline ) ) {
         FD_LOG_WARNING(( "timed out waiting for RPC server to respond" ));
+        fd_rpc_client_close( ctx->rpc, ctx->blockhash_request );
+        ctx->blockhash_state    = FD_BENCHO_STATE_WAIT;
+        ctx->blockhash_deadline = fd_log_wallclock() + 100L * 1000L * 1000L; /* 100 millis to retry */
+      }
       return did_work;
     }
 


### PR DESCRIPTION
Correct `firedancer-dev bench` to avoid rpc `delay_startup`. This allows the RPC tile to start accepting HTTP requests immediately instead of waiting for replay to fully bootstrap.
There is also a correction to the timeout recovery.