### PR TITLE
accdb: vinyl data cache size

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -547,7 +547,7 @@ telemetry = true
 
     # Keep frequently accessed accounts in memory to improve
     # performance.
-    cache_size_gib = 4
+    cache_size_gib = 8
 
     # Delay writing of accounts to disk by a number of slots to reduce
     # disk write rate.
@@ -579,7 +579,7 @@ telemetry = true
     # The expected mean size of recently accessed accounts.
     #
     # This heuristic is used to pack accounts into caches optimally.
-    mean_account_footprint = 256
+    mean_account_footprint = 1024
 
     # io_uring specific options
     #

--- a/src/vinyl/data/fd_vinyl_data.c
+++ b/src/vinyl/data/fd_vinyl_data.c
@@ -138,6 +138,17 @@ fd_vinyl_data_init( void * lmem,
   data->vol      = (fd_vinyl_data_vol_t *)_vol0;
   data->vol_cnt  = vol_cnt;
 
+  /* Precompute the max possible inactive stack depth for any szc.
+     Used for cycle detection in the free path stack walk.  This is
+     shmem_sz / min_superblock_footprint across all szcs. */
+
+  ulong min_sb_fp = ULONG_MAX;
+  for( ulong s=0UL; s<FD_VINYL_DATA_SZC_CNT; s++ )
+    min_sb_fp = fd_ulong_min( min_sb_fp, sizeof(fd_vinyl_data_obj_t)
+                + (ulong)fd_vinyl_data_szc_cfg[ s ].obj_cnt * fd_vinyl_data_szc_obj_footprint( s ) );
+  FD_TEST( min_sb_fp );
+  data->inactive_stack_max = shmem_sz / min_sb_fp;
+
   return data;
 }
 
@@ -358,16 +369,11 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
      it to circulation as szc's active superblock, pushing any displaced
      superblock onto the szc's inactive superblock stack.
 
-     Otherwise, if this free made the superblock totally empty, we check
-     if the szc'c inactive superblock top is also totally empty.  If so,
-     we pop the inactive stack and free that.
-
-     This keeps a small bounded supply empty superblocks around for fast
-     future allocations in this szc while allowing memory to reclaimed
-     for different szc objs.  Note that we can't just free superblock if
-     it is totally empty fast O(1) because we don't know where it is in
-     circulation (and, even if we did, this is a bad idea).  Other
-     strategies are possible, see fd_alloc for discussion of tradeoffs. */
+     Otherwise, if this free made the superblock totally empty, we
+     unlink it from circulation (active or inactive stack) and free it
+     back to the parent szc.  This enables cascading coalescence up
+     the full hierarchy to the volume level, allowing volumes committed
+     to one size class to be reclaimed for a different size class. */
 
   if( FD_UNLIKELY( free_blocks==block ) ) {
 
@@ -389,18 +395,51 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
 
     if( FD_UNLIKELY( free_blocks==all_blocks ) ) {
 
-      fd_vinyl_data_obj_t * candidate_superblock = data->superblock[ szc ].inactive_top;
+      /* Superblock is now fully empty.  If it is the active
+         superblock for this szc, remove it from active and coalesce
+         it to its parent.  This enables volume reclamation when an
+         entire volume's worth of objects have been freed (e.g. via
+         LRU eviction).  At spine levels (obj_cnt==2), the second
+         child free typically finds the parent still active, allowing
+         coalescence to cascade up the full hierarchy to the volume. */
 
-      if( FD_UNLIKELY( candidate_superblock ) ) {
+      if( FD_LIKELY( data->superblock[ szc ].active == superblock ) ) {
 
-        FD_ALERT( !fd_vinyl_data_superblock_test( data, candidate_superblock, szc ), "corruption detected" );
+        data->superblock[ szc ].active = NULL;
 
-        if( FD_UNLIKELY( candidate_superblock->free_blocks==all_blocks ) ) {
+        fd_vinyl_data_free( data, superblock );
 
-          data->superblock[ szc ].inactive_top = fd_vinyl_data_obj_ptr( data->laddr0, candidate_superblock->next_off );
+      } else {
 
-          fd_vinyl_data_free( data, candidate_superblock );
+        /* Not the active superblock -- it is on the inactive stack.
+           Walk the stack to find and unlink it, then coalesce. */
+
+        void * laddr0 = data->laddr0;
+
+        if( FD_LIKELY( data->superblock[ szc ].inactive_top == superblock ) ) {
+
+          data->superblock[ szc ].inactive_top = fd_vinyl_data_obj_ptr( laddr0, superblock->next_off );
+
+        } else {
+
+          fd_vinyl_data_obj_t * prev = data->superblock[ szc ].inactive_top;
+          ulong rem = data->inactive_stack_max;
+
+          for(;;) {
+            FD_CRIT( prev, "corruption detected" );
+            FD_CRIT( rem,  "corruption detected" ); rem--;
+
+            fd_vinyl_data_obj_t * next = fd_vinyl_data_obj_ptr( laddr0, prev->next_off );
+            if( next == superblock ) {
+              prev->next_off = superblock->next_off;
+              break;
+            }
+            prev = next;
+          }
+
         }
+
+        fd_vinyl_data_free( data, superblock );
 
       }
 
@@ -522,6 +561,8 @@ fd_vinyl_data_verify( fd_vinyl_data_t const * data ) {
 
   TEST( (laddr0<shmem0) & (shmem0<=vol0) & (vol0<vol1) & (vol1<=shmem1) );
 
+  TEST( data->inactive_stack_max );
+
   /* Verify free volume stack */
 
   ulong vol_free_cnt = 0UL;
@@ -559,7 +600,7 @@ fd_vinyl_data_verify( fd_vinyl_data_t const * data ) {
     }
 
     TEST( vol_used_rem );
-    TEST( !fd_vinyl_data_verify_superblock( data, vol->obj ) );
+    TEST( !fd_vinyl_data_verify_superblock( data, vol[ vol_idx ].obj ) );
     vol_used_rem--;
   }
 
@@ -573,6 +614,7 @@ fd_vinyl_data_verify( fd_vinyl_data_t const * data ) {
     if( active ) {
       TEST( !fd_vinyl_data_superblock_test( data, active, szc ) );
       TEST( active->free_blocks );
+      TEST( active->free_blocks != fd_vinyl_data_szc_all_blocks( szc ) );
     }
 
     ulong obj_footprint        = fd_vinyl_data_szc_obj_footprint( szc );
@@ -586,6 +628,7 @@ fd_vinyl_data_verify( fd_vinyl_data_t const * data ) {
       TEST( superblock!=active );
       TEST( !fd_vinyl_data_superblock_test( data, superblock, szc ) );
       TEST( superblock->free_blocks );
+      TEST( superblock->free_blocks != fd_vinyl_data_szc_all_blocks( szc ) );
       superblock = fd_vinyl_data_obj_ptr( (void *)laddr0, superblock->next_off );
     }
   }

--- a/src/vinyl/data/fd_vinyl_data.c
+++ b/src/vinyl/data/fd_vinyl_data.c
@@ -196,6 +196,8 @@ fd_vinyl_data_alloc( fd_vinyl_data_t * data,
 
     *_active = NULL;
 
+    data->diag.alloc_from_active_cnt++;
+
   } else {
 
     superblock = *_inactive_top;
@@ -206,6 +208,8 @@ fd_vinyl_data_alloc( fd_vinyl_data_t * data,
 
       *_inactive_top = fd_vinyl_data_obj_ptr( laddr0, superblock->next_off );
 
+      data->diag.alloc_from_inactive_cnt++;
+
     } else {
 
       ulong parent_szc = (ulong)fd_vinyl_data_szc_cfg[ szc ].parent_szc;
@@ -213,6 +217,8 @@ fd_vinyl_data_alloc( fd_vinyl_data_t * data,
 
         superblock = fd_vinyl_data_alloc( data, parent_szc );
         if( FD_UNLIKELY( !superblock ) ) return NULL;
+
+        data->diag.alloc_from_parent_cnt++;
 
         /* superblock->type        init by obj_alloc to ALLOC, reset below */
         /* superblock->szc         init by obj_alloc */
@@ -226,6 +232,8 @@ fd_vinyl_data_alloc( fd_vinyl_data_t * data,
         ulong vol_idx = data->vol_idx_free;
         if( FD_UNLIKELY( vol_idx >= data->vol_cnt ) ) return NULL;
         data->vol_idx_free = vol[ vol_idx ].obj->idx;
+
+        data->diag.alloc_from_volume_cnt++;
 
         superblock = vol[ vol_idx ].obj;
 
@@ -309,6 +317,8 @@ fd_vinyl_data_alloc( fd_vinyl_data_t * data,
 //obj->free_blocks = ... d/c (not a superblock)
 //obj->next_off    = ... d/c (not a superblock)
 
+  data->diag.alloc_cnt++;
+
   return obj;
 }
 
@@ -319,6 +329,8 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
   FD_CRIT( data, "NULL data" );
 
   if( FD_UNLIKELY( !obj ) ) return;
+
+  data->diag.free_cnt++;
 
   FD_CRIT( fd_ulong_is_aligned( (ulong)obj, FD_VINYL_BSTREAM_BLOCK_SZ ),                               "obj misaligned"        );
   FD_CRIT( ((ulong)data->vol<=(ulong)obj) & ((ulong)obj<(ulong)(data->vol+data->vol_cnt)),             "obj not in data cache" );
@@ -339,6 +351,8 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
     obj->type          = FD_VINYL_DATA_OBJ_TYPE_FREEVOL; /* Mark as on the free stack */
     obj->idx           = data->vol_idx_free;
     data->vol_idx_free = idx;
+
+    data->diag.free_volume_reclaim_cnt++;
 
     return;
   }
@@ -395,6 +409,8 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
 
     if( FD_UNLIKELY( free_blocks==all_blocks ) ) {
 
+      data->diag.free_coalesce_cnt++;
+
       /* Superblock is now fully empty.  If it is the active
          superblock for this szc, remove it from active and coalesce
          it to its parent.  This enables volume reclamation when an
@@ -449,6 +465,100 @@ fd_vinyl_data_free( fd_vinyl_data_t *     data,
 
 }
 
+#include "../line/fd_vinyl_line.h"
+
+void
+fd_vinyl_data_diag_log( fd_vinyl_data_t const *      data,
+                        ulong                        szc_req,
+                        struct fd_vinyl_line const * line,
+                        ulong                        line_cnt ) {
+
+  /* Volume state */
+
+  ulong vol_cnt      = data->vol_cnt;
+  ulong free_vol_cnt = 0UL;
+
+  for( ulong idx=data->vol_idx_free; idx<vol_cnt; free_vol_cnt++, idx=data->vol[ idx ].obj->idx )
+    if( free_vol_cnt>=vol_cnt ) break; /* safety */
+
+  FD_LOG_WARNING(( "DIAG alloc failed szc=%lu (obj_fp=%lu val_max=%u)",
+                   szc_req, fd_vinyl_data_szc_obj_footprint( szc_req ), fd_vinyl_data_szc_cfg[ szc_req ].val_max ));
+  FD_LOG_WARNING(( "DIAG volumes: total=%lu free=%lu used=%lu shmem_sz=%lu",
+                   vol_cnt, free_vol_cnt, vol_cnt-free_vol_cnt, data->shmem_sz ));
+
+  /* Allocator counters */
+
+  FD_LOG_WARNING(( "DIAG alloc: total=%lu active=%lu inactive=%lu parent=%lu volume=%lu",
+                   data->diag.alloc_cnt, data->diag.alloc_from_active_cnt,
+                   data->diag.alloc_from_inactive_cnt, data->diag.alloc_from_parent_cnt,
+                   data->diag.alloc_from_volume_cnt ));
+  FD_LOG_WARNING(( "DIAG free: total=%lu coalesce=%lu vol_reclaim=%lu",
+                   data->diag.free_cnt, data->diag.free_coalesce_cnt,
+                   data->diag.free_volume_reclaim_cnt ));
+
+  /* Per-szc superblock state (non-empty only) */
+
+  for( ulong s=0UL; s<FD_VINYL_DATA_SZC_CNT; s++ ) {
+    int has_active   = !!data->superblock[s].active;
+    int has_inactive = !!data->superblock[s].inactive_top;
+    if( !has_active && !has_inactive ) continue;
+
+    ulong active_free  = has_active ? (ulong)fd_ulong_popcnt( data->superblock[s].active->free_blocks ) : 0UL;
+    ulong inactive_cnt = 0UL, inactive_free = 0UL;
+
+    fd_vinyl_data_obj_t * sb = data->superblock[s].inactive_top;
+    for( ulong rem=data->inactive_stack_max; sb && rem; rem--, inactive_cnt++ ) {
+      inactive_free += (ulong)fd_ulong_popcnt( sb->free_blocks );
+      sb = fd_vinyl_data_obj_ptr( data->laddr0, sb->next_off );
+    }
+
+    FD_LOG_WARNING(( "DIAG   szc %3lu: val_max=%7u obj_fp=%7lu obj_cnt=%2u active_free=%lu inactive_sbs=%lu inactive_free=%lu%s",
+                     s, fd_vinyl_data_szc_cfg[s].val_max, fd_vinyl_data_szc_obj_footprint(s),
+                     fd_vinyl_data_szc_cfg[s].obj_cnt, active_free, inactive_cnt, inactive_free,
+                     sb ? " (truncated)" : "" ));
+  }
+
+  /* Per-volume child_szc histogram */
+
+  ulong vol_szc_hist[ FD_VINYL_DATA_SZC_CNT+1 ];
+  memset( vol_szc_hist, 0, sizeof(vol_szc_hist) );
+
+  for( ulong v=0UL; v<vol_cnt; v++ ) {
+    fd_vinyl_data_obj_t * vobj = data->vol[v].obj;
+    if( vobj->type==FD_VINYL_DATA_OBJ_TYPE_FREEVOL ) continue;
+    ulong cs = (ulong)vobj->child_szc;
+    vol_szc_hist[ fd_ulong_min( cs, FD_VINYL_DATA_SZC_CNT ) ]++;
+  }
+
+  for( ulong s=0UL; s<=FD_VINYL_DATA_SZC_CNT; s++ ) {
+    if( !vol_szc_hist[s] ) continue;
+    if( s<FD_VINYL_DATA_SZC_CNT )
+      FD_LOG_WARNING(( "DIAG   %lu vols child_szc=%lu (val_max=%u obj_fp=%lu)",
+                       vol_szc_hist[s], s, fd_vinyl_data_szc_cfg[s].val_max, fd_vinyl_data_szc_obj_footprint(s) ));
+    else
+      FD_LOG_WARNING(( "DIAG   %lu vols child_szc>=SZC_CNT", vol_szc_hist[s] ));
+  }
+
+  /* Cache line utilization */
+
+  if( line && line_cnt ) {
+    ulong lines_empty = 0UL, lines_cached = 0UL, lines_pinned = 0UL, footprint = 0UL;
+
+    for( ulong i=0UL; i<line_cnt; i++ ) {
+      fd_vinyl_data_obj_t * obj = line[i].obj;
+      if( !obj ) { lines_empty++; continue; }
+      long ref = fd_vinyl_line_ctl_ref( line[i].ctl );
+      if( ref ) lines_pinned++; else lines_cached++;
+      ulong s = (ulong)obj->szc;
+      if( s<FD_VINYL_DATA_SZC_CNT ) footprint += fd_vinyl_data_szc_obj_footprint( s );
+    }
+
+    FD_LOG_WARNING(( "DIAG lines: total=%lu empty=%lu cached=%lu pinned=%lu footprint=%lu (%.1f%% of shmem)",
+                     line_cnt, lines_empty, lines_cached, lines_pinned,
+                     footprint, 100.0*(double)footprint/(double)fd_ulong_max( data->shmem_sz, 1UL ) ));
+  }
+}
+
 static FD_FOR_ALL_BEGIN( fd_vinyl_data_reset_task, 1L ) {
   fd_vinyl_data_t * data  = (fd_vinyl_data_t *)arg[0];
   int               level = (int)              arg[1];
@@ -498,6 +608,8 @@ fd_vinyl_data_reset( fd_tpool_t * tpool, ulong t0, ulong t1, int level,
     data->superblock[ szc ].active       = NULL;
     data->superblock[ szc ].inactive_top = NULL;
   }
+
+  memset( &data->diag, 0, sizeof(data->diag) );
 
 }
 

--- a/src/vinyl/data/fd_vinyl_data.h
+++ b/src/vinyl/data/fd_vinyl_data.h
@@ -349,6 +349,20 @@ struct __attribute((aligned(FD_VINYL_DATA_ALIGN))) fd_vinyl_data {
     fd_vinyl_data_obj_t * active;        /* active superblock for this size class */
     fd_vinyl_data_obj_t * inactive_top;  /* top of the inactive superblock stack for this size class */
   } superblock[ FD_VINYL_DATA_SZC_CNT ];
+
+  /* Diagnostic counters (near-zero cost, single increment per
+     alloc/free).  Dumped at crash time by fd_vinyl_data_diag_log. */
+
+  struct {
+    ulong alloc_cnt;              /* Successful alloc calls (including recursive superblock splits) */
+    ulong free_cnt;               /* Successful free calls (including recursive superblock coalesces, excluding no-op free(NULL)) */
+    ulong alloc_from_active_cnt;  /* Alloc served from active superblock */
+    ulong alloc_from_inactive_cnt;/* Alloc served from inactive stack */
+    ulong alloc_from_parent_cnt;  /* Alloc split from parent szc */
+    ulong alloc_from_volume_cnt;  /* Alloc consumed a fresh volume */
+    ulong free_coalesce_cnt;      /* Free coalesced a superblock to parent */
+    ulong free_volume_reclaim_cnt;/* Free returned a volume to free stack */
+  } diag;
 };
 
 typedef struct fd_vinyl_data fd_vinyl_data_t;
@@ -473,6 +487,19 @@ fd_vinyl_data_reset( fd_tpool_t * tpool, ulong t0, ulong t1, int level,
 
 int
 fd_vinyl_data_verify( fd_vinyl_data_t const * data );
+
+/* fd_vinyl_data_diag_log dumps diagnostic state about the data cache.
+   Intended to be called immediately before a CRIT on alloc failure.
+   szc_req is the sizeclass that failed.  line/line_cnt give the cache
+   line array for per-line utilization stats (NULL/0 to skip). */
+
+struct fd_vinyl_line;
+
+void
+fd_vinyl_data_diag_log( fd_vinyl_data_t const *      data,
+                        ulong                        szc_req,
+                        struct fd_vinyl_line const * line,
+                        ulong                        line_cnt );
 
 FD_PROTOTYPES_END
 

--- a/src/vinyl/data/fd_vinyl_data.h
+++ b/src/vinyl/data/fd_vinyl_data.h
@@ -344,6 +344,7 @@ struct __attribute((aligned(FD_VINYL_DATA_ALIGN))) fd_vinyl_data {
   fd_vinyl_data_vol_t * vol;             /* Vols, indexed [0,vol_cnt), in raw shared memory region */
   ulong                 vol_cnt;         /* Num vols, in [0,FD_VINYL_DATA_VOL_MAX) */
   ulong                 vol_idx_free;    /* Idx of first free volume if in [0,vol_cnt), no free volumes o.w. */
+  ulong                 inactive_stack_max; /* Upper bound on inactive stack depth for any szc (cycle detection in free) */
   struct {
     fd_vinyl_data_obj_t * active;        /* active superblock for this size class */
     fd_vinyl_data_obj_t * inactive_top;  /* top of the inactive superblock stack for this size class */

--- a/src/vinyl/data/test_vinyl_data.c
+++ b/src/vinyl/data/test_vinyl_data.c
@@ -258,6 +258,109 @@ main( int     argc,
 
   FD_TEST( !fd_vinyl_data_verify( data ) );
 
+  FD_LOG_NOTICE(( "Testing coalescence and volume reclamation" ));
+
+  fd_vinyl_data_reset( tpool,0UL,thread_cnt, level, data );
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* Allocate objects of a large szc (few objects per volume, fits in
+     ALLOC_MAX) until the cache is full, consuming all available
+     volumes.  Then free them all and verify that coalescence returns
+     the volumes.  Finally, allocate an object of a different szc to
+     confirm volume reclamation. */
+
+  ulong fill_szc = FD_VINYL_DATA_SZC_CNT - 1UL; /* largest szc, fewest objects */
+
+  ulong coalesce_cnt = 0UL;
+  for(;;) {
+    fd_vinyl_data_obj_t * obj = fd_vinyl_data_alloc( data, fill_szc );
+    if( !obj ) break;
+    FD_TEST( coalesce_cnt<ALLOC_MAX );
+    alloc[ coalesce_cnt++ ] = obj;
+  }
+
+  FD_TEST( coalesce_cnt ); /* At least one allocation succeeded */
+
+  /* Free all -- should trigger cascading coalescence back to volumes */
+
+  for( ulong i=0UL; i<coalesce_cnt; i++ ) {
+    fd_vinyl_data_free( data, alloc[ i ] );
+    alloc[ i ] = NULL;
+  }
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* All volumes should now be free; allocating a different szc should
+     succeed because volumes were reclaimed. */
+
+  ulong other_szc = 0UL;
+  fd_vinyl_data_obj_t * reclaimed = fd_vinyl_data_alloc( data, other_szc );
+  FD_TEST( reclaimed ); /* Volume reclamation worked */
+  fd_vinyl_data_free( data, reclaimed );
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  FD_LOG_NOTICE(( "Testing inactive stack middle-unlink coalescence" ));
+
+  fd_vinyl_data_reset( tpool,0UL,thread_cnt, level, data );
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* Build 3 fully-used superblocks for the largest szc, then
+     selectively free to construct an inactive stack with a fully-empty
+     superblock at the bottom (not the top), exercising the O(n) unlink
+     path in fd_vinyl_data_free. */
+
+  ulong mid_szc     = FD_VINYL_DATA_SZC_CNT - 1UL;
+  ulong mid_obj_cnt = (ulong)fd_vinyl_data_szc_cfg[ mid_szc ].obj_cnt;
+  ulong mid_total   = 3UL * mid_obj_cnt;
+  FD_TEST( mid_total<=ALLOC_MAX );
+
+  for( ulong i=0UL; i<mid_total; i++ ) {
+    alloc[ i ] = fd_vinyl_data_alloc( data, mid_szc );
+    FD_TEST( alloc[ i ] );
+  }
+
+  /* alloc layout: [0,obj_cnt) in SB0, [obj_cnt,2*obj_cnt) in SB1,
+     [2*obj_cnt,3*obj_cnt) in SB2.  All superblocks fully used, none
+     in circulation. */
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* Free one object from each SB in order to build inactive stack:
+       free from SB0 -> SB0 becomes active
+       free from SB1 -> SB1 becomes active, SB0 pushed to inactive
+       free from SB2 -> SB2 becomes active, SB1 pushed to inactive
+     Result: active=SB2, inactive stack: SB1 -> SB0 */
+
+  fd_vinyl_data_free( data, alloc[ 0UL ] );
+  alloc[ 0UL ] = NULL;
+  fd_vinyl_data_free( data, alloc[ mid_obj_cnt ] );
+  alloc[ mid_obj_cnt ] = NULL;
+  fd_vinyl_data_free( data, alloc[ 2UL*mid_obj_cnt ] );
+  alloc[ 2UL*mid_obj_cnt ] = NULL;
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* Free remaining objects in SB0 (bottom of inactive stack).
+     The last free makes SB0 fully empty, triggering the stack walk
+     to find and unlink SB0 from the middle of the inactive stack. */
+
+  for( ulong i=1UL; i<mid_obj_cnt; i++ ) {
+    fd_vinyl_data_free( data, alloc[ i ] );
+    alloc[ i ] = NULL;
+  }
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
+  /* Clean up remaining allocations in SB1 and SB2 */
+
+  for( ulong i=mid_obj_cnt+1UL; i<mid_total; i++ ) {
+    fd_vinyl_data_free( data, alloc[ i ] );
+    alloc[ i ] = NULL;
+  }
+
+  FD_TEST( !fd_vinyl_data_verify( data ) );
+
   FD_LOG_NOTICE(( "Testing fd_vinyl_data_t destruction" ));
 
   FD_TEST( !fd_vinyl_data_fini( NULL ) );

--- a/src/vinyl/fd_vinyl_case_acquire.c
+++ b/src/vinyl/fd_vinyl_case_acquire.c
@@ -162,7 +162,7 @@
           if( FD_UNLIKELY( szc_new != szc_old ) ) {
 
             fd_vinyl_data_obj_t * obj_new = fd_vinyl_data_alloc( data, szc_new );
-            if( FD_UNLIKELY( !obj_new ) ) FD_LOG_CRIT(( "increase data cache size" ));
+            if( FD_UNLIKELY( !obj_new ) ) { fd_vinyl_data_diag_log( data, szc_new, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (acquire resize szc=%lu)", szc_new )); }
 
             fd_vinyl_bstream_phdr_t * phdr_new = fd_vinyl_data_obj_phdr( obj_new );
 
@@ -256,7 +256,7 @@
         ulong szc = fd_vinyl_data_szc( val_max );
 
         fd_vinyl_data_obj_t * obj = fd_vinyl_data_alloc( data, szc );
-        if( FD_UNLIKELY( !obj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+        if( FD_UNLIKELY( !obj ) ) { fd_vinyl_data_diag_log( data, szc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (acquire cache-miss szc=%lu)", szc )); }
 
         line[ line_idx ].obj = obj; obj->line_idx = line_idx;
 
@@ -281,8 +281,9 @@
 
           if( FD_LIKELY( style==FD_VINYL_BSTREAM_CTL_STYLE_RAW ) ) cobj = obj;
           else {
-            cobj = fd_vinyl_data_alloc( data, fd_vinyl_data_szc( val_esz ) );
-            if( FD_UNLIKELY( !cobj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+            ulong cszc = fd_vinyl_data_szc( val_esz );
+            cobj = fd_vinyl_data_alloc( data, cszc );
+            if( FD_UNLIKELY( !cobj ) ) { fd_vinyl_data_diag_log( data, cszc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (acquire lz4-tmp szc=%lu)", cszc )); }
           }
 
           cobj->rd->ctx = (ulong)obj;
@@ -348,7 +349,7 @@
       ulong szc = fd_vinyl_data_szc( req_val_max );
 
       fd_vinyl_data_obj_t * obj = fd_vinyl_data_alloc( data, szc );
-      if( FD_UNLIKELY( !obj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+      if( FD_UNLIKELY( !obj ) ) { fd_vinyl_data_diag_log( data, szc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (acquire create szc=%lu)", szc )); }
 
       line[ line_idx ].obj = obj; obj->line_idx = line_idx; obj->rd_active = (short)0;
 

--- a/src/vinyl/fd_vinyl_case_fetch.c
+++ b/src/vinyl/fd_vinyl_case_fetch.c
@@ -77,7 +77,7 @@
       ulong szc = fd_vinyl_data_szc( val_sz );
 
       fd_vinyl_data_obj_t * obj = fd_vinyl_data_alloc( data, szc );
-      if( FD_UNLIKELY( !obj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+      if( FD_UNLIKELY( !obj ) ) { fd_vinyl_data_diag_log( data, szc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (fetch cache-miss szc=%lu)", szc )); }
 
       line[ line_idx ].obj = obj; obj->line_idx = line_idx;
 
@@ -97,8 +97,9 @@
 
       if( FD_LIKELY( style==FD_VINYL_BSTREAM_CTL_STYLE_RAW ) ) cobj = obj;
       else {
-        cobj = fd_vinyl_data_alloc( data, fd_vinyl_data_szc( val_esz ) );
-        if( FD_UNLIKELY( !cobj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+        ulong cszc = fd_vinyl_data_szc( val_esz );
+        cobj = fd_vinyl_data_alloc( data, cszc );
+        if( FD_UNLIKELY( !cobj ) ) { fd_vinyl_data_diag_log( data, cszc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (fetch lz4-tmp szc=%lu)", cszc )); }
       }
 
       cobj->rd->ctx = (ulong)obj;

--- a/src/vinyl/fd_vinyl_case_move.c
+++ b/src/vinyl/fd_vinyl_case_move.c
@@ -126,8 +126,9 @@
         FD_CRIT( (style==FD_VINYL_BSTREAM_CTL_STYLE_RAW) | (style==FD_VINYL_BSTREAM_CTL_STYLE_LZ4), "corruption detected" );
         FD_CRIT( val_esz<=FD_VINYL_VAL_MAX,                                                         "corruption detected" );
 
-        fd_vinyl_data_obj_t * cobj = fd_vinyl_data_alloc( data, fd_vinyl_data_szc( val_esz ) );
-        if( FD_UNLIKELY( !cobj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+        ulong cszc_move = fd_vinyl_data_szc( val_esz );
+        fd_vinyl_data_obj_t * cobj = fd_vinyl_data_alloc( data, cszc_move );
+        if( FD_UNLIKELY( !cobj ) ) { fd_vinyl_data_diag_log( data, cszc_move, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (move read szc=%lu)", cszc_move )); }
 
         fd_vinyl_bstream_phdr_t * cphdr    = fd_vinyl_data_obj_phdr( cobj );
         ulong                     cpair_sz = fd_vinyl_bstream_pair_sz( val_esz );
@@ -151,8 +152,9 @@
 
         } else {
 
-          obj_src = fd_vinyl_data_alloc( data, fd_vinyl_data_szc( val_sz ) );
-          if( FD_UNLIKELY( !obj_src ) ) FD_LOG_CRIT(( "increase data cache size" ));
+          ulong dszc_move = fd_vinyl_data_szc( val_sz );
+          obj_src = fd_vinyl_data_alloc( data, dszc_move );
+          if( FD_UNLIKELY( !obj_src ) ) { fd_vinyl_data_diag_log( data, dszc_move, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (move decompress szc=%lu)", dszc_move )); }
 
           char const * cval = (char const *)fd_vinyl_data_obj_val( cobj    );
           char *       val  = (char *)      fd_vinyl_data_obj_val( obj_src );

--- a/src/vinyl/fd_vinyl_case_release.c
+++ b/src/vinyl/fd_vinyl_case_release.c
@@ -162,7 +162,7 @@
           FD_CRIT( szc_after<szc_before, "corruption detected" );
 
           fd_vinyl_data_obj_t * obj_after = fd_vinyl_data_alloc( data, szc_after );
-          if( FD_UNLIKELY( !obj_after ) ) FD_LOG_CRIT(( "increase data cache size" ));
+          if( FD_UNLIKELY( !obj_after ) ) { fd_vinyl_data_diag_log( data, szc_after, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (release downsize szc=%lu)", szc_after )); }
 
           fd_vinyl_bstream_phdr_t * phdr_after = fd_vinyl_data_obj_phdr( obj_after );
 
@@ -265,7 +265,7 @@
           FD_CRIT( szc_before<szc_after, "corruption detected" );
 
           fd_vinyl_data_obj_t * obj_before = fd_vinyl_data_alloc( data, szc_before );
-          if( FD_UNLIKELY( !obj_before ) ) FD_LOG_CRIT(( "increase data cache size" ));
+          if( FD_UNLIKELY( !obj_before ) ) { fd_vinyl_data_diag_log( data, szc_before, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (release cancel-revert szc=%lu)", szc_before )); }
 
           fd_vinyl_bstream_phdr_t * phdr_before = fd_vinyl_data_obj_phdr( obj_before );
 

--- a/src/vinyl/fd_vinyl_case_try.c
+++ b/src/vinyl/fd_vinyl_case_try.c
@@ -130,7 +130,7 @@
       ulong szc = fd_vinyl_data_szc( val_sz );
 
       fd_vinyl_data_obj_t * obj = fd_vinyl_data_alloc( data, szc );
-      if( FD_UNLIKELY( !obj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+      if( FD_UNLIKELY( !obj ) ) { fd_vinyl_data_diag_log( data, szc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (try cache-miss szc=%lu)", szc )); }
 
       line[ line_idx ].obj = obj; obj->line_idx = line_idx;
 
@@ -155,8 +155,9 @@
 
       if( FD_LIKELY( style==FD_VINYL_BSTREAM_CTL_STYLE_RAW ) ) cobj = obj;
       else {
-        cobj = fd_vinyl_data_alloc( data, fd_vinyl_data_szc( val_esz ) );
-        if( FD_UNLIKELY( !cobj ) ) FD_LOG_CRIT(( "increase data cache size" ));
+        ulong cszc = fd_vinyl_data_szc( val_esz );
+        cobj = fd_vinyl_data_alloc( data, cszc );
+        if( FD_UNLIKELY( !cobj ) ) { fd_vinyl_data_diag_log( data, cszc, line, line_cnt ); FD_LOG_CRIT(( "increase data cache size (try lz4-tmp szc=%lu)", cszc )); }
       }
 
       cobj->rd->ctx = (ulong)obj;


### PR DESCRIPTION
```
CRIT    2026-04-02 18:03:23.816724965 GMT+00 3262635:3262664 svc_firedancer:tsfra2-solana-mainnet-val5:54   fd1:[group]:accdb:0 src/discof/accdb/../../vinyl/fd_vinyl_case_acquire.c(259)[before_credit]: increase data cache size
```

The issue could be reproduced.
Additional crash-time diagnostic showed that:
- this happened at `szc=2`, despite only 15.8% of cache lines being occupied.
- the `root cause` was volume lock-in: once a volume was committed to a size class, it was never reclaimed, even if every object in it was freed.
- during snapshot load, 88 of 125 volumes (70%, ~2.86 GiB of 4 GiB) were permanently locked to the largest size class (szc=326, ~17 MiB accounts), starving small-account allocations.
- `free_volume_reclaim=0`: no volume had ever been returned to the free pool.
- the `actual mean account footprint` on `mainnet` is ~650 bytes (the crash data shows szc=2 / 512-byte objects dominating at 76.6% of cached accounts, with a long tail of larger accounts pulling the mean up); with overhead from the allocator's superblock headers and size-class rounding, the effective footprint is closer to ~1024 bytes per cached account.

Analysis:
- the existing free path used a heuristic: when a superblock became fully empty, it checked whether the inactive stack top for that szc was also empty, and if so, freed the top. This, unfortunately, never produced a cascade deep enough to reach the volume level.

What this PR does:
- it replaces the heuristic with "eager" coalescence: when a superblock becomes fully empty, it is immediately unlinked from wherever it is in circulation (active superblock, inactive stack top, or middle of the inactive stack) and it is recursively freed to its parent. This cascades up through all spine levels to the volume, returning it to the free pool for reuse by a different size class.
- `default.toml`: it increases `cache_size_gib` from 4 to 8 and `mean_account_footprint` from 256 to 1024 to match actual mainnet conditions (see crash-time diagnostics above) - Note that 512 bytes would only delay the crash.
- it adds `fd_vinyl_data_verify invariants`: active and inactive superblocks must never be fully empty.
- it also corrects `fd_vinyl_data_verify `where non-zero volume indices were verified against vol[0] instead of vol[vol_idx].
- it adds diagnostic counters and fd_vinyl_data_diag_log() to dump allocator state (volume breakdown, per-szc superblock state, cache line utilization) on alloc failure, making it easier to diagnose future crashes. Note that this is a separate commit, and optional.

Closes https://github.com/firedancer-io/firedancer/issues/8490.
