### PR TITLE
watch: reduce CPU usage

### DIFF
--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -604,7 +604,7 @@ backtest_cmd_fn( args_t *   args,
   args_t watch_args;
   int pipefd[2];
   if( !args->backtest.no_watch ) {
-    if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( pipe2( pipefd, 0 ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
     watch_args.watch.drain_output_fd = pipefd[0];
     if( FD_UNLIKELY( -1==dup2( pipefd[ 1 ], STDERR_FILENO ) ) ) FD_LOG_ERR(( "dup2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));

--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -681,7 +681,7 @@ forktest_fn( args_t *   args,
   args_t watch_args;
   int pipefd[2];
   if( !args->forktest.no_watch ) {
-    if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( pipe2( pipefd, 0 ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
     watch_args.watch.drain_output_fd = pipefd[0];
     if( FD_UNLIKELY( -1==dup2( pipefd[1], STDERR_FILENO ) ) ) FD_LOG_ERR(( "dup2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));

--- a/src/app/shared/commands/watch/generated/watch_seccomp.h
+++ b/src/app/shared/commands/watch/generated/watch_seccomp.h
@@ -24,28 +24,26 @@
 #else
 # error "Target architecture is unsupported by seccomp."
 #endif
-static const unsigned int sock_filter_policy_watch_instr_cnt = 24;
+static const unsigned int sock_filter_policy_watch_instr_cnt = 23;
 
 static void populate_sock_filter_policy_watch( ulong out_cnt, struct sock_filter * out, unsigned int logfile_fd, unsigned int drain_output_fd ) {
-  FD_TEST( out_cnt >= 24 );
-  struct sock_filter filter[24] = {
+  FD_TEST( out_cnt >= 23 );
+  struct sock_filter filter[23] = {
     /* Check: Jump to RET_KILL_PROCESS if the script's arch != the runtime arch */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, arch ) ) ),
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 20 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, ARCH_NR, 0, /* RET_KILL_PROCESS */ 19 ),
     /* loading syscall number in accumulator */
     BPF_STMT( BPF_LD | BPF_W | BPF_ABS, ( offsetof( struct seccomp_data, nr ) ) ),
     /* allow write based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 6, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_write, /* check_write */ 5, 0 ),
     /* allow fsync based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 11, 0 ),
-    /* simply allow nanosleep */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_nanosleep, /* RET_ALLOW */ 17, 0 ),
-    /* simply allow sched_yield */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_sched_yield, /* RET_ALLOW */ 16, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_fsync, /* check_fsync */ 10, 0 ),
     /* simply allow exit_group */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_exit_group, /* RET_ALLOW */ 15, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_exit_group, /* RET_ALLOW */ 16, 0 ),
     /* allow read based on expression */
-    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_read, /* check_read */ 9, 0 ),
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_read, /* check_read */ 10, 0 ),
+    /* simply allow ppoll */
+    BPF_JUMP( BPF_JMP | BPF_JEQ | BPF_K, SYS_ppoll, /* RET_ALLOW */ 14, 0 ),
     /* none of the syscalls matched */
     { BPF_JMP | BPF_JA, 0, 0, /* RET_KILL_PROCESS */ 12 },
 //  check_write:

--- a/src/app/shared/commands/watch/watch.c
+++ b/src/app/shared/commands/watch/watch.c
@@ -7,6 +7,7 @@
 #include "../../../../util/tile/fd_tile.h"
 
 #include <errno.h>
+#include <poll.h>
 #include <unistd.h>
 #include <sys/resource.h>
 #include <linux/capability.h>
@@ -52,6 +53,10 @@ drain( int fd ) {
   int needs_reprint = 0;
 
   while( 1 ) {
+    struct pollfd pfd = { .fd = fd, .events = POLLIN };
+    int timeout_ms = 1;
+    if( 0==fd_syscall_poll( &pfd, 1, timeout_ms ) ) break;
+
     uchar buf[ 16384UL ];
     long result = read( fd, buf, sizeof(buf) );
     if( FD_UNLIKELY( -1==result && errno==EAGAIN ) ) break;

--- a/src/app/shared/commands/watch/watch.seccomppolicy
+++ b/src/app/shared/commands/watch/watch.seccomppolicy
@@ -29,20 +29,6 @@ write: (or (eq (arg 0) 1)
 # arg 0 is the file descriptor to fsync.
 fsync: (eq (arg 0) logfile_fd)
 
-# watch: wait until we need to print again
-#
-# The watcher calls fd_log_wait_until() to wait until the diagnostic
-# output screen should be refreshed, and that function can call
-# nanosleep depending on the amount of time left to wait.
-nanosleep
-
-# watch: wait until we need to print again
-#
-# The watcher calls fd_log_wait_until() to wait until the diagnostic
-# output screen should be refreshed, and that function can call
-# sched_yield depending on the amount of time left to wait.
-sched_yield
-
 # watch: exit the process
 #
 # If the watcher is signalled with SIGINT or SIGTERM it will exit
@@ -64,3 +50,12 @@ exit_group
 # used by the monitor.
 read: (or (eq (arg 0) drain_output_fd)
           (eq (arg 0) 0))
+
+# watch: wait for log message from a firedancer child process
+#
+# The watcher supports a development mode where it can be run as the
+# supervisor process of Firedancer.  In this mode, poll() is used to
+# wait for the child processes to generate a new log line.
+#
+# This is not needed in production environments.
+ppoll

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -209,7 +209,7 @@ bench_cmd_fn( args_t *   args,
     config->development.no_clone = 1;
 
     int pipefd[2];
-    if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    if( FD_UNLIKELY( pipe2( pipefd, 0 ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
     args_t watch_args;
     watch_args.watch.drain_output_fd = pipefd[0];

--- a/src/app/shared_dev/commands/dev.c
+++ b/src/app/shared_dev/commands/dev.c
@@ -161,7 +161,7 @@ dev_cmd_fn( args_t *   args,
       install_parent_signals();
 
       int pipefd[2];
-      if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      if( FD_UNLIKELY( pipe2( pipefd, 0 ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       initialize_workspaces(config);
       firedancer_pid = fork();
       if( !firedancer_pid ) {
@@ -208,7 +208,7 @@ dev_cmd_fn( args_t *   args,
       fd_sys_util_exit_group( exit_code );
     } else {
       int pipefd[2];
-      if( FD_UNLIKELY( pipe2( pipefd, O_NONBLOCK ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      if( FD_UNLIKELY( pipe2( pipefd, 0 ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
       if( FD_LIKELY( !args->dev.no_init_workspaces ) ) initialize_workspaces( config );
 


### PR DESCRIPTION
The stderr pipe between the watch CUI and Firedancer tiles was
previously non-blocking and busy-polled, causing watch to use 100%
CPU.

This patch converts the pipe to a blocking socket and interleaves
log pipe read() calls and CUI rendering using poll().
