### PR TITLE
ssping: fix no-clone startup race

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -388,9 +388,8 @@ populate_allowed_seccomp( fd_topo_t const *      topo,
   int min_ping_fd = INT_MAX;
   int max_ping_fd = 0;
   if( download_enabled( tile ) ) {
-    fd_ssping_sockfd_range_t fd_range = fd_ssping_get_sockfds( ctx->ssping );
-    min_ping_fd = fd_range.min_fd;
-    max_ping_fd = fd_range.max_fd;
+    min_ping_fd = FD_SSPING_FD_MIN;
+    max_ping_fd = FD_SSPING_FD_MIN + (int)FD_SSPING_FD_CNT - 1;
   }
 
   populate_sock_filter_policy_fd_snapct_tile( out_cnt, out, (uint)fd_log_private_logfile_fd(), (uint)ctx->local_out.dir_fd, (uint)ctx->local_out.full_snapshot_fd, (uint)ctx->local_out.incremental_snapshot_fd, (uint)min_ping_fd, (uint)max_ping_fd );
@@ -418,10 +417,12 @@ populate_allowed_fds( fd_topo_t const *      topo,
   if( FD_LIKELY( -1!=ctx->local_out.full_snapshot_fd ) )        out_fds[ out_cnt++ ] = ctx->local_out.full_snapshot_fd;
   if( FD_LIKELY( -1!=ctx->local_out.incremental_snapshot_fd ) ) out_fds[ out_cnt++ ] = ctx->local_out.incremental_snapshot_fd;
   if( FD_LIKELY( download_enabled( tile ) ) ) {
-    fd_ssping_sockfd_range_t fd_range = fd_ssping_get_sockfds( ctx->ssping );
-    ulong needed_fd_cnt = out_cnt+(ulong)(fd_range.max_fd - fd_range.min_fd + 1);
-    if( FD_UNLIKELY( needed_fd_cnt>out_fds_cnt ) ) FD_LOG_ERR(( "out_fds_cnt %lu must be at least %lu", out_fds_cnt, needed_fd_cnt ));
-    for( int i=fd_range.min_fd; i<=fd_range.max_fd; i++ ) out_fds[ out_cnt++ ] = i;
+    if( FD_UNLIKELY( out_cnt+FD_SSPING_FD_CNT > out_fds_cnt ) ) {
+      FD_LOG_ERR(( "out_fds_cnt %lu must be at least %lu", out_fds_cnt, out_cnt + FD_SSPING_FD_CNT ));
+    }
+    for( int i=FD_SSPING_FD_MIN; i<FD_SSPING_FD_MIN+(int)FD_SSPING_FD_CNT; i++ ) {
+      out_fds[ out_cnt++ ] = i;
+    }
   }
 
   return out_cnt;

--- a/src/discof/restore/utils/fd_ssping.c
+++ b/src/discof/restore/utils/fd_ssping.c
@@ -7,6 +7,7 @@
 #include "../../../util/log/fd_log.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -97,7 +98,6 @@ struct fd_ssping_private {
   /* ping_to_pool[ i ]==x means that used_fds[ i ].fd is in use for
      pinging the peer in pool[ x ]. */
   ulong                    ping_to_pool[ FD_SSPING_FD_CNT ]; /* indexed [0, used_fd_cnt) */
-  fd_ssping_sockfd_range_t ping_fds; /* redundant with the above info, but stored separately for convenience. */
 };
 
 
@@ -164,60 +164,29 @@ fd_ssping_new( void *                 shmem,
   ssping->refreshing = deadline_list_join( deadline_list_new( _refreshing ) );
   ssping->invalid    = deadline_list_join( deadline_list_new( _invalid ) );
 
-  /* There's no automatic way to allocate contiguous file descriptors.
-     We could probe for which are open with fcntl( fd, F_GETFD ), but
-     that's racy.  Another way to do it is to read /proc/fd, but that's
-     a bit gross from here, and still racy.  A third way to do it is to
-     allocate a few more and hope that is enough to find a contiguous
-     region.  All this happens during privileged_init, so we have a lot
-     of control over it, and in practice, I think either solution would
-     be fine.  We'll go with the overallocation solution. */
-#define MAX_FDESC_ALLOC_ATTEMPT 128UL
-  /* If we started allocating a range of contiguous file descriptors,
-     but found it wasn't big enough for our uses, we stash it in
-     bad_fdesc_allocs to close it later. */
-  fd_ssping_sockfd_range_t bad_fdesc_allocs[ MAX_FDESC_ALLOC_ATTEMPT ];
-  ulong bad_fdesc_alloc_cnt = 0UL;
+  /* Allocate a contiguous range of file descriptors */
+  int next_fd = FD_SSPING_FD_MIN;
 
-  /* Start with one fd to make the code cleaner.  We definitely don't
-     need to worry about FD_SSPING_FD_CNT==0 */
-  int fd = socket( AF_INET, SOCK_STREAM|SOCK_NONBLOCK, IPPROTO_TCP );
-  if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "socket(SOCK_STREAM,IPPROTO_TCP) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-
-  int min_fd = fd;
-  int max_fd = fd;
-
-  while( (ulong)(max_fd-min_fd)<FD_SSPING_FD_CNT-1UL ) {
+  for( ulong i=0UL; i<FD_SSPING_FD_CNT; i++, next_fd++ ) {
     int fd = socket( AF_INET, SOCK_STREAM|SOCK_NONBLOCK, IPPROTO_TCP );
     if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "socket(SOCK_STREAM,IPPROTO_TCP) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
-    if( FD_LIKELY( fd==max_fd+1 ) ) {
-      /* The happy case, we're still extending a contiguous range */
-      max_fd = fd;
-    } else {
-      if( FD_UNLIKELY( bad_fdesc_alloc_cnt==128UL ) ) FD_LOG_ERR(( "could not allocate %lu contiguous sockets", FD_SSPING_FD_CNT ));
-      bad_fdesc_allocs[ bad_fdesc_alloc_cnt++ ] = (fd_ssping_sockfd_range_t) { .min_fd = min_fd, .max_fd = max_fd };
-      min_fd = fd;
-      max_fd = fd;
+    int actual_fd = fcntl( fd, F_DUPFD_CLOEXEC, next_fd );
+    if( FD_UNLIKELY( actual_fd<0 ) ) {
+      FD_LOG_ERR(( "fcntl(F_DUPFD_CLOEXEC,%d) failed (%i-%s)", next_fd, errno, fd_io_strerror( errno ) ));
     }
-  }
-
-  /* At this point, [min_fd, max_fd] are the sockets we'll use, and
-     max_fd - min_fd == FD_SSPING_FD_CNT-1.  We should close the
-     extraneous ones though. */
-  for( ulong i=0UL; i<bad_fdesc_alloc_cnt; i++ ) {
-    for( int j=bad_fdesc_allocs[ i ].min_fd; j<=bad_fdesc_allocs[ i ].max_fd; j++ ) {
-      close( j );
+    if( FD_UNLIKELY( actual_fd!=next_fd ) ) {
+      FD_LOG_ERR(( "file descriptor collision at %d", next_fd ));
     }
-  }
+    if( FD_UNLIKELY( 0!=close( fd ) ) ) {
+      FD_LOG_ERR(( "close(%d) failed (%i-%s)", fd, errno, fd_io_strerror( errno ) ));
+    }
 
-  for( ulong i=0UL; i<FD_SSPING_FD_CNT; i++ ) {
     int tcp_nodelay = 1;
-    int fd = min_fd + (int)i;
-    if( FD_UNLIKELY( setsockopt( fd, SOL_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(int) ) ) ) {
+    if( FD_UNLIKELY( setsockopt( next_fd, SOL_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(int) ) ) ) {
       FD_LOG_ERR(( "setsockopt(SOL_TCP,TCP_NODELAY,1) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     }
-    ssping->idle_fds[ i ] = fd;
+    ssping->idle_fds[ i ] = next_fd;
 
     ssping->used_fds[ i ].fd      = -1;
     ssping->used_fds[ i ].events  = POLLOUT|POLLRDHUP|POLLPRI;
@@ -228,9 +197,6 @@ fd_ssping_new( void *                 shmem,
 
   ssping->on_ping_cb = on_ping_cb;
   ssping->cb_arg     = cb_arg;
-
-  ssping->ping_fds.min_fd = min_fd;
-  ssping->ping_fds.max_fd = max_fd;
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( ssping->magic ) = FD_SSPING_MAGIC;
@@ -527,9 +493,4 @@ fd_ssping_advance( fd_ssping_t *          ssping,
   }
 
   recv_pings( ssping, selector );
-}
-
-fd_ssping_sockfd_range_t
-fd_ssping_get_sockfds( fd_ssping_t const * ssping ) {
-  return ssping->ping_fds;
 }

--- a/src/discof/restore/utils/fd_ssping.h
+++ b/src/discof/restore/utils/fd_ssping.h
@@ -20,9 +20,10 @@
 struct fd_sspeer_selector_private;
 typedef struct fd_sspeer_selector_private fd_sspeer_selector_t;
 
-#define FD_SSPING_FD_CNT    (249UL) /* Limit to how many pings can be
-                                       inflight.  Chosen so that it doesn't
-                                       overflow the tile limit. */
+#define FD_SSPING_FD_MIN 20000
+#define FD_SSPING_FD_CNT   249 /* Limit to how many pings can be
+                                  inflight.  Chosen so that it doesn't
+                                  overflow the tile limit. */
 
 #define FD_SSPING_MAGIC (0xF17EDA2CE55A1A60) /* FIREDANCE SSPING V0 */
 
@@ -33,13 +34,6 @@ typedef void
 (* fd_ssping_on_ping_fn_t)( void *        _ctx,
                             fd_ip4_port_t addr,
                             ulong         latency );
-
-/* fd_ssping_sockfd_range_t is used by get_sockfds and a few internal
-   uses to represent the range of file descriptors [min_fd, max_fd]. */
-typedef struct {
-  int min_fd;
-  int max_fd; /* inclusive */
-} fd_ssping_sockfd_range_t;
 
 FD_PROTOTYPES_BEGIN
 
@@ -100,12 +94,6 @@ void
 fd_ssping_advance( fd_ssping_t *          ssping,
                    long                   now,
                    fd_sspeer_selector_t * selector);
-
-/* Returns the socket file descriptors that this ping tracker may use.
-   These file descriptors are guaranteed to be contiguous to facilitate
-   SECCOMP filtering. */
-fd_ssping_sockfd_range_t
-fd_ssping_get_sockfds( fd_ssping_t const * ssping );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Fixes a file descriptor numbering race condition on startup with
no-clone mode.  Uses F_DUPFD to rename ssping sockets to a high FD
range instead of hoping that FD allocation happens to be contiguous.
