### PR TITLE
fix: resolve solcap flush and dev stderr color issues

### DIFF
--- a/src/app/shared_dev/commands/dev.c
+++ b/src/app/shared_dev/commands/dev.c
@@ -148,6 +148,13 @@ dev_cmd_fn( args_t *   args,
   }
 
   update_config_for_dev( config );
+
+  /* If we are about to redirect stderr to a pipe, we should decide whether
+     to colorize now, because isatty(stderr) will be false later. */
+  if( fd_log_should_colorize() ) {
+    fd_log_colorize_set( 1 );
+    setenv( "RUST_LOG_STYLE", "always", 1 );
+  }
   if( FD_UNLIKELY( args->dev.no_agave ) ) config->development.no_agave = 1;
 
   if( FD_LIKELY( args->dev.no_watch ) ) {

--- a/src/discof/capture/fd_solcap_tile.c
+++ b/src/discof/capture/fd_solcap_tile.c
@@ -367,6 +367,11 @@ returnable_frag( fd_solcap_tile_ctx_t * ctx,
     FD_TEST( ctx->block_len > 0 );  /* Must have valid block length before writing footer */
     fd_solcap_write_ftr( ctx->capture_ctx->capture, ctx->block_len );
 
+    /* For bank preimage messages, the file is synced to disk */
+    if( ctx->msg_set_sig==SOLCAP_WRITE_BANK_PREIMAGE ) {
+      FD_TEST( fsync( ctx->fd )==0 );
+    }
+
     ctx->msg_idx        = 0;
     ctx->block_len      = 0;
     ctx->msg_set_sig    = 0;
@@ -490,6 +495,13 @@ unprivileged_init( fd_topo_t *      topo,
 #define STEM_CALLBACK_CONTEXT_ALIGN alignof(fd_solcap_tile_ctx_t)
 
 #define STEM_CALLBACK_RETURNABLE_FRAG returnable_frag
+
+static void
+during_housekeeping( fd_solcap_tile_ctx_t * ctx ) {
+  if( FD_LIKELY( ctx->fd != -1 ) ) fsync( ctx->fd );
+}
+
+#define STEM_CALLBACK_DURING_HOUSEKEEPING during_housekeeping
 
 #include "../../disco/stem/fd_stem.c"
 


### PR DESCRIPTION
### Updates

Addresses two issues:

1. **solcap**
   - Added `fsync()` calls to ensure critical debug data (such as bank preimages) and periodic buffers are properly flushed to disk  
   - Prevents data loss during sudden termination  
   - Reference: #7629  

2. **dev**
   - Fixed stderr colorization when using `--no-sandbox` and `--no-clone`  
   - Now detects TTY and forces correct color state before redirecting the stream to the watch pipe  
   - Reference: #7906  