### PR TITLE
restore: snapin FD_TEST upgrades

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -392,8 +392,8 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     offset for each slot, and stick it into the appropriate bank in
     our chain. */
 
-  FD_TEST( blockhashes_len<=301UL );
-  FD_TEST( blockhashes_len>0UL );
+  if( FD_UNLIKELY( blockhashes_len>301UL ) ) FD_LOG_ERR(( "blockhashes_len %lu exceeds max 301", blockhashes_len ));
+  if( FD_UNLIKELY( blockhashes_len==0UL ) ) FD_LOG_ERR(( "blockhashes_len is zero" ));
 
   ulong seq_min = ULONG_MAX;
   for( ulong i=0UL; i<blockhashes_len; i++ ) seq_min = fd_ulong_min( seq_min, blockhashes[ i ].hash_index );
@@ -450,7 +450,7 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
 
   uchar * _map = fd_alloca_check( alignof(blockhash_map_t), blockhash_map_footprint( 1024UL ) );
   blockhash_map_t * blockhash_map = blockhash_map_join( blockhash_map_new( _map, 1024UL, ctx->seed ) );
-  FD_TEST( blockhash_map );
+  if( FD_UNLIKELY( !blockhash_map ) ) FD_LOG_ERR(( "failed to create blockhash map" ));
 
   fd_blockhash_entry_t blockhash_pool[ 151UL ];
   for( ulong i=0UL; i<chain_len; i++ ) {
@@ -467,7 +467,7 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
   }
 
   /* Now load the blockhash offsets for these blockhashes ... */
-  FD_TEST( ctx->blockhash_offsets_len ); /* Must be at least one else nothing would be rooted */
+  if( FD_UNLIKELY( !ctx->blockhash_offsets_len ) ) FD_LOG_ERR(( "blockhash_offsets_len is zero, nothing would be rooted" ));
   for( ulong i=0UL; i<ctx->blockhash_offsets_len; i++ ) {
     fd_hash_t key;
     fd_memcpy( key.uc, ctx->blockhash_offsets[ i ].blockhash, 32UL );
@@ -672,7 +672,8 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
                  fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
   }
 
-  FD_TEST( chunk>=ctx->in.chunk0 && chunk<=ctx->in.wmark && sz<=ctx->in.mtu );
+  if( FD_UNLIKELY( !( chunk>=ctx->in.chunk0 && chunk<=ctx->in.wmark && sz<=ctx->in.mtu ) ) )
+    FD_LOG_ERR(( "invalid frag: chunk=%lu chunk0=%lu wmark=%lu sz=%lu mtu=%lu", chunk, ctx->in.chunk0, ctx->in.wmark, sz, ctx->in.mtu ));
 
   if( FD_UNLIKELY( !ctx->lthash_disabled && ctx->buffered_batch.batch_cnt>0UL ) ) {
     fd_snapin_process_account_batch( ctx, NULL, &ctx->buffered_batch );
@@ -1035,7 +1036,8 @@ returnable_frag( fd_snapin_tile_t *  ctx,
                  ulong               tsorig FD_PARAM_UNUSED,
                  ulong               tspub  FD_PARAM_UNUSED,
                  fd_stem_context_t * stem ) {
-  FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
+  if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_SHUTDOWN ) )
+    FD_LOG_ERR(( "received frag while in SHUTDOWN state" ));
 
   ctx->stem = stem;
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_DATA ) ) return handle_data_frag( ctx, chunk, sz, stem );

--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -40,7 +40,7 @@ fd_snapin_process_account_header_funk( fd_snapin_tile_t *            ctx,
   if( FD_LIKELY( !rec ) ) {
     should_publish = 1;
     rec = fd_funk_rec_prepare( funk, ctx->xid, &id, prepare, NULL );
-    FD_TEST( rec );
+    if( FD_UNLIKELY( !rec ) ) FD_LOG_ERR(( "failed to prepare funk record while loading snapshot for slot %lu", result->account_header.slot ));
   }
 
   fd_account_meta_t * meta = fd_funk_val( rec, funk->wksp );
@@ -196,7 +196,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     fd_funk_rec_t * r = rec[ i ];
     if( FD_LIKELY( !r ) ) {  /* optimize for new account */
       r = fd_funk_rec_pool_acquire( funk->rec_pool );
-      FD_TEST( r );
+      if( FD_UNLIKELY( !r ) ) FD_LOG_ERR(( "failed to acquire funk record from pool" ));
       ulong rec_idx = (ulong)( r - rec_tbl );
 
       fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
@@ -225,7 +225,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     } else {  /* existing record for key found */
       fd_account_meta_t const * existing = fd_funk_val( r, funk->wksp );
       if( FD_UNLIKELY( !existing ) ) FD_LOG_HEXDUMP_NOTICE(( "r", r, sizeof(fd_funk_rec_t) ));
-      FD_TEST( existing );
+      if( FD_UNLIKELY( !existing ) ) FD_LOG_ERR(( "existing funk record has no value" ));
       if( existing->slot > slot ) {
         rec[ i ] = NULL;  /* skip record if existing value is newer */
         /* send the skipped account to the subtracting hash tile */
@@ -237,13 +237,13 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
         ctx->dup_capitalization = fd_ulong_sat_add( ctx->dup_capitalization, existing->lamports );
         fd_snapin_send_duplicate_account( ctx, existing->lamports, (uchar const *)existing + sizeof(fd_account_meta_t), existing->dlen, existing->executable, existing->owner, pubkey, 1, &early_exit );
       } else { /* slot==existing->slot */
-        FD_TEST( 0 );
+        FD_LOG_ERR(( "duplicate account in same slot (slot=%lu)", slot ));
       }
 
       if( FD_LIKELY( early_exit ) ) {
         /* buffer account batch if not already buffered */
         if( FD_LIKELY( result && i<FD_SSPARSE_ACC_BATCH_MAX-1UL ) ) {
-          FD_TEST( ctx->buffered_batch.batch_cnt==0UL );
+          if( FD_UNLIKELY( ctx->buffered_batch.batch_cnt!=0UL ) ) FD_LOG_ERR(( "buffered batch not empty (batch_cnt=%lu)", ctx->buffered_batch.batch_cnt ));
           fd_memcpy( ctx->buffered_batch.batch, result->account_batch.batch, sizeof(uchar const*)*FD_SSPARSE_ACC_BATCH_MAX );
           ctx->buffered_batch.slot          = result->account_batch.slot;
           ctx->buffered_batch.batch_cnt     = result->account_batch.batch_cnt;

--- a/src/discof/restore/fd_snapin_tile_vinyl.c
+++ b/src/discof/restore/fd_snapin_tile_vinyl.c
@@ -34,7 +34,7 @@ fd_snapin_process_account_header_vinyl( fd_snapin_tile_t *            ctx,
   FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
   ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-  FD_TEST( pair_sz<=ctx->hash_out.mtu );
+  if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "pair_sz %lu exceeds mtu %lu", pair_sz, ctx->hash_out.mtu ));
   uchar * pair    = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
 
   uchar * dst     = pair;
@@ -129,7 +129,7 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
     ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-    FD_TEST( pair_sz<=ctx->hash_out.mtu );
+    if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "pair_sz %lu exceeds mtu %lu", pair_sz, ctx->hash_out.mtu ));
 
     uchar * dst     = pair;
     ulong   dst_rem = pair_sz;


### PR DESCRIPTION
Converting most of runtime `FD_TESTs` into `if( FD_UNLIKELY ( ... ) ) FD_LOG_ERR(( "..." ));` in `snapin`.
This should help with debugging errors during snapshot load, e.g.
```
src/discof/restore/fd_snapin_tile_funk.c(199): FAIL: r
```

Upgrade: superseded by https://github.com/firedancer-io/firedancer/pull/9469.