### PR TITLE
restore: snapin FD_TEST vs FD_LOG_ERR

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -392,8 +392,8 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     offset for each slot, and stick it into the appropriate bank in
     our chain. */
 
-  FD_TEST( blockhashes_len<=301UL );
-  FD_TEST( blockhashes_len>0UL );
+  if( FD_UNLIKELY( blockhashes_len>301UL ) ) FD_LOG_ERR(( "corrupt snapshot: blockhash queue length %lu exceeds maximum 301", blockhashes_len ));
+  if( FD_UNLIKELY( !blockhashes_len ) ) FD_LOG_ERR(( "corrupt snapshot: blockhash queue is empty" ));
 
   ulong seq_min = ULONG_MAX;
   for( ulong i=0UL; i<blockhashes_len; i++ ) seq_min = fd_ulong_min( seq_min, blockhashes[ i ].hash_index );
@@ -450,7 +450,7 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
 
   uchar * _map = fd_alloca_check( alignof(blockhash_map_t), blockhash_map_footprint( 1024UL ) );
   blockhash_map_t * blockhash_map = blockhash_map_join( blockhash_map_new( _map, 1024UL, ctx->seed ) );
-  FD_TEST( blockhash_map );
+  if( FD_UNLIKELY( !blockhash_map ) ) FD_LOG_ERR(( "failed to create blockhash map" ));
 
   fd_blockhash_entry_t blockhash_pool[ 151UL ];
   for( ulong i=0UL; i<chain_len; i++ ) {
@@ -467,7 +467,7 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
   }
 
   /* Now load the blockhash offsets for these blockhashes ... */
-  FD_TEST( ctx->blockhash_offsets_len ); /* Must be at least one else nothing would be rooted */
+  if( FD_UNLIKELY( !ctx->blockhash_offsets_len ) ) FD_LOG_ERR(( "corrupt snapshot: no blockhash offsets found (nothing is rooted)" ));
   for( ulong i=0UL; i<ctx->blockhash_offsets_len; i++ ) {
     fd_hash_t key;
     fd_memcpy( key.uc, ctx->blockhash_offsets[ i ].blockhash, 32UL );
@@ -672,7 +672,7 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
                  fd_ssctrl_state_str( (ulong)ctx->state ), (ulong)ctx->state ));
   }
 
-  FD_TEST( chunk>=ctx->in.chunk0 && chunk<=ctx->in.wmark && sz<=ctx->in.mtu );
+  if( FD_UNLIKELY( chunk<ctx->in.chunk0 || chunk>ctx->in.wmark || sz>ctx->in.mtu ) ) FD_LOG_ERR(( "invalid data frag bounds (chunk=%lu chunk0=%lu wmark=%lu sz=%lu mtu=%lu)", chunk, ctx->in.chunk0, ctx->in.wmark, sz, ctx->in.mtu ));
 
   if( FD_UNLIKELY( !ctx->lthash_disabled && ctx->buffered_batch.batch_cnt>0UL ) ) {
     fd_snapin_process_account_batch( ctx, NULL, &ctx->buffered_batch );
@@ -971,7 +971,7 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
         ctx->metrics.accounts_loaded   -= ctx->accdb_admin->base.reclaim_cnt;
         ctx->metrics.accounts_replaced += ctx->accdb_admin->base.reclaim_cnt;
       }
-      FD_TEST( !fd_funk_last_publish_is_frozen( ctx->funk ) );
+      if( FD_UNLIKELY( fd_funk_last_publish_is_frozen( ctx->funk ) ) ) FD_LOG_ERR(( "funk last publish is still frozen after advance_root" ));
 
       /* Make 'Last published' XID equal the restored slot number */
       fd_funk_txn_xid_t target_xid = { .ul = { ctx->bank_slot, 0UL } };

--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -39,8 +39,9 @@ fd_snapin_process_account_header_funk( fd_snapin_tile_t *            ctx,
   fd_funk_rec_prepare_t prepare[1];
   if( FD_LIKELY( !rec ) ) {
     should_publish = 1;
-    rec = fd_funk_rec_prepare( funk, ctx->xid, &id, prepare, NULL );
-    FD_TEST( rec );
+    int err;
+    rec = fd_funk_rec_prepare( funk, ctx->xid, &id, prepare, &err );
+    if( FD_UNLIKELY( !rec ) ) FD_LOG_ERR(( "failed to prepare funk record for account insertion at slot %lu (err=%d%s)", result->account_header.slot, err, err==FD_FUNK_ERR_REC ? ", increase [accounts.rec_max]" : "" ));
   }
 
   fd_account_meta_t * meta = fd_funk_val( rec, funk->wksp );
@@ -196,7 +197,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     fd_funk_rec_t * r = rec[ i ];
     if( FD_LIKELY( !r ) ) {  /* optimize for new account */
       r = fd_funk_rec_pool_acquire( funk->rec_pool );
-      FD_TEST( r );
+      if( FD_UNLIKELY( !r ) ) FD_LOG_ERR(( "funk record pool exhausted while loading snapshot batch (increase [accounts.rec_max])" ));
       ulong rec_idx = (ulong)( r - rec_tbl );
 
       fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
@@ -225,7 +226,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     } else {  /* existing record for key found */
       fd_account_meta_t const * existing = fd_funk_val( r, funk->wksp );
       if( FD_UNLIKELY( !existing ) ) FD_LOG_HEXDUMP_NOTICE(( "r", r, sizeof(fd_funk_rec_t) ));
-      FD_TEST( existing );
+      if( FD_UNLIKELY( !existing ) ) FD_LOG_ERR(( "corrupt funk record: existing record has no value" ));
       if( existing->slot > slot ) {
         rec[ i ] = NULL;  /* skip record if existing value is newer */
         /* send the skipped account to the subtracting hash tile */
@@ -237,13 +238,13 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
         ctx->dup_capitalization = fd_ulong_sat_add( ctx->dup_capitalization, existing->lamports );
         fd_snapin_send_duplicate_account( ctx, existing->lamports, (uchar const *)existing + sizeof(fd_account_meta_t), existing->dlen, existing->executable, existing->owner, pubkey, 1, &early_exit );
       } else { /* slot==existing->slot */
-        FD_TEST( 0 );
+        FD_LOG_ERR(( "corrupt snapshot: duplicate account in same slot (slot=%lu)", slot ));
       }
 
       if( FD_LIKELY( early_exit ) ) {
         /* buffer account batch if not already buffered */
         if( FD_LIKELY( result && i<FD_SSPARSE_ACC_BATCH_MAX-1UL ) ) {
-          FD_TEST( ctx->buffered_batch.batch_cnt==0UL );
+          if( FD_UNLIKELY( ctx->buffered_batch.batch_cnt!=0UL ) ) FD_LOG_ERR(( "unexpected non-empty buffered batch during early exit (batch_cnt=%lu i=%lu slot=%lu)", ctx->buffered_batch.batch_cnt, i, slot ));
           fd_memcpy( ctx->buffered_batch.batch, result->account_batch.batch, sizeof(uchar const*)*FD_SSPARSE_ACC_BATCH_MAX );
           ctx->buffered_batch.slot          = result->account_batch.slot;
           ctx->buffered_batch.batch_cnt     = result->account_batch.batch_cnt;

--- a/src/discof/restore/fd_snapin_tile_vinyl.c
+++ b/src/discof/restore/fd_snapin_tile_vinyl.c
@@ -34,7 +34,7 @@ fd_snapin_process_account_header_vinyl( fd_snapin_tile_t *            ctx,
   FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
   ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-  FD_TEST( pair_sz<=ctx->hash_out.mtu );
+  if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
   uchar * pair    = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
 
   uchar * dst     = pair;
@@ -129,7 +129,7 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
     ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-    FD_TEST( pair_sz<=ctx->hash_out.mtu );
+    if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
 
     uchar * dst     = pair;
     ulong   dst_rem = pair_sz;


### PR DESCRIPTION
```
src/discof/restore/fd_snapin_tile_funk.c(199): FAIL: r
```

Replacing specific runtime `FD_TEST` in `snapin` with `if( FD_UNLIKELY ( ... ) ) FD_LOG_ERR(( "..." ));`.
This should help debugging runtime errors like the above.
( Note: `FD_TEST` is literally a wrapper around `FD_LOG_ERR` ). 
