### PR TITLE
ci: enable verbosity for build failures and fail-fast for PRs

### DIFF
--- a/.github/workflows/on_nightly.yml
+++ b/.github/workflows/on_nightly.yml
@@ -39,6 +39,7 @@ jobs:
         ALL,linux_clang_zen4,ALL;
         ALL,linux_clang_zen5,ALL;
       build_arm: true
+      verbose: true
       cid: 3
   builds_2:
     uses: ./.github/workflows/builds.yml
@@ -46,6 +47,7 @@ jobs:
       machine: linux_gcc_icelake
       build_arm: false
       clang: none
+      verbose: true
       cid: 4
       gcc_runner_labels: '["self-hosted", "X64", "750G"]'
   builds_3:
@@ -54,6 +56,7 @@ jobs:
       machine: linux_gcc_x86_64
       build_arm: false
       clang: none
+      verbose: true
       cid: 5
       gcc_runner_labels: '["self-hosted", "X64", "750G"]'
   builds_4:
@@ -65,6 +68,7 @@ jobs:
       machine: linux_gcc_zen2
       build_arm: false
       clang: none
+      verbose: true
       cid: 6
       gcc_runner_labels: '["self-hosted", "X64", "750G"]'
   backtest:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -34,6 +34,8 @@ jobs:
       cid: 1
       build_arm: false
       check_run: true
+      verbose: true
+      exit_on_err: true
         # compiler,machine,target
       gcc_exceptions: |
         gcc-8.5.0,linux_gcc_zen2,ALL;
@@ -58,6 +60,8 @@ jobs:
       cid: 2
       clang: none
       machine: linux_gcc_icelake,linux_gcc_x86_64
+      verbose: true
+      exit_on_err: true
       build_arm: false
       check_run: true
   build_checks_3:
@@ -68,6 +72,8 @@ jobs:
       gcc: gcc-12.4.0
       clang: clang-19.1.7
       machine: linux_gcc_zen2,linux_clang_zen2
+      verbose: true
+      exit_on_err: true
       build_arm: false
       check_run: true
       no_optimization: true

--- a/contrib/build.sh
+++ b/contrib/build.sh
@@ -196,7 +196,6 @@ CUSTOM_TARGETS+=( ["linux_clang_noarch128"]="${OTHER_TARGETS[@]}" )
 CUSTOM_TARGETS+=( ["freebsd_clang_noarch128"]="${OTHER_TARGETS[@]}" )
 
 FAIL=0
-LOG_FILE=$(mktemp)
 START=$(date +%s)
 
 # By default, use all the compilers that are available.
@@ -255,6 +254,8 @@ echo
 if [[ $DRY_RUN -eq 1 ]]; then
   exit 0
 fi
+
+LOG_FILE=$(mktemp)
 
 skip_compiler() {
   local compiler=$1


### PR DESCRIPTION
Example failure (exit on first error and verbose output): https://github.com/firedancer-io/firedancer/actions/runs/24969507249/job/73109920762?pr=9503