### PR TITLE
poh: fix pacing, don't limit hashing as follower

### DIFF
--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -225,7 +225,8 @@ fd_poh_begin_leader( fd_poh_t * poh,
                      ulong      hashcnt_per_tick,
                      ulong      ticks_per_slot,
                      ulong      tick_duration_ns,
-                     ulong      max_microblocks_in_slot ) {
+                     ulong      max_microblocks_in_slot,
+                     long       slot_start_ns ) {
   FD_TEST( poh->state==STATE_FOLLOWER || poh->state==STATE_WAITING_FOR_BANK );
   FD_TEST( slot==poh->next_leader_slot );
 
@@ -243,6 +244,7 @@ fd_poh_begin_leader( fd_poh_t * poh,
   else                                          poh->state = STATE_LEADER;
 
   poh->microblocks_lower_bound = 0UL;
+  poh->leader_slot_start_ns    = slot_start_ns;
 
   FD_LOG_INFO(( "begin_leader(slot=%lu, last_slot=%lu, last_hashcnt=%lu)", slot, poh->last_slot, poh->last_hashcnt ));
 }
@@ -388,21 +390,32 @@ fd_poh_advance( fd_poh_t *          poh,
 
   /* If we are the leader, always leave enough capacity in the slot so
      that we can mixin any potential microblocks still coming from the
-     pack tile for this slot. */
-  ulong max_remaining_microblocks = poh->max_microblocks_per_slot - poh->microblocks_lower_bound;
+     pack tile for this slot.
 
-  /* With hashcnt_per_tick hashes per tick, we actually get
-     hashcnt_per_tick-1 chances to mixin a microblock.  For each tick
-     span that we need to reserve, we also need to reserve the hashcnt
-     for the tick, hence the +
-     max_remaining_microblocks/(hashcnt_per_tick-1) rounded up.
+     When not leading (FOLLOWER or WAITING_FOR_SLOT), no microblocks
+     will be mixed in, so there is nothing to reserve so
+     restricted_hashcnt does not need to be reduced from hashcnt_per_slot. */
+  ulong max_remaining_microblocks;
+  ulong restricted_hashcnt;
+  if( FD_LIKELY( poh->state==STATE_LEADER ) ) {
+    max_remaining_microblocks = poh->max_microblocks_per_slot - poh->microblocks_lower_bound;
 
-     However, if hashcnt_per_tick is 1 because we're in low power mode,
-     this should probably just be max_remaining_microblocks. */
-  ulong max_remaining_ticks_or_microblocks = max_remaining_microblocks;
-  if( FD_LIKELY( !low_power_mode ) ) max_remaining_ticks_or_microblocks += (max_remaining_microblocks+poh->hashcnt_per_tick-2UL)/(poh->hashcnt_per_tick-1UL);
+    /* With hashcnt_per_tick hashes per tick, we actually get
+       hashcnt_per_tick-1 chances to mixin a microblock.  For each tick
+       span that we need to reserve, we also need to reserve the hashcnt
+       for the tick, hence the +
+       max_remaining_microblocks/(hashcnt_per_tick-1) rounded up.
 
-  ulong restricted_hashcnt = fd_ulong_if( poh->hashcnt_per_slot>=max_remaining_ticks_or_microblocks, poh->hashcnt_per_slot-max_remaining_ticks_or_microblocks, 0UL );
+       However, if hashcnt_per_tick is 1 because we're in low power mode,
+       this should probably just be max_remaining_microblocks. */
+    ulong max_remaining_ticks_or_microblocks = max_remaining_microblocks;
+    if( FD_LIKELY( !low_power_mode ) ) max_remaining_ticks_or_microblocks += (max_remaining_microblocks+poh->hashcnt_per_tick-2UL)/(poh->hashcnt_per_tick-1UL);
+
+    restricted_hashcnt = fd_ulong_if( poh->hashcnt_per_slot>=max_remaining_ticks_or_microblocks, poh->hashcnt_per_slot-max_remaining_ticks_or_microblocks, 0UL );
+  } else {
+    max_remaining_microblocks = 0UL;
+    restricted_hashcnt        = poh->hashcnt_per_slot;
+  }
 
   ulong min_hashcnt = poh->hashcnt;
 

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -502,7 +502,8 @@ fd_poh_begin_leader( fd_poh_t * poh,
                      ulong      hashcnt_per_tick,
                      ulong      ticks_per_slot,
                      ulong      tick_duration_ns,
-                     ulong      max_microblocks_in_slot );
+                     ulong      max_microblocks_in_slot,
+                     long       slot_start_ns );
 
 void
 fd_poh_done_packing( fd_poh_t * poh,

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -192,7 +192,7 @@ returnable_frag( fd_poh_tile_t *     ctx,
     case IN_KIND_REPLAY: {
       if( FD_LIKELY( sig==REPLAY_SIG_BECAME_LEADER ) ) {
         fd_became_leader_t const * became_leader = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
-        fd_poh_begin_leader( ctx->poh, became_leader->slot, became_leader->hashcnt_per_tick, became_leader->ticks_per_slot, became_leader->tick_duration_ns, became_leader->max_microblocks_in_slot );
+        fd_poh_begin_leader( ctx->poh, became_leader->slot, became_leader->hashcnt_per_tick, became_leader->ticks_per_slot, became_leader->tick_duration_ns, became_leader->max_microblocks_in_slot, became_leader->slot_start_ns );
       } else if( sig==REPLAY_SIG_RESET ) {
         fd_poh_reset_t const * reset = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
         fd_poh_reset( ctx->poh, stem, reset->timestamp, reset->hashcnt_per_tick, reset->ticks_per_slot, reset->tick_duration_ns, reset->completed_slot, reset->completed_blockhash, reset->next_leader_slot, reset->max_microblocks_in_slot, reset->completed_block_id );


### PR DESCRIPTION
Fixes
>3. PoH Tile Crash at Leader Slot Boundary

from https://github.com/firedancer-io/firedancer/issues/9162

Also includes a fix for a pacing bug which I thought I had already fixed but it seems like I didn't.