### PR TITLE
runtime: add vote deserialize error-code regression tests

### DIFF
--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -8,9 +8,11 @@
 #include "fd_runtime.h"
 #include "fd_runtime_stack.h"
 #include "fd_bank.h"
+#include "fd_executor_err.h"
 #include "fd_system_ids.h"
 #include "program/fd_vote_program.h"
 #include "program/vote/fd_vote_codec.h"
+#include "program/vote/fd_vote_state_versioned.h"
 #include "sysvar/fd_sysvar_rent.h"
 #include "sysvar/fd_sysvar_epoch_schedule.h"
 #include "sysvar/fd_sysvar_stake_history.h"
@@ -417,6 +419,31 @@ test_deprecate_rent_exemption_threshold( fd_wksp_t * wksp ) {
   test_env_destroy( env );
 }
 
+static void
+test_vote_state_deserialize_error_codes( void ) {
+  fd_vote_state_versioned_t vsv_uninit[1];
+  FD_TEST( fd_vote_state_versioned_new( vsv_uninit, fd_vote_state_versioned_enum_uninitialized ) );
+
+  uchar serialized[8] = {0};
+  ulong serialized_sz = fd_vote_state_versioned_serialized_size( vsv_uninit );
+  FD_TEST( serialized_sz<=sizeof(serialized) );
+  FD_TEST( !fd_vote_state_versioned_serialize( vsv_uninit, serialized, sizeof(serialized) ) );
+
+  uchar storage[ sizeof(fd_account_meta_t) + sizeof(serialized) ] = {0};
+  fd_account_meta_t * meta = (fd_account_meta_t *)storage;
+  meta->dlen = (uint)serialized_sz;
+  fd_memcpy( fd_account_data( meta ), serialized, serialized_sz );
+
+  fd_vote_state_versioned_t decoded[1];
+  FD_TEST( fd_vsv_deserialize( meta, decoded )==FD_EXECUTOR_INSTR_ERR_UNINITIALIZED_ACCOUNT );
+
+  meta->dlen = 1U;
+  fd_account_data( meta )[0] = 0U;
+  FD_TEST( fd_vsv_deserialize( meta, decoded )==FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA );
+
+  FD_LOG_NOTICE(( "test_vote_state_deserialize_error_codes: PASSED" ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -436,6 +463,7 @@ main( int     argc,
   fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
+  test_vote_state_deserialize_error_codes();
   test_deprecate_rent_exemption_threshold( wksp );
 
   fd_wksp_delete_anonymous( wksp );

--- a/src/flamenco/runtime/tests/test_inflation_rewards.c
+++ b/src/flamenco/runtime/tests/test_inflation_rewards.c
@@ -4,8 +4,10 @@
 #include "../../rewards/fd_rewards_base.h"
 #include "../../rewards/fd_stake_rewards.h"
 #include "../../stakes/fd_stake_types.h"
+#include "../fd_executor_err.h"
 #include "../program/fd_vote_program.h"
 #include "../program/vote/fd_vote_codec.h"
+#include "../program/vote/fd_vote_state_versioned.h"
 #include "../sysvar/fd_sysvar_epoch_rewards.h"
 #include "../sysvar/fd_sysvar_epoch_schedule.h"
 #include <stdlib.h>
@@ -1312,6 +1314,31 @@ test_get_reward_distribution_num_blocks_none( void ) {
   FD_LOG_NOTICE(( "test_get_reward_distribution_num_blocks_none: PASSED" ));
 }
 
+static void
+test_vote_state_deserialize_error_codes( void ) {
+  fd_vote_state_versioned_t vsv_uninit[1];
+  FD_TEST( fd_vote_state_versioned_new( vsv_uninit, fd_vote_state_versioned_enum_uninitialized ) );
+
+  uchar serialized[8] = {0};
+  ulong serialized_sz = fd_vote_state_versioned_serialized_size( vsv_uninit );
+  FD_TEST( serialized_sz<=sizeof(serialized) );
+  FD_TEST( !fd_vote_state_versioned_serialize( vsv_uninit, serialized, sizeof(serialized) ) );
+
+  uchar storage[ sizeof(fd_account_meta_t) + sizeof(serialized) ] = {0};
+  fd_account_meta_t * meta = (fd_account_meta_t *)storage;
+  meta->dlen = (uint)serialized_sz;
+  fd_memcpy( fd_account_data( meta ), serialized, serialized_sz );
+
+  fd_vote_state_versioned_t decoded[1];
+  FD_TEST( fd_vsv_deserialize( meta, decoded )==FD_EXECUTOR_INSTR_ERR_UNINITIALIZED_ACCOUNT );
+
+  meta->dlen = 1U;
+  fd_account_data( meta )[0] = 0U;
+  FD_TEST( fd_vsv_deserialize( meta, decoded )==FD_EXECUTOR_INSTR_ERR_INVALID_ACC_DATA );
+
+  FD_LOG_NOTICE(( "test_vote_state_deserialize_error_codes: PASSED" ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -1345,6 +1372,7 @@ main( int     argc,
   test_get_reward_distribution_num_blocks_normal();
   test_get_reward_distribution_num_blocks_warmup();
   test_get_reward_distribution_num_blocks_none();
+  test_vote_state_deserialize_error_codes();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_svm_test_halt( mini );


### PR DESCRIPTION
This adds regression tests for fd_vsv_deserialize uninitialized and malformed paths, preventing silent error-code regressions.