### PR TITLE
restore: oversized manifest tar entry

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -683,6 +683,11 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
       case FD_SSPARSE_ADVANCE_AGAIN:
         break;
       case FD_SSPARSE_ADVANCE_MANIFEST: {
+        if( FD_UNLIKELY( ctx->flags.manifest_done ) ) {
+          FD_LOG_WARNING(( "excess data after manifest" ));
+          transition_malformed( ctx, stem );
+          return 0;
+        }
         int res = fd_ssmanifest_parser_consume( ctx->manifest_parser,
                                                 result->manifest.data,
                                                 result->manifest.data_sz,

--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -1567,7 +1567,10 @@ state_process( fd_ssmanifest_parser_t * parser,
                acc_vec_t *              acc_vec_pool ) {
   fd_snapshot_manifest_t * manifest = parser->manifest;
 
-  FD_TEST( parser->state!=STATE_DONE );
+  if( FD_UNLIKELY( parser->state==STATE_DONE ) ) {
+    FD_LOG_WARNING(( "manifest parser re-entered after completion" ));
+    return -1;
+  }
 
   if( FD_UNLIKELY( parser->state==STATE_ACCOUNTS_DB_STORAGES_ACCOUNT_VECS_FILE_SZ && acc_vec_map && acc_vec_pool ) ) {
     if( FD_UNLIKELY( !acc_vec_pool_free( acc_vec_pool ) ) ) {

--- a/src/discof/restore/utils/test_ssmanifest_parser.c
+++ b/src/discof/restore/utils/test_ssmanifest_parser.c
@@ -62,7 +62,14 @@ main( int     argc,
   long ts = -fd_log_wallclock();
 
   int result = fd_ssmanifest_parser_consume( parser, buffer, size, NULL, NULL );
-  if( FD_UNLIKELY( result ) ) FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed (%d)", result ));
+  if( FD_UNLIKELY( result!=FD_SSMANIFEST_PARSER_ADVANCE_DONE ) ) FD_LOG_ERR(( "fd_ssmanifest_parser_consume failed (%d)", result ));
+
+  /* re-entering the parser after DONE must return ERROR. */
+  fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, (uint)fd_log_wallclock(), 0UL ) );
+  uchar garbage[16];
+  for( ulong i=0UL; i<sizeof(garbage); i++ ) garbage[i] = (uchar)fd_rng_uint( rng );
+  int reentry_result = fd_ssmanifest_parser_consume( parser, garbage, sizeof(garbage), NULL, NULL );
+  FD_TEST( reentry_result==FD_SSMANIFEST_PARSER_ADVANCE_ERROR );
 
   long elapsed = fd_log_wallclock() + ts;
   FD_LOG_NOTICE(( "fd_ssmanifest_parser decoded %lu bytes in %ld ms", size, elapsed/(1000L*1000L) ));


### PR DESCRIPTION
Rejecting snapshots with excess data after manifest parsing completes in the snapin tile, and replacing a fatal assertion with graceful error return in the manifest parser.

Closes https://github.com/firedancer-io/firedancer/issues/9590.