### PR TITLE
restore: http extra bytes beyond content_len

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -1309,7 +1309,8 @@ static void
 snapld_frag( fd_snapct_tile_t *  ctx,
              ulong               sig,
              ulong               sz,
-             ulong               chunk ) {
+             ulong               chunk,
+             fd_stem_context_t * stem ) {
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) {
     /* Before snapld starts sending down data fragments, it first sends
        a metadata message containing the total size of the snapshot as
@@ -1329,8 +1330,11 @@ snapld_frag( fd_snapct_tile_t *  ctx,
     fd_ssctrl_meta_t const * meta = fd_chunk_to_laddr_const( ctx->snapld_in_mem, chunk );
 
     if( FD_UNLIKELY( meta->total_sz==0UL ) ) {
-      FD_LOG_WARNING(( "received zero Content-Length metadata for %s snapshot, marking malformed", full ? "full" : "incremental" ));
-      ctx->malformed = 1;
+      if( FD_UNLIKELY( !ctx->malformed ) ) {
+        FD_LOG_WARNING(( "received zero Content-Length metadata for %s snapshot, marking malformed", full ? "full" : "incremental" ));
+        ctx->malformed = 1;
+        fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
+      }
       return;
     }
 
@@ -1383,7 +1387,9 @@ snapld_frag( fd_snapct_tile_t *  ctx,
       /* Based on previously received data frags, we expected that the
          current full / incremental snapshot was finished, but then we
          received additional data frags.  Unsafe to continue so throw
-         away the whole snapshot. */
+         away the whole snapshot.  Do not publish MSG_CTRL_ERROR here:
+         data forwarding is already complete, and the state machine
+         will publish MSG_CTRL_FAIL on the next tick. */
       if( !ctx->malformed ) {
         ctx->malformed = 1;
         FD_LOG_WARNING(( "complete snapshot loaded but read %lu extra bytes", sz ));
@@ -1404,6 +1410,7 @@ snapld_frag( fd_snapct_tile_t *  ctx,
     if( !ctx->malformed ) {
       ctx->malformed = 1;
       FD_LOG_WARNING(( "received data frag for full snapshot with zero bytes_total" ));
+      fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
     }
     return;
   }
@@ -1411,6 +1418,7 @@ snapld_frag( fd_snapct_tile_t *  ctx,
     if( !ctx->malformed ) {
       ctx->malformed = 1;
       FD_LOG_WARNING(( "received data frag for incremental snapshot with zero bytes_total" ));
+      fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
     }
     return;
   }
@@ -1444,8 +1452,9 @@ snapld_frag( fd_snapct_tile_t *  ctx,
                        full ? "full" : "incremental",
                        full ? ctx->metrics.full.bytes_total : ctx->metrics.incremental.bytes_total,
                        full ? ctx->metrics.full.bytes_read  : ctx->metrics.incremental.bytes_read ));
-
+      fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
     }
+    return;
   }
 }
 
@@ -1524,6 +1533,9 @@ ctrl_ack_frag( fd_snapct_tile_t *  ctx,
         case FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP:
         case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_FINI:
         case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_DONE:
+          /* Do not publish MSG_CTRL_ERROR: the error originated
+             downstream, so re-publishing would be redundant.
+             MSG_CTRL_FAIL follows on the next state machine tick. */
           FD_LOG_WARNING(( "received error from downstream tile while in state %s",
                            fd_snapct_state_str( ctx->state ) ));
           ctx->malformed = 1;
@@ -1546,11 +1558,11 @@ returnable_frag( fd_snapct_tile_t *  ctx,
                  ulong               ctl    FD_PARAM_UNUSED,
                  ulong               tsorig FD_PARAM_UNUSED,
                  ulong               tspub  FD_PARAM_UNUSED,
-                 fd_stem_context_t * stem   FD_PARAM_UNUSED ) {
+                 fd_stem_context_t * stem ) {
   if( FD_LIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP ) ) {
     gossip_frag( ctx, sig, sz, chunk );
   } else if( ctx->in_kind[ in_idx ]==IN_KIND_SNAPLD ) {
-    snapld_frag( ctx, sig, sz, chunk );
+    snapld_frag( ctx, sig, sz, chunk, stem );
   } else if( ctx->in_kind[ in_idx ]==IN_KIND_ACK ) {
     ctrl_ack_frag( ctx, sig );
   } else FD_LOG_ERR(( "invalid in_kind %lu %u", in_idx, (uint)ctx->in_kind[ in_idx ] ));

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -380,8 +380,14 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     offset for each slot, and stick it into the appropriate bank in
     our chain. */
 
-  if( FD_UNLIKELY( blockhashes_len>301UL ) ) FD_LOG_ERR(( "corrupt snapshot: blockhash queue length %lu exceeds maximum 301", blockhashes_len ));
-  if( FD_UNLIKELY( !blockhashes_len ) ) FD_LOG_ERR(( "corrupt snapshot: blockhash queue is empty" ));
+  if( FD_UNLIKELY( blockhashes_len>301UL ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: blockhash queue length %lu exceeds maximum 301", blockhashes_len ));
+    return 1;
+  }
+  if( FD_UNLIKELY( !blockhashes_len ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: blockhash queue is empty" ));
+    return 1;
+  }
 
   ulong seq_min = ULONG_MAX;
   for( ulong i=0UL; i<blockhashes_len; i++ ) seq_min = fd_ulong_min( seq_min, blockhashes[ i ].hash_index );
@@ -389,7 +395,6 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
   ulong seq_max;
   if( FD_UNLIKELY( __builtin_uaddl_overflow( seq_min, blockhashes_len, &seq_max ) ) ) {
     FD_LOG_WARNING(( "corrupt snapshot: blockhash queue sequence number wraparound (seq_min=%lu age_cnt=%lu)", seq_min, blockhashes_len ));
-    transition_malformed( ctx, ctx->stem );
     return 1;
   }
 
@@ -408,19 +413,16 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     ulong idx;
     if( FD_UNLIKELY( __builtin_usubl_overflow( elem->hash_index, seq_min, &idx ) ) ) {
       FD_LOG_WARNING(( "corrupt snapshot: gap in blockhash queue (seq=[%lu,%lu) idx=%lu)", seq_min, seq_max, blockhashes[ i ].hash_index ));
-      transition_malformed( ctx, ctx->stem );
       return 1;
     }
 
     if( FD_UNLIKELY( idx>=blockhashes_len ) ) {
       FD_LOG_WARNING(( "corrupt snapshot: blockhash queue index out of range (seq_min=%lu age_cnt=%lu idx=%lu)", seq_min, blockhashes_len, idx ));
-      transition_malformed( ctx, ctx->stem );
       return 1;
     }
 
     if( FD_UNLIKELY( banks[ blockhashes_len-1UL-idx ].exists ) ) {
       FD_LOG_WARNING(( "corrupt snapshot: duplicate blockhash hash_index %lu", elem->hash_index ));
-      transition_malformed( ctx, ctx->stem );
       return 1;
     }
 
@@ -447,7 +449,6 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     if( FD_UNLIKELY( blockhash_map_ele_query_const( blockhash_map, &blockhash_pool[ i ].blockhash, NULL, blockhash_pool ) ) ) {
       FD_BASE58_ENCODE_32_BYTES( banks[ i ].blockhash, blockhash_b58 );
       FD_LOG_WARNING(( "corrupt snapshot: duplicate blockhash %s in 151 most recent blockhashes", blockhash_b58 ));
-      transition_malformed( ctx, ctx->stem );
       return 1;
     }
 
@@ -455,7 +456,10 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
   }
 
   /* Now load the blockhash offsets for these blockhashes ... */
-  if( FD_UNLIKELY( !ctx->blockhash_offsets_len ) ) FD_LOG_ERR(( "corrupt snapshot: no blockhash offsets found (nothing is rooted)" ));
+  if( FD_UNLIKELY( !ctx->blockhash_offsets_len ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: no blockhash offsets found (nothing is rooted)" ));
+    return 1;
+  }
   for( ulong i=0UL; i<ctx->blockhash_offsets_len; i++ ) {
     fd_hash_t key;
     fd_memcpy( key.uc, ctx->blockhash_offsets[ i ].blockhash, 32UL );
@@ -467,7 +471,6 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     if( FD_UNLIKELY( banks[ chain_idx ].txnhash_offset!=ULONG_MAX && banks[ chain_idx ].txnhash_offset!=ctx->blockhash_offsets[ i ].txnhash_offset ) ) {
       FD_BASE58_ENCODE_32_BYTES( entry->blockhash.uc, blockhash_b58 );
       FD_LOG_WARNING(( "corrupt snapshot: conflicting txnhash offsets for blockhash %s", blockhash_b58 ));
-      transition_malformed( ctx, ctx->stem );
       return 1;
     }
 
@@ -663,7 +666,10 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
   if( FD_UNLIKELY( chunk<ctx->in.chunk0 || chunk>ctx->in.wmark || sz>ctx->in.mtu ) ) FD_LOG_ERR(( "invalid data frag bounds (chunk=%lu chunk0=%lu wmark=%lu sz=%lu mtu=%lu)", chunk, ctx->in.chunk0, ctx->in.wmark, sz, ctx->in.mtu ));
 
   if( FD_UNLIKELY( !ctx->lthash_disabled && ctx->buffered_batch.batch_cnt>0UL ) ) {
-    fd_snapin_process_account_batch( ctx, NULL, &ctx->buffered_batch );
+    if( FD_UNLIKELY( fd_snapin_process_account_batch( ctx, NULL, &ctx->buffered_batch )<0 ) ) {
+      transition_malformed( ctx, stem );
+      return 0;
+    }
     return 1;
   }
 
@@ -711,13 +717,21 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
             transition_malformed( ctx, stem );
             return 0;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) ) {
-            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) FD_LOG_ERR(( "blockhash offsets overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+            if( FD_UNLIKELY( ctx->blockhash_offsets_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) {
+              FD_LOG_WARNING(( "blockhash offsets overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
 
             memcpy( ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].blockhash, sd_result->group.blockhash, 32UL );
             ctx->blockhash_offsets[ ctx->blockhash_offsets_len ].txnhash_offset = sd_result->group.txnhash_offset;
             ctx->blockhash_offsets_len++;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) ) {
-            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) FD_LOG_ERR(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) {
+              FD_LOG_WARNING(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+              transition_malformed( ctx, stem );
+              return 0;
+            }
             ctx->txncache_entries[ ctx->txncache_entries_len++ ] = *sd_result->entry;
           }
 
@@ -730,6 +744,10 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
       }
       case FD_SSPARSE_ADVANCE_ACCOUNT_HEADER:
         early_exit = fd_snapin_process_account_header( ctx, result );
+        if( FD_UNLIKELY( early_exit<0 ) ) {
+          transition_malformed( ctx, stem );
+          return 0;
+        }
 
         if( FD_UNLIKELY( ctx->gui_out.idx!=ULONG_MAX
                       && !memcmp( result->account_header.owner, fd_solana_config_program_id.key, sizeof(fd_hash_t) )
@@ -774,6 +792,10 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
         break;
       case FD_SSPARSE_ADVANCE_ACCOUNT_BATCH:
         early_exit = fd_snapin_process_account_batch( ctx, result, NULL );
+        if( FD_UNLIKELY( early_exit<0 ) ) {
+          transition_malformed( ctx, stem );
+          return 0;
+        }
         break;
       case FD_SSPARSE_ADVANCE_DONE:
         ctx->state = FD_SNAPSHOT_STATE_FINISHING;

--- a/src/discof/restore/fd_snapin_tile_funk.c
+++ b/src/discof/restore/fd_snapin_tile_funk.c
@@ -41,7 +41,10 @@ fd_snapin_process_account_header_funk( fd_snapin_tile_t *            ctx,
     should_publish = 1;
     int err;
     rec = fd_funk_rec_prepare( funk, ctx->xid, &id, prepare, &err );
-    if( FD_UNLIKELY( !rec ) ) FD_LOG_ERR(( "failed to prepare funk record for account insertion at slot %lu (err=%d%s)", result->account_header.slot, err, err==FD_FUNK_ERR_REC ? ", increase [accounts.rec_max]" : "" ));
+    if( FD_UNLIKELY( !rec ) ) {
+      FD_LOG_WARNING(( "failed to prepare funk record for account insertion at slot %lu (err=%d%s)", result->account_header.slot, err, err==FD_FUNK_ERR_REC ? ", increase [accounts.rec_max]" : "" ));
+      return -1;
+    }
   }
 
   fd_account_meta_t * meta = fd_funk_val( rec, funk->wksp );
@@ -50,7 +53,12 @@ fd_snapin_process_account_header_funk( fd_snapin_tile_t *            ctx,
   ulong const alloc_sz = sizeof(fd_account_meta_t)+result->account_header.data_len;
   ulong       alloc_max;
   meta = fd_alloc_malloc_at_least( funk->alloc, 16UL, alloc_sz, &alloc_max );
-  if( FD_UNLIKELY( !meta ) ) FD_LOG_ERR(( "Ran out of memory while loading snapshot (increase [accounts.file_size_gib])" ));
+  if( FD_UNLIKELY( !meta ) ) {
+    /* rec is left with no value (val_gaddr=0) after val_flush above.
+       This is safe because funk is fully reset on MSG_CTRL_FAIL. */
+    FD_LOG_WARNING(( "Ran out of memory while loading snapshot (increase [accounts.file_size_gib])" ));
+    return -1;
+  }
   memset( meta, 0, sizeof(fd_account_meta_t) );
   rec->val_gaddr = fd_wksp_gaddr_fast( funk->wksp, meta );
   rec->val_max   = (uint)( fd_ulong_min( alloc_max, FD_FUNK_REC_VAL_MAX ) & FD_FUNK_REC_VAL_MAX );
@@ -87,7 +95,7 @@ fd_snapin_process_account_data_funk( fd_snapin_tile_t *            ctx,
 /* streamlined_insert inserts an unfragmented account.
    Only used while loading a full snapshot, not an incremental. */
 
-static void
+static int
 streamlined_insert( fd_snapin_tile_t * ctx,
                     fd_funk_rec_t *    rec,
                     uchar const *      frame,
@@ -99,12 +107,20 @@ streamlined_insert( fd_snapin_tile_t * ctx,
   _Bool executable = !!frame[ 0x60UL ];
 
   fd_funk_t * funk = ctx->funk;
-  if( FD_UNLIKELY( data_len > FD_RUNTIME_ACC_SZ_MAX ) ) FD_LOG_ERR(( "Found unusually large account (data_sz=%lu), aborting", data_len ));
+  if( FD_UNLIKELY( data_len > FD_RUNTIME_ACC_SZ_MAX ) ) {
+    FD_LOG_WARNING(( "Found unusually large account (data_sz=%lu), aborting", data_len ));
+    return -1;
+  }
   fd_funk_val_flush( rec, funk->alloc, funk->wksp );
   ulong const alloc_sz = sizeof(fd_account_meta_t)+data_len;
   ulong       alloc_max;
   fd_account_meta_t * meta = fd_alloc_malloc_at_least( funk->alloc, 16UL, alloc_sz, &alloc_max );
-  if( FD_UNLIKELY( !meta ) ) FD_LOG_ERR(( "Ran out of memory while loading snapshot (increase [accounts.file_size_gib])" ));
+  if( FD_UNLIKELY( !meta ) ) {
+    /* rec is left with no value (val_gaddr=0) after val_flush above.
+       This is safe because funk is fully reset on MSG_CTRL_FAIL. */
+    FD_LOG_WARNING(( "Ran out of memory while loading snapshot (increase [accounts.file_size_gib])" ));
+    return -1;
+  }
   memset( meta, 0, sizeof(fd_account_meta_t) );
   rec->val_gaddr = fd_wksp_gaddr_fast( funk->wksp, meta );
   rec->val_max   = (uint)( fd_ulong_min( alloc_max, FD_FUNK_REC_VAL_MAX ) & FD_FUNK_REC_VAL_MAX );
@@ -123,6 +139,7 @@ streamlined_insert( fd_snapin_tile_t * ctx,
 
   /* update capitalization */
   ctx->capitalization = fd_ulong_sat_add( ctx->capitalization, lamports );
+  return 0;
 }
 
 /* process_account_batch is a happy path performance optimization
@@ -197,7 +214,10 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     fd_funk_rec_t * r = rec[ i ];
     if( FD_LIKELY( !r ) ) {  /* optimize for new account */
       r = fd_funk_rec_pool_acquire( funk->rec_pool );
-      if( FD_UNLIKELY( !r ) ) FD_LOG_ERR(( "funk record pool exhausted while loading snapshot batch (increase [accounts.rec_max])" ));
+      if( FD_UNLIKELY( !r ) ) {
+        FD_LOG_WARNING(( "funk record pool exhausted while loading snapshot batch (increase [accounts.rec_max])" ));
+        return -1;
+      }
       ulong rec_idx = (ulong)( r - rec_tbl );
 
       fd_funk_txn_xid_copy( r->pair.xid, ctx->xid );
@@ -225,8 +245,11 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
       rec[ i ]         = r;
     } else {  /* existing record for key found */
       fd_account_meta_t const * existing = fd_funk_val( r, funk->wksp );
-      if( FD_UNLIKELY( !existing ) ) FD_LOG_HEXDUMP_NOTICE(( "r", r, sizeof(fd_funk_rec_t) ));
-      if( FD_UNLIKELY( !existing ) ) FD_LOG_ERR(( "corrupt funk record: existing record has no value" ));
+      if( FD_UNLIKELY( !existing ) ) {
+        FD_LOG_HEXDUMP_NOTICE(( "r", r, sizeof(fd_funk_rec_t) ));
+        FD_LOG_WARNING(( "corrupt funk record: existing record has no value" ));
+        return -1;
+      }
       if( existing->slot > slot ) {
         rec[ i ] = NULL;  /* skip record if existing value is newer */
         /* send the skipped account to the subtracting hash tile */
@@ -238,7 +261,8 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
         ctx->dup_capitalization = fd_ulong_sat_add( ctx->dup_capitalization, existing->lamports );
         fd_snapin_send_duplicate_account( ctx, existing->lamports, (uchar const *)existing + sizeof(fd_account_meta_t), existing->dlen, existing->executable, existing->owner, pubkey, 1, &early_exit );
       } else { /* slot==existing->slot */
-        FD_LOG_ERR(( "corrupt snapshot: duplicate account in same slot (slot=%lu)", slot ));
+        FD_LOG_WARNING(( "corrupt snapshot: duplicate account in same slot (slot=%lu)", slot ));
+        return -1;
       }
 
       if( FD_LIKELY( early_exit ) ) {
@@ -262,7 +286,7 @@ fd_snapin_process_account_batch_funk( fd_snapin_tile_t *            ctx,
     uchar const * frame = result ? result->account_batch.batch[ i ] : buffered_batch->batch[ i ];
     ulong slot = result ? result->account_batch.slot : buffered_batch->slot;
     if( rec[ i ] ) {
-      streamlined_insert( ctx, rec[ i ], frame, slot );
+      if( FD_UNLIKELY( streamlined_insert( ctx, rec[ i ], frame, slot ) ) ) return -1;
     }
   }
 
@@ -297,9 +321,11 @@ fd_snapin_read_account_funk( fd_snapin_tile_t *  ctx,
 
   ulong data_sz = fd_accdb_ref_data_sz( ro );
   if( FD_UNLIKELY( data_sz>data_max ) ) {
-    FD_BASE58_ENCODE_32_BYTES( acct_addr, acct_addr_b58 );
-    FD_LOG_CRIT(( "failed to read account %s: account data size (%lu bytes) exceeds buffer size (%lu bytes)",
-                  acct_addr_b58, data_sz, data_max ));
+    /* Don't copy data that doesn't fit.  Unlike the vinyl path, meta
+       fields (lamports, owner, etc.) are not yet populated here, so
+       we leave meta zeroed from the memset above (dlen==0). */
+    fd_accdb_close_ro( ctx->accdb, ro );
+    return;
   }
 
   fd_memcpy( meta->owner, fd_accdb_ref_owner( ro )->hash, sizeof(fd_pubkey_t) );

--- a/src/discof/restore/fd_snapin_tile_vinyl.c
+++ b/src/discof/restore/fd_snapin_tile_vinyl.c
@@ -34,7 +34,10 @@ fd_snapin_process_account_header_vinyl( fd_snapin_tile_t *            ctx,
   FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
   ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-  if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
+  if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) {
+    FD_LOG_WARNING(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
+    return -1;
+  }
   uchar * pair    = fd_chunk_to_laddr( ctx->hash_out.mem, ctx->hash_out.chunk );
 
   uchar * dst     = pair;
@@ -129,7 +132,10 @@ fd_snapin_process_account_batch_vinyl( fd_snapin_tile_t *            ctx,
     FD_CRIT( val_sz<=FD_VINYL_VAL_MAX, "corruption detected" );
 
     ulong   pair_sz = fd_vinyl_bstream_pair_sz( val_sz );
-    if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) FD_LOG_ERR(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
+    if( FD_UNLIKELY( pair_sz>ctx->hash_out.mtu ) ) {
+      FD_LOG_WARNING(( "account pair size (%lu) exceeds hash output MTU (%lu)", pair_sz, ctx->hash_out.mtu ));
+      return -1;
+    }
 
     uchar * dst     = pair;
     ulong   dst_rem = pair_sz;

--- a/src/discof/restore/fd_snapwm_tile.c
+++ b/src/discof/restore/fd_snapwm_tile.c
@@ -82,7 +82,10 @@ verify_slot_deltas_with_slot_history( fd_snapwm_tile_t * ctx ) {
 
   fd_account_meta_t meta;
   uchar data[ FD_SYSVAR_SLOT_HISTORY_BINCODE_SZ ];
-  fd_snapwm_vinyl_read_account( ctx, &fd_sysvar_slot_history_id, &meta, data, sizeof(data) );
+  if( FD_UNLIKELY( fd_snapwm_vinyl_read_account( ctx, &fd_sysvar_slot_history_id, &meta, data, sizeof(data) ) ) ) {
+    FD_LOG_WARNING(( "failed to read SlotHistory sysvar account" ));
+    return -1;
+  }
 
   if( FD_UNLIKELY( !meta.lamports || !meta.dlen ) ) {
     FD_LOG_WARNING(( "SlotHistory sysvar account missing or empty" ));
@@ -143,7 +146,10 @@ handle_data_frag( fd_snapwm_tile_t *  ctx,
 
   FD_TEST( chunk>=ctx->in.chunk0 && chunk<=ctx->in.wmark && acc_cnt<=FD_SNAPWM_PAIR_BATCH_CNT_MAX );
 
-  fd_snapwm_vinyl_process_account( ctx, chunk, acc_cnt, stem );
+  if( FD_UNLIKELY( fd_snapwm_vinyl_process_account( ctx, chunk, acc_cnt, stem ) ) ) {
+    transition_malformed( ctx, stem );
+    return 0;
+  }
 
   return 0;
 }

--- a/src/discof/restore/fd_snapwm_tile_private.h
+++ b/src/discof/restore/fd_snapwm_tile_private.h
@@ -196,30 +196,32 @@ void
 fd_snapwm_vinyl_shutdown( fd_snapwm_tile_t * ctx );
 
 /* fd_snapwm_vinyl_process_account reads a set of pre-generated bstream
-   pairs and decides whether to actually add then to the vinyl database.
+   pairs and decides whether to actually add them to the vinyl database.
    It supports batch mode as well as single account (pair). */
 
-void
+int
 fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
                                  ulong               chunk,
                                  ulong               acc_cnt,
                                  fd_stem_context_t * stem );
 
 /* fd_snapwm_vinyl_read_account retrieves an account from the vinyl
-   database. */
+   database.  Returns 0 on success, -1 on failure (e.g. account not
+   found, or data exceeds data_max). */
 
-void
+int
 fd_snapwm_vinyl_read_account( fd_snapwm_tile_t *  ctx,
                               void const *        acct_addr,
                               fd_account_meta_t * meta,
                               uchar *             data,
                               ulong               data_max );
 
-/* fd_snapwm_vinyl_duplicate_accounts_batch_{init,append,fini} handle
-   duplicate accounts batching when lthash computation is enabled.
+/* fd_snapwm_vinyl_duplicate_accounts_batch_{init,append,cancel,fini}
+   handle duplicate accounts batching when lthash computation is enabled.
    The batch is needed to minimize the STEM_BURST, and make the stem
    credit handling possible.  _fini is responsible for sending the
-   message downstream.
+   message downstream.  _cancel discards the accumulated batch without
+   publishing (used on error paths).
 
    Typical usage:
      fd_snapwm_vinyl_duplicate_accounts_batch_init( ctx, stem );
@@ -229,7 +231,9 @@ fd_snapwm_vinyl_read_account( fd_snapwm_tile_t *  ctx,
      }
      fd_snapwm_vinyl_duplicate_accounts_batch_fini( ctx, stem );
 
-   They all return 1 on success, and 0 otherwise.
+   _init, _append, and _fini return 1 when work was performed
+   (output link credits consumed), 0 otherwise (e.g. lthash disabled
+   or empty batch).  _cancel always returns 0 (nothing is published).
 
    IMPORTANT: there is an fseq check inside init, since every append
    modifies the output link's dcache directly.  However, there is no
@@ -242,6 +246,8 @@ int
 fd_snapwm_vinyl_duplicate_accounts_batch_append( fd_snapwm_tile_t *        ctx,
                                                  fd_vinyl_bstream_phdr_t * phdr,
                                                  ulong                     seq );
+int
+fd_snapwm_vinyl_duplicate_accounts_batch_cancel( fd_snapwm_tile_t * ctx );
 int
 fd_snapwm_vinyl_duplicate_accounts_batch_fini( fd_snapwm_tile_t *  ctx,
                                                fd_stem_context_t * stem );

--- a/src/discof/restore/fd_snapwm_tile_vinyl.c
+++ b/src/discof/restore/fd_snapwm_tile_vinyl.c
@@ -370,6 +370,9 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx ) {
       block_sz = fd_vinyl_bstream_pair_sz( val_esz );
       ulong                 memo = fd_vinyl_key_memo( meta_map->seed, &phdr.key );
       fd_vinyl_meta_ele_t * ele  = fd_vinyl_meta_prepare_nolock( meta_map, &phdr.key, memo );
+      /* Unable to recover from errors mid-commit: the meta_map is
+         partially updated and txn_cancel has no rollback mechanism
+         to restore overwritten full-snapshot entries. */
       if( FD_UNLIKELY( !ele ) ) FD_LOG_CRIT(( "fd_vinyl_meta_prepare failed (full)" ));
 
       /* Erase value if existing is newer */
@@ -383,9 +386,13 @@ fd_snapwm_vinyl_txn_commit( fd_snapwm_tile_t * ctx ) {
         }
         ctx->metrics.accounts_replaced++;
       } else {
-        if( FD_UNLIKELY( ctx->vinyl.pair_cnt++ > ctx->vinyl.pair_cnt_max ) ) {
+        /* Unable to recover from errors mid-commit: the meta_map is
+           partially updated and txn_cancel has no rollback mechanism
+           to restore overwritten full-snapshot entries. */
+        if( FD_UNLIKELY( ctx->vinyl.pair_cnt >= ctx->vinyl.pair_cnt_max ) ) {
           FD_LOG_ERR(( "failed to load snapshot: exceeded [accounts.max_accounts] (%lu)", ctx->vinyl.pair_cnt_max ));
         }
+        ctx->vinyl.pair_cnt++;
       }
 
       /* Overwrite map entry */
@@ -495,7 +502,7 @@ bstream_alloc( fd_vinyl_io_t * io,
    pre-generated bstream pairs, handles the meta_map, and determines
    whether to forward each of the accounts (pairs) to the database. */
 
-void
+int
 fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
                                  ulong               chunk,
                                  ulong               acc_cnt,
@@ -532,7 +539,11 @@ fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
     if( FD_LIKELY( do_meta_update ) ) {
       ulong memo = fd_vinyl_key_memo( map->seed, &phdr.key );
       ele = fd_vinyl_meta_prepare_nolock( map, &phdr.key, memo );
-      if( FD_UNLIKELY( !ele ) ) FD_LOG_CRIT(( "Failed to update vinyl index (full)" ));
+      if( FD_UNLIKELY( !ele ) ) {
+        FD_LOG_WARNING(( "Failed to update vinyl index (meta map exhausted)" ));
+        fd_snapwm_vinyl_duplicate_accounts_batch_cancel( ctx );
+        return -1;
+      }
 
       if( FD_UNLIKELY( fd_vinyl_meta_ele_in_use( ele ) ) ) {
         /* Drop current value if existing is newer */
@@ -547,9 +558,12 @@ fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
           ctx->metrics.accounts_replaced++;
         }
       } else {
-        if( FD_UNLIKELY( ctx->vinyl.pair_cnt++ > ctx->vinyl.pair_cnt_max ) ) {
-          FD_LOG_ERR(( "failed to load snapshot: exceeded [accounts.max_accounts] (%lu)", ctx->vinyl.pair_cnt_max ));
+        if( FD_UNLIKELY( ctx->vinyl.pair_cnt >= ctx->vinyl.pair_cnt_max ) ) {
+          FD_LOG_WARNING(( "failed to load snapshot: exceeded [accounts.max_accounts] (%lu)", ctx->vinyl.pair_cnt_max ));
+          fd_snapwm_vinyl_duplicate_accounts_batch_cancel( ctx );
+          return -1;
         }
+        ctx->vinyl.pair_cnt++;
       }
 
       fd_snapin_vinyl_pair_info_update_recovery_seq( &phdr.info, recovery_seq );
@@ -573,6 +587,7 @@ fd_snapwm_vinyl_process_account( fd_snapwm_tile_t *  ctx,
   }
 
   fd_snapwm_vinyl_duplicate_accounts_batch_fini( ctx, stem );
+  return 0;
 }
 
 void
@@ -586,7 +601,7 @@ fd_snapwm_vinyl_shutdown( fd_snapwm_tile_t * ctx ) {
   fd_vinyl_io_wd_ctrl( ctx->vinyl.io_wd, FD_SNAPSHOT_MSG_CTRL_SHUTDOWN, 0UL );
 }
 
-void
+int
 fd_snapwm_vinyl_read_account( fd_snapwm_tile_t *  ctx,
                               void const *        acct_addr,
                               fd_account_meta_t * meta,
@@ -606,7 +621,7 @@ fd_snapwm_vinyl_read_account( fd_snapwm_tile_t *  ctx,
   fd_vinyl_meta_ele_t const * ele = fd_vinyl_meta_prepare_nolock( ctx->vinyl.map, key, memo );
   if( FD_UNLIKELY( !ele || !fd_vinyl_meta_ele_in_use( ele ) ) ) {
     /* account not found */
-    return;
+    return -1;
   }
 
   uchar * mmio    = fd_vinyl_mmio   ( ctx->vinyl.io_mm );
@@ -651,14 +666,16 @@ fd_snapwm_vinyl_read_account( fd_snapwm_tile_t *  ctx,
 
   memcpy( meta, mmio+seq_meta, sizeof(fd_account_meta_t) );
   if( FD_UNLIKELY( sizeof(fd_account_meta_t)+(ulong)meta->dlen > val_esz ) ) {
-    FD_LOG_CRIT(( "corrupt bstream record: seq0=%lu val_esz=%lu dlen=%u", seq0, val_esz, meta->dlen ));
+    FD_LOG_WARNING(( "corrupt bstream record: seq0=%lu val_esz=%lu dlen=%u", seq0, val_esz, meta->dlen ));
+    return -1;
   }
   if( FD_UNLIKELY( meta->dlen > data_max ) ) {
-    FD_BASE58_ENCODE_32_BYTES( acct_addr, acct_addr_b58 );
-    FD_LOG_CRIT(( "failed to read account %s: account data size (%lu bytes) exceeds buffer size (%lu bytes)",
-                  acct_addr_b58, (ulong)meta->dlen, data_max ));
+    /* Don't copy data that doesn't fit.  Preserve meta->dlen so the
+       caller can detect the oversized account gracefully. */
+    return -1;
   }
   memcpy( data, mmio+seq_data, meta->dlen );
+  return 0;
 }
 
 /* handle_hash_out_fseq_check is a blocking operation */
@@ -701,6 +718,13 @@ fd_snapwm_vinyl_duplicate_accounts_batch_append( fd_snapwm_tile_t *        ctx,
   ctx->vinyl.duplicate_accounts_batch_sz  += FD_SNAPWM_DUP_META_SZ;
   ctx->vinyl.duplicate_accounts_batch_cnt +=1UL;
   return 1;
+}
+
+int
+fd_snapwm_vinyl_duplicate_accounts_batch_cancel( fd_snapwm_tile_t * ctx ) {
+  ctx->vinyl.duplicate_accounts_batch_sz  = 0UL;
+  ctx->vinyl.duplicate_accounts_batch_cnt = 0UL;
+  return 0;
 }
 
 int

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -610,7 +610,7 @@ read_response( fd_sshttp_t * http,
 
   http->state = FD_SSHTTP_STATE_DL;
   if( FD_UNLIKELY( (ulong)parsed<http->response_len ) ) {
-    ulong need_len = http->response_len - (ulong)parsed;
+    ulong need_len = fd_ulong_min( http->response_len - (ulong)parsed, http->content_len );
     if( FD_UNLIKELY( *data_len<need_len ) ) {
       FD_LOG_WARNING(( "data buffer too small (data_len=%lu required=%lu response_len=%lu parsed=%lu)",
                        *data_len, need_len, http->response_len, (ulong)parsed ));


### PR DESCRIPTION
HTTP Content-Length handling in `fd_sshttp` now trims the first inline body chunk to the declared `Content-Length`, preventing extra bytes from being forwarded into the snapshot restore pipeline.                                                                                                                         
`fd_snapct_tile` now sends `FD_SNAPSHOT_MSG_CTRL_ERROR` when setting `malformed` so downstream tiles are promptly notified.

Taking the opportunity to convert multiple `FD_LOG_{ERR,CRIT}` calls in `fd_snapin` and `fd_snapwm` tiles to gracefully log `FD_LOG_WARNING` + `transition_malformed`, avoiding a crash and giving the pipeline a chance to recover.

Closes https://github.com/firedancer-io/firedancer/issues/9593.
Closes https://github.com/firedancer-io/firedancer/issues/9636.

Partially addresses https://github.com/firedancer-io/firedancer/issues/9588 as well.