### PR TITLE
fuzz: correctly handle CU exhaustion for direct mapping

### DIFF
--- a/src/flamenco/runtime/tests/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/fd_harness_common.c
@@ -2,6 +2,7 @@
 #include "generated/context.pb.h"
 #include "../fd_runtime.h"
 #include "../fd_bank.h"
+#include "../fd_executor_err.h"
 #include "../fd_system_ids.h"
 #include "../../features/fd_features.h"
 #include "../../accdb/fd_accdb_sync.h"
@@ -110,4 +111,17 @@ fd_solfuzz_pb_restore_features( fd_features_t *                    features,
     fd_features_set( features, id, 0UL );
   }
   return 1;
+}
+
+void
+fd_solfuzz_direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
+                                                int                         exec_err,
+                                                fd_exec_test_acct_state_t * accounts,
+                                                pb_size_t                   accounts_cnt ) {
+  if( FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
+      && exec_err == FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED ) {
+    for( pb_size_t i=0; i<accounts_cnt; i++ ) {
+      accounts[i].data = NULL;
+    }
+  }
 }

--- a/src/flamenco/runtime/tests/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/fd_harness_common.c
@@ -2,7 +2,6 @@
 #include "generated/context.pb.h"
 #include "../fd_runtime.h"
 #include "../fd_bank.h"
-#include "../fd_executor_err.h"
 #include "../fd_system_ids.h"
 #include "../../features/fd_features.h"
 #include "../../accdb/fd_accdb_sync.h"
@@ -115,11 +114,13 @@ fd_solfuzz_pb_restore_features( fd_features_t *                    features,
 
 void
 fd_solfuzz_direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
-                                                int                         exec_err,
+                                                ulong                       cu_avail,
+                                                int                         has_err,
                                                 fd_exec_test_acct_state_t * accounts,
                                                 pb_size_t                   accounts_cnt ) {
   if( FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
-      && exec_err == FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED ) {
+      && cu_avail == 0UL
+      && has_err ) {
     for( pb_size_t i=0; i<accounts_cnt; i++ ) {
       accounts[i].data = NULL;
     }

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -361,9 +361,13 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
   effects->modified_accounts       = modified_accts;
   effects->modified_accounts_count = 0UL;
 
-  int skip_data = FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
-               && effects->cu_avail == 0UL
-               && effects->result   != 0;
+  /* Due to how Firedancer's VM CU accounting works, when
+     virtual_address_space_adjustments is enabled and the transaction
+     fails due to the CU meter being exhausted, we cannot compare the
+     data region of the accounts with Agave. */
+  int zero_acc_data = FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
+                      && effects->cu_avail == 0UL
+                      && effects->result   != 0;
 
   /* Capture borrowed accounts */
 
@@ -383,7 +387,7 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
 
     memcpy( out_acct->address, acc_key, sizeof(fd_pubkey_t) );
     out_acct->lamports = acc->lamports;
-    if( !skip_data && acc->dlen>0UL ) {
+    if( !zero_acc_data && acc->dlen>0UL ) {
       out_acct->data =
         FD_SCRATCH_ALLOC_APPEND( l, alignof(pb_bytes_array_t),
                                     PB_BYTES_ARRAY_T_ALLOCSIZE( acc->dlen ) );

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -361,14 +361,6 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
   effects->modified_accounts       = modified_accts;
   effects->modified_accounts_count = 0UL;
 
-  /* Due to how Firedancer's VM CU accounting works, when
-     virtual_address_space_adjustments is enabled and the transaction
-     fails due to the CU meter being exhausted, we cannot compare the
-     data region of the accounts with Agave. */
-  int zero_acc_data = FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
-                      && effects->cu_avail == 0UL
-                      && effects->result   != 0;
-
   /* Capture borrowed accounts */
 
   for( ulong j=0UL; j < ctx->txn_out->accounts.cnt; j++ ) {
@@ -387,7 +379,7 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
 
     memcpy( out_acct->address, acc_key, sizeof(fd_pubkey_t) );
     out_acct->lamports = acc->lamports;
-    if( !zero_acc_data && acc->dlen>0UL ) {
+    if( acc->dlen>0UL ) {
       out_acct->data =
         FD_SCRATCH_ALLOC_APPEND( l, alignof(pb_bytes_array_t),
                                     PB_BYTES_ARRAY_T_ALLOCSIZE( acc->dlen ) );
@@ -404,6 +396,10 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
 
     effects->modified_accounts_count++;
   }
+
+  fd_solfuzz_direct_mapping_handle_cu_exhaustion(
+      runner, exec_result,
+      effects->modified_accounts, (pb_size_t)effects->modified_accounts_count );
 
   /* Capture return data */
   fd_txn_return_data_t * return_data = &ctx->txn_out->details.return_data;

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -361,6 +361,10 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
   effects->modified_accounts       = modified_accts;
   effects->modified_accounts_count = 0UL;
 
+  int skip_data = FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
+               && effects->cu_avail == 0UL
+               && effects->result   != 0;
+
   /* Capture borrowed accounts */
 
   for( ulong j=0UL; j < ctx->txn_out->accounts.cnt; j++ ) {
@@ -379,7 +383,7 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
 
     memcpy( out_acct->address, acc_key, sizeof(fd_pubkey_t) );
     out_acct->lamports = acc->lamports;
-    if( acc->dlen>0UL ) {
+    if( !skip_data && acc->dlen>0UL ) {
       out_acct->data =
         FD_SCRATCH_ALLOC_APPEND( l, alignof(pb_bytes_array_t),
                                     PB_BYTES_ARRAY_T_ALLOCSIZE( acc->dlen ) );

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -398,7 +398,7 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
   }
 
   fd_solfuzz_direct_mapping_handle_cu_exhaustion(
-      runner, exec_result,
+      runner, effects->cu_avail, effects->result,
       effects->modified_accounts, (pb_size_t)effects->modified_accounts_count );
 
   /* Capture return data */

--- a/src/flamenco/runtime/tests/fd_solfuzz_private.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz_private.h
@@ -55,13 +55,14 @@ fd_solfuzz_pb_restore_features( fd_features_t *                    features,
                                 fd_exec_test_feature_set_t const * feature_set );
 
 /* Due to how Firedancer's VM CU accounting works, when
-   virtual_address_space_adjustments is enabled and the transaction
-   fails due to the CU meter being exhausted, we cannot compare the
-   data region of the accounts with Agave. This function clears the
+   virtual_address_space_adjustments is enabled and execution
+   fails with the CU meter exhausted, we cannot compare the data
+   region of the accounts with Agave. This function clears the
    data field on each captured account in this case. */
 void
 fd_solfuzz_direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
-                                                int                         exec_err,
+                                                ulong                       cu_avail,
+                                                int                         has_err,
                                                 fd_exec_test_acct_state_t * accounts,
                                                 pb_size_t                   accounts_cnt );
 

--- a/src/flamenco/runtime/tests/fd_solfuzz_private.h
+++ b/src/flamenco/runtime/tests/fd_solfuzz_private.h
@@ -54,6 +54,17 @@ int
 fd_solfuzz_pb_restore_features( fd_features_t *                    features,
                                 fd_exec_test_feature_set_t const * feature_set );
 
+/* Due to how Firedancer's VM CU accounting works, when
+   virtual_address_space_adjustments is enabled and the transaction
+   fails due to the CU meter being exhausted, we cannot compare the
+   data region of the accounts with Agave. This function clears the
+   data field on each captured account in this case. */
+void
+fd_solfuzz_direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
+                                                int                         exec_err,
+                                                fd_exec_test_acct_state_t * accounts,
+                                                pb_size_t                   accounts_cnt );
+
 typedef ulong( exec_test_run_pb_fn_t )( fd_solfuzz_runner_t *,
                                         void const *,
                                         void **,

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -310,9 +310,8 @@ fd_solfuzz_pb_txn_run( fd_solfuzz_runner_t * runner,
         exec_res
     );
 
-    int instr_exec_err = ( exec_res==FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR ) ? txn_out->err.exec_err : 0;
     fd_solfuzz_direct_mapping_handle_cu_exhaustion(
-        runner, instr_exec_err,
+        runner, txn_out->err.exec_err,
         txn_result->modified_accounts, txn_result->modified_accounts_count );
 
     txn_out->err.is_committable = 0;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -238,6 +238,24 @@ fd_solfuzz_pb_txn_serialize( uchar *                                      txn_ra
   return (ulong)(txn_raw_cur_ptr - txn_raw_begin);
 }
 
+/* Due to how Firedancer's VM CU accounting works, when
+   virtual_address_space_adjustments is enabled and the transaction
+   fails due to the CU meter being exhausted, we cannot compare the
+   data region of the accounts with Agave. */
+static void
+direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
+                                     fd_txn_out_t const *        txn_out,
+                                     int                         exec_res,
+                                     fd_exec_test_txn_result_t * txn_result ) {
+  if( FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
+      && exec_res              == FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR
+      && txn_out->err.exec_err == FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED ) {
+    for( pb_size_t i=0; i<txn_result->modified_accounts_count; i++ ) {
+      txn_result->modified_accounts[i].data = NULL;
+    }
+  }
+}
+
 void
 fd_solfuzz_txn_ctx_exec( fd_solfuzz_runner_t * runner,
                          fd_runtime_t *        runtime,
@@ -309,6 +327,8 @@ fd_solfuzz_pb_txn_run( fd_solfuzz_runner_t * runner,
         txn_out,
         exec_res
     );
+
+    direct_mapping_handle_cu_exhaustion( runner, txn_out, exec_res, txn_result );
 
     txn_out->err.is_committable = 0;
     fd_runtime_cancel_txn( runner->runtime, txn_out );

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -311,7 +311,7 @@ fd_solfuzz_pb_txn_run( fd_solfuzz_runner_t * runner,
     );
 
     fd_solfuzz_direct_mapping_handle_cu_exhaustion(
-        runner, txn_out->err.exec_err,
+        runner, txn_out->details.compute_budget.compute_meter, exec_res,
         txn_result->modified_accounts, txn_result->modified_accounts_count );
 
     txn_out->err.is_committable = 0;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -238,24 +238,6 @@ fd_solfuzz_pb_txn_serialize( uchar *                                      txn_ra
   return (ulong)(txn_raw_cur_ptr - txn_raw_begin);
 }
 
-/* Due to how Firedancer's VM CU accounting works, when
-   virtual_address_space_adjustments is enabled and the transaction
-   fails due to the CU meter being exhausted, we cannot compare the
-   data region of the accounts with Agave. */
-static void
-direct_mapping_handle_cu_exhaustion( fd_solfuzz_runner_t *       runner,
-                                     fd_txn_out_t const *        txn_out,
-                                     int                         exec_res,
-                                     fd_exec_test_txn_result_t * txn_result ) {
-  if( FD_FEATURE_ACTIVE_BANK( runner->bank, virtual_address_space_adjustments )
-      && exec_res              == FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR
-      && txn_out->err.exec_err == FD_EXECUTOR_INSTR_ERR_COMPUTE_BUDGET_EXCEEDED ) {
-    for( pb_size_t i=0; i<txn_result->modified_accounts_count; i++ ) {
-      txn_result->modified_accounts[i].data = NULL;
-    }
-  }
-}
-
 void
 fd_solfuzz_txn_ctx_exec( fd_solfuzz_runner_t * runner,
                          fd_runtime_t *        runtime,
@@ -328,7 +310,10 @@ fd_solfuzz_pb_txn_run( fd_solfuzz_runner_t * runner,
         exec_res
     );
 
-    direct_mapping_handle_cu_exhaustion( runner, txn_out, exec_res, txn_result );
+    int instr_exec_err = ( exec_res==FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR ) ? txn_out->err.exec_err : 0;
+    fd_solfuzz_direct_mapping_handle_cu_exhaustion(
+        runner, instr_exec_err,
+        txn_result->modified_accounts, txn_result->modified_accounts_count );
 
     txn_out->err.is_committable = 0;
     fd_runtime_cancel_txn( runner->runtime, txn_out );


### PR DESCRIPTION
If direct mapping is enabled, we can't compare account regions directly in the case where transactions fail due to CU exhaustion. This is because of differences in our CU accounting inside basic blocks.

Note that we only have to do this for the instruction and txn harnesses.