### PR TITLE
test: strengthen resolv and txn parser coverage

### DIFF
--- a/src/ballet/txn/test_txn_parse.c
+++ b/src/ballet/txn/test_txn_parse.c
@@ -138,6 +138,37 @@ void txn2_correctness( void ) {
 
 }
 
+void test_trailing_payload_contract( void ) {
+  fd_txn_parse_counters_t counters = {0};
+  ulong payload_sz = ULONG_MAX;
+
+  FD_TEST( transaction4_sz+1UL<=FD_TXN_MTU );
+  fd_memcpy( payload_c, transaction4, transaction4_sz );
+  payload_c[ transaction4_sz ] = (uchar)0xa5;
+
+  ulong expected_sz = fd_txn_parse( transaction4, transaction4_sz, test_buf, NULL );
+  FD_TEST( expected_sz );
+  ulong out_sz = fd_txn_parse_core( payload_c, transaction4_sz+1UL, out_buf,
+                                    &counters, &payload_sz );
+  FD_TEST( expected_sz==out_sz );
+  FD_TEST( payload_sz==transaction4_sz );
+  FD_TEST( counters.success_cnt==1UL );
+  FD_TEST( counters.failure_cnt==0UL );
+
+  FD_TEST( !fd_txn_parse( payload_c, transaction4_sz+1UL, out_buf,
+                          &counters ) );
+  FD_TEST( counters.success_cnt==1UL );
+  FD_TEST( counters.failure_cnt==1UL );
+
+  payload_sz = ULONG_MAX;
+  out_sz = fd_txn_parse_core( transaction4, transaction4_sz-1UL, out_buf,
+                              &counters, &payload_sz );
+  FD_TEST( !out_sz );
+  FD_TEST( payload_sz==ULONG_MAX );
+  FD_TEST( counters.success_cnt==1UL );
+  FD_TEST( counters.failure_cnt==2UL );
+}
+
 void test_mutate( uchar const * payload,
     ulong len ) {
   fd_txn_parse_counters_t counters = {0};
@@ -241,6 +272,7 @@ main( int     argc,
 
   txn1_correctness( );
   txn2_correctness( );
+  test_trailing_payload_contract( );
 
   test_performance( transaction1, transaction1_sz );
   test_performance( transaction2, transaction2_sz );
@@ -268,4 +300,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-

--- a/src/waltz/resolv/test_resolv.c
+++ b/src/waltz/resolv/test_resolv.c
@@ -1,15 +1,49 @@
 #define _GNU_SOURCE
 #include <sys/mman.h>
 #include <unistd.h>
+#include "fd_resolv.h"
 #include "fd_lookup.h"
 #include "../../util/fd_util.h"
 
 FD_IMPORT_BINARY( test_resolvconf, "src/waltz/resolv/test_resolvconf.txt" );
 
+static void
+test_dn_expand( void ) {
+  char name[ 256 ];
+
+  static uchar const compressed[] = {
+    3, 'w', 'w', 'w',
+    7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+    3, 'c', 'o', 'm',
+    0,
+    3, 'a', 'p', 'i',
+    0xc0, 4
+  };
+  int ret = fd_dn_expand( compressed, compressed+sizeof(compressed),
+                          compressed+17, name, (int)sizeof(name) );
+  FD_TEST( 6==ret );
+  FD_TEST( 0==strcmp( name, "api.example.com" ) );
+
+  static uchar const self_loop[] = { 0xc0, 0 };
+  FD_TEST( -1==fd_dn_expand( self_loop, self_loop+sizeof(self_loop),
+                              self_loop, name, (int)sizeof(name) ) );
+
+  static uchar const out_of_bounds[] = { 0xc0, 2 };
+  FD_TEST( -1==fd_dn_expand( out_of_bounds, out_of_bounds+sizeof(out_of_bounds),
+                              out_of_bounds, name, (int)sizeof(name) ) );
+
+  static uchar const short_name[] = { 3, 'w', 'w', 'w', 0 };
+  char short_buf[ 3 ];
+  FD_TEST( -1==fd_dn_expand( short_name, short_name+sizeof(short_name),
+                              short_name, short_buf, (int)sizeof(short_buf) ) );
+}
+
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+
+  test_dn_expand();
 
   /* Test normal resolv.conf */
 


### PR DESCRIPTION
## Summary

Adds two deterministic unit-test refinements:

- DNS `fd_dn_expand` compression, pointer-loop, pointer-bounds, and
  destination-truncation assertions in `test_resolv`.
- Transaction parser trailing-payload contract assertions in
  `test_txn_parse`.

## Why

The DNS resolver test previously covered `resolv.conf` parsing but did
not directly assert `fd_dn_expand` compression and failure boundaries.
The transaction parser already line-covered the trailing-payload path,
but did not directly assert the contract difference between
`fd_txn_parse_core(..., payload_sz_opt)` and exact `fd_txn_parse`.

## Test Coverage/Fuzz Delta

- `src/waltz/resolv/fd_dn_expand.c`: after-only targeted coverage is
  26/26 lines and 1/1 functions.  No pre-patch `test_resolv` coverage
  artifact was available.
- `src/ballet/txn/fd_txn_parse.c`: targeted coverage stayed 131/131
  lines and 1/1 functions; regions improved 462/492 to 463/492 and
  branches improved 179/236 to 180/236.
- No fuzzer or corpus files changed.  Canary detection still reports
  all `FD_FUZZ_MUST_BE_COVERED` markers live under the affected
  unit-test LCOV files.

## Validation Commands

```bash
MACHINE=linux_clang_x86_64 EXTRAS='rpath handholding' make test_resolv
build/linux/clang/x86_64/unit-test/test_resolv
MACHINE=linux_clang_x86_64 EXTRAS='rpath handholding' make test_txn_parse
build/linux/clang/x86_64/unit-test/test_txn_parse --log-level-stderr 3
build/linux/clang/x86_64/unit-test/test_resolv --page-sz normal --page-cnt 65536
build/linux/clang/x86_64/unit-test/test_txn_parse --page-sz normal --page-cnt 65536 --log-level-stderr 3
MACHINE=linux_clang_x86_64 CC=clang BUILDDIR=linux/clang/x86_64_asan_after EXTRAS='asan ubsan handholding' make -j test_resolv test_txn_parse
ASAN_OPTIONS=detect_leaks=1 build/linux/clang/x86_64_asan_after/unit-test/test_resolv
ASAN_OPTIONS=detect_leaks=1 build/linux/clang/x86_64_asan_after/unit-test/test_txn_parse --log-level-stderr 3
```

All commands exited 0 in this validation run.

## Risk

Low.  The patch changes only two existing unit-test files, adds no
corpus or fuzzer changes, does not touch production code, and requires
no privileged runtime path.

## Files Changed

- `src/waltz/resolv/test_resolv.c`
- `src/ballet/txn/test_txn_parse.c`


- Commit: `fb8506ee78be56179ddd91c67764b934847945ce`

