### PR TITLE
progcache: fix epoch slot 0 confusion

### DIFF
--- a/src/flamenco/progcache/README.md
+++ b/src/flamenco/progcache/README.md
@@ -132,7 +132,7 @@ Each record access considers the following slot numbers:
 - **epoch_slot0**: the first slot of the epoch of load_slot
 - **deploy_slot**: the most recent slot in which the program was
   deployed or retracted, as of load_slot
-- **revision_slot**: derived from the above three (`>=deploy_slot`,
+- **revision_key**: derived from the above three (`>=deploy_slot`,
   `>=epoch_slot0`)
 
 ### Record life cycle

--- a/src/flamenco/progcache/fd_progcache_rec.h
+++ b/src/flamenco/progcache/fd_progcache_rec.h
@@ -17,9 +17,7 @@
 struct __attribute__((aligned(64))) fd_progcache_rec {
   fd_funk_xid_key_pair_t pair;  /* Transaction id and record key pair */
 
-  /* Slot number at which this cache entry was created.
-     Matches the XID's slot number for in-preparation transactions. */
-  ulong slot;
+  ulong revision_key;
 
   uint        map_next;  /* Internal use by map */
   atomic_uint txn_idx;

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -116,7 +116,7 @@ static int
 fd_progcache_search_chain( fd_progcache_t const *    cache,
                            ulong                     chain_idx,
                            fd_funk_rec_key_t const * key,
-                           ulong                     revision_slot,
+                           ulong                     revision_key,
                            fd_progcache_rec_t **     out_rec ) { /* read locked */
   *out_rec = NULL;
 
@@ -149,7 +149,7 @@ fd_progcache_search_chain( fd_progcache_t const *    cache,
     if( FD_UNLIKELY( !fd_funk_rec_key_eq( rec->pair.key, key ) ) ) continue;
 
     /* Skip over other revisions */
-    if( FD_UNLIKELY( rec->slot!=revision_slot ) ) continue;
+    if( FD_UNLIKELY( rec->revision_key != revision_key ) ) continue;
     fd_xid_t rec_xid[1];
     fd_funk_txn_xid_ld_atomic( rec_xid, rec->pair.xid );
     if( FD_UNLIKELY( !fd_accdb_lineage_has_xid( lineage, rec_xid ) ) ) continue;
@@ -177,9 +177,9 @@ fd_progcache_search_chain( fd_progcache_t const *    cache,
 
 static fd_progcache_rec_t * /* read locked */
 fd_progcache_query( fd_progcache_t *          cache,
-                    fd_xid_t const * xid,
+                    fd_xid_t const *          xid,
                     fd_funk_rec_key_t const * key,
-                    ulong                     revision_slot ) {
+                    ulong                     revision_key ) {
   /* Hash key to chain */
   fd_funk_xid_key_pair_t pair[1];
   fd_funk_txn_xid_copy( pair->xid, xid );
@@ -191,7 +191,7 @@ fd_progcache_query( fd_progcache_t *          cache,
   /* Traverse chain for candidate */
   fd_progcache_rec_t * rec = NULL;
   for(;;) {
-    int err = fd_progcache_search_chain( cache, chain_idx, key, revision_slot, &rec );
+    int err = fd_progcache_search_chain( cache, chain_idx, key, revision_key, &rec );
     if( FD_LIKELY( err==FD_MAP_SUCCESS ) ) break;
     fd_racesan_hook( "prog_query:retry" );
     FD_SPIN_PAUSE();
@@ -205,11 +205,11 @@ fd_progcache_rec_t * /* read locked */
 fd_progcache_peek( fd_progcache_t    * cache,
                    fd_xid_t    const * xid,
                    fd_pubkey_t const * prog_addr,
-                   ulong               revision_slot ) {
+                   ulong               revision_key ) {
   if( FD_UNLIKELY( !cache || !cache->join->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
   fd_progcache_load_fork( cache, xid );
   fd_funk_rec_key_t key[1]; fd_memcpy( key->uc, prog_addr->hash, 32UL );
-  fd_progcache_rec_t * rec = fd_progcache_query( cache, xid, key, revision_slot );
+  fd_progcache_rec_t * rec = fd_progcache_query( cache, xid, key, revision_key );
   if( FD_UNLIKELY( !rec ) ) return NULL;
   return rec;
 }
@@ -245,7 +245,7 @@ fd_progcache_push( fd_progcache_join_t * cache,
                    fd_progcache_txn_t *  txn, /* read locked */
                    fd_progcache_rec_t *  rec,
                    void const *          prog_addr,
-                   ulong                 revision_slot ) {
+                   ulong                 revision_key ) {
 
   /* Determine record's xid-key pair */
 
@@ -279,7 +279,7 @@ fd_progcache_push( fd_progcache_join_t * cache,
   if( FD_UNLIKELY( query_err==FD_MAP_SUCCESS ) ) {
     /* Always replace existing rooted records */
     fd_progcache_rec_t * prev_rec = query->ele;
-    if( fd_funk_txn_xid_eq_root( rec->pair.xid ) && prev_rec->slot < revision_slot ) {
+    if( fd_funk_txn_xid_eq_root( rec->pair.xid ) && prev_rec->revision_key < revision_key ) {
       fd_rwlock_write( &prev_rec->lock );
       fd_prog_recm_txn_remove( cache->rec.map, &rec->pair, NULL, query, FD_MAP_FLAG_USE_HINT );
       fd_progcache_val_free( prev_rec, cache );
@@ -340,7 +340,7 @@ fd_progcache_push( fd_progcache_join_t * cache,
 
 struct insert_params {
   void const *            prog_addr;
-  ulong                   revision_slot;
+  ulong                   revision_key;
   fd_sbpf_elf_info_t      elf_info;
   fd_sbpf_loader_config_t config;
   fd_features_t const *   features;
@@ -361,9 +361,9 @@ insert_params( insert_params_t *          p,
   memset( p, 0, sizeof(insert_params_t) );
 
   /* Derive executable info */
-  uchar const * bin           = (uchar const *)fd_accdb_ref_data_const( prog_ro ) + info->elf_off;
-  ulong         bin_sz        = info->elf_sz;
-  ulong         revision_slot = fd_progcache_revision_slot( env->epoch_slot0, info->deploy_slot );
+  uchar const * bin          = (uchar const *)fd_accdb_ref_data_const( prog_ro ) + info->elf_off;
+  ulong         bin_sz       = info->elf_sz;
+  ulong         revision_key = fd_progcache_revision_key( env->epoch_slot0, info->deploy_slot );
 
   /* Pre-flight checks, determine required buffer size */
 
@@ -378,14 +378,14 @@ insert_params( insert_params_t *          p,
   int peek_err = fd_sbpf_elf_peek( &elf_info, bin, bin_sz, &config );
 
   *p = (insert_params_t) {
-    .prog_addr     = prog_addr,
-    .revision_slot = revision_slot,
-    .features      = features,
-    .bin           = !peek_err ? bin    : NULL,
-    .bin_sz        = !peek_err ? bin_sz : 0UL,
-    .peek_err      = peek_err,
-    .elf_info      = elf_info,
-    .config        = config
+    .prog_addr    = prog_addr,
+    .revision_key = revision_key,
+    .features     = features,
+    .bin          = !peek_err ? bin    : NULL,
+    .bin_sz       = !peek_err ? bin_sz : 0UL,
+    .peek_err     = peek_err,
+    .elf_info     = elf_info,
+    .config       = config
   };
   return p;
 }
@@ -412,9 +412,9 @@ fd_progcache_spill_open( fd_progcache_t *        cache,
   shmem->spill.spad_off[ rec_idx ] = shmem->spill.spad_used;
   fd_progcache_rec_t * rec = &shmem->spill.rec[ rec_idx ];
   memset( rec, 0, sizeof(fd_progcache_rec_t) );
-  rec->lock.value = 1; /* read lock; no concurrency, don't need CAS */
-  rec->exists     = 1;
-  rec->slot       = params->revision_slot;
+  rec->lock.value   = 1; /* read lock; no concurrency, don't need CAS */
+  rec->exists       = 1;
+  rec->revision_key = params->revision_key;
 
   /* Load program */
 
@@ -427,8 +427,9 @@ fd_progcache_spill_open( fd_progcache_t *        cache,
     rec->data_gaddr = fd_wksp_gaddr_fast( join->data_base, shmem->spill.spad + off0 );
     rec->data_max   = (uint)( off1 - off0 );
 
+    ulong load_slot = fd_progcache_revision_key_slot( params->revision_key );
     long dt = -fd_tickcount();
-    if( FD_LIKELY( fd_progcache_rec_load( rec, join->data_base, &params->elf_info, &params->config, params->revision_slot, params->features, params->bin, params->bin_sz, cache->scratch, cache->scratch_sz ) ) ) {
+    if( FD_LIKELY( fd_progcache_rec_load( rec, join->data_base, &params->elf_info, &params->config, load_slot, params->features, params->bin, params->bin_sz, cache->scratch, cache->scratch_sz ) ) ) {
       /* Valid program, allocate data */
       shmem->spill.spad_used = (uint)off1;
     } else {
@@ -464,7 +465,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
   int                             peek_err      = params->peek_err;
   fd_sbpf_elf_info_t const *      elf_info      = &params->elf_info;
   fd_sbpf_loader_config_t const * config        = &params->config;
-  ulong                           revision_slot = params->revision_slot;
+  ulong                           revision_key  = params->revision_key;
   fd_features_t const *           features      = params->features;
   uchar const *                   bin           = params->bin;
   ulong                           bin_sz        = params->bin_sz;
@@ -484,7 +485,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
   }
   memset( rec, 0, sizeof(fd_progcache_rec_t) );
   rec->exists       = 1;
-  rec->slot         = revision_slot;
+  rec->revision_key = revision_key;
   rec->txn_idx      = UINT_MAX;
   rec->reclaim_next = UINT_MAX;
 
@@ -512,12 +513,13 @@ fd_progcache_insert( fd_progcache_t *        cache,
      yet visible to other threads. */
   fd_rwlock_write( &rec->lock );
   fd_racesan_hook( "prog_insert:pre_push" );
+  ulong revision_slot = fd_progcache_revision_key_slot( revision_key );
   fd_xid_t const * xid = fd_lineage_xid( cache->lineage, revision_slot );
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
   fd_progcache_txn_t * txn = NULL;
   if( xid ) txn = (fd_progcache_txn_t *)fd_prog_txnm_ele_query_const( ljoin->txn.map, xid, NULL, ljoin->txn.pool );
   if( txn ) fd_rwlock_write( &txn->lock );
-  int push_ok = fd_progcache_push( ljoin, txn, rec, prog_addr, revision_slot );
+  int push_ok = fd_progcache_push( ljoin, txn, rec, prog_addr, revision_key );
   if( txn ) fd_rwlock_unwrite( &txn->lock );
   if( FD_UNLIKELY( !push_ok ) ) {
     fd_rwlock_unread( &ljoin->shmem->txn.rwlock );
@@ -567,12 +569,12 @@ fd_progcache_pull( fd_progcache_t           * cache,
 
   fd_prog_info_t info[1];
   if( FD_UNLIKELY( !fd_prog_info( info, prog_ro, program_owner ) ) ) return NULL;
-  ulong revision_slot = fd_progcache_revision_slot( env->epoch_slot0, info->deploy_slot );
+  ulong revision_key = fd_progcache_revision_key( env->epoch_slot0, info->deploy_slot );
 
   insert_params_t insert[1];
   fd_progcache_rec_t * found_rec = NULL;
   for( int attempt=0;; attempt++ ) {
-    found_rec = fd_progcache_peek( cache, xid, prog_addr, revision_slot );
+    found_rec = fd_progcache_peek( cache, xid, prog_addr, revision_key );
     if( FD_LIKELY( found_rec ) ) {
       cache->metrics->hit_cnt++;
       break;

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -134,15 +134,25 @@ void *
 fd_progcache_leave( fd_progcache_t *        cache,
                     fd_progcache_shmem_t ** opt_shmem );
 
-/* fd_progcache_revision_slot returns the slot number under which a
-   progcache entry is indexed at.  epoch_slot0 is the first slot number
-   of the epoch.  deploy_slot is the slot at which the program was
-   deployed using the program loader. */
+/* fd_progcache_revision_key returns the search key of a progcache
+   entry.  The 63 upper bits are the effective slot of the entry.  The
+   LSB is 1 if this revision was created by a redeploy, and 0 if it was
+   created by a cache invalidation.  epoch_slot0 is the first slot
+   number of the epoch.  deploy_slot is the slot at which the program
+   was deployed using the program loader. */
 
 static inline ulong
-fd_progcache_revision_slot( ulong epoch_slot0,
-                            ulong deploy_slot ) {
-  return fd_ulong_max( epoch_slot0, deploy_slot );
+fd_progcache_revision_key( ulong epoch_slot0,
+                           ulong deploy_slot ) {
+  if( FD_UNLIKELY( deploy_slot < epoch_slot0 ) ) {
+    return epoch_slot0<<1;
+  }
+  return (deploy_slot<<1) | 1;
+}
+
+static inline ulong
+fd_progcache_revision_key_slot( ulong revision_key ) {
+  return revision_key>>1;
 }
 
 /* fd_progcache_peek queries the program cache for an existing cache
@@ -155,7 +165,7 @@ fd_progcache_rec_t * /* read locked */
 fd_progcache_peek( fd_progcache_t    * cache,
                    fd_xid_t    const * xid,
                    fd_pubkey_t const * prog_addr,
-                   ulong               revision_slot );
+                   ulong               revision_key );
 
 /* fd_progcache_pull loads a program from cache, filling the cache if
    necessary.  The load operation can have a number of outcomes:

--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -6,7 +6,6 @@
 #include "../runtime/fd_system_ids.h"
 #include "../runtime/program/fd_bpf_loader_program.h"
 #include "../features/fd_features.h"
-#include "../types/fd_types.h"
 #include <stdlib.h>
 #include <regex.h>
 
@@ -113,20 +112,33 @@ query_rec_exact( test_env_t *           env,
    safe in single-threaded tests where record lifetimes are managed
    by cancel/publish/destroy. */
 
-static fd_progcache_rec_t    *
-test_peek( fd_progcache_t    * cache,
-           fd_xid_t    const * xid,
-           fd_pubkey_t const * prog_addr,
-           ulong               epoch_slot0 ) {
-  fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, epoch_slot0 );
+static fd_progcache_rec_t *
+test_peek1( fd_progcache_t *    cache,
+            fd_xid_t const *    xid,
+            fd_pubkey_t const * prog_addr,
+            ulong               epoch_slot0,
+            ulong               deploy_slot ) {
+  ulong key = fd_progcache_revision_key( epoch_slot0, deploy_slot );
+  fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, key );
   if( rec ) fd_progcache_rec_close( cache, rec );
   return rec;
 }
 
-static fd_progcache_rec_t    *
-test_pull( fd_progcache_t    *        cache,
-           fd_accdb_ro_t     *        prog_ro,
-           fd_xid_t    const *        xid,
+static fd_progcache_rec_t *
+test_peek( fd_progcache_t *    cache,
+           fd_xid_t const *    xid,
+           fd_pubkey_t const * prog_addr,
+           ulong               epoch_slot0 ) {
+  ulong key = fd_progcache_revision_key( epoch_slot0, 0UL );
+  fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, key );
+  if( rec ) fd_progcache_rec_close( cache, rec );
+  return rec;
+}
+
+static fd_progcache_rec_t *
+test_pull( fd_progcache_t *           cache,
+           fd_accdb_ro_t *            prog_ro,
+           fd_xid_t const *           xid,
            fd_pubkey_t const *        prog_addr,
            fd_prog_load_env_t const * env ) {
   fd_progcache_rec_t * rec = fd_progcache_pull( cache, xid, prog_addr, env, prog_ro, fd_accdb_ref_owner( prog_ro ) );
@@ -290,6 +302,70 @@ test_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_destroy( env );
 }
 
+static void
+test_epoch_boundary2( fd_wksp_t * wksp ) {
+  test_env_t * env = test_env_create( wksp );
+  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  test_env_txn_prepare( env, NULL, &fork_a );
+
+  fd_pubkey_t prog_key       = test_key( 1UL );
+  fd_pubkey_t prog0_data_key = test_key( 2UL );
+  fd_pubkey_t prog1_data_key = test_key( 4UL );
+
+  test_account_t prog0;      static uchar prog0_buf     [ 4096  ];
+  test_account_t prog0_data; static uchar prog0_data_buf[ 50000 ];
+  test_account_t prog1;      static uchar prog1_buf     [ 4096  ];
+  test_account_t prog1_data; static uchar prog1_data_buf[ 50000 ];
+
+  /* Invoke old program at epoch 0 */
+  test_account_init_v3( &prog0, prog0_buf, sizeof(prog0_buf), &prog_key, &prog0_data_key );
+  test_account_init_v3_data(
+      &prog0_data,
+      prog0_data_buf, sizeof(prog0_data_buf),
+      &prog0_data_key,
+      valid_program_data, valid_program_data_sz,
+      1UL
+  );
+  fd_prog_load_env_t load_env = {
+    .features    = env->features,
+    .epoch       = 0UL,
+    .epoch_slot0 = 0UL
+  };
+  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, prog0_data.ro, &fork_a, &prog_key, &load_env );
+  FD_TEST( rec1 );
+  FD_TEST( test_peek1( env->progcache, &fork_a, &prog_key, 0UL, 1UL )==rec1 );
+
+  /* Invoke old program at epoch 1 */
+  fd_prog_load_env_t load_env2 = {
+    .features    = env->features,
+    .epoch       = 1UL,
+    .epoch_slot0 = 64UL,
+  };
+  fd_xid_t fork_b = { .ul = { 64UL, 2UL } };
+  test_env_txn_prepare( env, &fork_a, &fork_b );
+  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, prog0_data.ro, &fork_b, &prog_key, &load_env2 );
+  FD_TEST( rec1!=rec2 );
+
+  /* Invoke new (redeployed) program at epoch1 */
+  test_account_init_v3( &prog1, prog1_buf, sizeof(prog1_buf), &prog_key, &prog1_data_key );
+  test_account_init_v3_data(
+      &prog1_data,
+      prog1_data_buf, sizeof(prog1_data_buf),
+      &prog1_data_key,
+      bigger_valid_program_data, bigger_valid_program_data_sz,
+      64UL
+  );
+  fd_xid_t fork_c = { .ul = { 65UL, 2UL } };
+  test_env_txn_prepare( env, &fork_b, &fork_c );
+  fd_progcache_rec_t const * rec3 = test_pull( env->progcache, prog1_data.ro, &fork_c, &prog_key, &load_env2 );
+  FD_TEST( rec3!=rec1 && rec3!=rec2 );
+
+  test_env_txn_cancel( env, &fork_c );
+  test_env_txn_cancel( env, &fork_b );
+  test_env_txn_cancel( env, &fork_a );
+  test_env_destroy( env );
+}
+
 /* test_publish_gc: fd_progcache_txn_publish should garbage-collect
    stale entries. */
 
@@ -419,7 +495,7 @@ test_root_nonroot_prio( fd_wksp_t * wksp ) {
   };
   fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_1, &key, &load_env1 );
   FD_TEST( rec1 );
-  FD_TEST( rec1->slot==1UL );
+  FD_TEST( fd_progcache_revision_key_slot( rec1->revision_key )==1UL );
 
   fd_prog_load_env_t load_env4 = {
     .features    = env->features,
@@ -428,7 +504,7 @@ test_root_nonroot_prio( fd_wksp_t * wksp ) {
   };
   fd_progcache_rec_t const * rec4 = test_pull( env->progcache, acc.ro, &fork_4, &key, &load_env4 );
   FD_TEST( rec4 );
-  FD_TEST( rec4->slot==4UL );
+  FD_TEST( fd_progcache_revision_key_slot( rec4->revision_key )==4UL );
 
   test_env_txn_cancel( env, &fork_4 );
   test_env_txn_cancel( env, &fork_3 );
@@ -552,7 +628,7 @@ test_reclaim_active_reader( fd_wksp_t * wksp ) {
   };
   FD_TEST( test_pull( env->progcache, acc.ro, &xid, &key, &load_env ) );
 
-  fd_progcache_rec_t * rec = fd_progcache_peek( env->progcache, &xid, &key, 0UL );
+  fd_progcache_rec_t * rec = fd_progcache_peek( env->progcache, &xid, &key, fd_progcache_revision_key( 0UL, 0UL ) );
   FD_TEST( rec );
 
   fd_prog_delete_rec( env->progcache->join, rec );
@@ -713,9 +789,9 @@ test_reclaim_mixed( fd_wksp_t * wksp ) {
   FD_TEST( test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env ) );
   FD_TEST( test_pull( env->progcache, acc2.ro, &xid, &key2, &load_env ) );
 
-  fd_progcache_rec_t * rec1 = fd_progcache_peek( env->progcache, &xid, &key1, 0UL );
+  fd_progcache_rec_t * rec1 = fd_progcache_peek( env->progcache, &xid, &key1, fd_progcache_revision_key( 0UL, 0UL ) );
   FD_TEST( rec1 );
-  fd_progcache_rec_t * rec2 = fd_progcache_peek( env->progcache, &xid, &key2, 0UL );
+  fd_progcache_rec_t * rec2 = fd_progcache_peek( env->progcache, &xid, &key2, fd_progcache_revision_key( 0UL, 0UL ) );
   FD_TEST( rec2 );
   fd_progcache_rec_close( env->progcache, rec2 );
 
@@ -737,31 +813,19 @@ test_reclaim_mixed( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_ok( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_xid_t fork_a = { .ul = { 42UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
-  ulong data_sz = PROGRAMDATA_METADATA_SIZE + valid_program_data_sz;
-  uchar data[ PROGRAMDATA_METADATA_SIZE + 655536 ];
-  FD_TEST( data_sz<=sizeof(data) );
-
-  fd_bpf_state_t state = {
-    .discriminant = FD_BPF_STATE_PROGRAM_DATA,
-    .inner = {
-      .program_data = {
-        .slot = 42UL,
-        .has_upgrade_authority_address = 0,
-        .upgrade_authority_address = {{0}}
-      }
-    }
-  };
-  ulong out_sz = 0UL;
-  FD_TEST( !fd_bpf_state_encode( &state, data, PROGRAMDATA_METADATA_SIZE, &out_sz ) );
-  fd_memcpy( data+PROGRAMDATA_METADATA_SIZE, valid_program_data, valid_program_data_sz );
-
+  uchar buf[ 655536 ];
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
-  test_account_init( &acc, &key, &fd_solana_bpf_loader_upgradeable_program_id,
-                     1, data, data_sz );
+  test_account_init_v3_data(
+      &acc,
+      buf, sizeof(buf),
+      &key,
+      valid_program_data, valid_program_data_sz,
+      42UL
+  );
 
   fd_prog_load_env_t load_env = {
     .features    = env->features,
@@ -772,7 +836,7 @@ test_loader_v3_ok( fd_wksp_t * wksp ) {
   FD_TEST( rec );
   FD_TEST( rec->data_gaddr );
 
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 42UL )==rec );
+  FD_TEST( test_peek1( env->progcache, &fork_a, &key, 0UL, 42UL )==rec );
   FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL ) );
 
   test_env_txn_cancel( env, &fork_a );
@@ -872,28 +936,16 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
-  ulong data_sz = PROGRAMDATA_METADATA_SIZE + valid_program_data_sz;
-  uchar data[ PROGRAMDATA_METADATA_SIZE + 1048576 ];
-  FD_TEST( data_sz<=sizeof(data) );
-
-  fd_bpf_state_t state = {
-    .discriminant = FD_BPF_STATE_PROGRAM_DATA,
-    .inner = {
-      .program_data = {
-        .slot = 42UL,
-        .has_upgrade_authority_address = 0,
-        .upgrade_authority_address = {{0}}
-      }
-    }
-  };
-  ulong out_sz = 0UL;
-  FD_TEST( !fd_bpf_state_encode( &state, data, PROGRAMDATA_METADATA_SIZE, &out_sz ) );
-  fd_memcpy( data+PROGRAMDATA_METADATA_SIZE, valid_program_data, valid_program_data_sz );
-
+  uchar buf[ 655536 ];
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
-  test_account_init( &acc, &key, &fd_solana_bpf_loader_upgradeable_program_id,
-                     1, data, data_sz );
+  test_account_init_v3_data(
+      &acc,
+      buf, sizeof(buf),
+      &key,
+      valid_program_data, valid_program_data_sz,
+      42UL
+  );
 
   fd_prog_load_env_t load_env = {
     .features    = env->features,
@@ -903,7 +955,7 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
   FD_TEST( rec1 );
   FD_TEST( rec1->data_gaddr );
-  FD_TEST( rec1->slot==42UL );
+  FD_TEST( fd_progcache_revision_key_slot( rec1->revision_key )==42UL );
 
   fd_xid_t fork_b = { .ul = { 100UL, 2UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
@@ -913,12 +965,12 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, &fork_b, &key, &load_env );
   FD_TEST( rec2 );
   FD_TEST( rec2->data_gaddr );
-  FD_TEST( rec2->slot==100UL );
+  FD_TEST( fd_progcache_revision_key_slot( rec2->revision_key )==100UL );
   FD_TEST( rec1!=rec2 );
 
-  FD_TEST( test_peek( env->progcache, &fork_a, &key,  42UL )==rec1 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 100UL )==rec2 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 42UL )==rec1 );
+  FD_TEST( test_peek1( env->progcache, &fork_a, &key,   0UL, 42UL )==rec1 );
+  FD_TEST( test_peek1( env->progcache, &fork_b, &key, 100UL, 42UL )==rec2 );
+  FD_TEST( test_peek1( env->progcache, &fork_b, &key,   0UL, 42UL )==rec1 );
 
   test_env_txn_cancel( env, &fork_b );
   test_env_txn_cancel( env, &fork_a );
@@ -1165,6 +1217,7 @@ main( int     argc,
     TEST( test_invalid_program ),
     TEST( test_valid_program ),
     TEST( test_epoch_boundary ),
+    TEST( test_epoch_boundary2 ),
     TEST( test_publish_gc ),
     TEST( test_publish_trivial ),
     TEST( test_root_nonroot_prio ),

--- a/src/flamenco/progcache/test_progcache_common.c
+++ b/src/flamenco/progcache/test_progcache_common.c
@@ -1,6 +1,8 @@
 
 #include "fd_progcache_admin.h"
 #include "fd_progcache_user.h"
+#include "../runtime/fd_system_ids.h"
+#include "../runtime/program/fd_bpf_loader_program.h"
 
 FD_FN_UNUSED static fd_pubkey_t
 test_key( ulong x ) {
@@ -28,6 +30,63 @@ test_account_init( test_account_t * acc,
   acc->meta->dlen       = (uint)data_sz;
   acc->meta->executable = executable;
   fd_accdb_ro_init_nodb_oob( acc->ro, address, acc->meta, data );
+  return acc;
+}
+
+FD_FN_UNUSED static test_account_t *
+test_account_init_v3( test_account_t * acc,
+                      uchar *          buf,
+                      ulong            buf_max,
+                      void const *     address,
+                      void const *     progdata_address ) {
+
+  struct __attribute__((packed)) {
+    uint        kind;
+    fd_pubkey_t progdata_address;
+  } v3_state = {
+    .kind             = FD_BPF_STATE_PROGRAM,
+    .progdata_address = FD_LOAD( fd_pubkey_t, progdata_address )
+  };
+  FD_TEST( buf_max>=sizeof(v3_state) );
+  fd_memcpy( buf, &v3_state, sizeof(v3_state) );
+
+  memcpy( acc->meta->owner, &fd_solana_bpf_loader_upgradeable_program_id, 32 );
+  acc->meta->lamports   = 42UL;
+  acc->meta->slot       = 0UL;
+  acc->meta->dlen       = (uint)sizeof(v3_state);
+  acc->meta->executable = 1;
+  fd_accdb_ro_init_nodb_oob( acc->ro, address, acc->meta, buf );
+  return acc;
+}
+
+FD_FN_UNUSED static test_account_t *
+test_account_init_v3_data( test_account_t * acc,
+                           uchar *          buf,
+                           ulong            buf_max,
+                           void const *     address,
+                           void const *     data,
+                           ulong            data_sz,
+                           ulong            slot ) {
+  struct __attribute__((packed)) {
+    uint  kind;
+    ulong slot;
+    uchar has_upgrade_authority;
+  } v3_state = {
+    .kind                  = FD_BPF_STATE_PROGRAM_DATA,
+    .slot                  = slot,
+    .has_upgrade_authority = 0
+  };
+  FD_TEST( buf_max>=PROGRAMDATA_METADATA_SIZE+data_sz );
+  fd_memset( buf, 0, PROGRAMDATA_METADATA_SIZE );
+  fd_memcpy( buf, &v3_state, sizeof(v3_state) );
+  fd_memcpy( buf+PROGRAMDATA_METADATA_SIZE, data, data_sz );
+
+  memcpy( acc->meta->owner, &fd_solana_bpf_loader_upgradeable_program_id, 32 );
+  acc->meta->lamports   = 42UL;
+  acc->meta->slot       = slot;
+  acc->meta->dlen       = (uint)(PROGRAMDATA_METADATA_SIZE+data_sz);
+  acc->meta->executable = 0;
+  fd_accdb_ro_init_nodb_oob( acc->ro, address, acc->meta, buf );
   return acc;
 }
 

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -47,7 +47,7 @@ struct fiber {
       fd_progcache_t * cache;
       fd_xid_t         xid;
       fd_pubkey_t      prog_addr;
-      ulong            revision_slot;
+      ulong            revision_key;
     } peek;
 
     struct {
@@ -108,7 +108,7 @@ static void
 fiber_peek_exec( void * _ctx ) {
   fiber_t * f = _ctx;
   fd_progcache_rec_t * res = fd_progcache_peek(
-      f->peek.cache, &f->peek.xid, &f->peek.prog_addr, f->peek.revision_slot );
+      f->peek.cache, &f->peek.xid, &f->peek.prog_addr, f->peek.revision_key );
   if( res ) fd_progcache_rec_close( f->peek.cache, res );
 }
 
@@ -116,13 +116,12 @@ static fd_racesan_async_t *
 fiber_peek( fiber_t *        fiber,
             void *           shmem,
             fd_xid_t const * xid,
-            void const *     prog_addr,
-            ulong            revision_slot ) {
+            void const *     prog_addr ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->peek.cache     = fiber->cache;
   fiber->peek.xid       = *xid;
   fiber->peek.prog_addr = FD_LOAD( fd_pubkey_t, prog_addr );
-  fiber->peek.revision_slot = revision_slot;
+  fiber->peek.revision_key = fd_progcache_revision_key( 1UL, 0UL );
   fd_racesan_async_new( fiber->async, fiber->stack+FIBER_STACK_MAX, FIBER_STACK_MAX, fiber_peek_exec, fiber );
   return fiber->async;
 }
@@ -293,7 +292,7 @@ test_pull_peek( fd_wksp_t * wksp ) {
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
     fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, &xid, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -345,7 +344,8 @@ test_pull_root( fd_wksp_t * wksp ) {
     FD_TEST( fd_progcache_metrics_default.hit_cnt   ==0UL );
     FD_TEST( fd_progcache_metrics_default.miss_cnt  ==1UL );
     if( !fd_progcache_admin_metrics_g.root_cnt ) {
-      fd_progcache_rec_t * rec = fd_progcache_peek( g_fiber[ 0 ].cache, &xid1, &key, 0UL );
+      fd_progcache_rec_t * rec = fd_progcache_peek( g_fiber[ 0 ].cache, &xid1, &key, fd_progcache_revision_key( 0UL, 0UL ) );
+      FD_TEST( rec );
       FD_TEST( rec->txn_idx==UINT_MAX );
       FD_TEST( rec->next_idx==UINT_MAX );
       FD_TEST( rec->prev_idx==UINT_MAX );
@@ -399,7 +399,7 @@ test_cancel_peek( fd_wksp_t * wksp ) {
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
     fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 0 ], shmem, &xid1 ) );
-    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 1 ], shmem, &xid0, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 1 ], shmem, &xid0, &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -489,7 +489,7 @@ test_pull_root_peek( fd_wksp_t * wksp ) {
     fd_racesan_weave_new( w );
     fd_racesan_weave_add( w, fiber_pull(         &g_fiber[ 0 ], shmem, &xid1, &key, &load_env, acc.ro ) );
     fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 2 ], shmem, &xid1, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 2 ], shmem, &xid1, &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -540,7 +540,7 @@ test_peek_root( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key ) );
     fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
 
     metrics_reset();
@@ -590,7 +590,7 @@ test_peek_cancel( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 0 ], shmem, &xid1, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 0 ], shmem, &xid1, &key ) );
     fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 1 ], shmem, &xid1 ) );
 
     metrics_reset();
@@ -637,8 +637,8 @@ test_peek_peek( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 0 ], shmem, &xid, &key, 1UL ) );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 0 ], shmem, &xid, &key ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -691,7 +691,7 @@ test_peek_root_sibling( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid2, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid2, &key ) );
     fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
 
     metrics_reset();
@@ -744,8 +744,8 @@ test_peek_peek_root( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key, 1UL ) );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 1 ], shmem, &xid2, &key, 1UL ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 1 ], shmem, &xid2, &key ) );
     fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 2 ], shmem, &xid1 ) );
 
     metrics_reset();
@@ -969,10 +969,6 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
   fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
 
-  /* epoch_slot0=0 for root pull gives revision_slot=0.
-     epoch_slot0=2 for child pull gives revision_slot=2, which matches
-     xid1.ul[0]=2 so fd_lineage_xid returns xid1 and the record is
-     inserted under xid1's txn (not at root). */
   fd_prog_load_env_t load_env_root  = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
   fd_prog_load_env_t load_env_child = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 2UL };
 
@@ -983,7 +979,7 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
 
-    /* Pre-populate the same program at root (revision_slot=0) */
+    /* Pre-populate the same program at root */
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
@@ -994,8 +990,7 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
     }
 
     /* Create child fork and populate the same key under xid1's txn
-       (revision_slot=2, matching xid1.ul[0]=2).  Peek won't hit
-       the root record because slot 2 != slot 0. */
+       Peek won't hit the root record because slot 2 != slot 0. */
     fd_progcache_attach_child( admin, &xid0, &xid1 );
     {
       fd_progcache_t tmp[1];

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -130,3 +130,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l vat-activation -y 1 -m 1000
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l enable_bls12_381_syscall -y 1 -m 1000 -e 379
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l bls_pubkey_management_in_vote_account_rekey -y 1 -m 1000 -e 329
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l raise_block_limits_to_100m -y 1 -m 10000 -e 603
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l progcache-stale-entry -y 1 -m 10000 -e 135

--- a/src/flamenco/runtime/tests/run_backtest_ci.sh
+++ b/src/flamenco/runtime/tests/run_backtest_ci.sh
@@ -37,3 +37,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l deployment-before-boundary-
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l mainnet-391824000-boundary -y 2 -m 2000000 -e 391824016
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l vote-stake-scenarios-v4.0.0-alpha.0 -y 1 -m 10000
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l vat-activation -y 1 -m 10000 -e 540
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l progcache-stale-entry -y 1 -m 10000 -e 135


### PR DESCRIPTION
Fixes a bug where the program cache confuses epoch boundary program
invalidations with programs deployed in the first slot of an epoch.

Fixes #9598