### PR TITLE
event should only poll dedup_resolv when block production pipeline enabled

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1014,7 +1014,7 @@ fd_topo_initialize( config_t * config ) {
       FOR(shred_tile_cnt) fd_topob_tile_in(  topo, "event", 0UL, "metric_in", "net_shred", i, FD_TOPOB_UNRELIABLE, FD_TOPOB_POLLED );
     }
 
-    if( FD_UNLIKELY( config->development.event.report_transactions ) ) {
+    if( FD_UNLIKELY( config->development.event.report_transactions && leader_enabled ) ) {
       fd_topob_tile_in( topo, "event", 0UL, "metric_in", "dedup_resolv", 0UL, FD_TOPOB_RELIABLE, FD_TOPOB_POLLED );
     }
 


### PR DESCRIPTION
`dedup_resolv` only exists when `enable_block_production` is set to true