### PR TITLE
restore: median-based cluster slot + permanent peer blacklist

### DIFF
--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -28,6 +28,7 @@ $(call make-unit-test,test_ssmanifest_parser,utils/test_ssmanifest_parser,fd_dis
 endif
 $(call make-unit-test,test_slot_delta_parser,utils/test_slot_delta_parser,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_sspeer_selector,utils/test_sspeer_selector,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_ssping,utils/test_ssping,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_ssarchive,utils/test_ssarchive,fd_discof fdctl_platform fd_ballet fd_util)
 $(call make-unit-test,test_ssparse,utils/test_ssparse,fd_discof fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_slot_delta_parser)

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -69,6 +69,37 @@ typedef struct gossip_ci_entry gossip_ci_entry_t;
 #define MAP_KEY_HASH(key,seed) fd_hash( seed, key, sizeof(fd_pubkey_t) )
 #include "../../util/tmpl/fd_map_chain.c"
 
+/* Standalone blacklist keyed on fd_sspeer_key_t (peer identity).
+   Keying on identity rather than network address is intentional:
+   a peer's address can change freely, but its identity cannot.
+   For gossip peers the identity is the pubkey; for URL peers it is
+   the (hostname, resolved_addr) pair.  Blacklisted peers are
+   permanently banned for the bootstrap lifetime.  The blacklist uses
+   its own dedicated pool so entries are never evicted by pool
+   pressure, unlike the ssping peer pool. */
+
+struct fd_sspeer_blacklist_entry {
+  fd_sspeer_key_t key;
+  ulong           pool_next;
+  ulong           map_next;
+};
+typedef struct fd_sspeer_blacklist_entry fd_sspeer_blacklist_entry_t;
+
+#define POOL_NAME  blacklist_pool
+#define POOL_T     fd_sspeer_blacklist_entry_t
+#define POOL_IDX_T ulong
+#define POOL_NEXT  pool_next
+#include "../../util/tmpl/fd_pool.c"
+
+#define MAP_NAME               blacklist_map
+#define MAP_KEY                key
+#define MAP_ELE_T              fd_sspeer_blacklist_entry_t
+#define MAP_KEY_T              fd_sspeer_key_t
+#define MAP_NEXT               map_next
+#define MAP_KEY_EQ(k0,k1)      (fd_sspeer_key_eq(k0,k1))
+#define MAP_KEY_HASH(key,seed) (fd_sspeer_key_hash(key,seed))
+#include "../../util/tmpl/fd_map_chain.c"
+
 struct fd_snapct_tile {
   struct fd_topo_tile_snapct config;
   int                        gossip_enabled;
@@ -78,6 +109,9 @@ struct fd_snapct_tile {
   fd_http_resolver_t *   ssresolver;
   fd_sspeer_selector_t * selector;
   ulong                  selector_seed;
+
+  fd_sspeer_blacklist_entry_t * blacklist_pool;
+  blacklist_map_t *             blacklist_map;
 
   int           state;
   int           malformed;
@@ -175,7 +209,9 @@ scratch_align( void ) {
          fd_ulong_max( alignof(gossip_ci_entry_t),
          fd_ulong_max( gossip_ci_map_align(),
          fd_ulong_max( fd_http_resolver_align(),
-                       fd_sspeer_selector_align() ) ) ) ) );
+         fd_ulong_max( fd_sspeer_selector_align(),
+         fd_ulong_max( blacklist_pool_align(),
+                       blacklist_map_align() ) ) ) ) ) ) );
 }
 
 static ulong
@@ -187,6 +223,8 @@ scratch_footprint( fd_topo_tile_t const * tile FD_PARAM_UNUSED ) {
   l = FD_LAYOUT_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
   l = FD_LAYOUT_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX )                             );
   l = FD_LAYOUT_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX )                            );
+  l = FD_LAYOUT_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX )                               );
+  l = FD_LAYOUT_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) )  );
   l = FD_LAYOUT_APPEND( l, fd_alloc_align(),           fd_alloc_footprint()                                                       );
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
@@ -249,30 +287,37 @@ predict_incremental( fd_snapct_tile_t * ctx ) {
 static void
 on_resolve( void *                  _ctx,
             fd_sspeer_key_t const * key,
+            fd_ip4_port_t           addr,
             ulong                   full_slot,
             ulong                   incr_slot,
             uchar                   full_hash[ FD_HASH_FOOTPRINT ],
             uchar                   incr_hash[ FD_HASH_FOOTPRINT ] ) {
   fd_snapct_tile_t * ctx = (fd_snapct_tile_t *)_ctx;
 
-  int status = fd_sspeer_selector_update_on_resolve( ctx->selector, key, full_slot, incr_slot, full_hash, incr_hash );
-  if( FD_UNLIKELY( status<0 ) ) {
-    /* The update may fail in normal operation, e.g. after a peer has
-       been removed from the selector.  The log level is set to a
-       minimum accordingly. */
+  /* Do not update peers that have been permanently blacklisted. */
+  if( FD_UNLIKELY( key && blacklist_map_ele_query( ctx->blacklist_map, key, NULL, ctx->blacklist_pool ) ) ) return;
+  /* Do not re-add peers whose addr is temporarily banned by ssping. */
+  if( FD_UNLIKELY( fd_ssping_is_invalidated( ctx->ssping, addr ) ) ) return;
+
+  /* add() handles both new and existing peers, so peers removed from
+     the selector during a previous blacklist, timeout, or failed
+     re-resolve are re-added with the freshly resolved data. */
+  ulong score = fd_sspeer_selector_add( ctx->selector, key, addr, FD_SSPEER_LATENCY_UNKNOWN,
+                                        full_slot, incr_slot, full_hash, incr_hash );
+  if( FD_UNLIKELY( score==FD_SSPEER_SCORE_INVALID ) ) {
     if( FD_UNLIKELY( key==NULL ) ) {
-      FD_LOG_DEBUG(( "selector update on resolve returned %d for NULL peer key", status ) );
+      FD_LOG_DEBUG(( "selector add on resolve failed for NULL peer key" ));
     } else {
       if( FD_UNLIKELY( !key->is_url ) ) {
         FD_BASE58_ENCODE_32_BYTES( key->pubkey->key, pubkey_b58 );
-        FD_LOG_DEBUG(( "selector update on resolve returned %d for peer with pubkey %s", status, pubkey_b58 ) );
+        FD_LOG_DEBUG(( "selector add on resolve failed for peer with pubkey %s", pubkey_b58 ));
       } else {
-        FD_LOG_DEBUG(( "selector update on resolve returned %d for peer %s with addr " FD_IP4_ADDR_FMT ":%hu", status, key->url.hostname,
+        FD_LOG_DEBUG(( "selector add on resolve failed for peer %s with addr " FD_IP4_ADDR_FMT ":%hu", key->url.hostname,
                        FD_IP4_ADDR_FMT_ARGS( key->url.resolved_addr.addr ), fd_ushort_bswap( key->url.resolved_addr.port ) ));
       }
     }
   }
-  fd_sspeer_selector_process_cluster_slot( ctx->selector, full_slot, incr_slot );
+  fd_sspeer_selector_process_cluster_slot( ctx->selector );
   predict_incremental( ctx );
 }
 
@@ -316,14 +361,17 @@ on_snapshot_hash( fd_snapct_tile_t *                 ctx,
     fd_sspeer_selector_remove( ctx->selector, key );
     return;
   }
-  /* The add may fail due to capacity/pool exhaustion, but the cluster
-     slot should still be updated since the gossip observation is valid
-     cluster-level intelligence regardless of whether this particular
-     peer can be tracked. */
+  /* Do not re-add peers that have been permanently blacklisted. */
+  if( FD_UNLIKELY( blacklist_map_ele_query( ctx->blacklist_map, key, NULL, ctx->blacklist_pool ) ) ) return;
+  /* Do not re-add peers whose addr is temporarily banned by ssping. */
+  if( FD_UNLIKELY( fd_ssping_is_invalidated( ctx->ssping, addr ) ) ) return;
+  /* The add may fail due to capacity/pool exhaustion.  The cluster
+     slot is recomputed from tracked peers only, so a failed add will
+     not influence the median. */
   fd_sspeer_selector_add( ctx->selector, key, addr, FD_SSPEER_LATENCY_UNKNOWN,
                           full_slot, incr_slot,
                           msg->snapshot_hashes->full_hash, incr_hash );
-  fd_sspeer_selector_process_cluster_slot( ctx->selector, full_slot, incr_slot );
+  fd_sspeer_selector_process_cluster_slot( ctx->selector );
   predict_incremental( ctx );
 }
 
@@ -579,6 +627,32 @@ log_completion( fd_snapct_tile_t * ctx,
   FD_LOG_NOTICE(( "%s snapshot load completed in %.3f seconds", full ? "full" : "incremental", elapsed ));
 }
 
+/* Blacklist the current peer: invalidate in ssping, remove from the
+   selector, and add to the dedicated blacklist map.  Skips the insert
+   if the peer is already blacklisted (dedup).  Warns if the pool is
+   full (the ssping ban still provides temporary protection). */
+static void
+blacklist_peer( fd_snapct_tile_t * ctx ) {
+  fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
+  fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+  fd_sspeer_selector_process_cluster_slot( ctx->selector );
+  if( FD_UNLIKELY( blacklist_map_ele_query( ctx->blacklist_map, &ctx->peer.key, NULL, ctx->blacklist_pool ) ) ) return;
+  if( FD_LIKELY( blacklist_pool_free( ctx->blacklist_pool ) ) ) {
+    fd_sspeer_blacklist_entry_t * bl = blacklist_pool_ele_acquire( ctx->blacklist_pool );
+    bl->key = ctx->peer.key;
+    blacklist_map_ele_insert( ctx->blacklist_map, bl, ctx->blacklist_pool );
+    if( FD_UNLIKELY( !ctx->peer.key.is_url ) ) {
+      FD_BASE58_ENCODE_32_BYTES( ctx->peer.key.pubkey->uc, pubkey_b58 );
+      FD_LOG_WARNING(( "permanently blacklisted peer identity %s", pubkey_b58 ));
+    } else {
+      FD_LOG_WARNING(( "permanently blacklisted peer identity %s",
+                       ctx->peer.key.url.hostname[0] ? ctx->peer.key.url.hostname : "(none)" ));
+    }
+  } else {
+    FD_LOG_WARNING(( "blacklist pool full, peer banned via ssping only" ));
+  }
+}
+
 static void
 after_credit( fd_snapct_tile_t *  ctx,
               fd_stem_context_t * stem,
@@ -588,6 +662,11 @@ after_credit( fd_snapct_tile_t *  ctx,
 
   if( FD_LIKELY( ctx->ssping ) ) fd_ssping_advance( ctx->ssping, now, ctx->selector );
   if( FD_LIKELY( ctx->ssresolver ) ) fd_http_resolver_advance( ctx->ssresolver, now, ctx->selector );
+
+  /* Advances above may remove peers, making cluster_slot dirty.
+     Recompute so best() calls below use up-to-date scores.
+     No-op when the dirty flag is not set internally. */
+  fd_sspeer_selector_process_cluster_slot( ctx->selector );
 
   /* send an expected slot message as the predicted incremental
      could have changed as a result of the pinger, resolver, or from
@@ -837,8 +916,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure.",
                          ctx->predicted_incremental.slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_incr_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
 
@@ -861,8 +939,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure.",
                          ctx->predicted_incremental.slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_incr_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
 
@@ -948,8 +1025,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure.",
                          ctx->predicted_incremental.full_slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_full_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
 
@@ -972,8 +1048,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure.",
                          ctx->predicted_incremental.full_slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_full_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
 
@@ -1118,8 +1193,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure",
                          ctx->predicted_incremental.full_slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_full_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
       if( FD_UNLIKELY( ctx->metrics.full.bytes_total!=0UL && ctx->metrics.full.bytes_read==ctx->metrics.full.bytes_total ) ) {
@@ -1143,8 +1217,7 @@ after_credit( fd_snapct_tile_t *  ctx,
                          "blacklisting peer due to download failure",
                          ctx->predicted_incremental.slot,
                          FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_incr_snapshot_name ));
-        fd_ssping_invalidate( ctx->ssping, ctx->peer.addr, fd_log_wallclock() );
-        fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
+        blacklist_peer( ctx );
         break;
       }
       if ( FD_UNLIKELY( ctx->metrics.incremental.bytes_total!=0UL && ctx->metrics.incremental.bytes_read==ctx->metrics.incremental.bytes_total ) ) {
@@ -1239,12 +1312,18 @@ gossip_frag( fd_snapct_tile_t *  ctx,
         *entry_key.pubkey = entry->pubkey;
         entry_key.is_url  = 0;
         if( FD_LIKELY( !!new_addr.l ) ) {
-          if( FD_UNLIKELY( FD_SSPEER_SCORE_INVALID==fd_sspeer_selector_add( ctx->selector, &entry_key, new_addr,
+          /* Do not re-add peers that have been permanently blacklisted
+             or whose new address is temporarily banned by ssping.
+             Bookkeeping (ssping cleanup, rpc_addr update) still runs
+             so the CI table and ssping pool stay consistent. */
+          if( FD_LIKELY( !blacklist_map_ele_query( ctx->blacklist_map, &entry_key, NULL, ctx->blacklist_pool ) &&
+                         !fd_ssping_is_invalidated( ctx->ssping, new_addr ) ) ) {
+            if( FD_LIKELY( FD_SSPEER_SCORE_INVALID!=fd_sspeer_selector_add( ctx->selector, &entry_key, new_addr,
                                                                             FD_SSPEER_LATENCY_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
                                                                             FD_SSPEER_SLOT_UNKNOWN, NULL, NULL ) ) ) {
-            break;
+              fd_ssping_add( ctx->ssping, new_addr );
+            }
           }
-          fd_ssping_add( ctx->ssping, new_addr );
         } else {
           fd_sspeer_selector_remove( ctx->selector, &entry_key );
         }
@@ -1584,6 +1663,8 @@ privileged_init( fd_topo_t *      topo,
                                    FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
   void *             _ssresolver = FD_SCRATCH_ALLOC_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX )  );
                                    FD_SCRATCH_ALLOC_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX ) );
+                                   FD_SCRATCH_ALLOC_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX ) );
+                                   FD_SCRATCH_ALLOC_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) ) );
 
 #if FD_HAS_OPENSSL
   void * _alloc = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(), fd_alloc_footprint() );
@@ -1730,12 +1811,16 @@ unprivileged_init( fd_topo_t *      topo,
   void * _ci_map          = FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
                             FD_SCRATCH_ALLOC_APPEND( l, fd_http_resolver_align(),   fd_http_resolver_footprint( SERVER_PEERS_MAX ) );
   void * _selector        = FD_SCRATCH_ALLOC_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX ) );
+  void * _bl_pool         = FD_SCRATCH_ALLOC_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX ) );
+  void * _bl_map          = FD_SCRATCH_ALLOC_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) ) );
 
   ctx->config = tile->snapct;
   ctx->gossip_enabled   = gossip_enabled( tile );
   ctx->download_enabled = download_enabled( tile );
 
-  ctx->selector = fd_sspeer_selector_join( fd_sspeer_selector_new( _selector, TOTAL_PEERS_MAX, ctx->config.incremental_snapshots, ctx->selector_seed ) );
+  ctx->selector       = fd_sspeer_selector_join( fd_sspeer_selector_new( _selector, TOTAL_PEERS_MAX, ctx->selector_seed ) );
+  ctx->blacklist_pool = blacklist_pool_join( blacklist_pool_new( _bl_pool, TOTAL_PEERS_MAX ) );
+  ctx->blacklist_map  = blacklist_map_join( blacklist_map_new( _bl_map, blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ), ctx->selector_seed ) );
 
   if( ctx->config.sources.servers_cnt ) {
     for( ulong i=0UL; i<tile->snapct.sources.servers_cnt; i++ ) {

--- a/src/discof/restore/utils/fd_http_resolver.c
+++ b/src/discof/restore/utils/fd_http_resolver.c
@@ -483,7 +483,7 @@ poll_advance( fd_http_resolver_t * resolver,
       deadline_list_ele_push_tail( resolver->valid, peer, resolver->pool );
       remove_peer( resolver, peer->fd.idx );
 
-      resolver->on_resolve_cb( resolver->cb_arg, &peer->key, peer->full_slot, peer->incr_slot, peer->full_hash,
+      resolver->on_resolve_cb( resolver->cb_arg, &peer->key, peer->addr, peer->full_slot, peer->incr_slot, peer->full_hash,
                                peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN ? peer->incr_hash : NULL );
     }
   }
@@ -501,13 +501,11 @@ fd_http_resolver_advance( fd_http_resolver_t *   resolver,
        Without this, a previously-valid peer could carry stale
        incr_slot/incr_hash through the invalid->unresolved cycle. */
     clear_peer_snapshot_data( peer );
-    /* Re-add the peer to the selector with unknown data.  The peer may
-       have been removed from the selector during a previous timeout or
-       failed re-resolve.  The add call may fail if the selector is
-       full, which is fine — the peer will still attempt to resolve and
-       the next cycle will try again. */
-    fd_sspeer_selector_add( selector, &peer->key, peer->addr, FD_SSPEER_LATENCY_UNKNOWN,
-                            FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, NULL, NULL );
+    /* Peers that were already removed from the selector due to
+       timeout or blacklist handling stay absent while resolving.
+       Re-adding such peers here with unknown slots would bypass
+       blacklist checks and contribute no useful data.  The
+       on_resolve callback re-adds them once resolution succeeds. */
     int result = peer_connect( resolver, peer );
     if( FD_UNLIKELY( -1==result ) ) {
       peer->state          = PEER_STATE_INVALID;

--- a/src/discof/restore/utils/fd_http_resolver.h
+++ b/src/discof/restore/utils/fd_http_resolver.h
@@ -15,6 +15,7 @@ typedef struct fd_http_resolver_private fd_http_resolver_t;
 typedef void
 (* fd_http_resolver_on_resolve_fn_t)( void *                  _ctx,
                                       fd_sspeer_key_t const * key,
+                                      fd_ip4_port_t           addr,
                                       ulong                   full_slot,
                                       ulong                   incr_slot,
                                       uchar                   full_hash[ FD_HASH_FOOTPRINT ],

--- a/src/discof/restore/utils/fd_sspeer.h
+++ b/src/discof/restore/utils/fd_sspeer.h
@@ -1,6 +1,7 @@
 #ifndef HEADER_fd_src_discof_restore_utils_fd_sspeer_h
 #define HEADER_fd_src_discof_restore_utils_fd_sspeer_h
 
+#include "../../../util/fd_util_base.h"
 #include "../../../util/net/fd_net_headers.h"
 #include "../../../flamenco/fd_flamenco_base.h"
 
@@ -16,5 +17,34 @@ struct fd_sspeer_key {
 };
 
 typedef struct fd_sspeer_key fd_sspeer_key_t;
+
+FD_FN_UNUSED static inline int
+fd_sspeer_key_eq( fd_sspeer_key_t const * k0,
+                  fd_sspeer_key_t const * k1 ) {
+  if( k0->is_url!=k1->is_url ) return 0;
+  if( k0->is_url ) {
+    return !strncmp( k0->url.hostname, k1->url.hostname, sizeof(k0->url.hostname) )
+           && k0->url.resolved_addr.l==k1->url.resolved_addr.l;
+  }
+  return !memcmp( k0->pubkey, k1->pubkey, FD_PUBKEY_FOOTPRINT );
+}
+
+FD_FN_UNUSED static inline ulong
+fd_sspeer_key_hash( fd_sspeer_key_t const * key,
+                    ulong                   seed ) {
+  if( key->is_url ) {
+    /* Use strnlen in case the string is not properly \0 terminated.
+       Ideally, one would prefer sizeof(key->url.hostname) but that
+       requires guaranteed zero-padding. */
+    ulong h = fd_hash( seed, key->url.hostname, strnlen( key->url.hostname, sizeof(key->url.hostname) ) );
+    /* fd_ip4_port_t is not a complete 64bit ulong, therefore compose
+       the word from its parts to avoid random unused bytes. */
+    ulong a = (ulong)key->url.resolved_addr.addr | ( ((ulong)key->url.resolved_addr.port) << 32 );
+    /* Chaining "a" through fd_hash would give better avalanche
+       properties, but it is probably overkill for a chain hash map. */
+    return h ^ a;
+  }
+  return fd_hash( seed, key->pubkey, FD_PUBKEY_FOOTPRINT );
+}
 
 #endif /* HEADER_fd_src_discof_restore_utils_fd_sspeer_h */

--- a/src/discof/restore/utils/fd_sspeer_selector.c
+++ b/src/discof/restore/utils/fd_sspeer_selector.c
@@ -1,35 +1,7 @@
 #include "fd_sspeer_selector.h"
 #include "../../../util/bits/fd_sat.h"
 #include "../../../util/log/fd_log.h"
-
-static int
-fd_sspeer_key_private_eq( fd_sspeer_key_t const * k0,
-                          fd_sspeer_key_t const * k1 ) {
-  if( k0->is_url!=k1->is_url ) return 0;
-  if( k0->is_url ) {
-    return !strncmp( k0->url.hostname, k1->url.hostname, sizeof(k0->url.hostname) )
-           && k0->url.resolved_addr.l==k1->url.resolved_addr.l;
-  }
-  return !memcmp( k0->pubkey, k1->pubkey, FD_PUBKEY_FOOTPRINT );
-}
-
-static ulong
-fd_sspeer_key_private_hash( fd_sspeer_key_t const * key,
-                            ulong                   seed ) {
-  if( key->is_url ) {
-    /* Use strnlen in case the string is not properly \0 terminated.
-       Ideally, one would prefer sizeof(key->url.hostname) but that
-       requires guaranteed zero-padding. */
-    ulong h = fd_hash( seed, key->url.hostname, strnlen( key->url.hostname, sizeof(key->url.hostname) ) );
-    /* fd_ip4_port_t is not a complete 64bit ulong, therefore compose
-       the word from its parts to avoid random unused bytes. */
-    ulong a = (ulong)key->url.resolved_addr.addr | ( ((ulong)key->url.resolved_addr.port) << 32 );
-    /* Chaining "a" through fd_hash would give better avalanche
-       properties, but it is probably overkill for a chain hash map. */
-    return h ^ a;
-  }
-  return fd_hash( seed, key->pubkey, FD_PUBKEY_FOOTPRINT );
-}
+#include "../../../util/math/fd_stat.h"
 
 struct fd_sspeer_private {
   fd_sspeer_key_t key;
@@ -78,8 +50,8 @@ typedef struct fd_sspeer_private fd_sspeer_private_t;
 #define MAP_KEY_T              fd_sspeer_key_t
 #define MAP_PREV               map_by_key.prev
 #define MAP_NEXT               map_by_key.next
-#define MAP_KEY_EQ(k0,k1)      (fd_sspeer_key_private_eq(k0,k1))
-#define MAP_KEY_HASH(key,seed) (fd_sspeer_key_private_hash(key,seed))
+#define MAP_KEY_EQ(k0,k1)      (fd_sspeer_key_eq(k0,k1))
+#define MAP_KEY_HASH(key,seed) (fd_sspeer_key_hash(key,seed))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../../util/tmpl/fd_map_chain.c"
 
@@ -129,8 +101,8 @@ struct fd_sspeer_selector_private {
   score_treap_t *           shadow_score_treap;
   ulong *                   peer_idx_list;
   fd_sscluster_slot_t       cluster_slot;
-  int                       incremental_snapshot_fetch;
   ulong                     max_peers;
+  int                       cluster_slot_dirty;
 
   ulong                     magic; /* ==FD_SSPEER_SELECTOR_MAGIC */
 };
@@ -152,14 +124,13 @@ fd_sspeer_selector_footprint( ulong max_peers ) {
   l = FD_LAYOUT_APPEND( l, peer_map_by_addr_align(),      peer_map_by_addr_footprint( peer_map_by_addr_chain_cnt_est( 2UL*max_peers ) ) );
   l = FD_LAYOUT_APPEND( l, score_treap_align(),           score_treap_footprint( max_peers ) );
   l = FD_LAYOUT_APPEND( l, score_treap_align(),           score_treap_footprint( max_peers ) );
-  l = FD_LAYOUT_APPEND( l, alignof(ulong),                max_peers * sizeof(ulong) );
+  l = FD_LAYOUT_APPEND( l, alignof(ulong),                2UL * max_peers * sizeof(ulong) ); /* 2UL={full_slots,incr_slots} each max_peers */
   return FD_LAYOUT_FINI( l, fd_sspeer_selector_align() );
 }
 
 void *
 fd_sspeer_selector_new( void * shmem,
                         ulong  max_peers,
-                        int    incremental_snapshot_fetch,
                         ulong  seed ) {
   if( FD_UNLIKELY( !shmem ) ) {
     FD_LOG_WARNING(( "NULL shmem" ));
@@ -183,7 +154,7 @@ fd_sspeer_selector_new( void * shmem,
   void * _multimap_by_addr        = FD_SCRATCH_ALLOC_APPEND( l, peer_map_by_addr_align(), peer_map_by_addr_footprint( peer_map_by_addr_chain_cnt_est( 2UL*max_peers ) )  );
   void * _score_treap             = FD_SCRATCH_ALLOC_APPEND( l, score_treap_align(),      score_treap_footprint( max_peers ) );
   void * _shadow_score_treap      = FD_SCRATCH_ALLOC_APPEND( l, score_treap_align(),      score_treap_footprint( max_peers ) );
-  void * _peer_idx_list           = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),           max_peers * sizeof(ulong) );
+  void * _peer_idx_list           = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),           2UL * max_peers * sizeof(ulong) ); /* 2UL={full_slots,incr_slots} each max_peers */
 
   selector->pool               = peer_pool_join( peer_pool_new( _pool, 2UL*max_peers ) );
   /* Seed treap priorities so the treap is balanced. */
@@ -197,7 +168,7 @@ fd_sspeer_selector_new( void * shmem,
 
   selector->cluster_slot.full          = 0UL;
   selector->cluster_slot.incremental   = FD_SSPEER_SLOT_UNKNOWN;
-  selector->incremental_snapshot_fetch = incremental_snapshot_fetch;
+  selector->cluster_slot_dirty         = 0;
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( selector->magic ) = FD_SSPEER_SELECTOR_MAGIC;
@@ -371,7 +342,7 @@ fd_sspeer_selector_update( fd_sspeer_selector_t * selector,
              peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN &&
              peer->incr_slot<full_slot ) {
     /* The caller is providing a new full_slot that has advanced past
-       the peer's existing incremental — the incremental is stale. */
+       the peer's existing incremental, the incremental is stale. */
     peer_incr_slot = FD_SSPEER_SLOT_UNKNOWN;
     clear_incr     = 1;
   } else {
@@ -398,22 +369,6 @@ fd_sspeer_selector_update( fd_sspeer_selector_t * selector,
   }
 
   score_treap_ele_insert( selector->score_treap, peer, selector->pool );
-  return FD_SSPEER_UPDATE_SUCCESS;
-}
-
-int
-fd_sspeer_selector_update_on_resolve( fd_sspeer_selector_t *  selector,
-                                      fd_sspeer_key_t const * key,
-                                      ulong                   full_slot,
-                                      ulong                   incr_slot,
-                                      uchar const             full_hash[ FD_HASH_FOOTPRINT ],
-                                      uchar const             incr_hash[ FD_HASH_FOOTPRINT ] ) {
-  if( FD_UNLIKELY( key==NULL ) ) return FD_SSPEER_UPDATE_ERR_NULL_KEY;
-  fd_sspeer_private_t * peer = peer_map_by_key_ele_query( selector->map_by_key, key, NULL, selector->pool );
-  if( FD_UNLIKELY( peer==NULL ) ) return FD_SSPEER_UPDATE_ERR_NOT_FOUND;
-  int update_status = fd_sspeer_selector_update( selector, peer, FD_SSPEER_LATENCY_UNKNOWN, full_slot, incr_slot, full_hash, incr_hash );
-  if( FD_UNLIKELY( update_status!=FD_SSPEER_UPDATE_SUCCESS ) ) return FD_SSPEER_UPDATE_ERR_INVALID_ARG;
-  peer->valid = peer->full_slot!=FD_SSPEER_SLOT_UNKNOWN;
   return FD_SSPEER_UPDATE_SUCCESS;
 }
 
@@ -470,8 +425,11 @@ fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
 
   fd_sspeer_private_t * peer = peer_map_by_key_ele_query( selector->map_by_key, key, NULL, selector->pool );
   if( FD_LIKELY( peer ) ) {
+    ulong old_full = peer->full_slot;
+    ulong old_incr = peer->incr_slot;
     int update_status = fd_sspeer_selector_update( selector, peer, latency, full_slot, incr_slot, full_hash, incr_hash );
     if( FD_UNLIKELY( update_status!=FD_SSPEER_UPDATE_SUCCESS ) ) return FD_SSPEER_SCORE_INVALID;
+    if( FD_UNLIKELY( peer->full_slot!=old_full || peer->incr_slot!=old_incr ) ) selector->cluster_slot_dirty = 1;
     /* Update the addr map after the selector update so that the peer
        is not mutated when the update fails. */
     if( FD_UNLIKELY( peer->addr.l!=addr.l ) ) {
@@ -508,6 +466,7 @@ fd_sspeer_selector_add( fd_sspeer_selector_t * selector,
     peer_map_by_key_ele_insert( selector->map_by_key, peer, selector->pool );
     peer_map_by_addr_ele_insert( selector->map_by_addr, peer, selector->pool );
     score_treap_ele_insert( selector->score_treap, peer, selector->pool );
+    if( FD_LIKELY( full_slot!=FD_SSPEER_SLOT_UNKNOWN || incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) selector->cluster_slot_dirty = 1;
   }
   peer->valid = peer->full_slot!=FD_SSPEER_SLOT_UNKNOWN;
   return peer->score;
@@ -523,6 +482,7 @@ fd_sspeer_selector_remove( fd_sspeer_selector_t * selector,
   peer_map_by_key_ele_remove_fast( selector->map_by_key, peer, selector->pool );
   peer_map_by_addr_ele_remove_fast( selector->map_by_addr, peer, selector->pool );
   peer_pool_ele_release( selector->pool, peer );
+  selector->cluster_slot_dirty = 1;
 }
 
 void
@@ -534,6 +494,7 @@ fd_sspeer_selector_remove_by_addr( fd_sspeer_selector_t * selector,
     score_treap_ele_remove( selector->score_treap, peer, selector->pool );
     peer_map_by_key_ele_remove_fast( selector->map_by_key, peer, selector->pool );
     peer_pool_ele_release( selector->pool, peer );
+    selector->cluster_slot_dirty = 1;
   }
 }
 
@@ -544,6 +505,7 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
   if( FD_UNLIKELY( incremental && base_slot==FD_SSPEER_SLOT_UNKNOWN ) ) {
     FD_LOG_WARNING(( "incremental selection requires a valid base_slot" ));
     return (fd_sspeer_t){
+      .key       = { .is_url = 0 },
       .addr      = { .l=0UL },
       .full_slot = FD_SSPEER_SLOT_UNKNOWN,
       .incr_slot = FD_SSPEER_SLOT_UNKNOWN,
@@ -564,6 +526,7 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
                    (!incremental ||
                    (peer->full_slot==base_slot && peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN) ) ) ) {
       fd_sspeer_t best = {
+        .key       = peer->key,
         .addr      = peer->addr,
         .full_slot = peer->full_slot,
         .incr_slot = peer->incr_slot,
@@ -576,6 +539,7 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
   }
 
   return (fd_sspeer_t){
+    .key       = { .is_url = 0 },
     .addr      = { .l=0UL },
     .full_slot = FD_SSPEER_SLOT_UNKNOWN,
     .incr_slot = FD_SSPEER_SLOT_UNKNOWN,
@@ -586,64 +550,71 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
 }
 
 void
-fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector,
-                                         ulong                  full_slot,
-                                         ulong                  incr_slot ) {
-  if( FD_UNLIKELY( full_slot==FD_SSPEER_SLOT_UNKNOWN ) ) return;
+fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector ) {
+  if( FD_LIKELY( !selector->cluster_slot_dirty ) ) return;
+  selector->cluster_slot_dirty = 0;
 
-  /* Reject cluster slot updates where the incremental slot is before
-     the full slot.  Both must be known for the check to apply.  Genesis
-     (full_slot=0, incr_slot=0) is supported. */
-  if( FD_UNLIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN && incr_slot<full_slot ) ) return;
-
-  if( FD_LIKELY( selector->incremental_snapshot_fetch ) ) {
-    /* The full slot must never regress, regardless of incr_slot. */
-    if( FD_UNLIKELY( full_slot<selector->cluster_slot.full ) ) return;
-
-    /* Reject updates that do not advance the cluster slot.
-       incr_slot     | stored incr   | reject when
-       --------------|---------------|--------------------------------
-       valid         | valid         | incr_slot < stored.incremental
-                     |               |   OR (incr_slot == stored.incremental
-                     |               |       AND full_slot <= stored.full)
-       valid         | _SLOT_UNKNOWN | incr_slot <  stored.full
-                     |               |   (strict: genesis accepted)
-       _SLOT_UNKNOWN | valid         | full_slot <= stored.full
-       _SLOT_UNKNOWN | _SLOT_UNKNOWN | full_slot <= stored.full  */
-    if( FD_UNLIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
-      if( FD_UNLIKELY( selector->cluster_slot.incremental!=FD_SSPEER_SLOT_UNKNOWN ) ) {
-        if( FD_UNLIKELY( ( incr_slot<selector->cluster_slot.incremental ||
-                         ( incr_slot==selector->cluster_slot.incremental &&
-                           full_slot<=selector->cluster_slot.full ) ) ) ) return;
-      } else {
-        if( FD_UNLIKELY( incr_slot<selector->cluster_slot.full ) ) return;
-      }
-    } else if( FD_UNLIKELY( full_slot<=selector->cluster_slot.full ) ) return;
-
-  } else {
-    if( FD_UNLIKELY( full_slot<=selector->cluster_slot.full ) ) return;
+  /* Collect full_slot and incr_slot values in a single treap pass.
+     full_slots occupies peer_idx_list[0..max_peers), incr_slots
+     occupies peer_idx_list[max_peers..2*max_peers). */
+  ulong full_cnt = 0UL;
+  ulong incr_cnt = 0UL;
+  ulong * full_slots = selector->peer_idx_list;
+  ulong * incr_slots = selector->peer_idx_list + selector->max_peers;
+  for( score_treap_fwd_iter_t iter = score_treap_fwd_iter_init( selector->score_treap, selector->pool );
+       !score_treap_fwd_iter_done( iter );
+       iter = score_treap_fwd_iter_next( iter, selector->pool ) ) {
+    fd_sspeer_private_t const * peer = score_treap_fwd_iter_ele_const( iter, selector->pool );
+    if( peer->full_slot!=FD_SSPEER_SLOT_UNKNOWN ) {
+      full_slots[ full_cnt++ ] = peer->full_slot;
+    }
+    if( peer->incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) {
+      incr_slots[ incr_cnt++ ] = peer->incr_slot;
+    }
   }
 
-  selector->cluster_slot.full = full_slot;
-  if( FD_LIKELY( incr_slot!=FD_SSPEER_SLOT_UNKNOWN ) ) {
-    selector->cluster_slot.incremental = incr_slot;
-  } else if( FD_UNLIKELY( selector->cluster_slot.incremental!=FD_SSPEER_SLOT_UNKNOWN &&
-                           selector->cluster_slot.incremental<full_slot ) ) {
-    /* The full slot advanced past the incremental slot, so the
-       incremental reference is stale and must be invalidated. */
+  /* If no known full_slot among tracked peers, reset so that a
+     subsequent add() is not scored against a stale cluster slot. */
+  if( FD_UNLIKELY( full_cnt==0UL ) ) {
+    selector->cluster_slot.full        = 0UL;
     selector->cluster_slot.incremental = FD_SSPEER_SLOT_UNKNOWN;
+    return;
   }
 
-  if( FD_UNLIKELY( score_treap_ele_cnt( selector->score_treap )==0UL ) ) return;
+  /* Lower median is more conservative against a single malicious peer
+     in small sets (e.g. 2 peers: picks the lower slot). */
+  ulong mid_full = (full_cnt-1UL)/2UL; /* full_cnt > 0 */
+  fd_sort_up_ulong_select( full_slots, full_cnt, mid_full );
+  ulong median_full = full_slots[ mid_full ];
 
-  /* Rescore all peers
-     TODO: make more performant, maybe make a treap rebalance API */
+  ulong median_incr = FD_SSPEER_SLOT_UNKNOWN;
+  if( FD_LIKELY( incr_cnt>0UL ) ) {
+    ulong mid_incr = (incr_cnt-1UL)/2UL;
+    fd_sort_up_ulong_select( incr_slots, incr_cnt, mid_incr );
+    median_incr = incr_slots[ mid_incr ];
+  }
+
+  /* The full and incremental medians are computed from different peer
+     subsets, so median_incr < median_full is possible.  Clamp to
+     maintain the invariant that incremental >= full. */
+  if( FD_UNLIKELY( median_incr!=FD_SSPEER_SLOT_UNKNOWN &&
+                   median_full!=FD_SSPEER_SLOT_UNKNOWN &&
+                   median_incr<median_full ) ) {
+    median_incr = median_full;
+  }
+
+  /* If neither median changed, no rescore needed. */
+  if( FD_LIKELY( median_full==selector->cluster_slot.full &&
+                 median_incr==selector->cluster_slot.incremental ) ) return;
+
+  selector->cluster_slot.full        = median_full;
+  selector->cluster_slot.incremental = median_incr;
+
+  /* Rescore all peers using the shadow treap swap mechanism. */
   ulong idx = 0UL;
   for( score_treap_fwd_iter_t iter = score_treap_fwd_iter_init( selector->score_treap, selector->pool );
         !score_treap_fwd_iter_done( iter );
         iter = score_treap_fwd_iter_next( iter, selector->pool ) ) {
-    /* Do not remove the peer from the treap while the iterator is
-       running.  Removing from peer_map(s) here is ok. */
     fd_sspeer_private_t * peer = score_treap_fwd_iter_ele( iter, selector->pool );
     fd_sspeer_private_t * shadow_peer = peer_pool_ele_acquire( selector->pool );
     shadow_peer->latency   = peer->latency;
@@ -663,7 +634,7 @@ fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector,
     peer_map_by_addr_ele_insert( selector->map_by_addr, shadow_peer, selector->pool );
   }
 
-  /* clear score treap*/
+  /* clear score treap */
   for( ulong i=0UL; i<idx; i++ ) {
     fd_sspeer_private_t * peer = peer_pool_ele( selector->pool, selector->peer_idx_list[ i ] );
     score_treap_ele_remove( selector->score_treap, peer, selector->pool );

--- a/src/discof/restore/utils/fd_sspeer_selector.h
+++ b/src/discof/restore/utils/fd_sspeer_selector.h
@@ -27,14 +27,11 @@
 /* Sentinel value indicating that peer latency has not been measured. */
 #define FD_SSPEER_LATENCY_UNKNOWN (ULONG_MAX)
 
-/* Return codes for fd_sspeer_selector_update_on_resolve. */
-#define FD_SSPEER_UPDATE_SUCCESS         ( 0)
-#define FD_SSPEER_UPDATE_ERR_NULL_KEY    (-1)
-#define FD_SSPEER_UPDATE_ERR_NOT_FOUND   (-2)
-#define FD_SSPEER_UPDATE_ERR_INVALID_ARG (-3)
+/* Return code for fd_sspeer_selector_update (internal). */
+#define FD_SSPEER_UPDATE_SUCCESS ( 0)
 
-/* fd_sscluster_slot stores the highest full and incremental slot pair
-   seen in the cluster. */
+/* fd_sscluster_slot stores the median full and incremental slot
+   computed from all tracked peers in the cluster. */
 struct fd_sscluster_slot {
   ulong full;
   ulong incremental;
@@ -46,12 +43,13 @@ typedef struct fd_sscluster_slot fd_sscluster_slot_t;
     selector, including the peer's address, resolved snapshot slots,
     and selector score. */
 struct fd_sspeer {
-  fd_ip4_port_t addr;      /* address of the peer */
-  ulong         full_slot;
-  ulong         incr_slot;
-  ulong         score;    /* selector score of peer */
-  uchar         full_hash[ FD_HASH_FOOTPRINT ];
-  uchar         incr_hash[ FD_HASH_FOOTPRINT ];
+  fd_sspeer_key_t key;       /* key identifying the peer */
+  fd_ip4_port_t   addr;      /* address of the peer */
+  ulong           full_slot;
+  ulong           incr_slot;
+  ulong           score;    /* selector score of peer */
+  uchar           full_hash[ FD_HASH_FOOTPRINT ];
+  uchar           incr_hash[ FD_HASH_FOOTPRINT ];
 };
 
 typedef struct fd_sspeer fd_sspeer_t;
@@ -70,7 +68,6 @@ fd_sspeer_selector_footprint( ulong max_peers );
 void *
 fd_sspeer_selector_new( void * shmem,
                         ulong  max_peers,
-                        int    incremental_snapshot_fetch,
                         ulong  seed );
 
 fd_sspeer_selector_t *
@@ -81,27 +78,6 @@ fd_sspeer_selector_leave( fd_sspeer_selector_t * selector );
 
 void *
 fd_sspeer_selector_delete( void * shselector );
-
-/* Update the selector when an http server is resolved.  The peer is
-   identified by key.  The values that can be updated are slot and
-   hash, for both full and incremental snapshots.  Returns
-   FD_SSPEER_UPDATE_SUCCESS on success, FD_SSPEER_UPDATE_ERR_NULL_KEY
-   if key==NULL, FD_SSPEER_UPDATE_ERR_NOT_FOUND if the key was not
-   found, and FD_SSPEER_UPDATE_ERR_INVALID_ARG if the update failed
-   due to invalid arguments (e.g. incr_slot < full_slot).
-
-   Slot-based incremental clearing: when the caller provides
-   incr_slot==FD_SSPEER_SLOT_UNKNOWN and full_slot!=FD_SSPEER_SLOT_UNKNOWN,
-   the peer's existing incremental data is cleared if it is stale
-   (peer->incr_slot < full_slot).  Otherwise, existing incremental
-   data is preserved. */
-int
-fd_sspeer_selector_update_on_resolve( fd_sspeer_selector_t *  selector,
-                                      fd_sspeer_key_t const * key,
-                                      ulong                   full_slot,
-                                      ulong                   incr_slot,
-                                      uchar const             full_hash[ FD_HASH_FOOTPRINT ],
-                                      uchar const             incr_hash[ FD_HASH_FOOTPRINT ] );
 
 /* Update the selector when a ping response is received.  The only
    value that can be updated is the latency.  If multiple peers
@@ -157,16 +133,16 @@ fd_sspeer_selector_best( fd_sspeer_selector_t * selector,
                          int                    incremental,
                          ulong                  base_slot );
 
-/* Updates the selector's internal cluster slot and re-score all peers
-   when the cluster slot updates (moves forward) */
+/* Recompute the selector's internal cluster slot from the median of
+   all tracked peers' slots.  If the median changes, all peers are
+   rescored.  add() and remove() only mark the selector dirty;
+   callers must invoke this function after mutations to apply the
+   recomputation.  No-op when the dirty flag is not set. */
 void
-fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector,
-                                         ulong                  full_slot,
-                                         ulong                  incr_slot );
+fd_sspeer_selector_process_cluster_slot( fd_sspeer_selector_t * selector );
 
-/* Obtain the cluster slot from the selector.  It is the highest
-   resolved full/incremental slot pair seen from snapshot hashes or
-   from resolved http peers. */
+/* Obtain the cluster slot from the selector.  It is the lower median
+   of all tracked peers' full/incremental slots. */
 fd_sscluster_slot_t
 fd_sspeer_selector_cluster_slot( fd_sspeer_selector_t * selector );
 

--- a/src/discof/restore/utils/fd_ssping.c
+++ b/src/discof/restore/utils/fd_ssping.c
@@ -494,3 +494,12 @@ fd_ssping_advance( fd_ssping_t *          ssping,
 
   recv_pings( ssping, selector );
 }
+
+int
+fd_ssping_is_invalidated( fd_ssping_t * ssping,
+                          fd_ip4_port_t addr ) {
+  if( FD_UNLIKELY( !ssping ) ) return 0;
+  fd_ssping_peer_t * peer = peer_map_ele_query( ssping->map, &addr, NULL, ssping->pool );
+  if( FD_UNLIKELY( !peer ) ) return 0;
+  return peer->state==PEER_STATE_INVALID;
+}

--- a/src/discof/restore/utils/fd_ssping.h
+++ b/src/discof/restore/utils/fd_ssping.h
@@ -85,6 +85,14 @@ fd_ssping_invalidate( fd_ssping_t * ssping,
                       fd_ip4_port_t addr,
                       long          now );
 
+/* Returns 1 if the peer at addr is currently in the INVALID state
+   (i.e. temporarily banned), 0 otherwise.  Safe to call with a NULL
+   ssping (returns 0). */
+
+int
+fd_ssping_is_invalidated( fd_ssping_t * ssping,
+                          fd_ip4_port_t addr );
+
 /* Advance the ping tracker forward in time until "now".  This should be
    called periodically to refresh pings and service networking to
    maintain ping states.  Takes a handle to the peer selector to

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -69,7 +69,6 @@ struct test_wksp_struct {
    fd_sspeer_selector_t * selector;
    void *                 shmem;
    ulong                  max_peers;
-   int                    incr_snap_fetch;
    ulong                  seed;
 };
 typedef struct test_wksp_struct test_wksp_t;
@@ -78,23 +77,21 @@ static void
 test_wksp_init( fd_wksp_t *   wksp,
                 test_wksp_t * t_wksp,
                 ulong         max_peers,
-                int           incr_snap_fetch,
                 ulong         seed ) {
   FD_TEST( t_wksp->selector==NULL );
   FD_TEST( t_wksp->shmem==NULL );
   t_wksp->shmem    = fd_wksp_alloc_laddr( wksp, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( max_peers ), 1UL );
-  t_wksp->selector = fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, max_peers, incr_snap_fetch, seed ) );
+  t_wksp->selector = fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, max_peers, seed ) );
   FD_TEST( t_wksp->selector );
-  t_wksp->max_peers       = max_peers;
-  t_wksp->incr_snap_fetch = incr_snap_fetch;
-  t_wksp->seed            = seed;
+  t_wksp->max_peers = max_peers;
+  t_wksp->seed      = seed;
 }
 
 static void
 test_wksp_reinit( test_wksp_t * t_wksp ) {
   FD_TEST( t_wksp->selector!=NULL );
   FD_TEST( fd_sspeer_selector_delete( fd_sspeer_selector_leave( t_wksp->selector ) )==t_wksp->shmem );
-  FD_TEST( fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, t_wksp->max_peers, t_wksp->incr_snap_fetch, t_wksp->seed ) )==t_wksp->selector );
+  FD_TEST( fd_sspeer_selector_join( fd_sspeer_selector_new( t_wksp->shmem, t_wksp->max_peers, t_wksp->seed ) )==t_wksp->selector );
 }
 
 static void
@@ -117,33 +114,39 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
                            fd_rng_t *             rng ) {
   FD_LOG_NOTICE(( "testing basic peer selection"));
 
-  ulong cluster_full_slot = 1000UL;
-  ulong cluster_incr_slot = 1500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
-
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* Add a peer and it should be the best peer */
+  /* Add a peer and compute the cluster slot from the median of its
+     slots.  With 1 peer at (1000, 1500), the median is (1000, 1500). */
   fd_sspeer_key_t key[1]; FD_TEST( generate_rand_sspeer_key( key, rng, fd_rng_int( rng )&0x1/*is_url*/) );
   fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 35, 123, 172, 227 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key, addr, 1000UL, 1500UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL );
+  FD_TEST( add_peer( selector, key, addr, 1000UL, 1500UL, 5UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==1000UL );
+  FD_TEST( cs.incremental==1500UL );
+
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr.l );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1500UL );
   FD_TEST( best.score==5UL*1000UL*1000UL );
+  FD_TEST( fd_sspeer_key_eq( &best.key, key ) );
 
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   /* Add a peer with better latency at the same slot and it should be
-     the best peer */
+     the best peer.  Cluster is (1000, 1500), peer at (1000, 1500),
+     so slots_behind=0, score=latency. */
   fd_sspeer_key_t key2[1]; FD_TEST( generate_rand_sspeer_key( key2, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr2 = { .addr = FD_IP4_ADDR( 35, 123, 172, 228 ), .port = fd_ushort_bswap( 8899 ) };
   FD_TEST( add_peer( selector, key2, addr2, 1000UL, 1500UL, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr2.l );
+  FD_TEST( fd_sspeer_key_eq( &best.key, key2 ) );
   FD_TEST( best.full_slot==1000UL );
   FD_TEST( best.incr_slot==1500UL );
   FD_TEST( best.score==3UL*1000UL*1000UL );
@@ -151,7 +154,9 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 2UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* Add a peer with the same latency but lagging slots behind */
+  /* Add a peer with the same latency but lagging slots behind.
+     Cluster incr is 1500, peer incr is 1400.  slots_behind=100.
+     score = 3_000_000 + 100*1000 = 3_100_000. */
   fd_sspeer_key_t key3[1]; FD_TEST( generate_rand_sspeer_key( key3, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr3 = { .addr = FD_IP4_ADDR( 35, 123, 172, 229 ), .port = fd_ushort_bswap( 8899 ) };
   FD_TEST( add_peer( selector, key3, addr3, 1000UL, 1400UL, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL + 100UL*1000UL );
@@ -164,18 +169,15 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   FD_TEST( 3UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 3UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  cluster_incr_slot = 1600UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
-
   /* Add a peer that is slightly slower but caught up in slots */
   fd_sspeer_key_t key4[1]; FD_TEST( generate_rand_sspeer_key( key4, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr4 = { .addr = FD_IP4_ADDR( 35, 123, 172, 230 ), .port = fd_ushort_bswap( 8899 ) };
-  FD_TEST( add_peer( selector, key4, addr4, 1000UL, 1600UL, 3UL*1000UL*1000UL + 75UL*1000UL )==3UL*1000UL*1000UL + 75UL*1000UL );
+  FD_TEST( add_peer( selector, key4, addr4, 1000UL, 1500UL, 3UL*1000UL*1000UL + 75UL*1000UL )==3UL*1000UL*1000UL + 75UL*1000UL );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr4.l );
+  FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
-  FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
+  FD_TEST( best.incr_slot==1500UL );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   FD_TEST( 4UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 4UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -185,34 +187,32 @@ test_basic_peer_selection( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr5 = { .addr = FD_IP4_ADDR( 35, 123, 172, 231 ), .port = fd_ushort_bswap( 8899 ) };
   FD_TEST( add_peer( selector, key5, addr5, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 1000UL*1000UL*1000UL);
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr4.l );
+  FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
-  FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
+  FD_TEST( best.incr_slot==1500UL );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   /* Test incremental peer selection */
   best = fd_sspeer_selector_best( selector, 1, 1000UL );
-  FD_TEST( best.addr.l==addr4.l );
+  FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
-  FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL );
+  FD_TEST( best.incr_slot==1500UL );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
-  cluster_incr_slot = 1700UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
-
-  /* Add a peer that is fast and at the highest slot but not building
-     off full slot, which makes it an invalid incremental peer */
+  /* Add a peer that is fast and at the highest incr slot but not
+     building off full slot 1000, which makes it an invalid incremental
+     candidate for base_slot=1000. */
   fd_sspeer_key_t key6[1]; FD_TEST( generate_rand_sspeer_key( key6, rng, fd_rng_int( rng )&0x1/*is_url*/ ) );
   fd_ip4_port_t addr6 = { .addr = FD_IP4_ADDR( 35, 123, 172, 232 ), .port = fd_ushort_bswap( 8899 ) };
   FD_TEST( add_peer( selector, key6, addr6, 900UL, 1700UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 1, 1000UL );
-  FD_TEST( best.addr.l==addr4.l );
+  FD_TEST( best.addr.l==addr2.l );
   FD_TEST( best.full_slot==1000UL );
-  FD_TEST( best.incr_slot==1600UL );
-  FD_TEST( best.score==3UL*1000UL*1000UL + 75UL*1000UL + 100UL*1000UL );
+  FD_TEST( best.incr_slot==1500UL );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   FD_TEST( 6UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 6UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
@@ -251,7 +251,6 @@ test_duplicate_peers( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 2000UL;
   ulong cluster_incr_slot = 2500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_pub_A[1]; FD_TEST( generate_rand_sspeer_key( key_pub_A, rng, 0 ) );
   fd_sspeer_key_t key_pub_B[1]; FD_TEST( generate_rand_sspeer_key( key_pub_B, rng, 0 ) );
@@ -261,7 +260,8 @@ test_duplicate_peers( fd_sspeer_selector_t * selector,
   /* This is a test, but in reality resolved_addr should match addr0. */
   fd_sspeer_key_t key_url_C[1]; *key_url_C = *key_url_A; key_url_C->url.resolved_addr.l = (key_url_A->url.resolved_addr.l ^ 2UL) | 1UL;
 
-  /* Add peers with same addr, same full_slot and incr_slot. */
+  /* Add peers with same addr, same full_slot and incr_slot.
+     With cluster at {0, UNKNOWN}, peers are ahead so scores = latency. */
 
   /* ... pubkey peer, latency 2us, expected best score 2e6. */
   FD_TEST( add_peer( selector, key_pub_A, addr0, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
@@ -318,7 +318,6 @@ test_peer_addr_change( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 3000UL;
   ulong cluster_incr_slot = 3500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
@@ -326,7 +325,8 @@ test_peer_addr_change( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_A1; FD_TEST( generate_rand_addr_non_zero( &addr_A1, rng ) );
   fd_ip4_port_t addr_B;  FD_TEST( generate_rand_addr_non_zero( &addr_B,  rng ) );
 
-  /* Add 2 peers change the addr of one of them. */
+  /* Add 2 peers change the addr of one of them.
+     With cluster at {0, UNKNOWN}, peers are ahead so scores = latency. */
 
   /* ... peer A, latency 2us, expected best score 2e6. */
   FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
@@ -368,7 +368,6 @@ test_update_on_ping( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 4000UL;
   ulong cluster_incr_slot = 4500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
@@ -380,7 +379,8 @@ test_update_on_ping( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_E;  FD_TEST( generate_rand_addr_non_zero( &addr_E,  rng ) );
   fd_ip4_port_t addr_X;  FD_TEST( generate_rand_addr_non_zero( &addr_X,  rng ) );
 
-  /* Add 5 peers: pairs AB, CD and single E. */
+  /* Add 5 peers: pairs AB, CD and single E.
+     With cluster at {0, UNKNOWN}, peers are ahead so scores = latency. */
 
   /* ... peers A and B, latency 2us, expected best score 2e6 (pair AB). */
   FD_TEST( add_peer( selector, key_A, addr_AB, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
@@ -451,9 +451,7 @@ test_update_on_ping( fd_sspeer_selector_t * selector,
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 5UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* Verify hashes are preserved after update_on_ping.  Add a peer with
-     explicit hashes, update latency via ping, and confirm hashes are
-     unchanged. */
+  /* Verify hashes are preserved after update_on_ping. */
   fd_sspeer_selector_remove_by_addr( selector, addr_AB );
   fd_sspeer_selector_remove_by_addr( selector, addr_CD );
   fd_sspeer_selector_remove_by_addr( selector, addr_E  );
@@ -490,61 +488,70 @@ test_update_on_ping( fd_sspeer_selector_t * selector,
 }
 
 static void
-test_update_on_resolve( fd_sspeer_selector_t * selector,
-                        fd_rng_t *             rng ) {
-  FD_LOG_NOTICE(( "testing update on_resolve" ));
+test_resolve_via_add( fd_sspeer_selector_t * selector,
+                      fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing resolve via add" ));
 
   ulong cluster_full_slot = 5000UL;
   ulong cluster_incr_slot = 5500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, 1/*is_url*/ ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, 1/*is_url*/ ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
   fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
 
-  /* Add 2 peers and update gradually. */
+  /* Add 2 peers with UNKNOWN slots (simulating initial discovery).
+     With cluster at {0, UNKNOWN}, unresolved peers get
+     DEFAULT_SLOTS_BEHIND penalty. */
 
-  /* ... peer A latency 3us, expected best score 3e6 (the expected
-     score must not match the default one). */
+  /* ... peer A latency 3us, expected best score != 3e6 (penalized). */
   FD_TEST( add_peer( selector, key_A, addr_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )!=3UL*1000UL*1000UL );
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
   FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, NULL,  cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NULL_KEY );
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+
+  /* add() with NULL key must return SCORE_INVALID. */
+  FD_TEST( fd_sspeer_selector_add( selector, NULL, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_SCORE_INVALID );
+
+  /* add() with UNKNOWN slots for both is a no-op on existing peer
+     (slots unchanged). */
+  FD_TEST( add_peer( selector, key_A, addr_A, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_LATENCY_UNKNOWN )!=FD_SSPEER_SCORE_INVALID );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
   FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
-  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is now rejected
+
+  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is rejected
      (an incremental slot requires a known full slot). */
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_INVALID_ARG  );
+  FD_TEST( add_peer( selector, key_A, addr_A, FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot, FD_SSPEER_LATENCY_UNKNOWN )==FD_SSPEER_SCORE_INVALID );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( !best.addr.l );
   FD_TEST( best.full_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+
+  /* Resolve peer A with valid slots via add() (production path). */
+  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, FD_SSPEER_LATENCY_UNKNOWN )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3UL*1000UL*1000UL );
 
-  /* ... peer B latency 2us, expected best score 2e6 (the expected
-     score must not match the default one). */
+  /* ... peer B latency 2us. */
   FD_TEST( add_peer( selector, key_B, addr_B, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=2UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==3UL*1000UL*1000UL );
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_SUCCESS  );
+
+  /* Resolve peer B with valid slots via add(). */
+  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_B.l );
   FD_TEST( best.full_slot==cluster_full_slot );
@@ -553,9 +560,7 @@ test_update_on_resolve( fd_sspeer_selector_t * selector,
 
   /* Cleanup and verification. */
   fd_sspeer_selector_remove( selector, key_A );
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_A, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
   fd_sspeer_selector_remove( selector, key_B );
-  FD_TEST(fd_sspeer_selector_update_on_resolve( selector, key_B, cluster_full_slot, cluster_incr_slot, NULL, NULL )==FD_SSPEER_UPDATE_ERR_NOT_FOUND );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
@@ -569,7 +574,6 @@ test_address_zero( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 6000UL;
   ulong cluster_incr_slot = 6500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
@@ -583,7 +587,8 @@ test_address_zero( fd_sspeer_selector_t * selector,
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* Add both peers with valid addresses. */
+  /* Add both peers with valid addresses.
+     With cluster at {0, UNKNOWN}, peers are ahead so scores = latency. */
   FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
@@ -631,7 +636,6 @@ test_duplicate_hostnames( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 7000UL;
   ulong cluster_incr_slot = 7500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   /* Two HTTP servers with same hostname but different resolved_addr. */
   fd_sspeer_key_t key_url_A[1]; FD_TEST( generate_rand_sspeer_key( key_url_A, rng, 1 ) );
@@ -639,7 +643,8 @@ test_duplicate_hostnames( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_A = key_url_A->url.resolved_addr;
   fd_ip4_port_t addr_B = key_url_B->url.resolved_addr;
 
-  /* Add both peers with valid addresses. */
+  /* Add both peers with valid addresses.
+     With cluster at {0, UNKNOWN}, peers are ahead so scores = latency. */
   FD_TEST( add_peer( selector, key_url_A, addr_A, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
@@ -675,7 +680,6 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 8000UL;
   ulong cluster_incr_slot = 8500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
@@ -685,6 +689,10 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
 
   /* Add peer A with valid incremental. */
   FD_TEST( add_peer( selector, key_A, addr_N, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
+
+  /* Establish the cluster slot via median computation. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_N.l );
   FD_TEST( best.full_slot==cluster_full_slot );
@@ -709,8 +717,7 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
   /* New gossip message for peer A arrives without an incremental but
      with the SAME full_slot.  The peer's existing incr_slot (8500) is
      >= full_slot (8000), so the incremental is not stale and should
-     be preserved (slot-based clearing only clears when incr_slot <
-     full_slot). */
+     be preserved. */
   uchar temp_full_hash[ FD_HASH_FOOTPRINT ];
   fd_memset( temp_full_hash, fd_rng_uchar( rng ), FD_HASH_FOOTPRINT );
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
@@ -728,9 +735,7 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( fd_memeq( best.full_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
 
-  /* Clear incremental by advancing full_slot past the peer's incr_slot.
-     Peer has incr_slot=8500, new full_slot=8501 > 8500, so the
-     incremental is genuinely stale and should be cleared. */
+  /* Clear incremental by advancing full_slot past the peer's incr_slot. */
   ulong new_full_slot = cluster_incr_slot + 1UL;
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
                                    new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
@@ -779,8 +784,7 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==cluster_incr_slot );
 
-  /* Now clear with full_slot one past incr_slot: incr_slot (8500) <
-     full_slot (8501), genuinely stale. */
+  /* Now clear with full_slot one past incr_slot: genuinely stale. */
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
                                    cluster_incr_slot + 1UL, FD_SSPEER_SLOT_UNKNOWN,
                                    temp_full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
@@ -800,8 +804,7 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
   FD_TEST( !best.addr.l );
   FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
 
-  /* Re-add peer A with a valid incremental slot.  This verifies the
-     full transition cycle: has-incremental -> clear -> has-incremental. */
+  /* Re-add peer A with a valid incremental slot. */
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
                                    cluster_full_slot, cluster_incr_slot,
                                    temp_full_hash, temp_full_hash )==2UL*1000UL*1000UL );
@@ -816,16 +819,13 @@ test_add_clears_incremental( fd_sspeer_selector_t * selector,
   FD_TEST( fd_memeq( best.incr_hash, temp_full_hash, FD_HASH_FOOTPRINT ) );
 
   /* add() with full_hash==NULL, incr_hash!=NULL: the full_hash should
-     be preserved (not overwritten) and the incr_hash should be updated.
-     No slot-based clearing because full_slot==UNKNOWN. */
+     be preserved and the incr_hash should be updated. */
   uchar new_incr_hash[ FD_HASH_FOOTPRINT ];
   fd_memset( new_incr_hash, 0xEE, FD_HASH_FOOTPRINT );
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
                                    FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
                                    NULL, new_incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
-  /* The peer's existing full_hash should be preserved (full_hash was
-     NULL so no overwrite), and incr_hash should be updated. */
   best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==cluster_full_slot );
@@ -849,7 +849,6 @@ test_on_resolve_clears_incremental( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 8700UL;
   ulong cluster_incr_slot = 8800UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
@@ -864,37 +863,38 @@ test_on_resolve_clears_incremental( fd_sspeer_selector_t * selector,
                                    cluster_full_slot, cluster_incr_slot,
                                    full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
+  /* Establish the cluster slot via median. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+
   /* Peer A should be a valid incremental candidate. */
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==cluster_incr_slot );
 
-  /* Call update_on_resolve with full_hash non-NULL and incr_hash NULL,
-     using the SAME full_slot.  Because the peer's incr_slot (8800) >=
-     full_slot (8700), the incremental is not stale and is preserved. */
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
-                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+  /* Re-add with the SAME full_slot via add() (production resolve path).
+     The peer's incr_slot (8800) >= full_slot (8700), not stale,
+     preserved. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
 
-  /* Peer A should STILL be a valid incremental candidate (not stale). */
+  /* Peer A should STILL be a valid incremental candidate. */
   best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==cluster_incr_slot );
 
-  /* Now advance full_slot past the peer's incr_slot so the slot-based
-     clear fires.  new_full_slot (8801) > incr_slot (8800). */
+  /* Advance full_slot past incr_slot so slot-based clear fires. */
   ulong new_full_slot = cluster_incr_slot + 1UL;
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
-                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
 
   /* Peer A should no longer be an incremental candidate. */
   best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   FD_TEST( !best.addr.l );
   FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
 
-  /* Peer A should still be valid for full selection with cleared
-     incremental (incr_slot==FD_SSPEER_SLOT_UNKNOWN, incr_hash zeroed). */
+  /* Peer A should still be valid for full selection with cleared incremental. */
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==new_full_slot );
@@ -912,97 +912,288 @@ test_on_resolve_clears_incremental( fd_sspeer_selector_t * selector,
 }
 
 static void
-test_cluster_slot_incremental( fd_sspeer_selector_t * selector,
-                               fd_rng_t *             rng ) {
-  FD_LOG_NOTICE(( "testing cluster slot incremental" ));
-
-  ulong cluster_full_slot = 9000UL;
-  ulong cluster_incr_slot = 9500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+test_cluster_slot_rescoring( fd_sspeer_selector_t * selector,
+                             fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing cluster slot rescoring" ));
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
   fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
 
-  /* Add two peers with valid incrementals at the cluster slot. */
-  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_incr_slot, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
-  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, cluster_incr_slot, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
+  /* Add two peers with different incremental slots. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 9000UL, 9500UL, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, 9000UL, 9200UL, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
 
-  /* Peer A is the best incremental candidate. */
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
-  FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2UL*1000UL*1000UL );
-
-  /* A newer full_slot arrives with no incremental.  The cluster full
-     slot advances but incremental is preserved (not reset). */
-  fd_sspeer_selector_process_cluster_slot( selector, 9001UL, FD_SSPEER_SLOT_UNKNOWN );
-
+  /* Compute lower median.  Full slots: [9000, 9000] -> mid=0 -> 9000.
+     Incr slots: sorted [9200, 9500] -> mid=0 -> 9200.
+     Cluster = (9000, 9200). */
+  fd_sspeer_selector_process_cluster_slot( selector );
   fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs.full==9001UL );
-  FD_TEST( cs.incremental==cluster_incr_slot );
+  FD_TEST( cs.full==9000UL );
+  FD_TEST( cs.incremental==9200UL );
 
-  /* Peers still have incr_slot==9500 so they are still valid
-     incremental candidates for base_slot 9000.  Cluster incremental
-     is preserved at 9500, so slots_behind==0 and score==latency. */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
+  /* After rescore:
+     Peer A: behind = max(0, 9200-9500) = 0. score = 2_000_000.
+     Peer B: behind = max(0, 9200-9200) = 0. score = 3_000_000. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.incr_slot==cluster_incr_slot );
   FD_TEST( best.score==2UL*1000UL*1000UL );
 
-  /* A subsequent observation with a higher incremental advances it. */
-  fd_sspeer_selector_process_cluster_slot( selector, 9001UL, 9600UL );
+  /* Add a third peer to shift the median. */
+  FD_TEST( add_peer( selector, key_C, addr_C, 9000UL, 9800UL, 4UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Recompute lower median.  Incr slots: sorted [9200, 9500, 9800].
+     mid=1 -> 9500.  Cluster = (9000, 9500). */
+  fd_sspeer_selector_process_cluster_slot( selector );
   cs = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs.full==9001UL );
-  FD_TEST( cs.incremental==9600UL );
+  FD_TEST( cs.full==9000UL );
+  FD_TEST( cs.incremental==9500UL );
 
-  /* Now peers are 100 slots behind (9600-9500). */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
-  FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 100UL*1000UL );
-
-  /* Advance full past incremental (9600) to 10000 with no new
-     incremental.  The cluster incremental is invalidated (set to
-     FD_SSPEER_SLOT_UNKNOWN).  All peers must be rescored: peers with
-     valid incr_slot now fall back to comparing full_slot against the
-     cluster full slot.  Peers have full_slot=9000, so
-     slots_behind = 10000-9000 = 1000. */
-  fd_sspeer_selector_process_cluster_slot( selector, 10000UL, FD_SSPEER_SLOT_UNKNOWN );
+  /* Remove peer A (the one at 9500) to shift the median.
+     Remaining incr slots: sorted [9200, 9800]. mid=0 -> 9200.
+     Cluster = (9000, 9200). */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_process_cluster_slot( selector );
   cs = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs.full==10000UL );
-  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( cs.full==9000UL );
+  FD_TEST( cs.incremental==9200UL );
 
-  /* Peers still have incr_slot==9500 so they are still incremental
-     candidates for base_slot 9000.  Score: latency + 1000*1000. */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
-  FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.incr_slot==cluster_incr_slot );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL*1000UL );
-
+  /* After rescore:
+     Peer B: behind = max(0, 9200-9200) = 0.   score = 3_000_000.
+     Peer C: behind = max(0, 9200-9800) = 0.   score = 4_000_000. */
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr_A.l );
-  /* Full selection falls back to full_slot comparison when
-     cluster.incremental == FD_SSPEER_SLOT_UNKNOWN.
-     Same score as incremental. */
-  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL*1000UL );
-
-  /* Re-establish cluster incremental.  Peers should be rescored back
-     to using incremental slot difference. */
-  fd_sspeer_selector_process_cluster_slot( selector, 10000UL, 10000UL );
-  cs = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs.full==10000UL );
-  FD_TEST( cs.incremental==10000UL );
-
-  /* Peers are now 500 slots behind (10000-9500).
-     Score = 2_000_000 + 500*1000 = 2_500_000. */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
-  FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 500UL*1000UL );
+  FD_TEST( best.addr.l==addr_B.l );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
 
   /* Cleanup */
-  fd_sspeer_selector_remove( selector, key_A );
   fd_sspeer_selector_remove( selector, key_B );
+  fd_sspeer_selector_remove( selector, key_C );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cluster_slot_regression( fd_sspeer_selector_t * selector,
+                              fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing cluster slot regression" ));
+
+  /* Verify that removing high-slot peers causes the median-based
+     cluster slot to decrease, and that scoring adjusts correctly. */
+
+  fd_sspeer_key_t keys[5];
+  fd_ip4_port_t   addrs[5];
+  for( ulong i=0; i<5UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &addrs[i], rng ) );
+  }
+
+  /* Add 5 peers: 3 at full=1000, 2 at full=500.
+     Full slots sorted: [500, 500, 1000, 1000, 1000].
+     Lower median = [(5-1)/2] = [2] = 1000. */
+  FD_TEST( add_peer( selector, &keys[0], addrs[0], 1000UL, 1500UL, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[1], addrs[1], 1000UL, 1500UL, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[2], addrs[2], 1000UL, 1500UL, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[3], addrs[3],  500UL,  800UL, 4UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[4], addrs[4],  500UL,  800UL, 5UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==1000UL );
+  FD_TEST( cs.incremental==1500UL );
+
+  /* Peer 3 (full=500): behind = 1000-500 = 500.
+     score = 4_000_000 + 500*1000 = 4_500_000.
+     Peer 0 (full=1000): behind = 0.
+     score = 1_000_000. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addrs[0].l );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  /* Remove 2 of the 3 high-slot peers.  Remaining:
+     keys[2] at full=1000, keys[3] at full=500, keys[4] at full=500.
+     Full slots sorted: [500, 500, 1000].
+     Lower median = [(3-1)/2] = [1] = 500.
+     Incr slots sorted: [800, 800, 1500].
+     Lower median = [1] = 800.
+     Cluster REGRESSES from (1000, 1500) to (500, 800). */
+  fd_sspeer_selector_remove( selector, &keys[0] );
+  fd_sspeer_selector_remove( selector, &keys[1] );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==500UL );
+  FD_TEST( cs.incremental==800UL );
+
+  /* After rescore with cluster=(500, 800):
+     Peer 2 (full=1000, incr=1500): ahead of cluster, behind=0.
+       score = 3_000_000.
+     Peer 3 (full=500, incr=800): at cluster, behind=0.
+       score = 4_000_000.
+     Peer 4 (full=500, incr=800): at cluster, behind=0.
+       score = 5_000_000.
+     Best = peer 2 (lowest score). */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addrs[2].l );
+  FD_TEST( best.score==3UL*1000UL*1000UL );
+
+  /* Remove the last high-slot peer.  Remaining:
+     keys[3] at full=500, keys[4] at full=500.
+     Lower median = [(2-1)/2] = [0] = 500.
+     Cluster stays at (500, 800). */
+  fd_sspeer_selector_remove( selector, &keys[2] );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==500UL );
+  FD_TEST( cs.incremental==800UL );
+
+  /* Best = peer 3 (lat=4ms, behind=0). */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addrs[3].l );
+  FD_TEST( best.score==4UL*1000UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, &keys[3] );
+  fd_sspeer_selector_remove( selector, &keys[4] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_cluster_slot_recovery_after_poison( fd_sspeer_selector_t * selector,
+                                         fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing cluster slot recovery after poison" ));
+
+  /* Simulate the exact malicious scenario: a single malicious peer
+     poisons the cluster slot with an extreme value, gets removed
+     (blacklisted), and then an honest peer arrives and corrects
+     the cluster slot. */
+
+  fd_sspeer_key_t malicious_key[1]; FD_TEST( generate_rand_sspeer_key( malicious_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t honest_key[1];    FD_TEST( generate_rand_sspeer_key( honest_key,   rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t malicious_addr; FD_TEST( generate_rand_addr_non_zero( &malicious_addr, rng ) );
+  fd_ip4_port_t honest_addr;    FD_TEST( generate_rand_addr_non_zero( &honest_addr,   rng ) );
+
+  ulong poison_slot = 999999999999998UL;  /* near MAX_SLOT */
+  ulong honest_slot = 300000000UL;        /* realistic mainnet slot */
+
+  /* Step 1: Malicious is the first and only peer.
+     Median of 1 = the malicious's slot.  Cluster slot is poisoned. */
+  FD_TEST( add_peer( selector, malicious_key, malicious_addr, poison_slot, poison_slot+1UL,
+                     2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==poison_slot );
+  FD_TEST( cs.incremental==poison_slot+1UL );
+
+  /* Step 2: Malicious is removed (simulating blacklist_peer removing
+     from selector).  With 0 peers, process_cluster_slot resets the
+     cluster slot to {0, UNKNOWN}, clearing the poisoned value. */
+  fd_sspeer_selector_remove( selector, malicious_key );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Verify no peer is available. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Step 3: Honest peer arrives.  Because the cluster slot was reset,
+     add() scores the honest peer against {0, UNKNOWN}, the peer is
+     ahead of the cluster, so slots_behind=0 and score=latency. */
+  ulong initial_score = add_peer( selector, honest_key, honest_addr, honest_slot, honest_slot+100UL,
+                                  5UL*1000UL*1000UL );
+  FD_TEST( initial_score!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( initial_score==5UL*1000UL*1000UL ); /* no penalty inflation */
+
+  /* Step 4: process_cluster_slot recomputes the median from the
+     single honest peer.  Cluster slot updates to the honest value.
+     No rescore is needed since the peer was already scored correctly. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==honest_slot );
+  FD_TEST( cs.incremental==honest_slot+100UL );
+
+  /* score = latency = 5_000_000. */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==honest_addr.l );
+  FD_TEST( best.full_slot==honest_slot );
+  FD_TEST( best.incr_slot==honest_slot+100UL );
+  FD_TEST( best.score==5UL*1000UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, honest_key );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_poison_recovery_with_unresolved_peers( fd_sspeer_selector_t * selector,
+                                             fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing poison recovery with unresolved peers" ));
+
+  /* If a malicious peer poisons the cluster slot and is then removed
+     while only unresolved (SLOT_UNKNOWN) peers remain, the cluster
+     slot must reset. */
+
+  fd_sspeer_key_t malicious_key[1]; FD_TEST( generate_rand_sspeer_key( malicious_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t unresolved_key[1]; FD_TEST( generate_rand_sspeer_key( unresolved_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t honest_key[1]; FD_TEST( generate_rand_sspeer_key( honest_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t malicious_addr; FD_TEST( generate_rand_addr_non_zero( &malicious_addr, rng ) );
+  fd_ip4_port_t unresolved_addr; FD_TEST( generate_rand_addr_non_zero( &unresolved_addr, rng ) );
+  fd_ip4_port_t honest_addr; FD_TEST( generate_rand_addr_non_zero( &honest_addr, rng ) );
+
+  ulong poison_slot = 999UL;
+  ulong honest_slot = 300UL;
+
+  /* Malicious peer poisons the cluster slot. */
+  FD_TEST( add_peer( selector, malicious_key, malicious_addr, poison_slot, poison_slot+1UL,
+                     2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==poison_slot );
+
+  /* Add an unresolved peer (full_slot==UNKNOWN). */
+  FD_TEST( add_peer( selector, unresolved_key, unresolved_addr,
+                     FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
+                     3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Remove the malicious peer.  The unresolved peer remains.
+     process_cluster_slot must reset because full_cnt==0 (the only
+     remaining peer has UNKNOWN slots). */
+  fd_sspeer_selector_remove( selector, malicious_key );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Honest peer arrives with real slots.  It should be scored
+     against {0, UNKNOWN}, not the poisoned value. */
+  ulong score = add_peer( selector, honest_key, honest_addr, honest_slot, honest_slot+100UL,
+                           5UL*1000UL*1000UL );
+  FD_TEST( score!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( score==5UL*1000UL*1000UL );  /* no penalty inflation */
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==honest_slot );
+
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==honest_addr.l );
+  FD_TEST( best.score==5UL*1000UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, unresolved_key );
+  fd_sspeer_selector_remove( selector, honest_key );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
@@ -1014,26 +1205,28 @@ test_slot_zero( fd_sspeer_selector_t * selector,
                 fd_rng_t *             rng ) {
   FD_LOG_NOTICE(( "testing slot zero" ));
 
-  /* full_slot==0 and incr_slot==0 are valid slot values (e.g. genesis).
-     Set (0, 1) so the peer at incr_slot=0 is one slot behind. */
-  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 1UL );
+  /* full_slot==0 and incr_slot==0 are valid slot values (e.g. genesis). */
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
   fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
 
-  /* Peer at full_slot=0, incr_slot=0, latency 2ms.  Cluster is at
-     (0, 1), which means the peer is 1 slot behind.  Then the score is
-     2_000_000 + 1*1000 = 2_001_000. */
-  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 1000UL );
+  /* Peer at full_slot=0, incr_slot=0, latency 2ms. */
+  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
 
-  /* Full selection: peer should be valid and best. */
+  /* Compute cluster slot from median.  cluster = (0, 0). */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==0UL );
+
+  /* Full selection: peer should be valid and best.  score = 2_000_000. */
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==0UL );
   FD_TEST( best.incr_slot==0UL );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* Incremental selection with base_slot=0: peer's full_slot==0
      matches base_slot, and incr_slot==0 != FD_SSPEER_SLOT_UNKNOWN. */
@@ -1041,24 +1234,17 @@ test_slot_zero( fd_sspeer_selector_t * selector,
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.full_slot==0UL );
   FD_TEST( best.incr_slot==0UL );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* Peer with full_slot==0, incr_slot==FD_SSPEER_SLOT_UNKNOWN: valid
-     for full but NOT for incremental selection.  full_slot uses the
-     full cluster slot branch: slots_behind = cluster_full(0) - 0 = 0.
-     score = 3_000_000. */
+     for full but NOT for incremental selection. */
   FD_TEST( add_peer( selector, key_B, addr_B, 0UL, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 1000UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
   best = fd_sspeer_selector_best( selector, 1, 0UL );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==0UL );
-
-  /* Score with incr_slot=0 when cluster has advanced.  Re-add peer A
-     to observe the rescored value via the add_peer return. */
-  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 100UL );
-  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 100UL*1000UL );
 
   /* Cleanup */
   fd_sspeer_selector_remove( selector, key_A );
@@ -1086,221 +1272,50 @@ test_score_saturation( fd_sspeer_selector_t * selector,
   FD_TEST( score==5UL*1000UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Score is never FD_SSPEER_SCORE_INVALID: verify the cap prevents
-     confusion with the "no peer" sentinel. */
+  /* Score is never FD_SSPEER_SCORE_INVALID. */
   FD_TEST( score!=FD_SSPEER_SCORE_INVALID );
   FD_TEST( FD_SSPEER_SCORE_MAX<FD_SSPEER_SCORE_INVALID );
 
-  /* Establish a cluster with both full and incremental slots. */
-  ulong cluster_full_slot = 10000UL;
-  ulong cluster_incr_slot = 10500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
+  /* Establish a cluster slot by adding a helper peer and computing
+     the median. */
+  fd_sspeer_key_t helper_key[1]; FD_TEST( generate_rand_sspeer_key( helper_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t   helper_addr;   FD_TEST( generate_rand_addr_non_zero( &helper_addr, rng ) );
+  FD_TEST( add_peer( selector, helper_key, helper_addr, 10000UL, 10500UL, 100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==10000UL );
+  FD_TEST( cs.incremental==10500UL );
 
-  /* Normal score, no overflow: peer at cluster slot, latency 5ms.
-     score = 5_000_000 + 0 = 5_000_000. */
+  /* Normal score, no overflow: peer at cluster slot, latency 5ms. */
   FD_TEST( add_peer( selector, key, addr, 10000UL, 10500UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Slots-behind penalty: peer incr_slot 100 behind cluster.
-     score = 5_000_000 + 100*1000 = 5_100_000. */
+  /* Slots-behind penalty: peer incr_slot 100 behind cluster. */
   FD_TEST( add_peer( selector, key, addr, 10000UL, 10400UL, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL + 100UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Default latency (FD_SSPEER_LATENCY_UNKNOWN input): peer at cluster slot.
-     score = DEFAULT_PEER_LATENCY = 100_000_000. */
+  /* Default latency (FD_SSPEER_LATENCY_UNKNOWN input). */
   FD_TEST( add_peer( selector, key, addr, 10000UL, 10500UL, FD_SSPEER_LATENCY_UNKNOWN )==100UL*1000UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Default latency + slot-behind penalty combined: peer has unknown
-     latency and incr_slot 100 behind cluster.
-     score = DEFAULT_PEER_LATENCY + 100*1000 = 100_100_000. */
+  /* Default latency + slot-behind penalty combined. */
   FD_TEST( add_peer( selector, key, addr, 10000UL, 10400UL, FD_SSPEER_LATENCY_UNKNOWN )==100UL*1000UL*1000UL + 100UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Unresolved full slot: peer has FD_SSPEER_SLOT_UNKNOWN for both slots.
-     slots_behind = DEFAULT_SLOTS_BEHIND = 1_000_000.
-     score = 5_000_000 + 1_000_000*1000 = 1_005_000_000. */
+  /* Unresolved full slot: DEFAULT_SLOTS_BEHIND penalty. */
   FD_TEST( add_peer( selector, key, addr, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 5UL*1000UL*1000UL )==5UL*1000UL*1000UL + 1000UL*1000UL*1000UL );
   fd_sspeer_selector_remove( selector, key );
 
-  /* Unresolved full slot with valid incr_slot:
-     full_slot==FD_SSPEER_SLOT_UNKNOWN with incr_slot!=UNKNOWN is now
-     rejected (an incremental slot requires a known full slot). */
+  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is rejected. */
   FD_TEST( add_peer( selector, key, addr, FD_SSPEER_SLOT_UNKNOWN, 10500UL, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
 
-  /* Score saturation: peer's full_slot is far behind a very high cluster
-     full slot.  slots_behind = (ULONG_MAX-1) - 0 = ULONG_MAX-1, which
-     causes sat_mul(1000, ULONG_MAX-1) to overflow, then sat_add also
-     overflows, and the result is clamped to FD_SSPEER_SCORE_MAX. */
-  fd_sspeer_selector_process_cluster_slot( selector, ULONG_MAX-1UL, ULONG_MAX-1UL );
+  /* Score saturation: establish cluster at near-ULONG_MAX via helper. */
+  fd_sspeer_selector_remove( selector, helper_key );
+  FD_TEST( add_peer( selector, helper_key, helper_addr, ULONG_MAX-1UL, ULONG_MAX-1UL, 100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
   FD_TEST( add_peer( selector, key, addr, 0UL, FD_SSPEER_SLOT_UNKNOWN, 5UL*1000UL*1000UL )==FD_SSPEER_SCORE_MAX );
   fd_sspeer_selector_remove( selector, key );
-
-  FD_LOG_NOTICE(( "... pass" ));
-}
-
-static void
-test_cluster_slot_monotonicity( fd_sspeer_selector_t * selector_incr,
-                                fd_sspeer_selector_t * selector_full ) {
-  FD_LOG_NOTICE(( "testing cluster slot monotonicity" ));
-
-  /* Incremental mode (incremental_snapshot_fetch=1).
-     Use slot values higher than any previous test to avoid
-     monotonicity rejection from prior cluster slot state. */
-
-  /* Establish baseline: full=20000, incr=20200. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20000UL, 20200UL );
-  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20000UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* Both FD_SSPEER_SLOT_UNKNOWN => no-op. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20000UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* full_slot==FD_SSPEER_SLOT_UNKNOWN with valid incr_slot => no-op. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, FD_SSPEER_SLOT_UNKNOWN, 99999UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20000UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* incr_slot==stored incr (20200), same full => rejected (no forward
-     progress on either axis). */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20000UL, 20200UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20000UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* incr_slot==stored incr (20200), but full advances (20050 > 20000):
-     accepted because the full slot has made forward progress. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20200UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20050UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* incr_slot < stored incr => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20199UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20050UL );
-  FD_TEST( cs.incremental==20200UL );
-
-  /* incr_slot > stored incr => accepted. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20050UL, 20201UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20050UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* Advance full with incr==FD_SSPEER_SLOT_UNKNOWN.  Full advances but
-     incremental is preserved (not reset). */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* incr==FD_SSPEER_SLOT_UNKNOWN, full<=stored full => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* incr==FD_SSPEER_SLOT_UNKNOWN, full<stored full => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20149UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* incr_slot==stored incr, full<=stored full => rejected (no forward
-     progress). */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20201UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* incr_slot < stored incr => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20200UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20201UL );
-
-  /* incr_slot > stored incr => accepted. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20150UL, 20202UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20150UL );
-  FD_TEST( cs.incremental==20202UL );
-
-  /* Advance full past incremental with incr==FD_SSPEER_SLOT_UNKNOWN.
-     The stored incremental (20202) is now stale because the full slot
-     (20300) advanced past it.  It must be invalidated. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20300UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20300UL );
-  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
-
-  /* Re-establish incremental after invalidation. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20300UL, 20400UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20300UL );
-  FD_TEST( cs.incremental==20400UL );
-
-  /* full_slot regression with valid incr_slot: rejected.  Even though
-     incr_slot (20500) advances past stored incremental (20400),
-     full_slot (20200) is less than stored full (20300), so the update
-     must be rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20200UL, 20500UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20300UL );
-  FD_TEST( cs.incremental==20400UL );
-
-  /* full_slot regression with valid incr_slot, stored incr unknown:
-     rejected.  First invalidate the stored incremental by advancing
-     full past it. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20500UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20500UL );
-  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
-
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20400UL, 20600UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20500UL );
-  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
-
-  /* Re-establish for subsequent tests. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20500UL, 20600UL );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20500UL );
-  FD_TEST( cs.incremental==20600UL );
-
-  /* Advance full to exactly the incremental slot with
-     incr==FD_SSPEER_SLOT_UNKNOWN.  incr==full is not stale
-     (incremental is at the same slot), so incremental is preserved. */
-  fd_sspeer_selector_process_cluster_slot( selector_incr, 20600UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_incr );
-  FD_TEST( cs.full==20600UL );
-  FD_TEST( cs.incremental==20600UL );
-
-  /* Full-only mode (incremental_snapshot_fetch=0). */
-
-  /* Establish baseline: full=500. */
-  fd_sspeer_selector_process_cluster_slot( selector_full, 500UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_full );
-  FD_TEST( cs.full==500UL );
-
-  /* full<=stored full => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_full, 500UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_full );
-  FD_TEST( cs.full==500UL );
-
-  /* full<stored full => rejected. */
-  fd_sspeer_selector_process_cluster_slot( selector_full, 499UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_full );
-  FD_TEST( cs.full==500UL );
-
-  /* full>stored full => accepted. */
-  fd_sspeer_selector_process_cluster_slot( selector_full, 501UL, FD_SSPEER_SLOT_UNKNOWN );
-  cs = fd_sspeer_selector_cluster_slot( selector_full );
-  FD_TEST( cs.full==501UL );
+  fd_sspeer_selector_remove( selector, helper_key );
 
   FD_LOG_NOTICE(( "... pass" ));
 }
@@ -1312,7 +1327,6 @@ test_pool_exhaustion( fd_sspeer_selector_t * selector,
 
   ulong cluster_full = 1000UL;
   ulong cluster_incr = 1500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full, cluster_incr );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, 0 ) );
   fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, 0 ) );
@@ -1321,7 +1335,7 @@ test_pool_exhaustion( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
   fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
 
-  /* Fill to max capacity. */
+  /* Fill to max capacity (max_peers=2). */
   FD_TEST( add_peer( selector, key_A, addr_A, cluster_full, cluster_incr, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
   FD_TEST( add_peer( selector, key_B, addr_B, cluster_full, cluster_incr, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
 
@@ -1362,7 +1376,7 @@ test_add_null_key( fd_sspeer_selector_t * selector,
   fd_ip4_port_t addr_A[1];
   FD_TEST( generate_rand_addr_non_zero( addr_A, rng ) );
 
-  /* Adding with NULL key should return FD_SSPEER_SCORE_INVALID and not modify state. */
+  /* Adding with NULL key should return FD_SSPEER_SCORE_INVALID. */
 
   FD_TEST( add_peer( selector, NULL, *addr_A, 100UL, 200UL, 1UL*1000UL*1000UL )==FD_SSPEER_SCORE_INVALID );
   FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1375,7 +1389,6 @@ test_add_null_key( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 100UL;
   ulong cluster_incr_slot = 200UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1414,7 +1427,6 @@ test_remove_null_key( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 100UL;
   ulong cluster_incr_slot = 200UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1451,7 +1463,6 @@ test_remove_unknown_key( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 100UL;
   ulong cluster_incr_slot = 200UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1490,7 +1501,6 @@ test_remove_by_addr_unknown( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 100UL;
   ulong cluster_incr_slot = 200UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   add_peer( selector, key_A, *addr_A, cluster_full_slot, cluster_incr_slot, 1UL*1000UL*1000UL );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1529,89 +1539,12 @@ test_best_empty_selector( fd_sspeer_selector_t * selector,
 }
 
 static void
-test_best_incremental_on_full_only_selector( fd_sspeer_selector_t * selector,
-                                             fd_rng_t *             rng ) {
-  FD_LOG_NOTICE(( "testing best incremental on full-only selector" ));
-
-  /* The selector was created with incr_snap_fetch=0 (full-only mode).
-     Verify that fd_sspeer_selector_best(selector, 1, base_slot) still
-     works correctly.  The incremental flag in best() filters by peer
-     attributes (full_slot==base_slot && incr_slot!=FD_SSPEER_SLOT_UNKNOWN),
-     it does NOT depend on the selector's incremental_snapshot_fetch
-     setting. */
-
-  ulong cluster_full_slot = 30000UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN );
-
-  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
-  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
-  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
-
-  /* Peer A: has incremental.  Peer B: no incremental.  Peer C: has
-     incremental at a different base slot. */
-  FD_TEST( add_peer( selector, key_A, addr_A, cluster_full_slot, cluster_full_slot + 500UL, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
-  FD_TEST( add_peer( selector, key_B, addr_B, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
-  FD_TEST( add_peer( selector, key_C, addr_C, cluster_full_slot - 1UL, cluster_full_slot + 400UL, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
-
-  /* Full selection: peer C has the lowest score.  Cluster incremental
-     is UNKNOWN so all peers with incr_slot fall back to the full_slot
-     comparison.  Peer C: latency=1ms, slots_behind=1 (30000-29999),
-     score = 1_000_000 + 1_000 = 1_001_000.  Peer B: latency=2ms,
-     slots_behind=0, score = 2_000_000.  Peer A: latency=3ms,
-     slots_behind=0, score = 3_000_000. */
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr_C.l );
-  FD_TEST( best.score==1UL*1000UL*1000UL + 1UL*1000UL );
-
-  /* Incremental selection with the right base_slot: only peer A
-     qualifies (peer B has no incr, peer C has a different full_slot). */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
-  FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.full_slot==cluster_full_slot );
-  FD_TEST( best.incr_slot==cluster_full_slot + 500UL );
-
-  /* Incremental selection with a base_slot that no peer matches. */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot + 999UL );
-  FD_TEST( best.addr.l==0UL );
-  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
-
-  /* Incremental selection with peer C's base_slot. */
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot - 1UL );
-  FD_TEST( best.addr.l==addr_C.l );
-  FD_TEST( best.full_slot==cluster_full_slot - 1UL );
-  FD_TEST( best.incr_slot==cluster_full_slot + 400UL );
-
-  /* Cleanup */
-  fd_sspeer_selector_remove( selector, key_A );
-  fd_sspeer_selector_remove( selector, key_B );
-  fd_sspeer_selector_remove( selector, key_C );
-  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
-  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
-
-  FD_LOG_NOTICE(( "... pass" ));
-}
-
-static void
 test_ping_preserves_cleared_incremental( fd_sspeer_selector_t * selector,
                                          fd_rng_t *             rng ) {
   FD_LOG_NOTICE(( "testing ping preserves cleared incremental" ));
 
-  /* Verify that update_on_ping does NOT restore stale incremental data
-     after a peer's incremental was cleared via slot-based clearing.
-
-     The update_on_ping codepath passes NULL, NULL for hashes and
-     FD_SSPEER_SLOT_UNKNOWN for both slots.  In fd_sspeer_selector_update,
-     since full_slot==UNKNOWN, no slot-based clearing fires and the
-     existing incr_slot/incr_hash are preserved (already cleared).
-     So the peer's incr_slot and incr_hash should remain as they were
-     (cleared to FD_SSPEER_SLOT_UNKNOWN and zeroed, respectively). */
-
   ulong cluster_full_slot = 31000UL;
   ulong cluster_incr_slot = 31500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
@@ -1626,15 +1559,16 @@ test_ping_preserves_cleared_incremental( fd_sspeer_selector_t * selector,
                                    cluster_full_slot, cluster_incr_slot,
                                    full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
+  /* Establish the cluster slot via median. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+
   /* Peer A should be a valid incremental candidate. */
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==cluster_incr_slot );
   FD_TEST( fd_memeq( best.incr_hash, incr_hash, FD_HASH_FOOTPRINT ) );
 
-  /* Clear the peer's incremental via slot-based clearing.  Advance
-     full_slot past incr_slot: new_full_slot (31501) > incr_slot
-     (31500), so the incremental is stale and will be cleared. */
+  /* Clear the peer's incremental via slot-based clearing. */
   ulong new_full_slot = cluster_incr_slot + 1UL;
   FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
                                    new_full_slot, FD_SSPEER_SLOT_UNKNOWN,
@@ -1657,15 +1591,11 @@ test_ping_preserves_cleared_incremental( fd_sspeer_selector_t * selector,
      incremental data. */
   FD_TEST( 1UL==fd_sspeer_selector_update_on_ping( selector, addr_A, 1UL*1000UL*1000UL ) );
 
-  /* The peer's incr_slot should still be FD_SSPEER_SLOT_UNKNOWN and
-     incr_hash should still be zeroed. */
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( fd_memeq( best.incr_hash, zeroed_hash, FD_HASH_FOOTPRINT ) );
-  /* full_hash should be preserved through the ping. */
   FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
-  /* Latency should have updated. */
   FD_TEST( best.score==1UL*1000UL*1000UL );
 
   /* Still not a valid incremental candidate. */
@@ -1700,24 +1630,19 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
                         ulong                  max_peers ) {
   FD_LOG_NOTICE(( "testing stress peer count (max_peers=%lu)", max_peers ));
 
-  /* Stress the selector with max_peers=32.  Try to add 34 peers
-     (exceeding capacity by 2) to exercise pool exhaustion, then
-     remove and re-add peers to verify the maps and treap stay
-     consistent under churn. */
-
   ulong const MAX_PEERS = 32UL;
   FD_TEST( MAX_PEERS==max_peers );
   ulong const TRY_CNT   = 34UL;
 
   ulong cluster_full_slot = 50000UL;
   ulong cluster_incr_slot = 50500UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t keys[ 34 ];
   fd_ip4_port_t   addrs[ 34 ];
 
   /* Try to add 34 peers.  The first 32 should succeed, the remaining
-     2 should be rejected (pool exhaustion). */
+     2 should be rejected (pool exhaustion).  With cluster at
+     {0, UNKNOWN}, all peers are ahead so scores = latency. */
 
   ulong best_full_score = FD_SSPEER_SCORE_INVALID;
   ulong best_full_idx   = ULONG_MAX;
@@ -1794,18 +1719,11 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
                        cluster_full_slot, overflow_inc, overflow_lat )!=FD_SSPEER_SCORE_INVALID );
     FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
 
-    /* Remove the overflow peer and half the original peers (note:
-       best_full_idx==0 was already removed, so i==0 is a no-op). */
-
     fd_sspeer_selector_remove( selector, &keys[ overflow_idx ] );
   }
   for( ulong i=0UL; i<MAX_PEERS; i+=2UL ) {
     fd_sspeer_selector_remove( selector, &keys[ i ] );
   }
-
-  /* 31 peers before the loop (32 - best_full + overflow - overflow).
-     Loop touches 16 even indices but best_full_idx==0 was already
-     removed, so only 15 actual removals => 16 remaining (odd indices). */
 
   ulong remaining = fd_sspeer_selector_peer_map_by_key_ele_cnt( selector );
   FD_TEST( remaining==16UL );
@@ -1817,9 +1735,9 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
     FD_TEST( best.score!=FD_SSPEER_SCORE_INVALID );
   }
 
-  /* Advance the cluster slot and verify rescoring. */
+  /* Compute the cluster slot from the median of remaining peers. */
 
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot + 100UL, cluster_incr_slot + 100UL );
+  fd_sspeer_selector_process_cluster_slot( selector );
 
   best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   if( remaining>0UL ) {
@@ -1831,10 +1749,8 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
 
   for( ulong i=0UL; i<MAX_PEERS; i+=2UL ) {
     ulong lat = (i + 1UL) * 1000UL * 1000UL;
-    ulong inc = i % 2UL == 0UL
-                ? cluster_incr_slot + 100UL - (i % 10UL)
-                : FD_SSPEER_SLOT_UNKNOWN;
-    add_peer( selector, &keys[ i ], addrs[ i ], cluster_full_slot + 100UL, inc, lat );
+    ulong inc = cluster_incr_slot - (i % 10UL);
+    add_peer( selector, &keys[ i ], addrs[ i ], cluster_full_slot, inc, lat );
   }
 
   FD_TEST( MAX_PEERS==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
@@ -1842,9 +1758,9 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
 
   /* Verify incremental selection still works. */
 
-  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot + 100UL );
+  best = fd_sspeer_selector_best( selector, 1, cluster_full_slot );
   if( best.addr.l ) {
-    FD_TEST( best.full_slot==cluster_full_slot + 100UL );
+    FD_TEST( best.full_slot==cluster_full_slot );
     FD_TEST( best.incr_slot!=FD_SSPEER_SLOT_UNKNOWN );
     FD_TEST( best.score!=FD_SSPEER_SCORE_INVALID );
   }
@@ -1862,98 +1778,58 @@ test_stress_peer_count( fd_sspeer_selector_t * selector,
 static void
 test_genesis_cluster_slot( fd_sspeer_selector_t * selector,
                            fd_rng_t *             rng ) {
-  FD_LOG_NOTICE(( "testing genesis cluster slot (0, 0)" ));
+  FD_LOG_NOTICE(( "testing genesis cluster slot" ));
 
-  /* Verify that process_cluster_slot(0, 0) succeeds from the initial
-     state {full=0, incremental=FD_SSPEER_SLOT_UNKNOWN}.  This is the
-     genesis case where both the full and incremental snapshots are at
-     slot 0. */
+  /* Verify initial state. */
   fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
   FD_TEST( cs.full==0UL );
   FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
 
-  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 0UL );
+  /* Add peers to establish cluster = (0, 0) via median. */
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
+
+  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL,                      2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, 0UL, FD_SSPEER_SLOT_UNKNOWN,   3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  fd_sspeer_selector_process_cluster_slot( selector );
   cs = fd_sspeer_selector_cluster_slot( selector );
   FD_TEST( cs.full==0UL );
   FD_TEST( cs.incremental==0UL );
 
-  /* Verify scoring when cluster.incremental == cluster.full == 0.
-     Peer with incr_slot=0: slots_behind = 0.  Score = latency.
-     Peer with incr_slot=FD_SSPEER_SLOT_UNKNOWN: uses full branch,
-     slots_behind = 0.  Score = latency. */
-  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
-  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
-
-  FD_TEST( add_peer( selector, key_A, addr_A, 0UL, 0UL,        2UL*1000UL*1000UL )==2UL*1000UL*1000UL );
-  FD_TEST( add_peer( selector, key_B, addr_B, 0UL, FD_SSPEER_SLOT_UNKNOWN,  3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
-
-  /* Peer A has lower score, so it's best for full selection. */
+  /* Verify scoring when cluster.incremental == cluster.full == 0. */
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.score==2UL*1000UL*1000UL );
 
-  /* Peer A is the only incremental candidate (B has
-     incr_slot==FD_SSPEER_SLOT_UNKNOWN). */
   best = fd_sspeer_selector_best( selector, 1, 0UL );
   FD_TEST( best.addr.l==addr_A.l );
   FD_TEST( best.incr_slot==0UL );
   FD_TEST( best.score==2UL*1000UL*1000UL );
 
-  /* Advance cluster to (0, 5).  Peer A is now 5 slots behind.
-     Score = 2_000_000 + 5*1000 = 2_005_000. */
-  fd_sspeer_selector_process_cluster_slot( selector, 0UL, 5UL );
+  /* Add peer C at (0, 5).
+     Incr slots: [0, 5] (peer B has UNKNOWN).  Lower median = [0] = 0.
+     Cluster = (0, 0).  No change, no rescore. */
+  FD_TEST( add_peer( selector, key_C, addr_C, 0UL, 5UL, 4UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==0UL );
+
   best = fd_sspeer_selector_best( selector, 1, 0UL );
   FD_TEST( best.addr.l==addr_A.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 5UL*1000UL );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
 
   /* Cleanup */
   fd_sspeer_selector_remove( selector, key_A );
   fd_sspeer_selector_remove( selector, key_B );
+  fd_sspeer_selector_remove( selector, key_C );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
-
-  FD_LOG_NOTICE(( "... pass" ));
-}
-
-static void
-test_cluster_slot_rescore_full_only( fd_sspeer_selector_t * selector,
-                                     fd_rng_t *             rng ) {
-  FD_LOG_NOTICE(( "testing cluster slot rescore full only" ));
-
-  ulong cluster_full_slot = 1000UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN );
-
-  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
-  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
-  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
-
-  /* Peer A at cluster slot, peer B 2 slots behind.
-     A: slots_behind=0, score=3_000_000.
-     B: slots_behind=2, score=2_000_000 + 2*1000 = 2_002_000. */
-  FD_TEST( add_peer( selector, key_A, addr_A, 1000UL, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )==3UL*1000UL*1000UL );
-  FD_TEST( add_peer( selector, key_B, addr_B,  998UL, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )==2UL*1000UL*1000UL + 2UL*1000UL );
-
-  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr_B.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 2UL*1000UL );
-
-  /* Advance cluster full slot.  All peers should be rescored.
-     A: slots_behind=100, score=3_000_000 + 100*1000 = 3_100_000.
-     B: slots_behind=102, score=2_000_000 + 102*1000 = 2_102_000. */
-  fd_sspeer_selector_process_cluster_slot( selector, 1100UL, FD_SSPEER_SLOT_UNKNOWN );
-
-  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.addr.l==addr_B.l );
-  FD_TEST( best.score==2UL*1000UL*1000UL + 102UL*1000UL );
-
-  /* Cleanup. */
-  fd_sspeer_selector_remove( selector, key_A );
-  fd_sspeer_selector_remove( selector, key_B );
-  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
-  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
   FD_LOG_NOTICE(( "... pass" ));
 }
@@ -1965,7 +1841,6 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
 
   ulong cluster_full_slot = 9500UL;
   ulong cluster_incr_slot = 9600UL;
-  fd_sspeer_selector_process_cluster_slot( selector, cluster_full_slot, cluster_incr_slot );
 
   fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
@@ -1980,13 +1855,13 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
                                    cluster_full_slot, cluster_incr_slot,
                                    full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
-  /* full_hash set, incr_hash NULL, incr_slot != FD_SSPEER_SLOT_UNKNOWN
-     is now valid (slot-based clearing handles the decision).  The
-     update should succeed because the existing peer's incr_slot (9600)
-     >= full_slot (9500), so the incremental is preserved. */
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
-                                                 full_hash, NULL )==FD_SSPEER_UPDATE_SUCCESS );
+  /* Establish cluster slot via median. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+
+  /* add() with same full_slot preserves incremental. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   cluster_full_slot, FD_SSPEER_SLOT_UNKNOWN,
+                                   full_hash, NULL )!=FD_SSPEER_SCORE_INVALID );
 
   /* Peer A should be unaffected (incremental preserved). */
   fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
@@ -1996,8 +1871,7 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
   FD_TEST( fd_memeq( best.full_hash, full_hash, FD_HASH_FOOTPRINT ) );
   FD_TEST( fd_memeq( best.incr_hash, incr_hash, FD_HASH_FOOTPRINT ) );
 
-  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is invalid.  add() for
-     a new peer with this combination must be rejected. */
+  /* full_slot==UNKNOWN with incr_slot!=UNKNOWN is invalid for new peer. */
   fd_sspeer_key_t key_new[1]; FD_TEST( generate_rand_sspeer_key( key_new, rng, fd_rng_uint( rng )&0x1 ) );
   fd_ip4_port_t addr_new; FD_TEST( generate_rand_addr_non_zero( &addr_new, rng ) );
   FD_TEST( fd_sspeer_selector_add( selector, key_new, addr_new, 2UL*1000UL*1000UL,
@@ -2006,12 +1880,12 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
-  /* update_on_resolve with full_slot==UNKNOWN and incr_slot!=UNKNOWN
-     on an existing peer with known full_slot succeeds because the
-     effective full_slot is the peer's stored value (not UNKNOWN). */
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot,
-                                                 NULL, incr_hash )==FD_SSPEER_UPDATE_SUCCESS );
+  /* add() with full_slot==UNKNOWN and incr_slot!=UNKNOWN on an
+     existing peer with known full_slot succeeds because the update
+     path uses the peer's stored full_slot. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   FD_SSPEER_SLOT_UNKNOWN, cluster_incr_slot,
+                                   NULL, incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
   /* fd_sspeer_selector_best with incremental=1 and
      base_slot=FD_SSPEER_SLOT_UNKNOWN should return the sentinel. */
@@ -2035,22 +1909,6 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
   FD_TEST( best.full_slot==cluster_full_slot );
   FD_TEST( best.incr_slot==cluster_incr_slot );
 
-  /* update_on_resolve with incr_slot < full_slot must be rejected. */
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 200UL, 100UL,
-                                                 full_hash, incr_hash )==FD_SSPEER_UPDATE_ERR_INVALID_ARG );
-  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
-  FD_TEST( best.full_slot==cluster_full_slot );
-  FD_TEST( best.incr_slot==cluster_incr_slot );
-
-  /* process_cluster_slot with incr_slot < full_slot should be silently
-     rejected (cluster slot unchanged). */
-  fd_sscluster_slot_t cs_before = fd_sspeer_selector_cluster_slot( selector );
-  fd_sspeer_selector_process_cluster_slot( selector, 50000UL, 40000UL );
-  fd_sscluster_slot_t cs_after = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs_before.full==cs_after.full );
-  FD_TEST( cs_before.incremental==cs_after.incremental );
-
   /* incr_slot == full_slot boundary (non-genesis). */
 
   /* add() for a new peer with incr_slot == full_slot must be accepted. */
@@ -2061,22 +1919,489 @@ test_invalid_clear_and_best_sentinel( fd_sspeer_selector_t * selector,
      be accepted. */
   FD_TEST( add_peer( selector, key_A, addr_A, 500UL, 500UL, 5UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
 
-  /* update_on_resolve with incr_slot == full_slot must be accepted. */
-  FD_TEST( fd_sspeer_selector_update_on_resolve( selector, key_A,
-                                                 600UL, 600UL,
-                                                 full_hash, incr_hash )==FD_SSPEER_UPDATE_SUCCESS );
-
-  /* process_cluster_slot with incr_slot == full_slot must be accepted. */
-  fd_sspeer_selector_process_cluster_slot( selector, 60000UL, 60000UL );
-  fd_sscluster_slot_t cs_eq = fd_sspeer_selector_cluster_slot( selector );
-  FD_TEST( cs_eq.full==60000UL );
-  FD_TEST( cs_eq.incremental==60000UL );
+  /* add() updating with incr_slot == full_slot via full add path. */
+  FD_TEST( fd_sspeer_selector_add( selector, key_A, addr_A, FD_SSPEER_LATENCY_UNKNOWN,
+                                   600UL, 600UL,
+                                   full_hash, incr_hash )!=FD_SSPEER_SCORE_INVALID );
 
   /* Cleanup. */
   fd_sspeer_selector_remove( selector, key_A );
   FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
 
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_median_outlier_robustness( fd_sspeer_selector_t * selector,
+                                fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing median outlier robustness" ));
+
+  /* Add 5 honest peers at slot 300. */
+  fd_sspeer_key_t honest_keys[5];
+  fd_ip4_port_t   honest_addrs[5];
+  for( ulong i=0; i<5UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Add malicious peer with high slot. */
+  fd_sspeer_key_t atk_key[1]; FD_TEST( generate_rand_sspeer_key( atk_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t   atk_addr;   FD_TEST( generate_rand_addr_non_zero( &atk_addr, rng ) );
+  FD_TEST( add_peer( selector, atk_key, atk_addr,
+                     1000UL, 1000UL,
+                     100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Compute median.  6 peers total.
+     Full slots sorted: [300, 300, 300, 300, 300, 1000].
+     median = [(6-1)/2] = [2] = 300.
+     Same for incremental.
+     The single outlier cannot shift the median. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==300UL );
+  FD_TEST( cs.incremental==300UL );
+
+  /* Verify that the malicious slot did NOT become the cluster slot. */
+  FD_TEST( cs.full!=1000UL );
+  FD_TEST( cs.incremental!=1000UL );
+
+  /* Best should be honest peer 0 (lat=1ms, at cluster slot, score=1M). */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==honest_addrs[0].l );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  /* Cleanup */
+  for( ulong i=0; i<5UL; i++ ) {
+    fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  }
+  fd_sspeer_selector_remove( selector, atk_key );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  /* ... Two malicious: 5 honest + 2 malicious = 7 total.
+     Sorted full slots: [300, 300, 300, 300, 300, 1000, 1000].
+     median = [7/2] = [3] = 300.  Honest majority still wins. */
+
+  for( ulong i=0; i<5UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_key_t mal_keys_2[2];
+  fd_ip4_port_t   mal_addrs_2[2];
+  for( ulong i=0; i<2UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &mal_keys_2[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &mal_addrs_2[i], rng ) );
+    FD_TEST( add_peer( selector, &mal_keys_2[i], mal_addrs_2[i],
+                       1000UL, 1000UL,
+                       100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==300UL );
+  FD_TEST( cs.incremental==300UL );
+
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==honest_addrs[0].l );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  for( ulong i=0; i<5UL; i++ ) fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  for( ulong i=0; i<2UL; i++ ) fd_sspeer_selector_remove( selector, &mal_keys_2[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  /* ... N/2 malicious: 3 honest + 3 malicious = 6 total.
+     Sorted full slots: [300, 300, 300, 1000, 1000, 1000].
+     Lower median = [(6-1)/2] = [2] = 300.
+     At exactly 50% the lower-median still picks the honest value. */
+
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_key_t mal_keys_3[3];
+  fd_ip4_port_t   mal_addrs_3[3];
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &mal_keys_3[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &mal_addrs_3[i], rng ) );
+    FD_TEST( add_peer( selector, &mal_keys_3[i], mal_addrs_3[i],
+                       1000UL, 1000UL,
+                       100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==300UL );
+  FD_TEST( cs.incremental==300UL );
+
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &mal_keys_3[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_median_low_slot_malicious( fd_sspeer_selector_t * selector,
+                                fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing median low slot malicious" ));
+
+  /* Verify that malicious peers reporting low slot values cannot drag
+     the cluster slot down when honest peers hold a majority. */
+
+  fd_sspeer_key_t honest_keys[5];
+  fd_ip4_port_t   honest_addrs[5];
+  for( ulong i=0; i<5UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Add 1 malicious peer with slot 0. */
+  fd_sspeer_key_t mal_key[1]; FD_TEST( generate_rand_sspeer_key( mal_key, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t   mal_addr;   FD_TEST( generate_rand_addr_non_zero( &mal_addr, rng ) );
+  FD_TEST( add_peer( selector, mal_key, mal_addr,
+                     0UL, 0UL,
+                     100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* 6 peers total.  Full slots sorted: [0, 300, 300, 300, 300, 300].
+     Lower median = [(6-1)/2] = [2] = 300.
+     Single low outlier cannot shift the median. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==300UL );
+  FD_TEST( cs.incremental==300UL );
+
+  /* Cleanup */
+  for( ulong i=0; i<5UL; i++ ) fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  fd_sspeer_selector_remove( selector, mal_key );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  /* 2 malicious low-slot + 5 honest = 7 total.
+     Sorted: [0, 0, 300, 300, 300, 300, 300].
+     Lower median = [(7-1)/2] = [3] = 300. */
+  for( ulong i=0; i<5UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_key_t mal_keys_2[2];
+  fd_ip4_port_t   mal_addrs_2[2];
+  for( ulong i=0; i<2UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &mal_keys_2[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &mal_addrs_2[i], rng ) );
+    FD_TEST( add_peer( selector, &mal_keys_2[i], mal_addrs_2[i],
+                       0UL, 0UL,
+                       100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==300UL );
+  FD_TEST( cs.incremental==300UL );
+
+  for( ulong i=0; i<5UL; i++ ) fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  for( ulong i=0; i<2UL; i++ ) fd_sspeer_selector_remove( selector, &mal_keys_2[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  /* 3 malicious low-slot + 3 honest = 6 total (50% split).
+     Sorted: [0, 0, 0, 300, 300, 300].
+     Lower median = [(6-1)/2] = [2] = 0.
+     At exactly 50% malicious, the lower-median picks the malicious
+     value.  This is a known property of median defenses. */
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &honest_keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &honest_addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &honest_keys[i], honest_addrs[i],
+                       300UL, 300UL,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_key_t mal_keys_3[3];
+  fd_ip4_port_t   mal_addrs_3[3];
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &mal_keys_3[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &mal_addrs_3[i], rng ) );
+    FD_TEST( add_peer( selector, &mal_keys_3[i], mal_addrs_3[i],
+                       0UL, 0UL,
+                       100UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==0UL );
+
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &honest_keys[i] );
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &mal_keys_3[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_all_unknown_slots( fd_sspeer_selector_t * selector,
+                        fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing all unknown slots" ));
+
+  /* When every tracked peer has full_slot==UNKNOWN, the median
+     computation should preserve the existing cluster slot (no known
+     slots to compute a median from). */
+
+  fd_sspeer_key_t keys[3];
+  fd_ip4_port_t   addrs[3];
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &keys[i], addrs[i],
+                       FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN,
+                       (i+1UL)*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  /* Cluster slot should remain at initial values {0, UNKNOWN} since
+     no peer has a known full_slot.  The dirty flag should not have been
+     set (add with UNKNOWN full_slot doesn't set dirty). */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==0UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* None of the peers are valid (full_slot==UNKNOWN), so best
+     should return the sentinel. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( !best.addr.l );
+  FD_TEST( best.score==FD_SSPEER_SCORE_INVALID );
+
+  /* Cleanup */
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &keys[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_process_cluster_slot_idempotent( fd_sspeer_selector_t * selector,
+                                      fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing process_cluster_slot idempotency" ));
+
+  /* Calling process_cluster_slot multiple times with no changes in
+     between should be a no-op (the dirty flag prevents recomputation). */
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  FD_TEST( add_peer( selector, key_A, addr_A, 5000UL, 5500UL, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, 6000UL, 6500UL, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* First call: computes median and rescores. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs1 = fd_sspeer_selector_cluster_slot( selector );
+  fd_sspeer_t best1 = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Second call: dirty flag is clear, should be a no-op. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs2 = fd_sspeer_selector_cluster_slot( selector );
+  fd_sspeer_t best2 = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+
+  FD_TEST( cs1.full==cs2.full );
+  FD_TEST( cs1.incremental==cs2.incremental );
+  FD_TEST( best1.addr.l==best2.addr.l );
+  FD_TEST( best1.score==best2.score );
+
+  /* Third call: still a no-op. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs3 = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs2.full==cs3.full );
+  FD_TEST( cs2.incremental==cs3.incremental );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_full_only_cluster_rescore( fd_sspeer_selector_t * selector,
+                                fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing full only cluster rescore" ));
+
+  /* When no peers have incremental slots, the cluster incremental
+     should remain UNKNOWN and scoring should fall back to comparing
+     full_slot against the cluster full slot. */
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_sspeer_key_t key_C[1]; FD_TEST( generate_rand_sspeer_key( key_C, rng, fd_rng_uint( rng )&0x1 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+  fd_ip4_port_t addr_C; FD_TEST( generate_rand_addr_non_zero( &addr_C, rng ) );
+
+  /* Add 3 peers with only full slots (incr=UNKNOWN). */
+  FD_TEST( add_peer( selector, key_A, addr_A, 1000UL, FD_SSPEER_SLOT_UNKNOWN, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_B, addr_B, 2000UL, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, key_C, addr_C, 3000UL, FD_SSPEER_SLOT_UNKNOWN, 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  /* Median of full slots [1000, 2000, 3000] = 2000.
+     Incr: no known values -> stays UNKNOWN. */
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==2000UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Scoring falls back to full_slot comparison:
+     Peer A: behind = 2000-1000 = 1000.
+       score = 1_000_000 + 1000*1000 = 2_000_000.
+     Peer B: behind = 2000-2000 = 0.
+       score = 2_000_000.
+     Peer C: behind = max(0, 2000-3000) = 0.
+       score = 3_000_000.
+     Best = Peer A or Peer B (both 2_000_000), treap ordering decides. */
+  fd_sspeer_t best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.score==2UL*1000UL*1000UL );
+
+  /* Remove the highest-slot peer.  Remaining: [1000, 2000].
+     Lower median = [(2-1)/2] = [0] = 1000.
+     Incr: still UNKNOWN. */
+  fd_sspeer_selector_remove( selector, key_C );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==1000UL );
+  FD_TEST( cs.incremental==FD_SSPEER_SLOT_UNKNOWN );
+
+  /* After rescore with cluster=(1000, UNKNOWN):
+     Peer A: behind = 1000-1000 = 0.  score = 1_000_000.
+     Peer B: behind = max(0, 1000-2000) = 0.  score = 2_000_000.
+     Best = Peer A. */
+  best = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best.addr.l==addr_A.l );
+  FD_TEST( best.score==1UL*1000UL*1000UL );
+
+  /* Cleanup */
+  fd_sspeer_selector_remove( selector, key_A );
+  fd_sspeer_selector_remove( selector, key_B );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_median_incr_clamped_to_full( fd_sspeer_selector_t * selector,
+                                   fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing median_incr < median_full clamping" ));
+
+  /* A(full=2000,incr=UNKNOWN), B(full=3000,incr=UNKNOWN), C(full=500,incr=500).
+     Full median = [500,2000,3000][1] = 2000.  Incr median = [500][0] = 500.
+     500 < 2000 -> clamped to (2000, 2000). */
+  fd_sspeer_key_t keys[3]; fd_ip4_port_t addrs[3];
+  for( ulong i=0; i<3UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &keys[i], rng, fd_rng_uint( rng )&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &addrs[i], rng ) );
+  }
+  FD_TEST( add_peer( selector, &keys[0], addrs[0], 2000UL, FD_SSPEER_SLOT_UNKNOWN, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[1], addrs[1], 3000UL, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  FD_TEST( add_peer( selector, &keys[2], addrs[2],  500UL,  500UL,                 3UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sscluster_slot_t cs = fd_sspeer_selector_cluster_slot( selector );
+  FD_TEST( cs.full==2000UL );
+  FD_TEST( cs.incremental==2000UL );  /* clamped from 500 */
+
+  for( ulong i=0; i<3UL; i++ ) fd_sspeer_selector_remove( selector, &keys[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_addr_ele_cnt( selector ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_median_four_distinct( fd_sspeer_selector_t * selector,
+                           fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing median four distinct" ));
+
+  /* sorted: [100,200,300,400], lower median index (4-1)/2=1 -> 200 */
+  fd_sspeer_key_t keys[4];
+  fd_ip4_port_t   addrs[4];
+  ulong slots[] = { 300UL, 100UL, 400UL, 200UL }; /* insertion order != sorted */
+  for( ulong i=0; i<4UL; i++ ) {
+    FD_TEST( generate_rand_sspeer_key( &keys[i], rng, fd_rng_uint(rng)&0x1 ) );
+    FD_TEST( generate_rand_addr_non_zero( &addrs[i], rng ) );
+    FD_TEST( add_peer( selector, &keys[i], addrs[i], slots[i], FD_SSPEER_SLOT_UNKNOWN, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  }
+
+  fd_sspeer_selector_process_cluster_slot( selector );
+  FD_TEST( fd_sspeer_selector_cluster_slot( selector ).full==200UL );
+
+  for( ulong i=0; i<4UL; i++ ) fd_sspeer_selector_remove( selector, &keys[i] );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_dirty_but_median_unchanged( fd_sspeer_selector_t * selector,
+                                 fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing dirty but median unchanged" ));
+
+  fd_sspeer_key_t key_A[1]; FD_TEST( generate_rand_sspeer_key( key_A, rng, 0 ) );
+  fd_sspeer_key_t key_B[1]; FD_TEST( generate_rand_sspeer_key( key_B, rng, 0 ) );
+  fd_ip4_port_t addr_A; FD_TEST( generate_rand_addr_non_zero( &addr_A, rng ) );
+  fd_ip4_port_t addr_B; FD_TEST( generate_rand_addr_non_zero( &addr_B, rng ) );
+
+  FD_TEST( add_peer( selector, key_A, addr_A, 5000UL, 5500UL, 1UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+  fd_sspeer_t best1 = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+
+  /* Add and remove a peer with UNKNOWN slots, sets dirty but cannot change median. */
+  FD_TEST( add_peer( selector, key_B, addr_B, FD_SSPEER_SLOT_UNKNOWN, FD_SSPEER_SLOT_UNKNOWN, 2UL*1000UL*1000UL )!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_remove( selector, key_B );
+  fd_sspeer_selector_process_cluster_slot( selector );
+
+  fd_sspeer_t best2 = fd_sspeer_selector_best( selector, 0, FD_SSPEER_SLOT_UNKNOWN );
+  FD_TEST( best1.score==best2.score );
+
+  fd_sspeer_selector_remove( selector, key_A );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_noop_readd( fd_sspeer_selector_t * selector,
+                 fd_rng_t *             rng ) {
+  FD_LOG_NOTICE(( "testing noop readd" ));
+
+  fd_sspeer_key_t key[1]; FD_TEST( generate_rand_sspeer_key( key, rng, 0 ) );
+  fd_ip4_port_t addr; FD_TEST( generate_rand_addr_non_zero( &addr, rng ) );
+
+  ulong score1 = add_peer( selector, key, addr, 5000UL, 5500UL, 1UL*1000UL*1000UL );
+  FD_TEST( score1!=FD_SSPEER_SCORE_INVALID );
+  fd_sspeer_selector_process_cluster_slot( selector );
+
+  /* Re-add with same slots, should not change score. */
+  ulong score2 = add_peer( selector, key, addr, 5000UL, 5500UL, 1UL*1000UL*1000UL );
+  FD_TEST( score1==score2 );
+
+  fd_sspeer_selector_remove( selector, key );
+  FD_TEST( !fd_sspeer_selector_peer_map_by_key_ele_cnt( selector ) );
   FD_LOG_NOTICE(( "... pass" ));
 }
 
@@ -2099,42 +2424,30 @@ main( int     argc,
 
   FD_TEST( wksp );
   test_wksp_t t_wksp_base  = {0};
-  test_wksp_t t_wksp_full  = {0};
   test_wksp_t t_wksp_small = {0};
   test_wksp_t t_wksp_stress= {0};
 
   test_wksp_init( wksp,
                   &t_wksp_base,
                   65536UL/*max_peers*/,
-                  1/*incr_snap_fetch*/,
-                  fd_rng_ulong( rng )/*seed*/ );
-
-  test_wksp_init( wksp,
-                  &t_wksp_full,
-                  4UL/*max_peers*/,
-                  0/*incr_snap_fetch*/,
                   fd_rng_ulong( rng )/*seed*/ );
 
   test_wksp_init( wksp,
                   &t_wksp_small,
                   2UL/*max_peers*/,
-                  1/*incr_snap_fetch*/,
                   fd_rng_ulong( rng )/*seed*/ );
 
   test_wksp_init( wksp,
                   &t_wksp_stress,
                   32UL/*max_peers*/,
-                  1/*incr_snap_fetch*/,
                   fd_rng_ulong( rng )/*seed*/ );
 
   verify_initial_cluster_slot( t_wksp_base.selector );
-  verify_initial_cluster_slot( t_wksp_full.selector );
   verify_initial_cluster_slot( t_wksp_small.selector );
   verify_initial_cluster_slot( t_wksp_stress.selector );
 
-  /* Subtests.  To make them independent from each other, the test
-     workspaces need to be re-initialized before usage.  This is because
-     the cluster slot can only increase monotonically over time. */
+  /* Subtests.  Each test reinitializes its workspace to start from
+     a clean state. */
 
   test_wksp_reinit( &t_wksp_base );
   test_slot_zero( t_wksp_base.selector, rng );
@@ -2152,7 +2465,7 @@ main( int     argc,
   test_update_on_ping( t_wksp_base.selector, rng );
 
   test_wksp_reinit( &t_wksp_base );
-  test_update_on_resolve( t_wksp_base.selector, rng );
+  test_resolve_via_add( t_wksp_base.selector, rng );
 
   test_wksp_reinit( &t_wksp_base );
   test_address_zero( t_wksp_base.selector, rng );
@@ -2167,14 +2480,19 @@ main( int     argc,
   test_on_resolve_clears_incremental( t_wksp_base.selector, rng );
 
   test_wksp_reinit( &t_wksp_base );
-  test_cluster_slot_incremental( t_wksp_base.selector, rng );
+  test_cluster_slot_rescoring( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_cluster_slot_regression( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_cluster_slot_recovery_after_poison( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_poison_recovery_with_unresolved_peers( t_wksp_base.selector, rng );
 
   test_wksp_reinit( &t_wksp_base );
   test_score_saturation( t_wksp_base.selector, rng );
-
-  test_wksp_reinit( &t_wksp_base );
-  test_wksp_reinit( &t_wksp_full );
-  test_cluster_slot_monotonicity( t_wksp_base.selector, t_wksp_full.selector );
 
   test_wksp_reinit( &t_wksp_small );
   test_pool_exhaustion( t_wksp_small.selector, rng );
@@ -2197,12 +2515,6 @@ main( int     argc,
   test_wksp_reinit( &t_wksp_base );
   test_genesis_cluster_slot( t_wksp_base.selector, rng );
 
-  test_wksp_reinit( &t_wksp_full );
-  test_cluster_slot_rescore_full_only( t_wksp_full.selector, rng );
-
-  test_wksp_reinit( &t_wksp_full );
-  test_best_incremental_on_full_only_selector( t_wksp_full.selector, rng );
-
   test_wksp_reinit( &t_wksp_base );
   test_invalid_clear_and_best_sentinel( t_wksp_base.selector, rng );
 
@@ -2212,11 +2524,37 @@ main( int     argc,
   test_wksp_reinit( &t_wksp_stress );
   test_stress_peer_count( t_wksp_stress.selector, rng, t_wksp_stress.max_peers );
 
+  test_wksp_reinit( &t_wksp_base );
+  test_median_outlier_robustness( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_median_low_slot_malicious( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_all_unknown_slots( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_process_cluster_slot_idempotent( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_full_only_cluster_rescore( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_median_incr_clamped_to_full( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_median_four_distinct( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_dirty_but_median_unchanged( t_wksp_base.selector, rng );
+
+  test_wksp_reinit( &t_wksp_base );
+  test_noop_readd( t_wksp_base.selector, rng );
+
   /* Cleanup. */
 
   fd_rng_delete( fd_rng_leave( rng ) );
   test_wksp_fini( &t_wksp_base );
-  test_wksp_fini( &t_wksp_full );
   test_wksp_fini( &t_wksp_small );
   test_wksp_fini( &t_wksp_stress );
 

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -1,0 +1,241 @@
+#include "fd_ssping.h"
+
+#include "../../../util/fd_util.h"
+
+/* Stub on_ping callback, required by fd_ssping_new but not exercised
+   in these unit tests (no actual pings are sent/received). */
+static void
+on_ping_stub( void *        _ctx,
+              fd_ip4_port_t addr,
+              ulong         latency ) {
+  (void)_ctx;
+  (void)addr;
+  (void)latency;
+}
+
+static void
+test_invalidate_and_remove( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing invalidate and remove" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 1 ), .port = fd_ushort_bswap( 8000 ) };
+  long now = fd_log_wallclock();
+
+  fd_ssping_add( ssping, addr );
+  fd_ssping_invalidate( ssping, addr, now );
+
+  /* Full removal (refcnt goes to 0). */
+  FD_TEST( fd_ssping_remove( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_double_invalidate( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing double invalidate" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 2 ), .port = fd_ushort_bswap( 8001 ) };
+  long now = fd_log_wallclock();
+
+  fd_ssping_add( ssping, addr );
+  fd_ssping_invalidate( ssping, addr, now );
+
+  /* Second invalidation should be a no-op (already INVALID). */
+  fd_ssping_invalidate( ssping, addr, now );
+
+  /* Cleanup. */
+  fd_ssping_remove( ssping, addr );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_invalidate_refcounted( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing invalidate refcounted" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 3 ), .port = fd_ushort_bswap( 8002 ) };
+  long now = fd_log_wallclock();
+
+  /* Add twice (refcnt=2). */
+  fd_ssping_add( ssping, addr );
+  fd_ssping_add( ssping, addr );
+
+  fd_ssping_invalidate( ssping, addr, now );
+
+  /* First remove: refcnt drops to 1, peer stays. */
+  FD_TEST( !fd_ssping_remove( ssping, addr ) );
+
+  /* Second remove: refcnt drops to 0, peer fully removed. */
+  FD_TEST( fd_ssping_remove( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_is_invalidated_null_ssping( void ) {
+  FD_LOG_NOTICE(( "testing is_invalidated null ssping" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 4 ), .port = fd_ushort_bswap( 8003 ) };
+  FD_TEST( !fd_ssping_is_invalidated( NULL, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_is_invalidated_unknown_peer( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing is_invalidated unknown peer" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 5 ), .port = fd_ushort_bswap( 8004 ) };
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_is_invalidated_after_invalidate( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing is_invalidated after invalidate" ));
+
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 0, 6 ), .port = fd_ushort_bswap( 8005 ) };
+  long now = fd_log_wallclock();
+
+  fd_ssping_add( ssping, addr );
+
+  /* Before invalidation: peer is UNPINGED, not INVALID. */
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  fd_ssping_invalidate( ssping, addr, now );
+
+  /* After invalidation: peer should be INVALID. */
+  FD_TEST( fd_ssping_is_invalidated( ssping, addr ) );
+
+  /* After removal: peer is gone, should return 0. */
+  fd_ssping_remove( ssping, addr );
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_pool_exhaustion( fd_ssping_t * ssping,
+                      ulong         max_peers ) {
+  FD_LOG_NOTICE(( "testing pool exhaustion" ));
+
+  /* Fill all max_peers slots, then verify the next add is silently
+     dropped (no crash). */
+  fd_ip4_port_t addrs[256]; /* large enough for max_peers=8 */
+  FD_TEST( max_peers<=sizeof(addrs)/sizeof(addrs[0]) );
+
+  for( ulong i=0; i<max_peers; i++ ) {
+    addrs[i] = (fd_ip4_port_t){ .addr = FD_IP4_ADDR( 10, 0, 1, (uchar)(i+1UL) ),
+                                .port = fd_ushort_bswap( (ushort)(9000U+i) ) };
+    fd_ssping_add( ssping, addrs[i] );
+  }
+
+  /* Pool is full.  This should be a no-op (logged warning). */
+  fd_ip4_port_t overflow_addr = { .addr = FD_IP4_ADDR( 10, 0, 1, 255 ),
+                                  .port = fd_ushort_bswap( 9999 ) };
+  fd_ssping_add( ssping, overflow_addr );
+
+  /* overflow_addr was never inserted, so remove returns 0. */
+  FD_TEST( !fd_ssping_remove( ssping, overflow_addr ) );
+
+  /* First and last tracked peers are still there and not invalidated. */
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addrs[0] ) );
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addrs[max_peers-1UL] ) );
+
+  /* Cleanup */
+  for( ulong i=0; i<max_peers; i++ ) {
+    fd_ssping_remove( ssping, addrs[i] );
+  }
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_add_after_invalidate( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing add after invalidate" ));
+
+  /* Adding a peer that is already invalidated should bump the refcnt
+     but the peer should remain in the INVALID state. */
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 2, 1 ), .port = fd_ushort_bswap( 9010 ) };
+  long now = fd_log_wallclock();
+
+  fd_ssping_add( ssping, addr );
+  fd_ssping_invalidate( ssping, addr, now );
+  FD_TEST( fd_ssping_is_invalidated( ssping, addr ) );
+
+  /* Re-add: refcnt goes from 1 to 2, but state stays INVALID. */
+  fd_ssping_add( ssping, addr );
+  FD_TEST( fd_ssping_is_invalidated( ssping, addr ) );
+
+  /* First remove: refcnt drops to 1, peer stays. */
+  FD_TEST( !fd_ssping_remove( ssping, addr ) );
+  FD_TEST( fd_ssping_is_invalidated( ssping, addr ) );
+
+  /* Second remove: refcnt drops to 0, peer fully removed. */
+  FD_TEST( fd_ssping_remove( ssping, addr ) );
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_remove_without_invalidate( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing remove without invalidate" ));
+
+  /* A peer can be removed without ever being invalidated. */
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 10, 0, 3, 1 ), .port = fd_ushort_bswap( 9020 ) };
+
+  fd_ssping_add( ssping, addr );
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  /* Remove directly: peer is fully removed. */
+  FD_TEST( fd_ssping_remove( ssping, addr ) );
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_remove_unknown( fd_ssping_t * ssping ) {
+  FD_LOG_NOTICE(( "testing remove unknown" ));
+  fd_ip4_port_t addr = { .addr = FD_IP4_ADDR( 192, 168, 99, 99 ), .port = fd_ushort_bswap( 9999 ) };
+  FD_TEST( !fd_ssping_remove( ssping, addr ) );
+  fd_ssping_invalidate( ssping, addr, fd_log_wallclock() ); /* should not crash */
+  FD_TEST( !fd_ssping_is_invalidated( ssping, addr ) );     /* not tracked -> 0 */
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong  page_cnt  = 1;
+  char * _page_sz  = "gigantic";
+  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_TEST( wksp );
+
+  /* Create a single ssping instance.  max_peers=8 is enough for all
+     tests (each test cleans up after itself). */
+  ulong max_peers = 8UL;
+  void * shmem = fd_wksp_alloc_laddr( wksp, fd_ssping_align(), fd_ssping_footprint( max_peers ), 1UL );
+  fd_ssping_t * ssping = fd_ssping_join( fd_ssping_new( shmem, max_peers, 42UL, on_ping_stub, NULL ) );
+  FD_TEST( ssping );
+
+  test_invalidate_and_remove( ssping );
+  test_double_invalidate( ssping );
+  test_invalidate_refcounted( ssping );
+  test_is_invalidated_null_ssping();
+  test_is_invalidated_unknown_peer( ssping );
+  test_is_invalidated_after_invalidate( ssping );
+  test_pool_exhaustion( ssping, max_peers );
+  test_add_after_invalidate( ssping );
+  test_remove_without_invalidate( ssping );
+  test_remove_unknown( ssping );
+
+  FD_LOG_NOTICE(( "all ssping tests passed" ));
+
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
`cluster_slot.full` was monotonically set to the maximum value ever seen from any single peer, meaning that once poisoned it could never recover. Even though a peer causing this would be temporarily banned, it could be re-inserted into the selector after the 5-minute cooldown.

To address this, this PR introduces:
1. Median-based cluster slot: `cluster_slot.full` and `cluster_slot.incremental` are computed as the lower-median of all tracked peers' slots, making it more robust against poisoning. When a peer is removed, the median is recomputed from the remaining peers, allowing recovery.
2. Permanent peer blacklist: a dedicated blacklist keyed on peer identity `fd_sspeer_key_t` (pubkey for gossip peers, (hostname, resolved_addr) pair for URL peers) that persists for the entire bootstrap run, preventing re-selection after download failure.

Closes https://github.com/firedancer-io/firedancer/issues/9573.