### PR TITLE
neigh: fix RTM_DELNEIGH lladdr handling

### DIFF
--- a/src/waltz/neigh/fd_neigh4_netlink.c
+++ b/src/waltz/neigh/fd_neigh4_netlink.c
@@ -93,11 +93,6 @@ fd_neigh4_netlink_ingest_message( fd_neigh4_hmap_t *      map,
 
   }
 
-  if( FD_UNLIKELY( !mac_addr.ul || !ip4_dst ) ) {
-    FD_LOG_DEBUG(( "Ignoring neighbor table update with missing or invalid L2 or L3 address" ));
-    return;
-  }
-
   /* Determine if we should remove or insert/update entry */
 
   int remove = 0;
@@ -117,12 +112,22 @@ fd_neigh4_netlink_ingest_message( fd_neigh4_hmap_t *      map,
     remove = 1;
   }
 
+  if( FD_UNLIKELY( !ip4_dst ) ) {
+    FD_LOG_DEBUG(( "Ignoring neighbor table update with missing or invalid L3 address" ));
+    return;
+  }
+
   /* Perform update */
 
   if( remove ) {
     fd_neigh4_entry_t * e = fd_neigh4_hmap_update( map, &ip4_dst );
     if( FD_LIKELY( e ) ) fd_neigh4_hmap_remove( map, e );
   } else {
+    if( FD_UNLIKELY( !mac_addr.ul ) ) {
+      FD_LOG_DEBUG(( "Ignoring neighbor table update with missing or invalid L2 address" ));
+      return;
+    }
+
     fd_neigh4_entry_t to_insert = {
       .ip4_addr = ip4_dst,
       .state    = FD_NEIGH4_STATE_ACTIVE,

--- a/src/waltz/neigh/fd_neigh4_netlink.h
+++ b/src/waltz/neigh/fd_neigh4_netlink.h
@@ -26,7 +26,7 @@ fd_neigh4_netlink_request_dump( fd_netlink_t * netlink,
 
 /* fd_neigh4_netlink_ingest_message imports an RTM_NEWNEIGH or RTM_DELNEIGH
    message.  Logs warning if a netlink message with a different type is
-   inserted.  Logs warning if link-layer addresses is not 6 bytes long.
+   inserted.  Logs warning if a link-layer address is not 6 bytes long.
    (The caller is expected to verify that if_idx is an Ethernet interface.)
    Ignores messages with an interface index other than if_idx.  Causes
    insert, update, or remove of a neighbor table entry.   Only respects

--- a/src/waltz/neigh/test_neigh4_netlink.c
+++ b/src/waltz/neigh/test_neigh4_netlink.c
@@ -8,6 +8,99 @@
 #include <linux/rtnetlink.h>
 #include "../../util/fd_util.h"
 
+struct test_neigh_msg {
+  struct nlmsghdr nlh;
+  struct ndmsg    ndm;
+  uchar           attr[ 64 ];
+};
+
+static void
+test_neigh_msg_init( struct test_neigh_msg * msg,
+                     ushort                  type,
+                     ushort                  state,
+                     int                     if_idx ) {
+  memset( msg, 0, sizeof(struct test_neigh_msg) );
+
+  msg->nlh = (struct nlmsghdr) {
+    .nlmsg_type = type,
+    .nlmsg_len  = NLMSG_LENGTH( sizeof(struct ndmsg) )
+  };
+  msg->ndm = (struct ndmsg) {
+    .ndm_family  = AF_INET,
+    .ndm_ifindex = if_idx,
+    .ndm_state   = state
+  };
+}
+
+static void
+test_neigh_msg_add_attr( struct test_neigh_msg * msg,
+                         ushort                  type,
+                         void const *            data,
+                         ulong                   data_sz ) {
+  ulong len  = RTA_LENGTH( data_sz );
+  ulong off  = NLMSG_ALIGN( msg->nlh.nlmsg_len );
+  FD_TEST( off+RTA_ALIGN( len )<=sizeof(struct test_neigh_msg) );
+
+  struct rtattr * rta = (struct rtattr *)( (uchar *)msg + off );
+  rta->rta_type = type;
+  rta->rta_len  = (ushort)len;
+  memcpy( RTA_DATA( rta ), data, data_sz );
+
+  msg->nlh.nlmsg_len = (uint)( off+RTA_ALIGN( len ) );
+}
+
+static void
+test_neigh_msg_add_dst( struct test_neigh_msg * msg,
+                        uint                    ip4_dst ) {
+  test_neigh_msg_add_attr( msg, NDA_DST, &ip4_dst, sizeof(uint) );
+}
+
+static void
+test_neigh_msg_add_lladdr( struct test_neigh_msg * msg,
+                           uchar const            mac_addr[ 6 ] ) {
+  test_neigh_msg_add_attr( msg, NDA_LLADDR, mac_addr, 6UL );
+}
+
+static void
+test_synthetic_neigh_messages( fd_neigh4_hmap_t * map ) {
+  int const if_idx  = 7;
+  uint      ip4_dst = FD_LOAD( uint, "\x0a\x01\x02\x03" );
+  uchar     mac[6]  = { 0x02, 0x00, 0x00, 0x01, 0x02, 0x03 };
+
+  struct test_neigh_msg msg[1];
+  fd_neigh4_entry_t     entry[1];
+
+  test_neigh_msg_init( msg, RTM_NEWNEIGH, NUD_REACHABLE, if_idx );
+  test_neigh_msg_add_dst( msg, ip4_dst );
+  test_neigh_msg_add_lladdr( msg, mac );
+  fd_neigh4_netlink_ingest_message( map, &msg->nlh, (uint)if_idx );
+
+  FD_TEST( fd_neigh4_hmap_query_entry( map, ip4_dst, entry )==FD_MAP_SUCCESS );
+  FD_TEST( entry->state==FD_NEIGH4_STATE_ACTIVE );
+  FD_TEST( !memcmp( entry->mac_addr, mac, 6UL ) );
+
+  test_neigh_msg_init( msg, RTM_DELNEIGH, NUD_FAILED, if_idx );
+  test_neigh_msg_add_dst( msg, ip4_dst );
+  fd_neigh4_netlink_ingest_message( map, &msg->nlh, (uint)if_idx );
+  FD_TEST( fd_neigh4_hmap_query_entry( map, ip4_dst, entry )==FD_MAP_ERR_KEY );
+
+  test_neigh_msg_init( msg, RTM_NEWNEIGH, NUD_REACHABLE, if_idx );
+  test_neigh_msg_add_dst( msg, ip4_dst );
+  test_neigh_msg_add_lladdr( msg, mac );
+  fd_neigh4_netlink_ingest_message( map, &msg->nlh, (uint)if_idx );
+  FD_TEST( fd_neigh4_hmap_query_entry( map, ip4_dst, entry )==FD_MAP_SUCCESS );
+
+  test_neigh_msg_init( msg, RTM_NEWNEIGH, NUD_FAILED, if_idx );
+  test_neigh_msg_add_dst( msg, ip4_dst );
+  fd_neigh4_netlink_ingest_message( map, &msg->nlh, (uint)if_idx );
+  FD_TEST( fd_neigh4_hmap_query_entry( map, ip4_dst, entry )==FD_MAP_ERR_KEY );
+
+  test_neigh_msg_init( msg, RTM_NEWNEIGH, NUD_REACHABLE, if_idx );
+  test_neigh_msg_add_dst( msg, ip4_dst );
+  fd_neigh4_netlink_ingest_message( map, &msg->nlh, (uint)if_idx );
+  FD_TEST( fd_neigh4_hmap_query_entry( map, ip4_dst, entry )==FD_MAP_ERR_KEY );
+}
+
 static void
 dump_neighbor_table( fd_neigh4_hmap_t * map,
                      fd_netlink_t *     netlink1,
@@ -130,6 +223,8 @@ main( int     argc,
   fd_neigh4_hmap_t _map[1];
   fd_neigh4_hmap_t * map = fd_neigh4_hmap_join( _map, hmap_mem, ele_max, probe_max, seed );
   FD_TEST( map );
+
+  test_synthetic_neigh_messages( map );
 
   dump_all_neighbor_tables( map, netlink0, netlink1 );
 


### PR DESCRIPTION
Fixes an issue where RTM_DELNEIGH issues can get dropped in some
cases due to a missing lladdr (MAC address).  This could have
caused connectivity loss on router failover in certain rare edge
cases.

Reported-by: https://immunefi.com/profile/innertia

Closes #9673 