### PR TITLE
restore: fix snapct crash with block-listed peer

### DIFF
--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -3,6 +3,8 @@ ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_SSE
 $(call add-hdrs,fd_snapct_tile.h)
 $(call add-objs,fd_snapct_tile,fd_discof)
+$(call make-unit-test,test_snapct_tile,test_snapct_tile,fd_discof fd_waltz fd_flamenco fd_ballet fd_util,$(OPENSSL_LIBS))
+$(call run-unit-test,test_snapct_tile)
 $(call add-objs,fd_snapld_tile,fd_discof)
 ifdef FD_HAS_ZSTD
 $(call add-objs,fd_snapdc_tile,fd_discof)

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -95,9 +95,9 @@ struct fd_snapct_tile {
   char http_full_snapshot_name[ PATH_MAX ];
   char http_incr_snapshot_name[ PATH_MAX ];
 
-  fd_wksp_t const * gossip_in_mem;
-  fd_wksp_t const * snapld_in_mem;
-  uchar             in_kind[ MAX_IN_LINKS ];
+  void const * gossip_in_mem;
+  void const * snapld_in_mem;
+  uchar        in_kind[ MAX_IN_LINKS ];
 
   struct {
     ulong full_slot;
@@ -1268,21 +1268,22 @@ gossip_frag( fd_snapct_tile_t *  ctx,
       FD_TEST( msg->contact_info_remove->idx<GOSSIP_PEERS_MAX );
       gossip_ci_entry_t * entry = ctx->gossip.ci_table + msg->contact_info_remove->idx;
       ulong rem_idx = gossip_ci_map_idx_remove( ctx->gossip.ci_map, &entry->pubkey, ULONG_MAX, ctx->gossip.ci_table );
-      if( rem_idx==ULONG_MAX ) break;
-      FD_TEST( entry->allowed && rem_idx==msg->contact_info_remove->idx );
-      ctx->gossip.allowed_cnt--;
-      fd_ip4_port_t addr = entry->rpc_addr;
-      if( FD_LIKELY( !!addr.l ) ) {
-        fd_ssping_remove( ctx->ssping, addr );
-        fd_sspeer_key_t entry_key = {0};
-        *entry_key.pubkey = entry->pubkey;
-        entry_key.is_url  = 0;
-        fd_sspeer_selector_remove( ctx->selector, &entry_key );
-      }
-      if( !ctx->config.sources.gossip.allow_any ) {
-        FD_BASE58_ENCODE_32_BYTES( entry->pubkey.uc, pubkey_b58 );
-        FD_LOG_WARNING(( "allowed gossip peer removed with public key `%s` and RPC address `" FD_IP4_ADDR_FMT ":%hu`",
-                         pubkey_b58, FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
+      if( rem_idx!=ULONG_MAX ) {
+        FD_TEST( entry->allowed && rem_idx==msg->contact_info_remove->idx );
+        ctx->gossip.allowed_cnt--;
+        fd_ip4_port_t addr = entry->rpc_addr;
+        if( FD_LIKELY( !!addr.l ) ) {
+          fd_ssping_remove( ctx->ssping, addr );
+          fd_sspeer_key_t entry_key = {0};
+          *entry_key.pubkey = entry->pubkey;
+          entry_key.is_url  = 0;
+          fd_sspeer_selector_remove( ctx->selector, &entry_key );
+        }
+        if( !ctx->config.sources.gossip.allow_any ) {
+          FD_BASE58_ENCODE_32_BYTES( entry->pubkey.uc, pubkey_b58 );
+          FD_LOG_WARNING(( "allowed gossip peer removed with public key `%s` and RPC address `" FD_IP4_ADDR_FMT ":%hu`",
+                           pubkey_b58, FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
+        }
       }
       fd_memset( entry, 0, sizeof(*entry) );
       break;
@@ -1822,6 +1823,7 @@ unprivileged_init( fd_topo_t *      topo,
 
 #include "../../disco/stem/fd_stem.c"
 
+#ifndef FD_TILE_TEST
 fd_topo_run_tile_t fd_tile_snapct = {
   .name                     = NAME,
   .rlimit_file_cnt_fn       = rlimit_file_cnt,
@@ -1837,5 +1839,6 @@ fd_topo_run_tile_t fd_tile_snapct = {
   .allow_connect            = 1,
   .allow_renameat           = 1,
 };
+#endif
 
 #undef NAME

--- a/src/discof/restore/test_snapct_tile.c
+++ b/src/discof/restore/test_snapct_tile.c
@@ -1,0 +1,224 @@
+#define FD_TILE_TEST 1
+#include "fd_snapct_tile.c"
+#include <stdlib.h>
+
+static void
+send_contact_info( fd_snapct_tile_t *           ctx,
+                   fd_gossip_update_message_t * msg,
+                   ulong                        idx,
+                   fd_pubkey_t const *          pubkey ) {
+  fd_memset( msg, 0, sizeof(*msg) );
+  msg->tag = FD_GOSSIP_UPDATE_TAG_CONTACT_INFO;
+  fd_memcpy( msg->origin, pubkey->uc, sizeof(fd_pubkey_t) );
+  msg->contact_info->idx = idx;
+  gossip_frag( ctx, FD_GOSSIP_UPDATE_TAG_CONTACT_INFO, FD_GOSSIP_UPDATE_SZ_CONTACT_INFO, 0UL );
+}
+
+static void
+send_contact_info_remove( fd_snapct_tile_t *           ctx,
+                          fd_gossip_update_message_t * msg,
+                          ulong                        idx,
+                          fd_pubkey_t const *          pubkey ) {
+  fd_memset( msg, 0, sizeof(*msg) );
+  msg->tag = FD_GOSSIP_UPDATE_TAG_CONTACT_INFO_REMOVE;
+  fd_memcpy( msg->origin, pubkey->uc, sizeof(fd_pubkey_t) );
+  msg->contact_info_remove->idx = idx;
+  gossip_frag( ctx, FD_GOSSIP_UPDATE_TAG_CONTACT_INFO_REMOVE, FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE, 0UL );
+}
+
+static void
+setup_gossip_only_snapct( void *                       scratch,
+                          fd_snapct_tile_t **          ctx_out,
+                          fd_gossip_update_message_t * msg ) {
+  FD_SCRATCH_ALLOC_INIT( l, scratch );
+  fd_snapct_tile_t * ctx  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapct_tile_t),  sizeof(fd_snapct_tile_t)       );
+  memset( ctx, 0, sizeof(fd_snapct_tile_t) );
+  gossip_ci_entry_t * ci_table = FD_SCRATCH_ALLOC_APPEND( l, alignof(gossip_ci_entry_t), sizeof(gossip_ci_entry_t)*GOSSIP_PEERS_MAX );
+  void *              ci_map   = FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
+
+  fd_memset( ci_table, 0, sizeof(gossip_ci_entry_t)*GOSSIP_PEERS_MAX );
+  ctx->gossip.ci_table = ci_table;
+  ctx->gossip.ci_map   = gossip_ci_map_join( gossip_ci_map_new( ci_map, gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ), 0UL ) );
+  FD_TEST( ctx->gossip.ci_map );
+
+  ctx->gossip_in_mem = msg;
+
+  ctx->gossip_enabled = 1;
+  ctx->config.sources.gossip.allow_any      = 0;
+  ctx->config.sources.gossip.allow_list_cnt = 0UL;
+  ctx->config.sources.gossip.block_list_cnt = 0UL;
+
+  *ctx_out = ctx;
+}
+
+static fd_pubkey_t
+test_pubkey( uchar first_byte ) {
+  fd_pubkey_t pubkey = {0};
+  pubkey.uc[ 0 ] = first_byte;
+  return pubkey;
+}
+
+static void
+test_allow_any_contact_info_insert_and_update( void ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_gossip_only_snapct( scratch, &ctx, msg );
+
+  ulong const idx = 3UL;
+  fd_pubkey_t peer = test_pubkey( 0x11 );
+
+  ctx->config.sources.gossip.allow_any = 1;
+
+  send_contact_info( ctx, msg, idx, &peer );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer ) );
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==1UL );
+  FD_TEST( idx==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  /* Updating the same peer at the same contact-info index should not
+     create a second map entry or increment allowed_cnt again. */
+  send_contact_info( ctx, msg, idx, &peer );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer ) );
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==1UL );
+  FD_TEST( idx==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  free( scratch );
+}
+
+static void
+test_allow_any_contact_info_remove( void ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_gossip_only_snapct( scratch, &ctx, msg );
+
+  ulong const idx = 4UL;
+  fd_pubkey_t peer = test_pubkey( 0x22 );
+
+  ctx->config.sources.gossip.allow_any = 1;
+
+  send_contact_info( ctx, msg, idx, &peer );
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==1UL );
+
+  send_contact_info_remove( ctx, msg, idx, &peer );
+  FD_TEST( fd_pubkey_check_zero( &ctx->gossip.ci_table[ idx ].pubkey ) );
+  FD_TEST( !ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==0UL );
+  FD_TEST( ULONG_MAX==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  free( scratch );
+}
+
+static void
+test_allow_list_contact_info_insert( void ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_gossip_only_snapct( scratch, &ctx, msg );
+
+  ulong const idx = 5UL;
+  fd_pubkey_t peer = test_pubkey( 0x33 );
+
+  ctx->config.sources.gossip.allow_any = 0;
+  ctx->config.sources.gossip.allow_list_cnt = 1UL;
+  ctx->config.sources.gossip.allow_list[ 0 ] = peer;
+
+  send_contact_info( ctx, msg, idx, &peer );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer ) );
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==1UL );
+  FD_TEST( ctx->gossip.saturated );
+  FD_TEST( idx==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  free( scratch );
+}
+
+static void
+test_block_list_contact_info_insert( void ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_gossip_only_snapct( scratch, &ctx, msg );
+
+  ulong const idx = 6UL;
+  fd_pubkey_t peer = test_pubkey( 0x44 );
+
+  ctx->config.sources.gossip.allow_any = 1;
+  ctx->config.sources.gossip.block_list_cnt = 1UL;
+  ctx->config.sources.gossip.block_list[ 0 ] = peer;
+
+  send_contact_info( ctx, msg, idx, &peer );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer ) );
+  FD_TEST( !ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==0UL );
+  FD_TEST( ULONG_MAX==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  free( scratch );
+}
+
+static void
+test_contact_info_slot_reuse_after_unallowed_peer_expires( void ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_gossip_only_snapct( scratch, &ctx, msg );
+
+  ulong const idx = 7UL;
+  fd_pubkey_t peer_x = test_pubkey( 0xbb );
+  fd_pubkey_t peer_y = test_pubkey( 0xcc );
+
+  /* Peer X is not allowed, so snapct tracks the table slot but does not
+     add X to the allowed-peer map. */
+  send_contact_info( ctx, msg, idx, &peer_x );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer_x ) );
+  FD_TEST( !ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==0UL );
+  FD_TEST( ULONG_MAX==gossip_ci_map_idx_query_const( ctx->gossip.ci_map, &peer_x, ULONG_MAX, ctx->gossip.ci_table ) );
+
+  /* Removing X must clear the table slot even though X was not in the
+     allowed-peer map.  Otherwise the next peer reusing idx would trip
+     the "new slot must be zero" FD_TEST in gossip_frag. */
+  send_contact_info_remove( ctx, msg, idx, &peer_x );
+  FD_TEST( fd_pubkey_check_zero( &ctx->gossip.ci_table[ idx ].pubkey ) );
+  FD_TEST( !ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==0UL );
+
+  /* The same CRDS contact-info index can now be reused for peer Y
+     without aborting. */
+  send_contact_info( ctx, msg, idx, &peer_y );
+  FD_TEST( fd_pubkey_eq( &ctx->gossip.ci_table[ idx ].pubkey, &peer_y ) );
+  FD_TEST( !ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.allowed_cnt==0UL );
+
+  free( scratch );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  (void)privileged_init;
+  (void)unprivileged_init;
+  (void)populate_allowed_fds;
+  (void)populate_allowed_seccomp;
+  (void)rlimit_file_cnt;
+
+  test_allow_any_contact_info_insert_and_update();
+  test_allow_any_contact_info_remove();
+  test_allow_list_contact_info_insert();
+  test_block_list_contact_info_insert();
+  test_contact_info_slot_reuse_after_unallowed_peer_expires();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
snapct can trip an overly defensive assertion when removing a
ContactInfo for a blocklisted peer.  An FD_TEST asserts that a
peer slot is zeroed/free, but one particular code path failed to
zero the slot.

Fixes the bug and adds regression tests.
