### PR TITLE
runtime: limit vote account epoch credits length

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -1119,7 +1119,9 @@ fd_tower_from_vote_acc( fd_tower_vote_t * votes,
                         uchar  const    * vote_acc ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
   uint                  kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
+  ulong                 vote_cnt = fd_vote_acc_vote_cnt( vote_acc );
+  FD_TEST( vote_cnt <= MAX_LOCKOUT_HISTORY );
+  for( ulong i=0; i<vote_cnt; i++ ) {
     switch( kind ) {
     case FD_VOTE_ACC_V4: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf } ); break;
     case FD_VOTE_ACC_V3: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf } ); break;
@@ -1132,10 +1134,13 @@ fd_tower_from_vote_acc( fd_tower_vote_t * votes,
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc ) {
+                                 uchar const        vote_acc[ static FD_VOTE_STATE_DATA_MAX ] ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
-  uint               kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
+  uint                  kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
+
+  ulong vote_cnt = fd_vote_acc_vote_cnt( vote_acc );
+  FD_TEST( vote_cnt <= MAX_LOCKOUT_HISTORY );
+  for( ulong i=0; i<vote_cnt; i++ ) {
     switch( kind ) {
     case FD_VOTE_ACC_V4: tower[ i ] = (fd_vote_acc_vote_t){ .latency = v4_off( voter )[i].latency, .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf }; break;
     case FD_VOTE_ACC_V3: tower[ i ] = (fd_vote_acc_vote_t){ .latency = voter->v3.votes[i].latency, .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf }; break;
@@ -1143,8 +1148,7 @@ fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_
     default:          FD_LOG_ERR(( "unsupported voter account version: %u", kind ));
     }
   }
-
-  return fd_vote_acc_vote_cnt( vote_acc );
+  return vote_cnt;
 }
 
 void

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -247,7 +247,7 @@ fd_tower_delete( void * shtower ) {
 
 static fd_vote_acc_vote_t const *
 v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
+  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + (!!voter->v4.has_bls_pubkey_compressed) * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
 }
 
 /* expiration calculates the expiration slot of vote given a slot and

--- a/src/choreo/tower/fd_tower.h
+++ b/src/choreo/tower/fd_tower.h
@@ -649,7 +649,7 @@ fd_tower_from_vote_acc( fd_tower_vote_t * votes,
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc );
+                                 uchar const        vote_acc[ static FD_VOTE_STATE_DATA_MAX ] );
 
 /* fd_tower_to_vote_txn writes tower into a fd_tower_sync_t vote
    instruction and serializes it into a Solana transaction.  Assumes

--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -141,18 +141,20 @@ fd_compact_tower_sync_ser( fd_compact_tower_sync_serde_t const * serde,
 
 static fd_vote_acc_vote_t const *
 v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
+  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + (!!voter->v4.has_bls_pubkey_compressed) * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
 }
 
 ulong
 fd_vote_acc_vote_cnt( uchar const * vote_account_data ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
+  ulong cnt;
   switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: return fd_ulong_load_8( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) );
-  case FD_VOTE_ACC_V3: return voter->v3.votes_cnt;
-  case FD_VOTE_ACC_V2: return voter->v2.votes_cnt;
+  case FD_VOTE_ACC_V4: cnt = fd_ulong_load_8( voter->v4.bls_pubkey_compressed + (!!voter->v4.has_bls_pubkey_compressed) * sizeof(voter->v4.bls_pubkey_compressed) ); break;
+  case FD_VOTE_ACC_V3: cnt = voter->v3.votes_cnt; break;
+  case FD_VOTE_ACC_V2: cnt = voter->v2.votes_cnt; break;
   default: FD_LOG_HEXDUMP_CRIT(( "bad voter", vote_account_data, 3762 ));
   }
+  return fd_ulong_min( cnt, MAX_LOCKOUT_HISTORY );
 }
 
 /* fd_vote_acc_vote_slot takes a voter's vote account data and returns the

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -364,7 +364,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
   if( FD_UNLIKELY( !vote_acc_found ) ) return 0;
 
   fd_vote_state_versioned_t vsv[1];
-  FD_CRIT( fd_vote_state_versioned_deserialize( vsv, ctx->our_vote_acct, ctx->our_vote_acct_sz ), "unable to decode vote state versioned" );
+  FD_TEST( fd_vote_state_versioned_deserialize( vsv, ctx->our_vote_acct, ctx->our_vote_acct_sz ) );
 
   fd_pubkey_t const * auth_vtr_addr = NULL;
   switch( vsv->kind ) {
@@ -405,7 +405,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
       FD_LOG_CRIT(( "unsupported vote state versioned discriminant: %u", vsv->kind ));
   }
 
-  FD_CRIT( auth_vtr_addr, "unable to find authorized voter, likely corrupt vote account state" );
+  FD_TEST( auth_vtr_addr );
 
   if( fd_pubkey_eq( auth_vtr_addr, ctx->identity_key ) ) {
     *authority_idx_out = ULONG_MAX;
@@ -1377,7 +1377,7 @@ during_housekeeping( fd_tower_tile_t * ctx ) {
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->identity_keyswitch )==FD_KEYSWITCH_STATE_UNHALT_PENDING ) ) {
     FD_LOG_DEBUG(( "keyswitch: unhalting signing" ));
-    FD_CRIT( ctx->halt_signing, "state machine corruption" );
+    FD_TEST( ctx->halt_signing );
     ctx->halt_signing = 0;
     fd_keyswitch_state( ctx->identity_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }

--- a/src/flamenco/runtime/program/vote/Local.mk
+++ b/src/flamenco/runtime/program/vote/Local.mk
@@ -15,3 +15,8 @@ $(call add-objs,fd_vote_state_v3,fd_flamenco)
 
 $(call add-hdrs,fd_vote_state_v4.h)
 $(call add-objs,fd_vote_state_v4,fd_flamenco)
+
+ifdef FD_HAS_HOSTED
+$(call make-fuzz-test,fuzz_vote_codec,fuzz_vote_codec,fd_flamenco fd_ballet fd_util)
+$(call run-fuzz-test,fuzz_vote_codec)
+endif

--- a/src/flamenco/runtime/program/vote/fd_vote_codec.c
+++ b/src/flamenco/runtime/program/vote/fd_vote_codec.c
@@ -564,6 +564,7 @@ seek_epoch_credits( uchar const *                    data,
 
   *out_ptr = (fd_vote_epoch_credits_t const *)ptr;
   *out_cnt = epoch_credits_len;
+  if( epoch_credits_len>MAX_EPOCH_CREDITS_HISTORY ) return 1;
   return 0;
 }
 

--- a/src/flamenco/runtime/program/vote/fd_vote_codec.h
+++ b/src/flamenco/runtime/program/vote/fd_vote_codec.h
@@ -22,6 +22,7 @@
 /* https://github.com/anza-xyz/solana-sdk/blob/vote-interface%40v5.1.1/vote-interface/src/state/mod.rs#L43 */
 #define MAX_EPOCH_CREDITS_HISTORY          (64UL)
 #define MAX_EPOCH_CREDITS_HISTORY_CAPACITY (MAX_EPOCH_CREDITS_HISTORY+1UL)
+FD_STATIC_ASSERT( FD_EPOCH_CREDITS_MAX==MAX_EPOCH_CREDITS_HISTORY, limits );
 
 /* This is an implicit bound derived from the vote program logic.  When
    authorized voters are updated inside the vote program, any authorized
@@ -258,16 +259,10 @@ FD_STATIC_ASSERT( sizeof(fd_vote_init_t)==97UL, vote_init_layout );
 #define DEQUE_NAME deq_ulong
 #define DEQUE_T ulong
 #include "../../../../util/tmpl/fd_deque_dynamic.c"
-#undef DEQUE_NAME
-#undef DEQUE_T
-#undef DEQUE_MAX
 
 #define DEQUE_NAME deq_fd_vote_lockout_t
 #define DEQUE_T fd_vote_lockout_t
 #include "../../../../util/tmpl/fd_deque_dynamic.c"
-#undef DEQUE_NAME
-#undef DEQUE_T
-#undef DEQUE_MAX
 
 /**********************************************************************/
 /* Deque templates -- vote account state                              */
@@ -277,16 +272,10 @@ FD_STATIC_ASSERT( sizeof(fd_vote_init_t)==97UL, vote_init_layout );
 #define DEQUE_T fd_vote_epoch_credits_t
 #define DEQUE_MAX MAX_EPOCH_CREDITS_HISTORY_CAPACITY
 #include "../../../../util/tmpl/fd_deque.c"
-#undef DEQUE_NAME
-#undef DEQUE_T
-#undef DEQUE_MAX
 
 #define DEQUE_NAME deq_fd_landed_vote_t
 #define DEQUE_T fd_landed_vote_t
 #include "../../../../util/tmpl/fd_deque_dynamic.c"
-#undef DEQUE_NAME
-#undef DEQUE_T
-#undef DEQUE_MAX
 
 /**********************************************************************/
 /* Treap / pool for authorized voters                                 */
@@ -670,7 +659,8 @@ fd_vote_account_is_v4_with_bls_pubkey( uchar const * data,
 
 /* Seeks through variable-length fields and returns a zero-copy pointer
    to the epoch_credits entries inside the raw buffer.  *cnt is set to
-   the number of entries.  Returns NULL on error. */
+   the number of entries.  *cnt is in [0,MAX_EPOCH_CREDITS_HISTORY].
+   Returns NULL on error. */
 fd_vote_epoch_credits_t const *
 fd_vote_account_epoch_credits( uchar const * data,
                                ulong         data_sz,

--- a/src/flamenco/runtime/program/vote/fuzz_vote_codec.c
+++ b/src/flamenco/runtime/program/vote/fuzz_vote_codec.c
@@ -1,0 +1,60 @@
+#include "fd_vote_codec.h"
+
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+
+  /* Disable parsing error logging */
+  fd_log_level_stderr_set(4);
+  fd_log_level_logfile_set(4);
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  fd_vote_state_versioned_t vsv[1];
+  if( fd_vote_state_versioned_deserialize( vsv, data, size ) ) {
+    switch( vsv->kind ) {
+    case fd_vote_state_versioned_enum_uninitialized:
+      break;
+    case fd_vote_state_versioned_enum_v1_14_11:
+      assert( !fd_vote_authorized_voters_treap_verify( vsv->v1_14_11.authorized_voters.treap, vsv->v1_14_11.authorized_voters.pool ) );
+      assert( deq_fd_landed_vote_t_cnt( vsv->v1_14_11.votes )<=MAX_LOCKOUT_HISTORY );
+      assert( deq_fd_vote_epoch_credits_t_cnt( vsv->v1_14_11.epoch_credits )<=MAX_EPOCH_CREDITS_HISTORY );
+      break;
+    case fd_vote_state_versioned_enum_v3:
+      assert( !fd_vote_authorized_voters_treap_verify( vsv->v3.authorized_voters.treap, vsv->v3.authorized_voters.pool ) );
+      assert( deq_fd_landed_vote_t_cnt( vsv->v3.votes )<=MAX_LOCKOUT_HISTORY );
+      assert( deq_fd_vote_epoch_credits_t_cnt( vsv->v3.epoch_credits )<=MAX_EPOCH_CREDITS_HISTORY );
+      break;
+    case fd_vote_state_versioned_enum_v4:
+      assert( !fd_vote_authorized_voters_treap_verify( vsv->v4.authorized_voters.treap, vsv->v4.authorized_voters.pool ) );
+      assert( deq_fd_landed_vote_t_cnt( vsv->v4.votes )<=MAX_LOCKOUT_HISTORY );
+      assert( deq_fd_vote_epoch_credits_t_cnt( vsv->v4.epoch_credits )<=MAX_EPOCH_CREDITS_HISTORY );
+      break;
+    default:
+      FD_LOG_CRIT(( "unsupported vote state version: %u", vsv->kind ));
+    }
+  }
+  ulong cnt;
+  fd_vote_epoch_credits_t const * ec = fd_vote_account_epoch_credits( data, size, &cnt );
+  if( ec ) {
+    assert( cnt<=MAX_EPOCH_CREDITS_HISTORY );
+    ulong ptr0 = (ulong)ec;
+    ulong ptr1 = (ulong)( ec + cnt );
+    assert( ptr0<=ptr1 && ptr1<=(ulong)( data+size ) );
+  }
+  return 0;
+}


### PR DESCRIPTION
Fixes a bug where fd_vote_account_epoch_credits permitted vote
accounts with a vote credit history exceeding
MAX_EPOCH_CREDITS_HISTORY which leads to issues down the line.
