### PR TITLE
runtime: unique XIDs 

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -89,7 +89,7 @@
 
 /* The first bank that the replay tile produces either for genesis
    or the snapshot boot will always be at bank index 0. */
-#define FD_REPLAY_BOOT_BANK_IDX (0UL)
+#define FD_REPLAY_BOOT_BANK_SEQ (0UL)
 
 static inline ulong
 fd_block_id_ele_get_idx( fd_block_id_ele_t * ele_arr, fd_block_id_ele_t * ele ) {
@@ -264,8 +264,6 @@ replay_block_start( fd_replay_tile_t *  ctx,
   FD_CRIT( parent_bank, "invariant violation: parent bank is NULL" );
   FD_CRIT( parent_bank->state==FD_BANK_STATE_FROZEN, "invariant violation: parent bank is not in correct state" );
 
-  ulong parent_slot = parent_bank->f.slot;
-
   /* Clone the bank from the parent.  We must special case the first
      slot that is executed as the snapshot does not provide a parent
      block id. */
@@ -279,8 +277,8 @@ replay_block_start( fd_replay_tile_t *  ctx,
 
   /* Create a new funk txn for the block. */
 
-  fd_funk_txn_xid_t xid        = { .ul = { slot, bank_idx } };
-  fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_funk_txn_xid_t xid        = fd_bank_xid( bank        );
+  fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
   fd_progcache_attach_child( ctx->progcache,   &parent_xid, &xid );
 
@@ -405,6 +403,7 @@ publish_slot_completed( fd_replay_tile_t *  ctx,
   bank->refcnt++; /* tower_tile */
   if( FD_LIKELY( ctx->rpc_enabled ) ) bank->refcnt++; /* rpc tile */
   slot_info->bank_idx = bank->idx;
+  slot_info->xid      = fd_bank_xid( bank );
   FD_LOG_DEBUG(( "bank (idx=%lu, slot=%lu) refcnt incremented to %lu for tower, rpc", bank->idx, slot, bank->refcnt ));
 
   fd_bank_t * parent_bank = fd_banks_get_parent( ctx->banks, bank );
@@ -509,7 +508,7 @@ replay_block_finalize( fd_replay_tile_t *  ctx,
 
   /* fetch identity / vote balance updates infrequently */
   ulong slot = bank->f.slot;
-  fd_funk_txn_xid_t xid = { .ul = { slot, bank->idx } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( bank );
   slot_info->identity_balance = FD_UNLIKELY( slot%4096==0UL ) ? get_identity_balance( ctx, xid ) : ULONG_MAX;
 
   /* Mark the bank as frozen. */
@@ -559,7 +558,6 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   if( FD_UNLIKELY( !parent_bank ) ) {
     FD_LOG_CRIT(( "invariant violation: parent bank not found for bank index %lu", parent_bank_idx ));
   }
-  ulong parent_slot = parent_bank->f.slot;
 
   ctx->leader_bank = fd_banks_new_bank( ctx->banks, parent_bank_idx, now );
   if( FD_UNLIKELY( !ctx->leader_bank ) ) {
@@ -576,8 +574,8 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   ctx->leader_bank->f.slot = slot;
   ctx->leader_bank->txncache_fork_id = fd_txncache_attach_child( ctx->txncache, parent_bank->txncache_fork_id );
   /* prepare the funk transaction for the leader bank */
-  fd_funk_txn_xid_t xid        = { .ul = { slot, ctx->leader_bank->idx } };
-  fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_funk_txn_xid_t xid        = fd_bank_xid( ctx->leader_bank );
+  fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank      );
   fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
   fd_progcache_attach_child( ctx->progcache,   &parent_xid, &xid );
 
@@ -648,7 +646,7 @@ fini_leader_bank( fd_replay_tile_t *  ctx,
 
   fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
   cost_tracker_snap( ctx->leader_bank, slot_info );
-  fd_funk_txn_xid_t xid = { .ul = { curr_slot, ctx->leader_bank->idx } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( ctx->leader_bank );
   slot_info->identity_balance = FD_UNLIKELY( curr_slot%4096==0UL ) ? get_identity_balance( ctx, xid ) : ULONG_MAX;
 
   fd_banks_mark_bank_frozen( ctx->leader_bank );
@@ -751,9 +749,9 @@ init_after_snapshot( fd_replay_tile_t *  ctx,
      of data required for the stake delegations. See
      fd_stake_delegations.h for why this is required. */
 
-  fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX );
+  fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ );
   if( FD_UNLIKELY( !bank ) ) {
-    FD_LOG_CRIT(( "invariant violation: replay bank is NULL at bank index %lu", FD_REPLAY_BOOT_BANK_IDX ));
+    FD_LOG_CRIT(( "invariant violation: replay bank is NULL at bank index %lu", FD_REPLAY_BOOT_BANK_SEQ ));
   }
 
   fd_runtime_update_next_leaders( bank, ctx->runtime_stack );
@@ -768,7 +766,7 @@ init_after_snapshot( fd_replay_tile_t *  ctx,
   publish_epoch_info( ctx, stem, bank, 0 );
   publish_epoch_info( ctx, stem, bank, 1 );
 
-  fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( bank );
   init_funk( ctx, bank->f.slot );
 
   bank->f.warmup_cooldown_rate_epoch = fd_slot_to_epoch( &bank->f.epoch_schedule, bank->f.features.reduce_stake_warmup_cooldown, NULL );
@@ -896,7 +894,7 @@ maybe_become_leader( fd_replay_tile_t *  ctx,
 
   /* Acquires bank, sets up initial state, and refcnts it. */
   fd_bank_t *       bank = prepare_leader_bank( ctx, stem, ctx->next_leader_slot, now_nanos, &ctx->reset_block_id );
-  fd_funk_txn_xid_t xid  = { .ul = { ctx->next_leader_slot, ctx->leader_bank->idx } };
+  fd_funk_txn_xid_t xid  = fd_bank_xid( ctx->leader_bank );
 
   fd_bundle_crank_tip_payment_config_t config[1] = { 0 };
   fd_pubkey_t tip_receiver_owner = {0};
@@ -1061,9 +1059,9 @@ boot_genesis( fd_replay_tile_t *        ctx,
   FD_TEST( meta->bootstrap && meta->has_lthash );
   FD_TEST( fd_genesis_parse( ctx->genesis, genesis_blob, meta->blob_sz ) );
 
-  fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX );
+  fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ );
   FD_TEST( bank );
-  fd_funk_txn_xid_t xid = { .ul = { 0UL, FD_REPLAY_BOOT_BANK_IDX } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( bank );
 
   /* Do genesis-related processing in a non-rooted transaction */
   fd_funk_txn_xid_t root_xid = { .ul = { LONG_MAX, LONG_MAX } };
@@ -1169,9 +1167,9 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
        state machine and set the state here accordingly. */
     ctx->is_booted = 1;
 
-    fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX );
+    fd_bank_t * bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ );
     if( FD_UNLIKELY( !bank ) ) {
-      FD_LOG_CRIT(( "invariant violation: bank is NULL for bank index %lu", FD_REPLAY_BOOT_BANK_IDX ));
+      FD_LOG_CRIT(( "invariant violation: bank is NULL for bank index %lu", FD_REPLAY_BOOT_BANK_SEQ ));
     }
 
     ulong snapshot_slot = bank->f.slot;
@@ -1193,7 +1191,7 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
        the block id of the snapshot slot from repair. */
     fd_hash_t manifest_block_id = ctx->initial_block_id;
 
-    fd_funk_txn_xid_t xid = { .ul = { snapshot_slot, FD_REPLAY_BOOT_BANK_IDX } };
+    fd_funk_txn_xid_t xid = { .ul = { snapshot_slot, FD_REPLAY_BOOT_BANK_SEQ } };
     fd_features_restore( bank, ctx->accdb, &xid );
 
     FD_TEST( fd_sysvar_cache_restore( bank, ctx->accdb, &xid ) );
@@ -1259,7 +1257,7 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
 
       fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
                          ctx->banks,
-                         fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_IDX ),
+                         fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ ),
                          msg==FD_SSMSG_MANIFEST_INCREMENTAL );
 
       fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
@@ -1721,21 +1719,19 @@ accdb_root_op_total( fd_replay_tile_t const * ctx ) {
 
 static void
 accdb_advance_root( fd_replay_tile_t * ctx,
-                    ulong              slot,
-                    ulong              bank_idx ) {
-  fd_funk_txn_xid_t xid = { .ul[0] = slot, .ul[1] = bank_idx };
-  FD_LOG_DEBUG(( "advancing root to slot=%lu", slot ));
+                    fd_xid_t const *   xid ) {
+  FD_LOG_DEBUG(( "advancing root to slot=%lu", xid->ul[0] ));
 
   long rooted_accounts   = -(long)accdb_root_op_total( ctx );
   long t0                = fd_tickcount();
-  fd_accdb_advance_root( ctx->accdb_admin, &xid );
+  fd_accdb_advance_root( ctx->accdb_admin, xid );
   rooted_accounts       += (long)accdb_root_op_total( ctx );
   long t1                = fd_tickcount();
   long root_accounts_dt  = t1 - t0;
   fd_histf_sample( ctx->metrics.root_slot_dur,    (ulong)root_accounts_dt );
   fd_histf_sample( ctx->metrics.root_account_dur, (ulong)root_accounts_dt / (ulong)fd_long_max( rooted_accounts, 1L ) );
 
-  fd_progcache_advance_root( ctx->progcache, &xid );
+  fd_progcache_advance_root( ctx->progcache, xid );
   long t2 = fd_tickcount();
   FD_MCNT_INC( REPLAY, PROGCACHE_TIME_SECONDS, (ulong)( t2-t1 ) );
 }
@@ -1773,7 +1769,8 @@ advance_published_root( fd_replay_tile_t * ctx ) {
   fd_block_id_ele_t * advanceable_root_ele = &ctx->block_id_arr[ advanceable_root_idx ];
 
   ulong advanceable_root_slot = bank->f.slot;
-  accdb_advance_root( ctx, advanceable_root_slot, bank->idx );
+  fd_xid_t const xid = fd_bank_xid( bank );
+  accdb_advance_root( ctx, &xid );
 
   fd_txncache_advance_root( ctx->txncache, bank->txncache_fork_id );
   fd_sched_advance_root( ctx->sched, advanceable_root_idx );
@@ -1837,7 +1834,7 @@ after_credit( fd_replay_tile_t *  ctx,
   int pruned = fd_banks_prune_one_dead_bank( ctx->banks, cancel_info );
   if( FD_UNLIKELY( pruned==2 ) ) {
     fd_txncache_cancel_fork( ctx->txncache, cancel_info->txncache_fork_id );
-    fd_funk_txn_xid_t xid = { .ul = { cancel_info->slot, cancel_info->bank_idx } };
+    fd_funk_txn_xid_t xid = { .ul = { cancel_info->slot, cancel_info->bank_seq } };
     fd_accdb_cancel    ( ctx->accdb_admin, &xid );
     fd_progcache_cancel( ctx->progcache,   &xid );
     *charge_busy = 1;
@@ -2501,7 +2498,7 @@ unprivileged_init( fd_topo_t *      topo,
   fd_bank_t * bank = fd_banks_init_bank( ctx->banks );
   FD_TEST( bank );
   bank->f.slot = 0UL;
-  FD_TEST( bank->idx==FD_REPLAY_BOOT_BANK_IDX );
+  FD_TEST( bank->idx==FD_REPLAY_BOOT_BANK_SEQ );
 
   ctx->consensus_root_slot = ULONG_MAX;
   ctx->consensus_root      = ctx->initial_block_id;

--- a/src/discof/replay/fd_replay_tile.h
+++ b/src/discof/replay/fd_replay_tile.h
@@ -111,7 +111,8 @@ struct fd_replay_slot_completed {
   /* Reference to the bank for this completed slot.  TODO: We can
      eliminate non-timestamp fields and have consumers just use
      bank_idx. */
-  ulong bank_idx;
+  ulong    bank_idx;
+  fd_xid_t xid;
 
   long first_fec_set_received_nanos;      /* timestamp when replay received the first fec of the slot from turbine or repair */
   long preparation_begin_nanos;           /* timestamp when replay began preparing the state to begin execution of the slot */

--- a/src/discof/resolv/fd_resolv_tile.c
+++ b/src/discof/resolv/fd_resolv_tile.c
@@ -252,7 +252,7 @@ peek_alut( fd_resolv_ctx_t *  ctx,
            fd_txn_m_t *       txnm,
            fd_alut_interp_t * interp,
            ulong              alut_idx ) {
-  fd_funk_txn_xid_t const xid = { .ul = { ctx->bank->f.slot, ctx->bank->idx } };
+  fd_funk_txn_xid_t const xid = fd_bank_xid( ctx->bank );
 
   fd_txn_t const * txn         = fd_txn_m_txn_t_const  ( txnm );
   uchar const *    txn_payload = fd_txn_m_payload_const( txnm );

--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -191,6 +191,7 @@ struct bank_info {
   ulong epoch;
   ulong slot_in_epoch;
   ulong slots_per_epoch;
+  fd_xid_t xid;
 
   ulong transaction_count;
   uchar block_hash[ 32 ];
@@ -440,6 +441,7 @@ returnable_frag( fd_rpc_tile_t *     ctx,
         bank->epoch = slot_completed->epoch;
         bank->slot_in_epoch = slot_completed->slot_in_epoch;
         bank->slots_per_epoch = slot_completed->slots_per_epoch;
+        bank->xid = slot_completed->xid;
         bank->transaction_count = slot_completed->transaction_count;
         bank->block_height = slot_completed->block_height;
         fd_memcpy( bank->block_hash, slot_completed->block_hash.uc, 32 );
@@ -1117,9 +1119,8 @@ getAccountInfo( fd_rpc_tile_t * ctx,
   if( FD_UNLIKELY( !config_valid ) ) return response;
 
   bank_info_t * info = &ctx->banks[ bank_idx ];
-  fd_funk_txn_xid_t xid = { .ul={ info->slot, bank_idx } };
   fd_accdb_ro_t ro[1];
-  if( FD_UNLIKELY( !fd_accdb_open_ro( ctx->accdb, ro, &xid, address.uc ) ) ) {
+  if( FD_UNLIKELY( !fd_accdb_open_ro( ctx->accdb, ro, &info->xid, address.uc ) ) ) {
     CSTR_JSON( id, id_cstr );
     return PRINTF_JSON( ctx, "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":%lu},\"value\":null},\"id\":%s}\n", info->slot, id_cstr );
   }
@@ -1164,9 +1165,8 @@ getBalance( fd_rpc_tile_t * ctx,
   if( FD_UNLIKELY( !config_valid ) ) return response;
 
   ulong balance = 0UL;
-  fd_funk_txn_xid_t xid = { .ul={ ctx->banks[ bank_idx ].slot, bank_idx } };
   fd_accdb_ro_t ro[ 1 ];
-  if( FD_UNLIKELY( fd_accdb_open_ro( ctx->accdb, ro, &xid, address.uc ) ) ) {
+  if( FD_UNLIKELY( fd_accdb_open_ro( ctx->accdb, ro, &ctx->banks[ bank_idx ].xid, address.uc ) ) ) {
     balance = fd_accdb_ref_lamports( ro );
     fd_accdb_close_ro( ctx->accdb, ro );
   }
@@ -1581,7 +1581,6 @@ getMultipleAccounts( fd_rpc_tile_t * ctx,
   if( FD_UNLIKELY( !config_valid ) ) return response;
 
   bank_info_t * info = &ctx->banks[ bank_idx ];
-  fd_funk_txn_xid_t xid = { .ul={ info->slot, bank_idx } };
 
   fd_pubkey_t addresses[ 100UL ];
   for( ulong i=0UL; i<(ulong)cnt; i++ ) {
@@ -1598,7 +1597,7 @@ getMultipleAccounts( fd_rpc_tile_t * ctx,
     if( i>0 ) fd_http_server_printf( ctx->http, "," );
 
     fd_accdb_ro_t ro[1];
-    if( FD_UNLIKELY( !fd_accdb_open_ro( ctx->accdb, ro, &xid, addresses[ i ].uc ) ) ) {
+    if( FD_UNLIKELY( !fd_accdb_open_ro( ctx->accdb, ro, &info->xid, addresses[ i ].uc ) ) ) {
       fd_http_server_printf( ctx->http, "null" );
       continue;
     }

--- a/src/discof/rpc/test_rpc_tile.c
+++ b/src/discof/rpc/test_rpc_tile.c
@@ -191,6 +191,7 @@ main( int     argc,
   fd_funk_txn_xid_t root_xid;
   fd_funk_txn_xid_set_root( &root_xid );
   fd_funk_txn_xid_t test_xid = { .ul = { 42UL, 0UL } };
+  ctx->banks[0].xid = test_xid;
   fd_funk_txn_prepare( funk, &root_xid, &test_xid );
 
   /* Account A: 4 bytes of data, 1000000 lamports */

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -916,7 +916,7 @@ query_vote_accs( fd_tower_tile_t *            ctx,
   fd_top_votes_iter_t *  iter          = fd_top_votes_iter_init( top_votes_t_2, ctx->iter_mem );
 
   fd_accdb_ro_pipe_t ro_pipe[1];
-  fd_funk_txn_xid_t  xid = { .ul = { slot_completed->slot, slot_completed->bank_idx } };
+  fd_funk_txn_xid_t  xid = fd_bank_xid( bank );
   fd_accdb_ro_pipe_init( ro_pipe, ctx->accdb, &xid );
 
   for(;;) {
@@ -965,7 +965,7 @@ query_vote_accs( fd_tower_tile_t *            ctx,
 
   *our_vote_acct_bal    = ULONG_MAX;
   *found_our_vote_acct  = 0;
-  fd_funk_txn_xid_t reconcile_xid = { .ul = { slot_completed->slot, slot_completed->bank_idx } };
+  fd_funk_txn_xid_t reconcile_xid = fd_bank_xid( bank );
   fd_accdb_ro_t reconcile_ro[1];
   if( FD_LIKELY( fd_accdb_open_ro( ctx->accdb, reconcile_ro, &reconcile_xid, ctx->vote_account ) ) ) {
     *found_our_vote_acct = 1;

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -1084,6 +1084,7 @@ fd_banks_prune_one_dead_bank( fd_banks_t *                   banks,
     if( FD_LIKELY( started_replaying ) ) {
       cancel->txncache_fork_id = bank->txncache_fork_id;
       cancel->slot             = bank->f.slot;
+      cancel->bank_seq         = bank->bank_seq;
       cancel->bank_idx         = bank->idx;
     }
 

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -341,6 +341,7 @@ typedef struct fd_bank fd_bank_t;
 struct fd_banks_prune_cancel_info {
   fd_txncache_fork_id_t txncache_fork_id;
   ulong                 slot;
+  ulong                 bank_seq;
   ulong                 bank_idx;
 };
 typedef struct fd_banks_prune_cancel_info fd_banks_prune_cancel_info_t;
@@ -665,7 +666,7 @@ fd_banks_clear_bank( fd_banks_t * banks,
 
 /* fd_banks_clear releases all banks back to the pool and resets the
    banks manager to its post-new state.  Assumes no active references to
-   any bank. */
+   any bank.  WARNING: collision risk, resets bank_seq to 0. */
 
 void
 fd_banks_clear( fd_banks_t * banks );
@@ -762,6 +763,14 @@ fd_banks_get_frontier( fd_banks_t * banks,
 
 int
 fd_banks_is_full( fd_banks_t * banks );
+
+/* fd_bank_xid returns the accdb/progcache xid for the given bank. */
+
+static inline fd_xid_t
+fd_bank_xid( fd_bank_t const * bank ) {
+  if( FD_UNLIKELY( !bank ) ) FD_LOG_CRIT(( "NULL bank" ));
+  return (fd_xid_t){ .ul = { bank->f.slot, bank->bank_seq } };
+}
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -790,7 +790,7 @@ fd_executor_create_rollback_fee_payer_account( fd_runtime_t *      runtime,
       fd_memcpy( fee_payer_data, (uchar *)meta, sizeof(fd_account_meta_t) + meta->dlen );
     } else {
       /* Copy from account database */
-      fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+      fd_funk_txn_xid_t xid = fd_bank_xid( bank );
       fd_accdb_ro_t fee_payer_ro[1];
       if( FD_UNLIKELY( !fd_accdb_open_ro( runtime->accdb, fee_payer_ro, &xid, fee_payer_key ) ) ) {
         FD_BASE58_ENCODE_32_BYTES( fee_payer_key->uc, fee_payer_key_b58 );
@@ -885,7 +885,7 @@ fd_executor_setup_txn_alut_account_keys( fd_runtime_t *      runtime,
       FD_LOG_DEBUG(( "fd_executor_setup_txn_alut_account_keys(): failed to get slot hashes" ));
       return FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND;
     }
-    fd_funk_txn_xid_t xid       = { .ul = { bank->f.slot, bank->idx } };
+    fd_funk_txn_xid_t xid       = fd_bank_xid( bank );
     fd_acct_addr_t *  accts_alt = (fd_acct_addr_t *) fd_type_pun( &txn_out->accounts.keys[txn_out->accounts.cnt] );
     int err = fd_runtime_load_txn_address_lookup_tables( txn_in,
                                                          TXN( txn_in->txn ),
@@ -1267,7 +1267,7 @@ fd_executor_setup_txn_account( fd_runtime_t *      runtime,
   }
 
   if( FD_LIKELY( !account ) ) {
-    fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+    fd_funk_txn_xid_t xid = fd_bank_xid( bank );
     account = (fd_accdb_rw_t *)fd_accdb_open_ro( runtime->accdb, ref_slot->ro, &xid, address );
     /* creates a database reference, which is explicitly dropped here
        or in commit/cancel */
@@ -1346,7 +1346,7 @@ fd_executor_setup_executable_account( fd_runtime_t *            runtime,
      will fail at the instruction execution level since the programdata
      account will not exist within the executable accounts list. */
   fd_pubkey_t *     programdata_acc = &program_loader_state->inner.program.programdata_address;
-  fd_funk_txn_xid_t xid             = { .ul = { bank->f.slot, bank->idx } };
+  fd_funk_txn_xid_t xid             = fd_bank_xid( bank );
 
   fd_accdb_ro_t * ro = &runtime->accounts.executable[ *executable_idx ];
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -346,7 +346,7 @@ fd_runtime_freeze( fd_bank_t *         bank,
                    fd_accdb_user_t *   accdb,
                    fd_capture_ctx_t *  capture_ctx ) {
 
-  fd_funk_txn_xid_t const xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_funk_txn_xid_t const xid = fd_bank_xid( bank );
 
   if( FD_LIKELY( bank->f.slot != 0UL ) ) {
     fd_sysvar_recent_hashes_update( bank, accdb, &xid, capture_ctx );
@@ -857,7 +857,7 @@ fd_runtime_block_execute_prepare( fd_banks_t *         banks,
                                   fd_capture_ctx_t *   capture_ctx,
                                   int *                is_epoch_boundary ) {
 
-  fd_funk_txn_xid_t const xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_funk_txn_xid_t const xid = fd_bank_xid( bank );
 
   fd_runtime_block_pre_execute_process_new_epoch( banks, bank, accdb, &xid, capture_ctx, runtime_stack, is_epoch_boundary );
 
@@ -1176,7 +1176,7 @@ fd_runtime_commit_txn( fd_runtime_t * runtime,
     }
   }
 
-  fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( bank );
 
   if( FD_UNLIKELY( txn_out->err.txn_err ) ) {
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2176,7 +2176,7 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
   }
 
   fd_prog_load_env_t load_env[1]; fd_prog_load_env_from_bank( load_env, ctx->bank );
-  fd_funk_txn_xid_t xid = { .ul = { ctx->bank->f.slot, ctx->bank->idx } };
+  fd_funk_txn_xid_t xid = fd_bank_xid( ctx->bank );
   fd_progcache_t * progcache = ctx->runtime->progcache;
   fd_progcache_rec_t * cache_entry =
       fd_progcache_pull( progcache, &xid, program_id, load_env, progdata_ro );

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -155,6 +155,8 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   FD_TEST( env->banks );
   env->bank = fd_banks_init_bank( env->banks );
   FD_TEST( env->bank );
+  env->bank->f.slot = 9UL;
+  env->bank->f.epoch = 4UL;
 
   env->runtime_stack = fd_wksp_alloc_laddr( wksp, fd_runtime_stack_align(), fd_runtime_stack_footprint( 2048UL, 2048UL, 2048UL ), env->tag );
   FD_TEST( env->runtime_stack );
@@ -162,7 +164,7 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
 
   fd_funk_txn_xid_t root[1];
   fd_funk_txn_xid_set_root( root );
-  env->xid = (fd_funk_txn_xid_t){ .ul = { 9UL, env->bank->idx } };
+  env->xid = fd_bank_xid( env->bank );
   fd_accdb_attach_child    ( env->accdb_admin,     root, &env->xid );
   fd_progcache_attach_child( env->progcache->join, root, &env->xid );
 
@@ -171,9 +173,6 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   init_stake_history_sysvar( env );
   init_clock_sysvar( env );
   init_blockhash_queue( env );
-
-  env->bank->f.slot = 9UL;
-  env->bank->f.epoch = 4UL;
 
   fd_bank_top_votes_t_2_modify( env->bank );
 
@@ -258,8 +257,8 @@ process_slot( test_env_t * env, ulong slot ) {
   ulong epoch = fd_slot_to_epoch( epoch_schedule, slot, NULL );
   new_bank->f.epoch = epoch;
 
-  fd_funk_txn_xid_t xid        = { .ul = { slot, new_bank_idx } };
-  fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_funk_txn_xid_t xid        = fd_bank_xid( new_bank    );
+  fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child    ( env->accdb_admin,     &parent_xid, &xid );
   fd_progcache_attach_child( env->progcache->join, &parent_xid, &xid );
 

--- a/src/flamenco/runtime/test_bank.c
+++ b/src/flamenco/runtime/test_bank.c
@@ -337,7 +337,13 @@ test_bank_dead_eviction( void * mem ) {
   FD_TEST( fd_banks_pool_used( bank_data_pool )==2UL );
   FD_TEST( bank_D->state==FD_BANK_STATE_DEAD );
 
-  FD_TEST( fd_banks_prune_one_dead_bank( banks, cancel ) );
+  ulong bank_D_slot = bank_D->f.slot;
+  ulong bank_D_seq  = bank_D->bank_seq;
+  ulong bank_D_idx  = bank_D->idx;
+  FD_TEST( fd_banks_prune_one_dead_bank( banks, cancel )==2 );
+  FD_TEST( cancel->slot    ==bank_D_slot );
+  FD_TEST( cancel->bank_seq==bank_D_seq  );
+  FD_TEST( cancel->bank_idx==bank_D_idx  );
   FD_TEST( fd_banks_pool_used( bank_data_pool )==1UL );
 
   /* Case: multiple isolated dead banks get pruned at once. */

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -167,14 +167,16 @@ init_rent_sysvar( test_env_t * env,
 
     env->bank = fd_banks_init_bank( env->banks );
     FD_TEST( env->bank );
+    env->bank->f.slot  = 9UL;
+    env->bank->f.epoch = 4UL;
 
     env->runtime_stack = fd_wksp_alloc_laddr( wksp, fd_runtime_stack_align(), fd_runtime_stack_footprint( 2048UL, 2048UL, 2048UL ), env->tag );
     FD_TEST( env->runtime_stack );
     FD_TEST( fd_runtime_stack_join( fd_runtime_stack_new( env->runtime_stack, 2048UL, 2048UL, 2048UL, 999UL ) ) );
 
-    fd_funk_txn_xid_t root[1];
+    fd_xid_t root[1];
     fd_funk_txn_xid_set_root( root );
-    env->xid = (fd_funk_txn_xid_t){ .ul = { 9UL, env->bank->idx } };
+    env->xid = fd_bank_xid( env->bank );
     fd_accdb_attach_child( env->accdb_admin, root, &env->xid );
 
     init_rent_sysvar( env, TEST_DEFAULT_LAMPORTS_PER_UINT8_YEAR, TEST_DEFAULT_EXEMPTION_THRESHOLD );
@@ -183,9 +185,6 @@ init_rent_sysvar( test_env_t * env,
     init_clock_sysvar( env );
     init_blockhash_queue( env );
     fd_sysvar_recent_hashes_init( env->bank, env->accdb, &env->xid, NULL );
-
-    env->bank->f.slot = 9UL;
-    env->bank->f.epoch = 4UL;
 
     fd_features_t features = {0};
     fd_features_disable_all( &features );
@@ -234,8 +233,8 @@ FD_TEST( parent_bank->state==FD_BANK_STATE_FROZEN );
   ulong epoch = fd_slot_to_epoch( epoch_schedule, slot, NULL );
   new_bank->f.epoch = epoch;
 
-  fd_funk_txn_xid_t xid        = { .ul = { slot, new_bank_idx } };
-  fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_funk_txn_xid_t xid        = fd_bank_xid( new_bank    );
+  fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child( env->accdb_admin, &parent_xid, &xid );
 
   env->xid  = xid;

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -224,6 +224,8 @@ test_env_create( test_env_t * env,
 
   env->bank = fd_banks_init_bank( env->banks );
   FD_TEST( env->bank );
+  env->bank->f.slot  = 1UL;
+  env->bank->f.epoch = 1UL;
 
   env->runtime_stack = fd_wksp_alloc_laddr( wksp, fd_runtime_stack_align(), fd_runtime_stack_footprint( 2048UL, 2048UL, 2048UL ), env->tag );
   FD_TEST( env->runtime_stack );
@@ -231,7 +233,7 @@ test_env_create( test_env_t * env,
 
   fd_funk_txn_xid_t root[1];
   fd_funk_txn_xid_set_root( root );
-  env->xid = (fd_funk_txn_xid_t){ .ul = { 1UL, env->bank->idx } };
+  env->xid = fd_bank_xid( env->bank );
   fd_accdb_attach_child( env->accdb_admin, root, &env->xid );
 
   init_rent_sysvar( env, TEST_DEFAULT_LAMPORTS_PER_UINT8_YEAR, TEST_DEFAULT_EXEMPTION_THRESHOLD );
@@ -239,9 +241,6 @@ test_env_create( test_env_t * env,
   init_stake_history_sysvar( env );
   init_clock_sysvar( env );
   init_blockhash_queue( env );
-
-  env->bank->f.slot = 1UL;
-  env->bank->f.epoch = 1UL;
 
   fd_bank_top_votes_t_2_modify( env->bank );
 
@@ -343,8 +342,8 @@ process_slot( test_env_t * env,
   ulong epoch = fd_slot_to_epoch( epoch_schedule, slot, NULL );
   new_bank->f.epoch = epoch;
 
-  fd_funk_txn_xid_t xid        = { .ul = { slot, new_bank_idx } };
-  fd_funk_txn_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_funk_txn_xid_t xid        = fd_bank_xid( new_bank    );
+  fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child( env->accdb_admin, &parent_xid, &xid );
 
   env->xid  = xid;

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -320,7 +320,7 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
   fd_runtime_update_leaders( bank, runtime_stack );
 
   /* Make a new funk transaction since we're done loading in accounts for context */
-  fd_funk_txn_xid_t fork_xid = { .ul = { slot, 0UL } };
+  fd_funk_txn_xid_t fork_xid = fd_bank_xid( bank );
   fd_accdb_attach_child    ( runner->accdb_admin,     xid, &fork_xid );
   fd_progcache_attach_child( runner->progcache->join, xid, &fork_xid );
   xid[0] = fork_xid;
@@ -397,7 +397,7 @@ fd_solfuzz_block_ctx_exec( fd_solfuzz_runner_t * runner,
 
     /* TODO: Make sure this is able to work with booting up inside
        the partitioned epoch rewards distribution phase. */
-    fd_funk_txn_xid_t xid = { .ul = { runner->bank->f.slot, runner->bank->idx } };
+    fd_funk_txn_xid_t xid = fd_bank_xid( runner->bank );
     fd_rewards_recalculate_partitioned_rewards( runner->banks, runner->bank, runner->accdb, &xid, runner->runtime_stack, capture_ctx );
 
     /* Process new epoch may push a new spad frame onto the runtime spad. We should make sure this frame gets

--- a/src/flamenco/runtime/tests/fd_bundle_harness.c
+++ b/src/flamenco/runtime/tests/fd_bundle_harness.c
@@ -37,13 +37,15 @@ fd_solfuzz_pb_bundle_ctx_create( fd_solfuzz_runner_t *                 runner,
 
   fd_accdb_user_t * accdb = runner->accdb;
 
-  ulong             slot = fd_solfuzz_pb_get_slot( test_ctx->account_shared_data, test_ctx->account_shared_data_count );
-  fd_funk_txn_xid_t xid  = { .ul = { slot, runner->bank->idx } };
+  fd_banks_clear_bank( runner->banks, runner->bank, 64UL );
+  ulong slot = fd_solfuzz_pb_get_slot( test_ctx->account_shared_data, test_ctx->account_shared_data_count );
+  runner->bank->f.slot = slot;
+
+  fd_funk_txn_xid_t xid = fd_bank_xid( runner->bank );
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
   fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
   fd_progcache_attach_child( runner->progcache->join, &parent_xid, &xid );
 
-  fd_banks_clear_bank( runner->banks, runner->bank, 64UL );
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;
 
@@ -51,7 +53,6 @@ fd_solfuzz_pb_bundle_ctx_create( fd_solfuzz_runner_t *                 runner,
   runner->bank->stake_delegations_fork_id = fd_stake_delegations_new_fork( stake_delegations );
   runner->bank->new_votes_fork_id = fd_new_votes_new_fork( fd_bank_new_votes( runner->bank ) );
 
-  runner->bank->f.slot = slot;
   fd_solfuzz_pb_restore_blockhash_queue( runner->bank, txn_bank->blockhash_queue, txn_bank->blockhash_queue_count );
   runner->bank->f.rbh_lamports_per_sig = txn_bank->rbh_lamports_per_signature;
 

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -512,8 +512,7 @@ create_block_context_protobuf_from_block( fd_block_dump_ctx_t * dump_ctx,
      was executed, since dumping is happening in the block finalize
      step. */
   fd_bank_t * parent_bank = fd_banks_get_parent( banks, bank );
-  ulong                          parent_slot    = parent_bank->f.slot;
-  fd_funk_txn_xid_t              parent_xid     = { .ul = { parent_slot, parent_bank->idx } };
+  fd_funk_txn_xid_t              parent_xid     = fd_bank_xid( parent_bank );
   fd_exec_test_block_context_t * block_context  = &dump_ctx->block_context;
   ulong                          dump_txn_count = dump_ctx->txns_to_dump_cnt;
   fd_spad_t *                    spad           = dump_ctx->spad;
@@ -780,7 +779,7 @@ create_txn_context_protobuf_from_txn( fd_exec_test_txn_context_t * txn_context_m
   txn_context_msg->account_shared_data = fd_spad_alloc( spad,
                                                         alignof(fd_exec_test_acct_state_t),
                                                         (256UL*2UL + txn_descriptor->addr_table_lookup_cnt + num_sysvar_entries) * sizeof(fd_exec_test_acct_state_t) );
-  fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_xid_t xid = fd_bank_xid( bank );
 
   /* Dump regular accounts first */
   for( ulong i = 0; i < txn_out->accounts.cnt; ++i ) {
@@ -903,7 +902,7 @@ create_instr_context_protobuf_from_instructions( fd_exec_test_instr_context_t * 
   /* Program ID */
   fd_memcpy( instr_context->program_id, txn_out->accounts.keys[ instr->program_id ].uc, sizeof(fd_pubkey_t) );
 
-  fd_funk_txn_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_xid_t xid = fd_bank_xid( bank );
 
   /* Accounts */
   instr_context->accounts_count = (pb_size_t) txn_out->accounts.cnt;

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -210,10 +210,6 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
     }
   }
 
-  fd_funk_txn_xid_t exec_xid[1] = {{ .ul={ runner->bank->f.slot, runner->bank->idx } }};
-  fd_accdb_attach_child    ( runner->accdb_admin,     xid, exec_xid );
-  fd_progcache_attach_child( runner->progcache->join, xid, exec_xid );
-
   /* Load instruction accounts */
 
   if( FD_UNLIKELY( test_ctx->instr_accounts_count > FD_INSTR_ACCT_MAX ) ) {
@@ -234,6 +230,10 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   fd_sol_sysvar_clock_t * clock = fd_sysvar_cache_clock_read( ctx->sysvar_cache, clock_ );
   FD_TEST( clock );
   runner->bank->f.slot = clock->slot;
+
+  fd_funk_txn_xid_t exec_xid[1] = { fd_bank_xid( runner->bank ) };
+  fd_accdb_attach_child    ( runner->accdb_admin,     xid, exec_xid );
+  fd_progcache_attach_child( runner->progcache->join, xid, exec_xid );
 
   fd_epoch_schedule_t epoch_schedule_[1];
   fd_epoch_schedule_t * epoch_schedule = fd_sysvar_cache_epoch_schedule_read( ctx->sysvar_cache, epoch_schedule_ );

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -393,7 +393,7 @@ fd_svm_mini_reset( fd_svm_mini_t *        mini,
 
   bank->f.slot = params->root_slot;
 
-  fd_xid_t root_xid = { .ul = { params->root_slot, bank_idx } };
+  fd_xid_t root_xid = fd_bank_xid( bank );
   fd_funk_t * funk = fd_accdb_user_v1_funk( mini->accdb );
   fd_funk_txn_xid_copy( funk->shmem->last_publish, &root_xid );
   fd_funk_txn_xid_copy( mini->progcache->join->shmem->txn.last_publish, &root_xid );
@@ -559,7 +559,7 @@ fd_svm_mini_attach_child( fd_svm_mini_t * mini,
   if( FD_UNLIKELY( !parent_bank ) ) FD_LOG_ERR(( "invalid parent_bank_idx" ));
   ulong parent_slot = parent_bank->f.slot;
   if( FD_UNLIKELY( child_slot<=parent_slot ) ) FD_LOG_ERR(( "child_slot (%lu) <= parent_slot (%lu)", child_slot, parent_slot ));
-  fd_xid_t parent_xid = { .ul = { parent_slot, parent_bank_idx } };
+  fd_xid_t parent_xid = fd_bank_xid( parent_bank );
 
   fd_bank_t * bank = fd_banks_new_bank( mini->banks, parent_bank_idx, 0L );
   if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "fd_banks_new_bank failed" ));
@@ -567,7 +567,7 @@ fd_svm_mini_attach_child( fd_svm_mini_t * mini,
   if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "fd_banks_clone_from_parent failed" ));
   ulong bank_idx = bank->idx;
   bank->f.slot = child_slot;
-  fd_xid_t xid = { .ul = { child_slot, bank_idx } };
+  fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_attach_child    ( mini->accdb_admin,     &parent_xid, &xid );
   fd_progcache_attach_child( mini->progcache->join, &parent_xid, &xid );
@@ -595,7 +595,7 @@ fd_svm_mini_cancel_fork( fd_svm_mini_t * mini,
 
   fd_bank_t * bank = fd_svm_mini_bank( mini, bank_idx );
   if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "invalid bank_idx" ));
-  fd_xid_t xid = { .ul = { bank->f.slot, bank->idx } };
+  fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_cancel    ( mini->accdb_admin,     &xid );
   fd_progcache_cancel( mini->progcache->join, &xid );
@@ -607,8 +607,7 @@ fd_svm_mini_advance_root( fd_svm_mini_t * mini,
 
   fd_bank_t * bank = fd_banks_bank_query( mini->banks, bank_idx );
   if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "invalid bank_idx" ));
-  ulong slot = bank->f.slot;
-  fd_xid_t xid = { .ul = { slot, bank_idx } };
+  fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_advance_root    ( mini->accdb_admin,     &xid );
   fd_progcache_advance_root( mini->progcache->join, &xid );
@@ -628,8 +627,7 @@ fd_xid_t
 fd_svm_mini_xid( fd_svm_mini_t * mini,
                  ulong           bank_idx ) {
   fd_bank_t * bank = fd_banks_bank_query( mini->banks, bank_idx );
-  if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "invalid bank_idx" ));
-  return (fd_xid_t){ .ul = { bank->f.slot, bank->idx } };
+  return fd_bank_xid( bank );
 }
 
 void

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -45,20 +45,20 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
                               fd_exec_test_txn_context_t const * test_ctx ) {
   fd_accdb_user_t * accdb = runner->accdb;
 
-  /* Set up the funk transaction */
-  ulong             slot = fd_solfuzz_pb_get_slot( test_ctx->account_shared_data, test_ctx->account_shared_data_count );
-  fd_funk_txn_xid_t xid  = { .ul = { slot, runner->bank->idx } };
-  fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
-  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_attach_child( runner->progcache->join, &parent_xid, &xid );
+  ulong slot = fd_solfuzz_pb_get_slot( test_ctx->account_shared_data, test_ctx->account_shared_data_count );
 
   /* Initialize bank from input txn bank */
   fd_banks_clear_bank( runner->banks, runner->bank, 64UL );
+  runner->bank->f.slot = slot;
+
+  /* Set up the funk transaction */
+  fd_xid_t xid = fd_bank_xid( runner->bank );
+  fd_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
+  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
+  fd_progcache_attach_child( runner->progcache->join, &parent_xid, &xid );
+
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;
-
-  /* Slot*/
-  runner->bank->f.slot = slot;
 
   /* Blockhash queue */
   fd_solfuzz_pb_restore_blockhash_queue( runner->bank, txn_bank->blockhash_queue, txn_bank->blockhash_queue_count );


### PR DESCRIPTION
Fixes a bug where XIDs are not technically unique across different
blocks.  Could have theoretically caused an ABA bug under rare
circumstances (slot equivocated and bank index reused).

This fix changes the second XID word from bank_idx to bank_seq.

Closes https://github.com/firedancer-io/firedancer/issues/9683
