### PR TITLE
Revert "ci: remove fc-ng workflow"

### DIFF
--- a/.github/workflows/fcng_intree_fuzzers.yml
+++ b/.github/workflows/fcng_intree_fuzzers.yml
@@ -1,0 +1,67 @@
+name: Push in-tree fuzzers to fc-ng
+
+on:
+  workflow_call:
+    secrets:
+      PAT:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  ARfuzz-publish:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - machine: linux_clang_icelake
+            artifact_dir: build/linux/clang/icelake
+            qualifier: modern
+    runs-on: ubuntu-latest
+    env:
+      MACHINE: ${{ matrix.machine }}
+      EXTRAS: fuzz asan ubsan
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/submodule-init
+
+      - uses: ./.github/actions/deps
+        with:
+          extras: +dev
+
+      - name: Install packaging tools
+        run: sudo apt update && sudo apt install -y zip zstd
+
+      - name: Build fuzz tests
+        uses: asymmetric-research/clusterfuzz-fuzzbot-builder@main
+        with:
+          command: make -j -Otarget fuzz-test
+
+      - name: List compiled binary directory structure
+        run: |
+          ls "${{ matrix.artifact_dir }}/fuzz-test"
+          ls "${{ matrix.artifact_dir }}/lib"
+
+      - name: Zip and upload to GitHub Artifacts
+        uses: actions/upload-artifact@v7
+        id: artifact-zip-m1
+        with:
+          path: ${{ matrix.artifact_dir }}
+          name: artifact-${{ matrix.machine }}-${{ github.run_id }}
+          retention-days: 10
+
+      - name: Get commit hash
+        id: get_commit_hash
+        shell: bash
+        run: |
+          echo "commit_hash=$(git rev-parse HEAD 2>/dev/null)" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch AR fuzz bundler
+        shell: bash
+        run: |
+          curl -L -X POST \
+              https://api.github.com/repos/asymmetric-research/FuzzCorp-bundler/dispatches \
+              -H 'Accept: application/vnd.github.everest-preview+json' \
+              -H "Authorization: Bearer ${{ secrets.PAT }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --data '{"event_type":"fd_main","client_payload":{"artifact_id":"${{ steps.artifact-zip-m1.outputs.artifact-id }}","bundle_type":"${{ matrix.qualifier }}","hash":"${{ steps.get_commit_hash.outputs.commit_hash }}","run_id":"${{ github.run_id }}","name":"artifact-${{ matrix.machine }}-${{ github.run_id }}"}}'


### PR DESCRIPTION
Reverts firedancer-io/firedancer#9722

This is run inside the [on_main_push](https://github.com/firedancer-io/firedancer/blob/8cad7287701203f3b1851e0211b54e0bbb083451/.github/workflows/on_main_push.yml#L14-L16) workflow.
E.g.: https://github.com/firedancer-io/firedancer/actions/runs/25673061513/job/75363239553