### PR TITLE
pack: add extra filtering

### DIFF
--- a/src/disco/pack/fd_compute_budget_program.h
+++ b/src/disco/pack/fd_compute_budget_program.h
@@ -23,7 +23,7 @@
 #define FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_FEE            ((ushort)0x02) /* ... SetComputeUnitPrice ... */
 #define FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_HEAP           ((ushort)0x04) /* ... RequestHeapFrame ... */
 #define FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_LOADED_DATA_SZ ((ushort)0x08) /* ... LoadedAccountDataSize ... */
-                                                                            /* ... so far? */
+                                                                         /* ... so far? */
 
 
 /* NOTE: THE FOLLOWING CONSTANTS ARE CONSENSUS CRITICAL AND CANNOT BE
@@ -35,8 +35,11 @@ static const uchar FD_COMPUTE_BUDGET_PROGRAM_ID[FD_TXN_ACCT_ADDR_SZ] = {
   0xbc,0x8c,0xe5,0xbb,0xc5,0xf7,0x12,0x6b,0x2c,0x43,0x9b,0x3a,0x40,0x00,0x00,0x00
 };
 
-/* Any requests for larger heap frames must be a multiple of 1k or the
+/* Heap frames must be between 32 KiB and 256 KiB inclusive, and any
+   requests for larger heap frames must be a multiple of 1 KiB or the
    transaction is malformed. */
+#define FD_COMPUTE_BUDGET_MIN_HEAP_FRAME_BYTES           (  32UL*1024UL)
+#define FD_COMPUTE_BUDGET_MAX_HEAP_FRAME_BYTES           ( 256UL*1024UL)
 #define FD_COMPUTE_BUDGET_HEAP_FRAME_GRANULARITY         (       1024UL)
 /* SetComputeUnitPrice specifies the price in "micro-lamports," which is
    10^(-6) lamports, so 10^(-15) SOL. */
@@ -107,7 +110,8 @@ fd_compute_budget_program_parse( uchar const * instr_data,
       if( FD_UNLIKELY( data_sz<5 ) ) return 0;
       if( FD_UNLIKELY( (state->flags & FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_HEAP)!=0 ) ) return 0;
       state->heap_size = FD_LOAD( uint, instr_data+1 );
-      if( (state->heap_size%FD_COMPUTE_BUDGET_HEAP_FRAME_GRANULARITY) ) return 0;
+      if( FD_UNLIKELY( state->heap_size%FD_COMPUTE_BUDGET_HEAP_FRAME_GRANULARITY ) ) return 0;
+      if( FD_UNLIKELY( state->heap_size<FD_COMPUTE_BUDGET_MIN_HEAP_FRAME_BYTES || state->heap_size>FD_COMPUTE_BUDGET_MAX_HEAP_FRAME_BYTES ) ) return 0;
       state->flags |= FD_COMPUTE_BUDGET_PROGRAM_FLAG_SET_HEAP;
       state->compute_budget_instr_cnt++;
       return 1;

--- a/src/disco/pack/test_compute_budget_program.c
+++ b/src/disco/pack/test_compute_budget_program.c
@@ -103,10 +103,52 @@ main( int     argc,
   FD_TEST( test_duplicate( 0, 1, 0, 1, 1 ) == 1 );
   FD_TEST( test_duplicate( 0, 0, 1, 1, 1 ) == 1 );
 
+  /* Test heap frame size bounds check.  RequestHeapFrame is instruction
+     type 1, followed by a little-endian uint for the requested heap
+     size. */
+  {
+    fd_compute_budget_program_state_t state;
+    uchar instr[5];
+    instr[0] = 1; /* RequestHeapFrame */
+
+#   define TEST_HEAP_FRAME(heap_sz, expected) \
+    do { \
+      fd_compute_budget_program_init( &state ); \
+      FD_STORE( uint, instr+1, (uint)(heap_sz) ); \
+      FD_TEST( fd_compute_budget_program_parse( instr, 5UL, &state ) == (expected) ); \
+    } while(0)
+
+    /* Below minimum (32 KiB) */
+    TEST_HEAP_FRAME(            0U, 0 ); /* zero               */
+    TEST_HEAP_FRAME(        1024UL, 0 ); /* 1 KiB              */
+    TEST_HEAP_FRAME( 31UL * 1024UL, 0 ); /* 31 KiB, just under */
+
+    /* At minimum */
+    TEST_HEAP_FRAME( 32UL * 1024UL, 1 ); /* 32 KiB, exact min  */
+
+    /* Valid interior values */
+    TEST_HEAP_FRAME(  33UL * 1024UL, 1 ); /* 33 KiB             */
+    TEST_HEAP_FRAME( 128UL * 1024UL, 1 ); /* 128 KiB            */
+    TEST_HEAP_FRAME( 255UL * 1024UL, 1 ); /* 255 KiB            */
+
+    /* Not a multiple of 1 KiB (rejected) */
+    TEST_HEAP_FRAME( 32UL * 1024UL + 1UL,   0 ); /* 32 KiB + 1 byte  */
+    TEST_HEAP_FRAME( 32UL * 1024UL + 512UL, 0 ); /* 32.5 KiB         */
+    TEST_HEAP_FRAME( 64UL * 1024UL + 500UL, 0 ); /* 64 KiB + 500     */
+
+    /* At maximum */
+    TEST_HEAP_FRAME( 256UL * 1024UL, 1 ); /* 256 KiB, exact max */
+
+    /* Above maximum (256 KiB) */
+    TEST_HEAP_FRAME( 257UL * 1024UL, 0 ); /* 257 KiB, just over */
+    TEST_HEAP_FRAME( 512UL * 1024UL, 0 ); /* 512 KiB            */
+
+#   undef TEST_HEAP_FRAME
+  }
+
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;
 }
-


### PR DESCRIPTION
Not a security issue, just a slight mismatch in filtering which lets txns through that would later get caught by the runtime