### PR TITLE
progcache: simplify fork edge cases

### DIFF
--- a/src/flamenco/accdb/fd_accdb_lineage.c
+++ b/src/flamenco/accdb/fd_accdb_lineage.c
@@ -124,15 +124,3 @@ fd_accdb_lineage_write_check( fd_accdb_lineage_t const * lineage,
   }
   return txn;
 }
-
-fd_xid_t const *
-fd_lineage_xid( fd_accdb_lineage_t const * lineage,
-                ulong                      slot ) {
-  ulong depth = lineage->fork_depth;
-  for( ulong i=0UL; i<depth; i++ ) {
-    if( lineage->fork[ i ].ul[0] == slot ) {
-      return &lineage->fork[ i ];
-    }
-  }
-  return NULL;
-}

--- a/src/flamenco/accdb/fd_accdb_lineage.h
+++ b/src/flamenco/accdb/fd_accdb_lineage.h
@@ -78,16 +78,6 @@ fd_funk_txn_t *
 fd_accdb_lineage_write_check( fd_accdb_lineage_t const * lineage,
                               fd_funk_t const *          funk );
 
-/* fd_lineage_xid returns the record XID of the given slot number.
-   In other words, all records that were created at this slot number
-   are tagged with this XID.  Possible return values:
-   - NULL: slot skipped or rooted slot
-   - else: slot part of lineage, non-rooted slot */
-
-fd_xid_t const *
-fd_lineage_xid( fd_accdb_lineage_t const * lineage,
-                ulong                      slot );
-
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_lineage_h */

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -243,8 +243,11 @@ fd_progcache_txn_publish_release( fd_progcache_join_t * cache,
     } _map_txn;
     fd_prog_recm_txn_t * map_txn = fd_prog_recm_txn_init( _map_txn.txn, cache->rec.map, 1UL );
     fd_prog_recm_txn_add( map_txn, &rec->pair, 1 );
-    int txn_err = fd_prog_recm_txn_try( map_txn, FD_MAP_FLAG_BLOCKING );
-    if( FD_UNLIKELY( txn_err!=FD_MAP_SUCCESS ) ) {
+    int txn_err = fd_prog_recm_txn_try( map_txn, 0 );
+    if( FD_UNLIKELY( txn_err==FD_MAP_ERR_AGAIN ) ) {
+      FD_SPIN_PAUSE();
+      continue;
+    } else if( FD_UNLIKELY( txn_err!=FD_MAP_SUCCESS ) ) {
       FD_LOG_CRIT(( "Failed to insert progcache record: cannot lock funk rec map chain: %i-%s", txn_err, fd_map_strerror( txn_err ) ));
     }
 
@@ -257,7 +260,12 @@ fd_progcache_txn_publish_release( fd_progcache_join_t * cache,
     }
 
     /* Migrate record to root */
-    fd_rwlock_write( &rec->lock );
+    if( FD_UNLIKELY( !fd_rwlock_trywrite( &rec->lock ) ) ) {
+      fd_prog_recm_txn_test( map_txn );
+      fd_prog_recm_txn_fini( map_txn );
+      FD_SPIN_PAUSE();
+      continue;
+    }
     fd_racesan_hook( "prog_publish_release:pre_retag" );
     rec->prev_idx = UINT_MAX;
     rec->next_idx = UINT_MAX;

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -69,6 +69,7 @@ fd_progcache_load_fork_slow( fd_progcache_t * cache,
   fd_progcache_join_t const * ljoin   = cache->join;
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
   lineage->fork_depth = 0UL;
+  lineage->tip_txn_idx = ULONG_MAX;
 
   ulong txn_max = fd_prog_txnp_max( ljoin->txn.pool );
   fd_xid_t next_xid = *xid;
@@ -85,7 +86,9 @@ fd_progcache_load_fork_slow( fd_progcache_t * cache,
 
     uint parent_idx = candidate->parent_idx;
     FD_TEST( parent_idx!=next_idx );
-    lineage->fork[ i ] = next_xid;
+    lineage->fork   [ i ] = next_xid;
+    lineage->txn_idx[ i ] = next_idx;
+    if( FD_LIKELY( !i ) ) lineage->tip_txn_idx = next_idx;
     if( parent_idx==UINT_MAX ) {
       i++;
       break;
@@ -242,21 +245,17 @@ fd_progcache_rec_push_tail( fd_progcache_rec_t * rec_pool,
 __attribute__((warn_unused_result))
 static int
 fd_progcache_push( fd_progcache_join_t * cache,
-                   fd_progcache_txn_t *  txn, /* read locked */
+                   fd_progcache_txn_t *  txn, /* write locked */
                    fd_progcache_rec_t *  rec,
-                   void const *          prog_addr,
-                   ulong                 revision_key ) {
+                   void const *          prog_addr ) {
 
   /* Determine record's xid-key pair */
 
   rec->prev_idx = UINT_MAX;
   rec->next_idx = UINT_MAX;
   memcpy( rec->pair.key, prog_addr, 32UL );
-  if( FD_UNLIKELY( txn ) ) {
-    fd_funk_txn_xid_copy( rec->pair.xid, &txn->xid );
-  } else {
-    fd_funk_txn_xid_set_root( rec->pair.xid );
-  }
+  if( FD_UNLIKELY( !txn ) ) FD_LOG_CRIT(( "NULL txn" ));
+  fd_funk_txn_xid_copy( rec->pair.xid, &txn->xid );
 
   /* Lock rec_map chain, entering critical section */
 
@@ -277,20 +276,9 @@ fd_progcache_push( fd_progcache_join_t * cache,
   fd_prog_recm_query_t query[1];
   int query_err = fd_prog_recm_txn_query( cache->rec.map, &rec->pair, NULL, query, 0 );
   if( FD_UNLIKELY( query_err==FD_MAP_SUCCESS ) ) {
-    /* Always replace existing rooted records */
-    fd_progcache_rec_t * prev_rec = query->ele;
-    if( fd_funk_txn_xid_eq_root( rec->pair.xid ) && prev_rec->revision_key < revision_key ) {
-      fd_rwlock_write( &prev_rec->lock );
-      fd_prog_recm_txn_remove( cache->rec.map, &rec->pair, NULL, query, FD_MAP_FLAG_USE_HINT );
-      fd_progcache_val_free( prev_rec, cache );
-      fd_rwlock_unwrite( &prev_rec->lock );
-      fd_prog_clock_remove( cache->clock.bits, (ulong)( prev_rec - cache->rec.pool->ele ) );
-      fd_prog_recp_release( cache->rec.pool, prev_rec );
-    } else {
-      fd_prog_recm_txn_test( map_txn );
-      fd_prog_recm_txn_fini( map_txn );
-      return 0;
-    }
+    fd_prog_recm_txn_test( map_txn );
+    fd_prog_recm_txn_fini( map_txn );
+    return 0;
   } else if( FD_UNLIKELY( query_err!=FD_MAP_ERR_KEY ) ) {
     FD_LOG_CRIT(( "fd_prog_recm_txn_query failed: %i-%s", query_err, fd_map_strerror( query_err ) ));
   }
@@ -306,18 +294,16 @@ fd_progcache_push( fd_progcache_join_t * cache,
   /* Phase 5: Insert rec into rec_map */
 
   ulong rec_max = fd_prog_recp_ele_max( cache->rec.pool );
-  if( txn ) {
-    fd_progcache_rec_push_tail( cache->rec.pool->ele,
-        rec,
-        &txn->rec_head_idx,
-        &txn->rec_tail_idx,
-        rec_max );
-    uint txn_idx_computed = (uint)( txn - cache->txn.pool );
-    ulong txn_max = fd_prog_txnp_max( cache->txn.pool );
-    if( FD_UNLIKELY( (ulong)txn_idx_computed >= txn_max ) )
-      FD_LOG_CRIT(( "progcache: corruption detected (push txn_idx=%u txn_max=%lu)", txn_idx_computed, txn_max ));
-    atomic_store_explicit( &rec->txn_idx, txn_idx_computed, memory_order_release );
-  }
+  fd_progcache_rec_push_tail( cache->rec.pool->ele,
+      rec,
+      &txn->rec_head_idx,
+      &txn->rec_tail_idx,
+      rec_max );
+  uint txn_idx_computed = (uint)( txn - cache->txn.pool );
+  ulong txn_max = fd_prog_txnp_max( cache->txn.pool );
+  if( FD_UNLIKELY( (ulong)txn_idx_computed >= txn_max ) )
+    FD_LOG_CRIT(( "progcache: corruption detected (push txn_idx=%u txn_max=%lu)", txn_idx_computed, txn_max ));
+  atomic_store_explicit( &rec->txn_idx, txn_idx_computed, memory_order_release );
 
   /* Phase 6: Finish rec_map transaction */
 
@@ -514,13 +500,13 @@ fd_progcache_insert( fd_progcache_t *        cache,
   fd_rwlock_write( &rec->lock );
   fd_racesan_hook( "prog_insert:pre_push" );
   ulong revision_slot = fd_progcache_revision_key_slot( revision_key );
-  fd_xid_t const * xid = fd_lineage_xid( cache->lineage, revision_slot );
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
-  fd_progcache_txn_t * txn = NULL;
-  if( xid ) txn = (fd_progcache_txn_t *)fd_prog_txnm_ele_query_const( ljoin->txn.map, xid, NULL, ljoin->txn.pool );
-  if( txn ) fd_rwlock_write( &txn->lock );
-  int push_ok = fd_progcache_push( ljoin, txn, rec, prog_addr, revision_key );
-  if( txn ) fd_rwlock_unwrite( &txn->lock );
+  ulong txn_idx = cache->lineage->tip_txn_idx;
+  if( FD_UNLIKELY( txn_idx==ULONG_MAX ) ) FD_LOG_CRIT(( "progcache insert requires a non-root transaction" ));
+  fd_progcache_txn_t * txn = &ljoin->txn.pool[ txn_idx ];
+  fd_rwlock_write( &txn->lock );
+  int push_ok = fd_progcache_push( ljoin, txn, rec, prog_addr );
+  fd_rwlock_unwrite( &txn->lock );
   if( FD_UNLIKELY( !push_ok ) ) {
     fd_rwlock_unread( &ljoin->shmem->txn.rwlock );
     fd_rwlock_unwrite( &rec->lock );

--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -345,6 +345,7 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
   test_env_txn_prepare( env, &fork_a, &fork_b );
   fd_progcache_rec_t const * rec2 = test_pull( env->progcache, prog0_data.ro, &fork_b, &prog_key, &load_env2 );
   FD_TEST( rec1!=rec2 );
+  FD_TEST( query_rec_exact( env, &fork_b, &prog_key )==rec2 );
 
   /* Invoke new (redeployed) program at epoch1 */
   test_account_init_v3( &prog1, prog1_buf, sizeof(prog1_buf), &prog_key, &prog1_data_key );
@@ -359,6 +360,7 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
   test_env_txn_prepare( env, &fork_b, &fork_c );
   fd_progcache_rec_t const * rec3 = test_pull( env->progcache, prog1_data.ro, &fork_c, &prog_key, &load_env2 );
   FD_TEST( rec3!=rec1 && rec3!=rec2 );
+  FD_TEST( query_rec_exact( env, &fork_c, &prog_key )==rec3 );
 
   test_env_txn_cancel( env, &fork_c );
   test_env_txn_cancel( env, &fork_b );
@@ -493,9 +495,10 @@ test_root_nonroot_prio( fd_wksp_t * wksp ) {
     .epoch       = 0UL,
     .epoch_slot0 = 1UL
   };
-  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_1, &key, &load_env1 );
+  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_2, &key, &load_env1 );
   FD_TEST( rec1 );
   FD_TEST( fd_progcache_revision_key_slot( rec1->revision_key )==1UL );
+  test_env_txn_publish( env, &fork_2 );
 
   fd_prog_load_env_t load_env4 = {
     .features    = env->features,
@@ -977,6 +980,78 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_destroy( env );
 }
 
+static void
+test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
+  test_env_t * env = test_env_create( wksp );
+
+  ulong const mainnet_slots_per_epoch = 432000UL;
+  ulong const epoch                   = 1000UL;
+  ulong const e0                      = mainnet_slots_per_epoch * epoch;
+
+  fd_pubkey_t key = test_key( 1UL );
+  test_account_t fork_a_acc;
+  uchar fork_a_buf[ 65536 ];
+  test_account_init_v3_data(
+      &fork_a_acc,
+      fork_a_buf, sizeof(fork_a_buf),
+      &key,
+      bigger_valid_program_data, bigger_valid_program_data_sz,
+      e0-1UL
+  );
+
+  test_account_t fork_b_acc;
+  uchar fork_b_buf[ 65536 ];
+  test_account_init_v3_data(
+      &fork_b_acc,
+      fork_b_buf, sizeof(fork_b_buf),
+      &key,
+      valid_program_data, valid_program_data_sz,
+      1UL
+  );
+  FD_TEST( fork_a_acc.meta->dlen!=fork_b_acc.meta->dlen );
+
+  fd_prog_load_env_t load_env = {
+    .features    = env->features,
+    .epoch       = epoch,
+    .epoch_slot0 = e0
+  };
+
+  fd_xid_t root; fd_funk_txn_xid_set_root( &root );
+
+  /* Fork A upgraded the program at e0-1 and invokes after skipped slot e0. */
+  fd_xid_t fork_a_deploy = { .ul = { e0-1UL, 1UL } };
+  test_env_txn_prepare( env, NULL, &fork_a_deploy );
+
+  fd_xid_t fork_a_invoke = { .ul = { e0+1UL, 2UL } };
+  test_env_txn_prepare( env, &fork_a_deploy, &fork_a_invoke );
+
+  fd_progcache_rec_t const * rec_a = test_pull( env->progcache, fork_a_acc.ro, &fork_a_invoke, &key, &load_env );
+  FD_TEST( rec_a );
+  FD_TEST( rec_a->data_gaddr );
+  FD_TEST( fd_progcache_revision_key_slot( rec_a->revision_key )==e0 );
+  FD_TEST( query_rec_exact( env, &fork_a_deploy, &key )==NULL  );
+  FD_TEST( query_rec_exact( env, &fork_a_invoke, &key )==rec_a );
+  FD_TEST( query_rec_exact( env, &root, &key )==NULL );
+
+  /* Fork B crosses the same skipped epoch boundary without fork A's
+     upgrade.  It supplies different loader-v3 ProgramData bytes, so it
+     must not receive fork A's loaded program record. */
+  fd_xid_t fork_b_invoke = { .ul = { e0+1UL, 3UL } };
+  test_env_txn_prepare( env, NULL, &fork_b_invoke );
+
+  fd_progcache_rec_t const * rec_b = test_pull( env->progcache, fork_b_acc.ro, &fork_b_invoke, &key, &load_env );
+  FD_TEST( rec_b );
+  FD_TEST( rec_b!=rec_a );
+  FD_TEST( query_rec_exact( env, &fork_a_invoke, &key )==rec_a );
+  FD_TEST( query_rec_exact( env, &fork_b_invoke, &key )==rec_b );
+  FD_TEST( query_rec_exact( env, &root,          &key )==NULL  );
+
+  test_env_txn_cancel( env, &fork_b_invoke );
+  test_env_txn_cancel( env, &fork_a_deploy );
+
+  test_env_destroy( env );
+}
+
 /* test_clock_evict_all_visited: First pass clears visited bits,
    second pass evicts. */
 
@@ -1239,6 +1314,7 @@ main( int     argc,
     TEST( test_loader_v3_undersize ),
     TEST( test_loader_v3_corrupt ),
     TEST( test_loader_v3_epoch_boundary ),
+    TEST( test_loader_v3_epoch_boundary_skipped_slots ),
     TEST( test_clock_evict_all_visited ),
     TEST( test_clock_evict_wraps_around ),
     TEST( test_clock_evict_empty_cache ),

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -179,19 +179,6 @@ fiber_cancel( fiber_t *        fiber,
   return fiber->async;
 }
 
-static void
-fiber_reclaim_exec( void * _ctx ) {
-  fiber_t * f = _ctx;
-  fd_prog_reclaim_work( f->cache->join );
-}
-
-static fd_racesan_async_t *
-fiber_reclaim( fiber_t * fiber ) {
-  FD_TEST( fiber->cache->join->shmem ); /* assume cache already joined */
-  fd_racesan_async_new( fiber->async, fiber->stack+FIBER_STACK_MAX, FIBER_STACK_MAX, fiber_reclaim_exec, fiber );
-  return fiber->async;
-}
-
 /* Utils */
 
 static void
@@ -247,6 +234,7 @@ test_pull_pull( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
+    fd_progcache_attach_child( admin, &ROOT_XID, &xid );
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
@@ -279,7 +267,7 @@ static void
 test_pull_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid = ROOT_XID;
+  fd_xid_t    xid = { .ul = { 1UL, 1UL } };
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -289,6 +277,8 @@ test_pull_peek( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
+    fd_progcache_attach_child( admin, &ROOT_XID, &xid );
+
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
     fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, &xid, &key, &load_env, acc.ro ) );
@@ -313,59 +303,6 @@ test_pull_peek( fd_wksp_t * wksp ) {
   test_progcache_shmem_delete( shmem );
 }
 
-/* test_pull_root races a cache fill against advance_root */
-
-static void
-test_pull_root( fd_wksp_t * wksp ) {
-  fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
-
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_pubkey_t key  = test_key( 42UL );
-  fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
-
-  test_account_t acc;
-  test_account_init( &acc, &key, &fd_solana_bpf_loader_deprecated_program_id, 1, valid_program_data, valid_program_data_sz );
-  fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
-
-  for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
-
-    fd_racesan_weave_t w[1];
-    fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, &xid1, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
-
-    metrics_reset();
-    fd_racesan_weave_exec_rand( w, i, STEP_MAX );
-    FD_TEST( !w->rem_cnt );
-    FD_TEST( fd_progcache_metrics_default.lookup_cnt==1UL );
-    FD_TEST( fd_progcache_metrics_default.fill_cnt  ==1UL );
-    FD_TEST( fd_progcache_metrics_default.hit_cnt   ==0UL );
-    FD_TEST( fd_progcache_metrics_default.miss_cnt  ==1UL );
-    if( !fd_progcache_admin_metrics_g.root_cnt ) {
-      fd_progcache_rec_t * rec = fd_progcache_peek( g_fiber[ 0 ].cache, &xid1, &key, fd_progcache_revision_key( 0UL, 0UL ) );
-      FD_TEST( rec );
-      FD_TEST( rec->txn_idx==UINT_MAX );
-      FD_TEST( rec->next_idx==UINT_MAX );
-      FD_TEST( rec->prev_idx==UINT_MAX );
-      fd_progcache_rec_close( g_fiber[ 0 ].cache, rec );
-    } else {
-      FD_TEST( fd_progcache_admin_metrics_g.root_cnt==1UL );
-    }
-    metrics_check_no_oom();
-
-    fd_racesan_weave_delete( w );
-    fiber_delete( &g_fiber[ 0 ] );
-    fiber_delete( &g_fiber[ 1 ] );
-    FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
-  }
-
-  FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
-  test_progcache_shmem_delete( shmem );
-}
-
 /* test_cancel_peek races a cancel against a peek for a child txn.
    Pre-populates cache under xid0, then races cancel(xid1) vs peek(xid0). */
 
@@ -374,6 +311,7 @@ test_cancel_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
   fd_xid_t    xid0 = ROOT_XID;
+  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
   fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
@@ -384,17 +322,19 @@ test_cancel_peek( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    /* Pre-populate the cache */
+    /* Pre-populate the cache at root through a real txn */
     {
+      fd_progcache_attach_child( admin, &xid0, &xid_pre );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid0, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
+      fd_progcache_advance_root( admin, &xid_pre );
     }
 
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_attach_child( admin, &xid_pre, &xid1 );
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
@@ -458,49 +398,6 @@ test_publish_evict( fd_wksp_t * wksp ) {
     fd_racesan_weave_delete( w );
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
-    FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
-  }
-
-  FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
-  test_progcache_shmem_delete( shmem );
-}
-
-/* test_pull_root_peek races a pull, advance_root, and peek */
-
-static void
-test_pull_root_peek( fd_wksp_t * wksp ) {
-  fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
-
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_pubkey_t key  = test_key( 42UL );
-  fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
-
-  test_account_t acc;
-  test_account_init( &acc, &key, &fd_solana_bpf_loader_deprecated_program_id, 1, valid_program_data, valid_program_data_sz );
-
-  fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
-
-  for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
-
-    fd_racesan_weave_t w[1];
-    fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_pull(         &g_fiber[ 0 ], shmem, &xid1, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 2 ], shmem, &xid1, &key ) );
-
-    metrics_reset();
-    fd_racesan_weave_exec_rand( w, i, STEP_MAX );
-    FD_TEST( !w->rem_cnt );
-    FD_TEST( fd_progcache_metrics_default.lookup_cnt==1UL );
-    metrics_check_no_oom();
-
-    fd_racesan_weave_delete( w );
-    fiber_delete( &g_fiber[ 0 ] );
-    fiber_delete( &g_fiber[ 1 ] );
-    fiber_delete( &g_fiber[ 2 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
     test_progcache_clear( admin );
   }
@@ -616,6 +513,7 @@ test_peek_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
   fd_xid_t    xid = ROOT_XID;
+  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -625,14 +523,16 @@ test_peek_peek( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    /* Pre-populate the cache */
+    /* Pre-populate the cache at root through a real txn */
     {
+      fd_progcache_attach_child( admin, &xid, &xid_pre );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
+      fd_progcache_advance_root( admin, &xid_pre );
     }
 
     fd_racesan_weave_t w[1];
@@ -855,51 +755,6 @@ test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
   test_progcache_shmem_delete( shmem );
 }
 
-static void
-test_publish_reclaim_queued( fd_wksp_t * wksp ) {
-  fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
-
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_pubkey_t key  = test_key( 42UL );
-  fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
-
-  test_account_t acc;
-  test_account_init( &acc, &key, &fd_solana_bpf_loader_deprecated_program_id, 1, valid_program_data, valid_program_data_sz );
-
-  fd_progcache_t * cache = g_fiber[ 2 ].cache;
-  for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    /* Insert entry and immediately mark it for reclaim */
-    FD_TEST( fd_progcache_join( cache, shmem, g_fiber[ 2 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-    FD_TEST( cache->join->rec.reclaim_head==UINT_MAX );
-    fd_progcache_attach_child( cache->join, &xid0, &xid1 );
-    fd_progcache_rec_t * rec = fd_progcache_pull( cache, &xid1, &key, &load_env, acc.ro );
-    FD_TEST( rec );
-    fd_progcache_rec_close( cache, rec );
-    fd_prog_delete_rec( cache->join, rec );
-    FD_TEST( cache->join->rec.reclaim_head!=UINT_MAX );
-
-    fd_racesan_weave_t w[1];
-    fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, &xid1 ) );
-    fd_racesan_weave_add( w, fiber_pull(         &g_fiber[ 1 ], shmem, &xid1, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_reclaim(      &g_fiber[ 2 ] ) );
-
-    metrics_reset();
-    fd_racesan_weave_exec_rand( w, i, STEP_MAX );
-    FD_TEST( !w->rem_cnt );
-
-    fd_racesan_weave_delete( w );
-    fiber_delete( &g_fiber[ 0 ] );
-    fiber_delete( &g_fiber[ 1 ] );
-    FD_TEST( !fd_progcache_verify( cache->join ) );
-    test_progcache_clear( cache->join );
-    fiber_delete( &g_fiber[ 2 ] );
-  }
-
-  test_progcache_shmem_delete( shmem );
-}
-
 /* test_root_evict_two races advance_root against eviction with
    two different programs populated on two sibling forks */
 
@@ -966,6 +821,7 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
   fd_xid_t    xid0 = ROOT_XID;
+  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
   fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
 
@@ -979,19 +835,21 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
 
-    /* Pre-populate the same program at root */
+    /* Pre-populate the same program at root through a real txn */
     {
+      fd_progcache_attach_child( admin, &xid0, &xid_pre );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid0, &key, &load_env_root, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env_root, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
+      fd_progcache_advance_root( admin, &xid_pre );
     }
 
     /* Create child fork and populate the same key under xid1's txn
        Peek won't hit the root record because slot 2 != slot 0. */
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_attach_child( admin, &xid_pre, &xid1 );
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
@@ -1049,10 +907,8 @@ main( int     argc,
   struct test_case cases[] = {
     TEST( test_pull_pull ),
     TEST( test_pull_peek ),
-    TEST( test_pull_root ),
     TEST( test_cancel_peek ),
     TEST( test_publish_evict ),
-    TEST( test_pull_root_peek ),
     TEST( test_peek_root ),
     TEST( test_peek_cancel ),
     TEST( test_peek_peek ),
@@ -1061,7 +917,6 @@ main( int     argc,
     TEST( test_inject_at_hook ),
     TEST( test_root_evict_two ),
     TEST( test_publish_reclaim_evicted ),
-    TEST( test_publish_reclaim_queued ),
     TEST( test_publish_evict_stale ),
     {0}
   };

--- a/src/flamenco/vm/syscall/test_cpi_semantics.c
+++ b/src/flamenco/vm/syscall/test_cpi_semantics.c
@@ -227,8 +227,8 @@ env_build( fd_svm_mini_t *        mini,
   /* Reset svm_mini */
   fd_svm_mini_params_t params[1];
   fd_svm_mini_params_default( params );
-  ulong bank_idx = fd_svm_mini_reset( mini, params );
-  fd_bank_t * bank = fd_svm_mini_bank( mini, bank_idx );
+  ulong root_bank_idx = fd_svm_mini_reset( mini, params );
+  fd_bank_t * bank = fd_svm_mini_bank( mini, root_bank_idx );
 
   fd_features_disable_all( &bank->f.features );
   bank->f.features.loosen_cpi_size_restriction = 0UL;
@@ -269,6 +269,9 @@ env_build( fd_svm_mini_t *        mini,
   for( ulong i=0UL; i<txn_acc_cnt; i++ ) {
     fd_svm_mini_put_account_rooted( mini, txn_out->accounts.account[i].ro );
   }
+
+  ulong exec_bank_idx = fd_svm_mini_attach_child( mini, root_bank_idx, bank->f.slot + 1UL );
+  bank = fd_svm_mini_bank( mini, exec_bank_idx );
 
   fd_instr_info_t * instr = &runtime->instr.trace[0];
   memset( instr, 0, sizeof(fd_instr_info_t) );

--- a/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
+++ b/src/flamenco/vm/syscall/test_cpi_shared_data_addr.c
@@ -103,8 +103,8 @@ test_env_setup( fd_svm_mini_t * mini ) {
   /* Reset svm_mini to get a fresh bank */
   fd_svm_mini_params_t params[1];
   fd_svm_mini_params_default( params );
-  ulong bank_idx = fd_svm_mini_reset( mini, params );
-  fd_bank_t * bank = fd_svm_mini_bank( mini, bank_idx );
+  ulong root_bank_idx = fd_svm_mini_reset( mini, params );
+  fd_bank_t * bank = fd_svm_mini_bank( mini, root_bank_idx );
 
   fd_features_disable_all( &bank->f.features );
   bank->f.features.loosen_cpi_size_restriction = 0UL;
@@ -139,6 +139,9 @@ test_env_setup( fd_svm_mini_t * mini ) {
   fd_accdb_rw_init_nodb( &txn_out->accounts.account[2], &acct2_pubkey, acct2_meta, FD_RUNTIME_ACC_SZ_MAX );
 
   for( uint i=0; i<3; i++ ) fd_svm_mini_put_account_rooted( mini, txn_out->accounts.account[i].ro );
+
+  ulong exec_bank_idx = fd_svm_mini_attach_child( mini, root_bank_idx, bank->f.slot + 1UL );
+  bank = fd_svm_mini_bank( mini, exec_bank_idx );
 
   /* Instruction info */
   fd_instr_info_t * instr = &runtime->instr.trace[0];


### PR DESCRIPTION
- Do not backdate program cache entries; insert them at the load
  fork ID instead
- Add a regression test for epoch boundary invalidations across
  skipped slots
- Relax progcache_admin locking when rooting

Closes #9707