### PR TITLE
restore: snapld msg load_complete to snapct

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -81,6 +81,7 @@ struct fd_snapct_tile {
 
   int           state;
   int           malformed;
+  int           load_complete;
   long          deadline_nanos;
   int           flush_ack;
   int           flush_load;
@@ -474,6 +475,7 @@ init_load( fd_snapct_tile_t *  ctx,
   ctx->out_ld.chunk = fd_dcache_compact_next( ctx->out_ld.chunk, sizeof(fd_ssctrl_init_t), ctx->out_ld.chunk0, ctx->out_ld.wmark );
   ctx->flush_ack = 0;
   ctx->flush_load = 0;
+  ctx->load_complete = 0;
 
   /* If we are downloading the snapshot, we will get the snapshot size
      in bytes from a metadata message sent from snapld. */
@@ -1076,8 +1078,8 @@ after_credit( fd_snapct_tile_t *  ctx,
                          ctx->local_in.full_snapshot_slot, ctx->local_in.full_snapshot_path ));
         break;
       }
-      FD_TEST( ctx->metrics.full.bytes_total!=0UL );
-      if( FD_UNLIKELY( ctx->metrics.full.bytes_read == ctx->metrics.full.bytes_total ) ) {
+      if( FD_UNLIKELY( ctx->load_complete ) ) {
+        ctx->load_complete = 0;
         fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_FINI, 0UL, 0UL, 0UL, 0UL, 0UL );
         ctx->state = FD_SNAPCT_STATE_FLUSHING_FULL_FILE_FINI;
         ctx->flush_ack = 0;
@@ -1097,8 +1099,8 @@ after_credit( fd_snapct_tile_t *  ctx,
                          ctx->local_in.incremental_snapshot_slot, ctx->local_in.incremental_snapshot_path ));
         break;
       }
-      FD_TEST( ctx->metrics.incremental.bytes_total!=0UL );
-      if ( FD_UNLIKELY( ctx->metrics.incremental.bytes_read == ctx->metrics.incremental.bytes_total ) ) {
+      if( FD_UNLIKELY( ctx->load_complete ) ) {
+        ctx->load_complete = 0;
         fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_FINI, 0UL, 0UL, 0UL, 0UL, 0UL );
         ctx->state = FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_FINI;
         ctx->flush_ack = 0;
@@ -1122,9 +1124,9 @@ after_credit( fd_snapct_tile_t *  ctx,
         fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
         break;
       }
-      if( FD_UNLIKELY( ctx->metrics.full.bytes_total!=0UL && ctx->metrics.full.bytes_read==ctx->metrics.full.bytes_total ) ) {
-        ulong sig = FD_SNAPSHOT_MSG_CTRL_FINI;
-        fd_stem_publish( stem, ctx->out_ld.idx, sig, 0UL, 0UL, 0UL, 0UL, 0UL );
+      if( FD_UNLIKELY( ctx->load_complete ) ) {
+        ctx->load_complete = 0;
+        fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_FINI, 0UL, 0UL, 0UL, 0UL, 0UL );
         ctx->state = FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_FINI;
         ctx->flush_ack = 0;
       }
@@ -1147,7 +1149,8 @@ after_credit( fd_snapct_tile_t *  ctx,
         fd_sspeer_selector_remove_by_addr( ctx->selector, ctx->peer.addr );
         break;
       }
-      if ( FD_UNLIKELY( ctx->metrics.incremental.bytes_total!=0UL && ctx->metrics.incremental.bytes_read==ctx->metrics.incremental.bytes_total ) ) {
+      if( FD_UNLIKELY( ctx->load_complete ) ) {
+        ctx->load_complete = 0;
         fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_FINI, 0UL, 0UL, 0UL, 0UL, 0UL );
         ctx->state = FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_FINI;
         ctx->flush_ack = 0;
@@ -1357,6 +1360,36 @@ snapld_frag( fd_snapct_tile_t *  ctx,
       }
       ctx->flush_load = 1;
     } else FD_LOG_ERR(( "invalid control frag %lu in state %s", sig, fd_snapct_state_str( ctx->state ) ));
+    return;
+  }
+  if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_LOAD_COMPLETE ) ) {
+    int full = 0;
+    switch( ctx->state ) {
+      case FD_SNAPCT_STATE_READING_FULL_FILE:
+      case FD_SNAPCT_STATE_READING_FULL_HTTP:        full = 1; break;
+      case FD_SNAPCT_STATE_READING_INCREMENTAL_FILE:
+      case FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP: full = 0; break;
+      case FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET:
+      case FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET:
+      case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_RESET:
+      case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET:
+        return; /* Ignore during reset. */
+      default:
+        FD_LOG_ERR(( "invalid load_complete in state %s", fd_snapct_state_str( ctx->state ) ));
+        return;
+    }
+    if( FD_UNLIKELY( ctx->malformed ) ) return;
+    /* Validate that all expected bytes were received. */
+    ulong bytes_read  = full ? ctx->metrics.full.bytes_read  : ctx->metrics.incremental.bytes_read;
+    ulong bytes_total = full ? ctx->metrics.full.bytes_total : ctx->metrics.incremental.bytes_total;
+    if( FD_UNLIKELY( !bytes_total || bytes_read!=bytes_total ) ) {
+      ctx->malformed = 1;
+      FD_LOG_WARNING(( "load_complete but bytes_read %lu != bytes_total %lu for %s snapshot",
+                       bytes_read, bytes_total, full ? "full" : "incremental" ));
+      fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
+      return;
+    }
+    ctx->load_complete = 1;
     return;
   }
   if( FD_UNLIKELY( sig!=FD_SNAPSHOT_MSG_DATA ) ) return;
@@ -1758,6 +1791,7 @@ unprivileged_init( fd_topo_t *      topo,
 
   ctx->state          = FD_SNAPCT_STATE_INIT;
   ctx->malformed      = 0;
+  ctx->load_complete  = 0;
   ctx->deadline_nanos = fd_log_wallclock() + FD_SNAPCT_WAITING_FOR_PEERS_TIMEOUT;
   ctx->flush_ack      = 0;
   ctx->flush_load     = 0;

--- a/src/discof/restore/fd_snapdc_tile.c
+++ b/src/discof/restore/fd_snapdc_tile.c
@@ -100,6 +100,7 @@ handle_control_frag( fd_snapdc_tile_t *  ctx,
                      ulong               chunk,
                      ulong               sz ) {
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) return;
+  if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_LOAD_COMPLETE ) ) return;
 
   /* All control messages cause us to want to reset the decompression stream */
   ulong error = ZSTD_DCtx_reset( ctx->zstd, ZSTD_reset_session_only );

--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -35,7 +35,6 @@ typedef struct fd_snapld_tile {
   } config;
 
   int   state;
-  ulong pending_ctrl_sig;
   int   load_full;
   int   load_file;
   int   sent_meta;
@@ -52,8 +51,6 @@ typedef struct fd_snapld_tile {
   int local_full_fd;
   int local_incr_fd;
   int sockfd;
-
-  int is_https;
 
   fd_sshttp_t * sshttp;
 
@@ -193,7 +190,6 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->config.min_download_speed_mibs = tile->snapld.min_download_speed_mibs;
 
   ctx->state            = FD_SNAPSHOT_STATE_IDLE;
-  ctx->pending_ctrl_sig = 0UL;
 
   ctx->download_speed_mibs = 0.0;
   ctx->bytes_in_batch      = 0UL;
@@ -278,19 +274,6 @@ after_credit( fd_snapld_tile_t *  ctx,
               fd_stem_context_t * stem,
               int *               opt_poll_in FD_PARAM_UNUSED,
               int *               charge_busy ) {
-  if( FD_UNLIKELY( ctx->pending_ctrl_sig ) ) {
-    FD_TEST( !ctx->load_file && ctx->is_https );
-    if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_FINISHING ) ) {
-      fd_stem_publish( stem, 0UL, ctx->pending_ctrl_sig, 0UL, 0UL, 0UL, 0UL, 0UL );
-      ctx->pending_ctrl_sig = 0UL;
-      return;
-    } else if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_ERROR ) ) {
-      /* Do not forward a deferred control message in ERROR state. */
-      ctx->pending_ctrl_sig = 0UL;
-      return;
-    } else FD_TEST( ctx->state==FD_SNAPSHOT_STATE_PROCESSING );
-  }
-
   if( ctx->state!=FD_SNAPSHOT_STATE_PROCESSING ) {
     fd_log_sleep( (long)1e6 );
     return;
@@ -304,6 +287,7 @@ after_credit( fd_snapld_tile_t *  ctx,
       if( result==0L ) {
         FD_LOG_NOTICE(( "finished reading %s snapshot from local file", ctx->load_full ? "full" : "incremental" ));
         ctx->state = FD_SNAPSHOT_STATE_FINISHING;
+        fd_stem_publish( stem, 0UL, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, 0UL, 0UL, 0UL );
       } else if( FD_UNLIKELY( errno!=EAGAIN && errno!=EINTR ) ) {
         FD_LOG_WARNING(( "read() failed on %s snapshot file (%i-%s)", ctx->load_full ? "full" : "incremental", errno, fd_io_strerror( errno ) ));
         transition_malformed( ctx, stem );
@@ -390,6 +374,7 @@ after_credit( fd_snapld_tile_t *  ctx,
         }
         FD_LOG_NOTICE(( "finished downloading %s snapshot", ctx->load_full ? "full" : "incremental" ));
         ctx->state = FD_SNAPSHOT_STATE_FINISHING;
+        fd_stem_publish( stem, 0UL, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, 0UL, 0UL, 0UL );
         break;
       case FD_SSHTTP_ADVANCE_ERROR:
         FD_LOG_WARNING(( "HTTP advance error during %s snapshot download, entering error state",
@@ -414,8 +399,6 @@ returnable_frag( fd_snapld_tile_t *  ctx,
                  ulong               tsorig FD_PARAM_UNUSED,
                  ulong               tspub  FD_PARAM_UNUSED,
                  fd_stem_context_t * stem ) {
-  FD_TEST( !ctx->pending_ctrl_sig );
-
   if( ctx->state==FD_SNAPSHOT_STATE_ERROR && sig!=FD_SNAPSHOT_MSG_CTRL_FAIL ) {
     /* Control messages move along the snapshot load pipeline.  Since
        error conditions can be triggered by any tile in the pipeline,
@@ -437,7 +420,6 @@ returnable_frag( fd_snapld_tile_t *  ctx,
       ctx->load_full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
       ctx->load_file = msg_in->file;
       ctx->sent_meta = 0;
-      ctx->is_https  = msg_in->is_https;
 
       ctx->window_deadline = LONG_MAX;
       ctx->bytes_in_window = 0UL;
@@ -462,18 +444,7 @@ returnable_frag( fd_snapld_tile_t *  ctx,
     }
 
     case FD_SNAPSHOT_MSG_CTRL_FINI: {
-      if( FD_UNLIKELY( ctx->state==FD_SNAPSHOT_STATE_PROCESSING ) ) {
-        /* snapld should be in the finishing state when reading from a
-           file or downloading from http.  It is only allowed to still
-           be in progress for shutting down an https connection. Save
-           the sig here and send the message when snapld is in the
-           finishing state. */
-        FD_TEST( ctx->is_https );
-        ctx->pending_ctrl_sig = sig;
-        forward_msg = 0;
-        break;
-      }
-      else FD_TEST( ctx->state==FD_SNAPSHOT_STATE_FINISHING );
+      FD_TEST( ctx->state==FD_SNAPSHOT_STATE_FINISHING );
       break;
     }
 

--- a/src/discof/restore/test_snapct_tile.c
+++ b/src/discof/restore/test_snapct_tile.c
@@ -164,6 +164,48 @@ test_block_list_contact_info_insert( void ) {
 }
 
 static void
+test_load_complete_signal( void ) {
+  fd_snapct_tile_t ctx[1];
+  memset( ctx, 0, sizeof(fd_snapct_tile_t) );
+
+  /* snapld_frag never dereferences stem in the paths below. */
+
+  /* READING_FULL_FILE with matching bytes sets load_complete */
+  ctx->state                    = FD_SNAPCT_STATE_READING_FULL_FILE;
+  ctx->metrics.full.bytes_read  = 1000UL;
+  ctx->metrics.full.bytes_total = 1000UL;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, NULL );
+  FD_TEST( ctx->load_complete==1 );
+  ctx->load_complete = 0;
+
+  /* READING_INCREMENTAL_HTTP with matching bytes sets load_complete */
+  ctx->state                           = FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP;
+  ctx->metrics.incremental.bytes_read  = 500UL;
+  ctx->metrics.incremental.bytes_total = 500UL;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, NULL );
+  FD_TEST( ctx->load_complete==1 );
+  ctx->load_complete = 0;
+
+  /* Ignored during reset states */
+  ctx->state = FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, NULL );
+  FD_TEST( ctx->load_complete==0 );
+
+  ctx->state = FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, NULL );
+  FD_TEST( ctx->load_complete==0 );
+
+  /* Ignored when already malformed */
+  ctx->state                    = FD_SNAPCT_STATE_READING_FULL_HTTP;
+  ctx->malformed                = 1;
+  ctx->metrics.full.bytes_read  = 1000UL;
+  ctx->metrics.full.bytes_total = 1000UL;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_LOAD_COMPLETE, 0UL, 0UL, NULL );
+  FD_TEST( ctx->load_complete==0 );
+  ctx->malformed = 0;
+}
+
+static void
 test_contact_info_slot_reuse_after_unallowed_peer_expires( void ) {
   void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
 
@@ -217,6 +259,7 @@ main( int     argc,
   test_allow_list_contact_info_insert();
   test_block_list_contact_info_insert();
   test_contact_info_slot_reuse_after_unallowed_peer_expires();
+  test_load_complete_signal();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -121,6 +121,9 @@
 /* snapla -> snapls */
 #define FD_SNAPSHOT_HASH_MSG_RESULT_ADD       (17UL) /* Hash result sent from snapla to snapls */
 
+/* snapld -> snapct (via snapld_dc) */
+#define FD_SNAPSHOT_MSG_LOAD_COMPLETE         (18UL) /* snapld finished reading/downloading all data */
+
 
 /* Sent by snapct to tell snapld whether to load a local file or
    download from a particular external peer. */
@@ -217,6 +220,7 @@ fd_ssctrl_msg_ctrl_str( ulong sig ) {
     case FD_SNAPSHOT_HASH_MSG_SUB_HDR:          return "hash_sub_hdr";
     case FD_SNAPSHOT_HASH_MSG_SUB_DATA:         return "hash_sub_data";
     case FD_SNAPSHOT_HASH_MSG_RESULT_ADD:       return "hash_result_add";
+    case FD_SNAPSHOT_MSG_LOAD_COMPLETE:         return "load_complete";
     default:                                    return "unknown";
   }
 }


### PR DESCRIPTION
`snapct` used to detect snapshot load completion by polling `bytes_read==bytes_total` on every tick. This created a race condition: `snapct` could send `CTRL_FINI` to `snapld` before the latter had transitioned from `PROCESSING` to `FINISHING` state, causing a FD_TEST crash on local file and HTTP loads.
Now `snapld` explicitly publishes `FD_SNAPSHOT_MSG_LOAD_COMPLETE` on the `snapld_dc` link (the feedback loop to `snapct`) after finishing all reads, and `snapct` now waits for this signal before sending `CTRL_FINI`, eliminating the race condition.
As a result of these changes, the `pending_ctrl_sig` deferral mechanism and the `is_https` check in `snapld` are no longer needed.

Closes https://github.com/firedancer-io/firedancer/issues/9756.

Partially addresses https://github.com/firedancer-io/firedancer/issues/9588 as well.