### PR TITLE
disco: clean up tile clock API

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -3,9 +3,8 @@
 #include "../../shared/fd_config.h" /* config_t */
 #include "../../../disco/topo/fd_topob.h"
 #include "../../../disco/net/fd_net_tile.h" /* fd_topos_net_tiles */
-#include "../../../disco/metrics/fd_metrics.h"
+#include "../../../disco/fd_clock_tile.h"
 #include "../../../discof/gossip/fd_gossip_tile.h"
-#include "../../../util/clock/fd_clock.h"
 
 #include "../../firedancer/commands/monitor_gossip/gossip_diag.h"
 
@@ -238,16 +237,14 @@ gossip_cmd_fn( args_t *   args,
   if( FD_UNLIKELY( fd_gossip_diag_init( diag_ctx, &config->topo, config ) ) )
     FD_LOG_ERR(( "Failed to initialize gossip diagnostics" ));
 
-  fd_clock_t   clock_lmem[1];
-  void       * clock_mem = aligned_alloc( FD_CLOCK_ALIGN, FD_CLOCK_FOOTPRINT );
-  FD_TEST( clock_mem );
-  fd_clock_default_init( clock_lmem, clock_mem );
+  fd_clock_tile_t clock[1];
+  fd_clock_tile_init( clock );
 
-  long start_time       = fd_clock_now( clock_lmem );
+  long start_time       = fd_clock_tile_now( clock );
   long next_report_time = start_time + 1000000000L;
 
   for(;;) {
-    long current_time = fd_clock_now( clock_lmem );
+    long current_time = fd_clock_tile_now( clock );
 
     if( FD_LIKELY( current_time < next_report_time ) ) {
       continue;
@@ -266,6 +263,7 @@ gossip_cmd_fn( args_t *   args,
               elapsed_secs, diag_ctx->last_total_crds, diag_ctx->last_total_contact_infos );
       break;
     }
+    fd_clock_tile_recal( clock );
   }
 }
 

--- a/src/app/firedancer/commands/monitor_gossip/monitor_gossip.c
+++ b/src/app/firedancer/commands/monitor_gossip/monitor_gossip.c
@@ -3,8 +3,7 @@
 #include "generated/monitor_gossip_seccomp.h"
 
 #include "../../../shared/commands/monitor/monitor.h" /* reconstruct_topo */
-#include "../../../../disco/metrics/fd_metrics.h"
-#include "../../../../util/clock/fd_clock.h"
+#include "../../../../disco/fd_clock_tile.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -128,19 +127,17 @@ monitor_gossip_cmd_fn( args_t *   args,
 
   printf( "Found %lu gossvf tiles\n", diag_ctx->gossvf.tile_count );
 
-  fd_clock_t   clock_lmem[1];
-  void       * clock_mem = aligned_alloc( FD_CLOCK_ALIGN, FD_CLOCK_FOOTPRINT );
-  FD_TEST( clock_mem );
-  fd_clock_default_init( clock_lmem, clock_mem );
+  fd_clock_tile_t clock[1];
+  fd_clock_tile_init( clock );
 
-  long next_report_time = fd_clock_now( clock_lmem ) + 1000000000L;
-
+  long next_report_time = fd_clock_tile_now( clock ) + 1000000000L;
   for(;;) {
-    long current_time = fd_clock_now( clock_lmem );
+    long current_time = fd_clock_tile_now( clock );
     if( FD_LIKELY( current_time < next_report_time ) ) continue;
     next_report_time += 1000000000L;
 
     fd_gossip_diag_render( diag_ctx, args->monitor_gossip.compact_mode );
+    fd_clock_tile_recal( clock );
   }
 }
 

--- a/src/app/shared_dev/commands/bench/fd_benchs.c
+++ b/src/app/shared_dev/commands/bench/fd_benchs.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 
 #include "../../../../disco/metrics/fd_metrics.h"
+#include "../../../../disco/fd_clock_tile.h"
 #include "../../../../disco/topo/fd_topo.h"
 #include "../../../../waltz/quic/fd_quic.h"
 #include "../../../../waltz/quic/tests/fd_quic_test_helpers.h"
@@ -17,7 +18,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-
 #include <time.h>
 
 /* max number of buffers batched for receive */
@@ -49,9 +49,8 @@ typedef struct {
   uint             service_ratio_idx;
   fd_aio_t         tx_aio;
 
-  long         now;        /* current time in ns    */
-  fd_clock_t   clock[1];   /* memory for fd_clock_t */
-  long         recal_next; /* next recalibration time (ns) */
+  long            now;  /* current time in ns */
+  fd_clock_tile_t clock[1];
 
   /* vector receive members */
   struct mmsghdr rx_msgs[IO_VEC_CNT];
@@ -64,8 +63,6 @@ typedef struct {
   ulong tx_idx;
 
   fd_wksp_t * mem;
-
-  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
 } fd_benchs_ctx_t;
 
 static void
@@ -213,7 +210,7 @@ before_frag( fd_benchs_ctx_t * ctx,
   (void)in_idx;
   (void)sig;
 
-  ctx->now = fd_clock_now( ctx->clock );
+  ctx->now = fd_clock_tile_now( ctx->clock );
 
   return (int)( (seq%ctx->round_robin_cnt)!=ctx->round_robin_id );
 }
@@ -437,10 +434,9 @@ unprivileged_init( fd_topo_t *      topo,
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
 
-  fd_clock_t * clock = ctx->clock;
-  fd_clock_default_init( clock, ctx->clock_mem );
-  ctx->recal_next = fd_clock_recal_next( clock );
-  ctx->now        = fd_clock_now( clock );
+  fd_clock_tile_t * clock = ctx->clock;
+  fd_clock_tile_init( clock );
+  ctx->now = fd_clock_tile_now( clock );
 }
 
 static void
@@ -520,8 +516,8 @@ quic_tx_aio_send( void *                    _ctx,
 
 static void
 during_housekeeping( fd_benchs_ctx_t * ctx ) {
-  if( FD_UNLIKELY( ctx->recal_next <= ctx->now ) ) {
-    ctx->recal_next = fd_clock_default_recal( ctx->clock );
+  if( FD_UNLIKELY( fd_clock_tile_recal_due( ctx->clock ) ) ) {
+    fd_clock_tile_recal( ctx->clock );
   }
 }
 

--- a/src/app/shared_dev/commands/dump.c
+++ b/src/app/shared_dev/commands/dump.c
@@ -1,6 +1,7 @@
 #include "../../shared/fd_config.h"
 #include "../../shared/fd_action.h"
 #include "../../../disco/metrics/fd_metrics.h"
+#include "../../../disco/fd_clock_tile.h"
 #include "../../../util/clock/fd_clock.h"
 #include "../../../util/net/fd_pcap.h"
 
@@ -29,10 +30,7 @@ struct dump_ctx {
 
   long                     warmup_until;
 
-  fd_clock_t               clock[ 1 ];
-  fd_clock_shmem_t         clock_mem[ 1 ];
-  fd_clock_epoch_t         clock_epoch[ 1 ];
-  long                     clock_recal_next;
+  fd_clock_tile_t          clock[ 1 ];
 };
 typedef struct dump_ctx dump_ctx_t;
 
@@ -187,11 +185,11 @@ after_frag( dump_ctx_t *        ctx,
   FD_TEST( (ulong)pcap_sz == ctx->pending_sz );
 
   long tickcount = fd_tickcount();
-  long now       = fd_clock_epoch_y( ctx->clock_epoch, tickcount );
+  long now       = fd_clock_epoch_y( ctx->clock->shmem->epoch, tickcount );
   if( FD_LIKELY( now>ctx->warmup_until ) ) {
     if( FD_LIKELY( tspub!=0UL ) ) {
       long   tspub_decomp    = fd_frag_meta_ts_decomp( tspub, tickcount );
-      long   tspub_wallclock = fd_clock_epoch_y( ctx->clock_epoch, tspub_decomp );
+      long   tspub_wallclock = fd_clock_epoch_y( ctx->clock->shmem->epoch, tspub_decomp );
       uint * pcap_tss        = fd_io_buffered_ostream_peek( &ctx->ostream );
       pcap_tss[ 0 ] = (uint)(((ulong)tspub_wallclock) / (ulong)1e9);
       pcap_tss[ 1 ] = (uint)(((ulong)tspub_wallclock) % (ulong)1e9); /* Actually nsec */
@@ -229,10 +227,9 @@ log_metrics( dump_ctx_t * ctx ) {
 
 static void
 during_housekeeping( dump_ctx_t * ctx ) {
-  long now = fd_clock_epoch_y( ctx->clock_epoch, fd_tickcount() );
-  if( FD_UNLIKELY( now > ctx->clock_recal_next ) ) {
-    ctx->clock_recal_next = fd_clock_default_recal( ctx->clock );
-    fd_clock_epoch_refresh( ctx->clock_epoch, ctx->clock_mem );
+  long now = fd_clock_tile_now( ctx->clock );
+  if( FD_UNLIKELY( now >= fd_clock_tile_recal_next( ctx->clock ) ) ) {
+    fd_clock_tile_recal( ctx->clock );
   }
   if( FD_UNLIKELY( now > ctx->next_stat_log ) ) {
     ctx->next_stat_log = now + (long)1e9;
@@ -324,10 +321,8 @@ dump_cmd_fn( args_t      * args,
        joining links, so at startup we get a full ~depth set of callbacks
        for old frags.  This code assumes that we are caught up and only
        processing new frags by the time the warmup timer expires. */
-    fd_clock_default_init( ctx.clock, ctx.clock_mem );
-    ctx.clock_recal_next = fd_clock_default_recal( ctx.clock );
-    fd_clock_epoch_init( ctx.clock_epoch, ctx.clock_mem );
-    ctx.warmup_until = fd_clock_epoch_y( ctx.clock_epoch, fd_tickcount() ) + (long)1e9;
+    fd_clock_tile_init( ctx.clock );
+    ctx.warmup_until = fd_clock_tile_now( ctx.clock ) + (long)1e9;
     ctx.next_stat_log = ctx.warmup_until + (long)1e9;
 
     stem_run1( ctx.link_cnt, /* in_cnt */
@@ -353,9 +348,6 @@ dump_cmd_fn( args_t      * args,
       FD_LOG_NOTICE(( "dumped %lu frags, %lu bytes in total from %s:%lu. Link hash: 0x%x",
                       frags, bytes, link->topo->name, link->topo->kind_id, link->link_hash ));
     }
-
-    fd_clock_leave( ctx.clock );
-    fd_clock_delete( ctx.clock_mem );
 
     fd_metrics_delete( fd_metrics_leave( ctx.metrics_base ) );
     ctx.metrics_base = NULL;

--- a/src/disco/Local.mk
+++ b/src/disco/Local.mk
@@ -1,4 +1,7 @@
 $(call make-lib,fd_disco)
 $(call add-hdrs,fd_disco_base.h fd_disco.h)
 $(call make-unit-test,test_disco_base,test_disco_base,fd_disco fd_tango fd_util)
-$(call run-unit-test,test_disco_base,)
+$(call run-unit-test,test_disco_base)
+ifdef FD_HAS_DOUBLE
+$(call add-hdrs,fd_clock_tile.h)
+endif

--- a/src/disco/fd_clock_tile.h
+++ b/src/disco/fd_clock_tile.h
@@ -1,0 +1,86 @@
+#ifndef HEADER_fd_src_disco_fd_clock_tile_h
+#define HEADER_fd_src_disco_fd_clock_tile_h
+
+/* fd_clock_tile.h provides fd_clock convenience APIs for tiles */
+
+#include "../tango/tempo/fd_tempo.h"
+#include "../util/clock/fd_clock.h"
+
+/* fd_clock_tile_t is a fast nanosecond clock source for Firedancer
+   tiles (single-threaded usage). */
+
+struct fd_clock_tile {
+  fd_clock_shmem_t shmem[1];
+  fd_clock_t       clock[1];
+  fd_clock_epoch_t epoch[1];
+};
+
+typedef struct fd_clock_tile fd_clock_tile_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_clock_tile_init creates a new fd_clock_tile_t.  Assumes that the
+   calling thread has pre-calibrated fd_tempo tick_per_ns value. */
+
+static inline void
+fd_clock_tile_init( fd_clock_tile_t * clock ) {
+  /* fdctl calibrates tick_per_ns on startup, no need to calibrate here */
+  double init_w = (double)fd_tempo_tick_per_ns( NULL );
+
+  long init_x0, init_y0;
+  int  clock_err = fd_clock_joint_read( _fd_tickcount, NULL, fd_log_wallclock_host, NULL, &init_x0, &init_y0, NULL );
+  if( FD_UNLIKELY( clock_err ) ) FD_LOG_ERR(( "fd_clock_joint_read failed (%i-%s)", clock_err, fd_clock_strerror( clock_err ) ));
+
+  long   recal_avg  = 10e6L; /* 10ms */
+  void * shclock = fd_clock_new( clock->shmem, recal_avg, 0L, 0., 0., init_x0, init_y0, init_w );
+  if( FD_UNLIKELY( !shclock ) ) FD_LOG_ERR(( "fd_clock_new failed" ));
+
+  fd_clock_t * clock_ptr = fd_clock_join( clock->clock, shclock, _fd_tickcount, NULL );
+  if( FD_UNLIKELY( !clock_ptr ) ) FD_LOG_ERR(( "fd_clock_join failed" ));
+
+  fd_clock_epoch_init( clock->epoch, clock->shmem );
+}
+
+/* fd_clock_tile_recal_next returns the wallclock deadline after which
+   the next recal should be done. */
+
+static inline long
+fd_clock_tile_recal_next( fd_clock_tile_t const * clock ) {
+  return fd_clock_recal_next( clock->clock );
+}
+
+/* fd_clock_tile_recal is called periodically to synchronize tickcount
+   to log_wallclock.  Returns the wallclock deadline after which the
+   next recal should be done. */
+
+static inline long
+fd_clock_tile_recal( fd_clock_tile_t * clock ) {
+  long x; long y;
+  int err = fd_clock_joint_read( _fd_tickcount, NULL, fd_log_wallclock_host, NULL, &x, &y, NULL );
+  if( FD_UNLIKELY( err ) ) {
+    /* on recal fail, retry in 1ms */
+    FD_LOG_WARNING(( "fd_clock_joint_read failed (%i-%s)", err, fd_clock_strerror( err ) ));
+    return ( clock->shmem->recal_next = fd_clock_epoch_y( clock->epoch, fd_tickcount() ) + 1000000L );
+  }
+  long recal_next = fd_clock_recal( clock->clock, x, y );
+  fd_clock_epoch_refresh( clock->epoch, clock->shmem );
+  return recal_next;
+}
+
+/* fd_clock_tile_now returns an approximation of fd_log_wallclock. */
+
+static inline long
+fd_clock_tile_now( fd_clock_tile_t const * clock ) {
+  return fd_clock_epoch_y( clock->epoch, fd_tickcount() );
+}
+
+/* fd_clock_tile_recal_due returns 1 if a recalibration is due, else 0. */
+
+static inline int
+fd_clock_tile_recal_due( fd_clock_tile_t * clock ) {
+  return fd_clock_tile_now( clock ) >= fd_clock_tile_recal_next( clock );
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_fd_clock_tile_h */

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -26,11 +26,11 @@ static fd_http_static_file_t * STATIC_FILES;
 #include "../../discof/replay/fd_execrp.h"
 #include "../../disco/metrics/fd_metrics.h"
 #include "../../disco/net/fd_net_tile.h"
+#include "../../disco/fd_clock_tile.h"
 #include "../../discof/genesis/fd_genesi_tile.h" // TODO: Layering violation
 #include "../../waltz/http/fd_http_server.h"
 #include "../../waltz/http/fd_http_server_private.h"
 #include "../../ballet/json/cJSON_alloc.h"
-#include "../../util/clock/fd_clock.h"
 #include "../../discof/repair/fd_repair.h"
 #include "../../discof/replay/fd_replay_tile.h"
 #include "../../disco/shred/fd_shred_tile.h"
@@ -112,10 +112,7 @@ typedef struct {
   long ref_tickcount;
   const double tick_per_ns;
 
-  fd_clock_t clock[1];
-  long       recal_next; /* next recalibration time (ns) */
-
-  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
+  fd_clock_tile_t clock[1];
 
   ulong chunk;
   union {
@@ -178,8 +175,8 @@ during_housekeeping( fd_gui_ctx_t * ctx ) {
   ctx->ref_wallclock = fd_log_wallclock();
   ctx->ref_tickcount = fd_tickcount();
 
-  if( FD_UNLIKELY( fd_clock_now( ctx->clock ) >= ctx->recal_next ) ) {
-    ctx->recal_next = fd_clock_default_recal( ctx->clock );
+  if( FD_UNLIKELY( fd_clock_tile_recal_due( ctx->clock ) ) ) {
+    fd_clock_tile_recal( ctx->clock );
   }
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
@@ -218,8 +215,8 @@ before_credit( fd_gui_ctx_t *      ctx,
   }
 
   int charge_poll = 0;
-  charge_poll |= fd_gui_poll( ctx->gui, fd_clock_now( ctx->clock ) );
-  if( FD_UNLIKELY( ctx->is_full_client ) ) charge_poll |= fd_gui_peers_poll( ctx->peers, fd_clock_now( ctx->clock ) );
+  charge_poll |= fd_gui_poll( ctx->gui, fd_clock_tile_now( ctx->clock ) );
+  if( FD_UNLIKELY( ctx->is_full_client ) ) charge_poll |= fd_gui_peers_poll( ctx->peers, fd_clock_tile_now( ctx->clock ) );
 
   *charge_busy = charge_busy_server | charge_poll;
 }
@@ -339,7 +336,7 @@ after_frag( fd_gui_ctx_t *      ctx,
   switch ( ctx->in_kind[ in_idx ] ) {
     case IN_KIND_PLUGIN: {
       FD_TEST( !ctx->is_full_client );
-      fd_gui_plugin_message( ctx->gui, sig, src, fd_clock_now( ctx->clock ) );
+      fd_gui_plugin_message( ctx->gui, sig, src, fd_clock_tile_now( ctx->clock ) );
       break;
     }
     case IN_KIND_EXECRP_REPLAY: {
@@ -368,9 +365,9 @@ after_frag( fd_gui_ctx_t *      ctx,
       if( FD_UNLIKELY( sig==REPLAY_SIG_SLOT_COMPLETED ) ) {
         fd_replay_slot_completed_t const * slot_completed =  (fd_replay_slot_completed_t const *)src;
 
-        fd_gui_peers_update_delinquency( ctx->peers, fd_clock_now( ctx->clock ) );
+        fd_gui_peers_update_delinquency( ctx->peers, fd_clock_tile_now( ctx->clock ) );
 
-        fd_gui_handle_replay_update( ctx->gui, slot_completed, ctx->peers->slot_voted, fd_clock_now( ctx->clock ) );
+        fd_gui_handle_replay_update( ctx->gui, slot_completed, ctx->peers->slot_voted, fd_clock_tile_now( ctx->clock ) );
       } else if( FD_UNLIKELY( sig==REPLAY_SIG_BECAME_LEADER ) ) {
         fd_became_leader_t * became_leader = (fd_became_leader_t *)src;
         fd_gui_became_leader( ctx->gui, became_leader->slot, became_leader->slot_start_ns, became_leader->slot_end_ns, became_leader->limits.slot_max_cost, became_leader->max_microblocks_in_slot );
@@ -383,8 +380,8 @@ after_frag( fd_gui_ctx_t *      ctx,
       FD_TEST( ctx->is_full_client );
 
       fd_epoch_info_msg_t * epoch_info = (fd_epoch_info_msg_t *)src;
-      fd_gui_handle_epoch_info( ctx->gui, epoch_info, fd_clock_now( ctx->clock ) );
-      fd_gui_peers_handle_epoch_info( ctx->peers, epoch_info, fd_clock_now( ctx->clock ) );
+      fd_gui_handle_epoch_info( ctx->gui, epoch_info, fd_clock_tile_now( ctx->clock ) );
+      fd_gui_peers_handle_epoch_info( ctx->peers, epoch_info, fd_clock_tile_now( ctx->clock ) );
       break;
     }
     case IN_KIND_SNAPIN: {
@@ -399,7 +396,7 @@ after_frag( fd_gui_ctx_t *      ctx,
         fd_gui_peers_commit_snapshot_manifest( ctx->peers );
       } else {
         fd_gui_stage_snapshot_manifest( ctx->gui, (fd_snapshot_manifest_t const *)src );
-        fd_gui_peers_stage_snapshot_manifest( ctx->peers, (fd_snapshot_manifest_t const *)src, fd_clock_now( ctx->clock ) );
+        fd_gui_peers_stage_snapshot_manifest( ctx->peers, (fd_snapshot_manifest_t const *)src, fd_clock_tile_now( ctx->clock ) );
       }
       break;
     }
@@ -413,7 +410,7 @@ after_frag( fd_gui_ctx_t *      ctx,
       FD_TEST( ctx->is_full_client );
       if( FD_LIKELY( sig==FD_TOWER_SIG_SLOT_DONE )) {
         fd_tower_slot_done_t const * tower = (fd_tower_slot_done_t const *)src;
-        fd_gui_handle_tower_update( ctx->gui, tower, fd_clock_now( ctx->clock ) );
+        fd_gui_handle_tower_update( ctx->gui, tower, fd_clock_tile_now( ctx->clock ) );
       }
       if( FD_UNLIKELY( sig==FD_TOWER_SIG_SLOT_CONFIRMED ) ) {
         fd_gui_handle_votes_update( ctx->gui, (fd_tower_slot_confirmed_t const *)src );
@@ -482,7 +479,7 @@ after_frag( fd_gui_ctx_t *      ctx,
     }
     case IN_KIND_GOSSIP_OUT: {
       FD_TEST( ctx->is_full_client );
-      fd_gui_peers_handle_gossip_update( ctx->peers, (fd_gossip_update_message_t *)src, fd_clock_now( ctx-> clock ) );
+      fd_gui_peers_handle_gossip_update( ctx->peers, (fd_gossip_update_message_t *)src, fd_clock_tile_now( ctx->clock ) );
       break;
     }
     case IN_KIND_POH_PACK: {
@@ -493,7 +490,7 @@ after_frag( fd_gui_ctx_t *      ctx,
       break;
     }
     case IN_KIND_PACK_POH: {
-      fd_gui_unbecame_leader( ctx->gui, fd_disco_execle_sig_slot( sig ), (fd_done_packing_t const *)src, fd_clock_now( ctx->clock ) );
+      fd_gui_unbecame_leader( ctx->gui, fd_disco_execle_sig_slot( sig ), (fd_done_packing_t const *)src, fd_clock_tile_now( ctx->clock ) );
       break;
     }
     case IN_KIND_PACK_EXECLE: {
@@ -649,8 +646,8 @@ gui_ws_open( ulong  conn_id,
              void * _ctx ) {
   fd_gui_ctx_t * ctx = (fd_gui_ctx_t *)_ctx;
 
-  fd_gui_ws_open( ctx->gui, conn_id, fd_clock_now( ctx->clock ) );
-  if( FD_UNLIKELY( ctx->is_full_client ) ) fd_gui_peers_ws_open( ctx->peers, conn_id, fd_clock_now( ctx->clock ) );
+  fd_gui_ws_open( ctx->gui, conn_id, fd_clock_tile_now( ctx->clock ) );
+  if( FD_UNLIKELY( ctx->is_full_client ) ) fd_gui_peers_ws_open( ctx->peers, conn_id, fd_clock_tile_now( ctx->clock ) );
 }
 
 static void
@@ -739,8 +736,7 @@ unprivileged_init( fd_topo_t *      topo,
   ctx->is_full_client = ULONG_MAX!=fd_topo_find_tile( topo, "repair", 0UL );
   ctx->snapshots_enabled = ULONG_MAX!=fd_topo_find_tile( topo, "snapct", 0UL );
 
-  fd_clock_default_init( ctx->clock, ctx->clock_mem );
-  ctx->recal_next = fd_clock_recal_next( ctx->clock );
+  fd_clock_tile_init( ctx->clock );
 
   ctx->ref_wallclock = fd_log_wallclock();
   ctx->ref_tickcount = fd_tickcount();
@@ -749,8 +745,8 @@ unprivileged_init( fd_topo_t *      topo,
   FD_TEST( fd_cstr_printf_check( ctx->version_string, sizeof( ctx->version_string ), NULL, "%s", fdctl_version_string ) );
 
   ctx->topo = topo;
-  ctx->peers = fd_gui_peers_join( fd_gui_peers_new( _peers, ctx->gui_server, ctx->topo, http_param.max_ws_connection_cnt, tile->gui.wfs_bank_hash, fd_clock_now( ctx->clock ) ) );
-  ctx->gui  = fd_gui_join(  fd_gui_new( _gui, ctx->gui_server, ctx->version_string, tile->gui.cluster, ctx->identity_key, ctx->has_vote_key, ctx->vote_key->uc, ctx->is_full_client, ctx->snapshots_enabled, tile->gui.is_voting, tile->gui.schedule_strategy, tile->gui.wfs_bank_hash, tile->gui.expected_shred_version, ctx->topo, fd_clock_now( ctx->clock ) ) );
+  ctx->peers = fd_gui_peers_join( fd_gui_peers_new( _peers, ctx->gui_server, ctx->topo, http_param.max_ws_connection_cnt, tile->gui.wfs_bank_hash, fd_clock_tile_now( ctx->clock ) ) );
+  ctx->gui   = fd_gui_join( fd_gui_new( _gui, ctx->gui_server, ctx->version_string, tile->gui.cluster, ctx->identity_key, ctx->has_vote_key, ctx->vote_key->uc, ctx->is_full_client, ctx->snapshots_enabled, tile->gui.is_voting, tile->gui.schedule_strategy, tile->gui.wfs_bank_hash, tile->gui.expected_shred_version, ctx->topo, fd_clock_tile_now( ctx->clock ) ) );
   FD_TEST( ctx->gui );
 
   ctx->keyswitch = fd_keyswitch_join( fd_topo_obj_laddr( topo, tile->id_keyswitch_obj_id ) );

--- a/src/disco/quic/fd_quic_tile.c
+++ b/src/disco/quic/fd_quic_tile.c
@@ -109,7 +109,7 @@ before_credit( fd_quic_ctx_t *     ctx,
   ctx->stem = stem;
 
   /* Publishes to mcache via callbacks */
-  long now = fd_clock_now( ctx->clock );
+  long now = fd_clock_tile_now( ctx->clock );
   ctx->now = now;
   *charge_busy = fd_quic_service( ctx->quic, now );
 }
@@ -445,12 +445,12 @@ quic_tls_keylog( void *       _ctx,
 
 static void
 during_housekeeping( fd_quic_ctx_t * ctx ) {
-  if( FD_UNLIKELY( ctx->recal_next <= ctx->now ) ) {
-    ctx->recal_next = fd_clock_default_recal( ctx->clock );
+  long now = ctx->now = fd_clock_tile_now( ctx->clock );
+  if( FD_UNLIKELY( now >= fd_clock_tile_recal_next( ctx->clock ) ) ) {
+    fd_clock_tile_recal( ctx->clock );
   }
 
   if( FD_UNLIKELY( ctx->keylog_stream.wbuf ) ) {
-    long now = ctx->now = fd_clock_now( ctx->clock );
     if( FD_UNLIKELY( now > ctx->keylog_next_flush ) ) {
       int err = fd_io_buffered_ostream_flush( &ctx->keylog_stream );
       if( FD_UNLIKELY( err ) ) {
@@ -542,10 +542,9 @@ unprivileged_init( fd_topo_t *      topo,
     fd_net_rx_bounds_init( &ctx->net_in_bounds[ i ], link->dcache );
   }
 
-  fd_clock_t * clock = ctx->clock;
-  fd_clock_default_init( clock, ctx->clock_mem );
-  ctx->recal_next = fd_clock_recal_next( clock );
-  ctx->now        = fd_clock_now( clock );
+  fd_clock_tile_t * clock = ctx->clock;
+  fd_clock_tile_init( clock );
+  ctx->now = fd_clock_tile_now( clock );
 
   if( FD_UNLIKELY( getrandom( ctx->tls_priv_key, ED25519_PRIV_KEY_SZ, 0 )!=ED25519_PRIV_KEY_SZ ) ) {
     FD_LOG_ERR(( "getrandom failed (%i-%s)", errno, fd_io_strerror( errno ) ));

--- a/src/disco/quic/fd_quic_tile.h
+++ b/src/disco/quic/fd_quic_tile.h
@@ -5,6 +5,7 @@
 #include "../stem/fd_stem.h"
 #include "../topo/fd_topo.h"
 #include "../net/fd_net_tile.h"
+#include "../fd_clock_tile.h"
 #include "../../waltz/quic/fd_quic.h"
 #include "../../util/io/fd_io.h"
 
@@ -17,9 +18,8 @@ typedef struct {
 
   fd_stem_context_t * stem;
 
-  long       now;        /* current time in ns     */
-  fd_clock_t clock[1];   /* memory for fd_clock_t   */
-  long       recal_next; /* next recalibration time (ns) */
+  long            now; /* current time in ns */
+  fd_clock_tile_t clock[1];
 
   fd_quic_t * quic;
   fd_aio_t    quic_tx_aio[1];
@@ -65,8 +65,6 @@ typedef struct {
     ulong quic_txn_too_small;
     ulong quic_txn_too_large;
   } metrics;
-
-  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
 } fd_quic_ctx_t;
 
 #endif /* HEADER_fd_src_disco_quic_fd_quic_tile_h */

--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -518,7 +518,7 @@ fd_poh_advance( fd_poh_t *          poh,
   /* Now figure out how many hashes are needed to "catch up" the hash
      count to the current system clock, and clamp it to the allowed
      range. */
-  long now = fd_clock_epoch_y( poh->clock_epoch, fd_tickcount() );
+  long now = fd_clock_tile_now( poh->clock );
   ulong target_hashcnt;
   if( FD_LIKELY( poh->state==STATE_FOLLOWER ||poh->state==STATE_WAITING_FOR_SLOT ) ) {
     target_hashcnt = (ulong)((double)(now - poh->reset_slot_start_ns) / poh->hashcnt_duration_ns) - (poh->slot-poh->reset_slot)*poh->hashcnt_per_slot;

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -309,9 +309,9 @@
 
 #include "../../disco/pack/fd_pack.h"
 #include "../../disco/stem/fd_stem.h"
+#include "../../disco/fd_clock_tile.h"
 #include "../../util/fd_util_base.h"
 #include "../../ballet/sha256/fd_sha256.h"
-#include "../../util/clock/fd_clock.h"
 
 /* FD_POH_ALIGN is the alignment needed for a memory region to hold a
    fd_poh_t.  It is a positive integer power of 2. */
@@ -440,12 +440,7 @@ struct __attribute__((aligned(FD_POH_ALIGN))) fd_poh_private {
 
   fd_sha256_t * sha256;
 
-  fd_clock_t clock[ 1 ];
-  long       recal_next;
-
-  fd_clock_epoch_t clock_epoch[ 1 ];
-
-  uchar __attribute__((aligned(FD_CLOCK_ALIGN))) clock_mem[ FD_CLOCK_FOOTPRINT ];
+  fd_clock_tile_t clock[ 1 ];
 
   fd_poh_out_t shred_out[ 1 ];
   fd_poh_out_t replay_out[ 1 ];

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -2,6 +2,7 @@
 #include "fd_poh_tile.h"
 #include "../replay/fd_replay_tile.h"
 #include "../../disco/tiles.h"
+#include "../../disco/fd_clock_tile.h"
 #include "../../discof/fd_startup.h"
 #include <time.h>
 #include "generated/fd_poh_tile_seccomp.h"
@@ -65,10 +66,8 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
 
 static inline void
 during_housekeeping( fd_poh_tile_t * ctx ) {
-  long now = fd_clock_epoch_y( ctx->poh->clock_epoch, fd_tickcount() );
-  if( FD_UNLIKELY( now >= ctx->poh->recal_next ) ) {
-    ctx->poh->recal_next = fd_clock_default_recal( ctx->poh->clock );
-    fd_clock_epoch_refresh( ctx->poh->clock_epoch, fd_clock_shclock_const( ctx->poh->clock ) );
+  if( FD_UNLIKELY( fd_clock_tile_recal_due( ctx->poh->clock ) ) ) {
+    fd_clock_tile_recal( ctx->poh->clock );
   }
 }
 
@@ -276,9 +275,7 @@ unprivileged_init( fd_topo_t *      topo,
 
   FD_TEST( fd_poh_join( fd_poh_new( ctx->poh ), ctx->shred_out, ctx->replay_out ) );
 
-  fd_clock_default_init( ctx->poh->clock, ctx->poh->clock_mem );
-  ctx->poh->recal_next = fd_clock_recal_next( ctx->poh->clock );
-  fd_clock_epoch_init( ctx->poh->clock_epoch, fd_clock_shclock_const( ctx->poh->clock ) );
+  fd_clock_tile_init( ctx->poh->clock );
 
   ulong scratch_top = FD_SCRATCH_ALLOC_FINI( l, 1UL );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )

--- a/src/util/clock/fd_clock.h
+++ b/src/util/clock/fd_clock.h
@@ -664,62 +664,6 @@ fd_clock_epoch_y( fd_clock_epoch_t const * epoch,
 
 char const * fd_clock_strerror( int err );
 
-
-/* Default tile usage APIs *********************************************/
-
-/* fd_clock_default_init initializes and joins fd_clock_t with default values,
-   using _fd_tickcount for clock x and fd_log_wallclock_host for clock y.
-   clock_lmem is local memory for fd_clock_t
-   clock_mem is shared memory for fd_clock_shmem_t
-   Intended for single threaded use cases (calibrating thread == observer thread)
-   Caution: This function spins for 20e6 ticks! */
-
-static inline void
-fd_clock_default_init( fd_clock_t   clock_lmem[1],
-                       void       * clock_mem     ) {
-   long   recal_avg  = 10e6L; /* 10ms */
-   long   recal_jit  = 0L;
-   double recal_hist = 0.;
-   double recal_frac = 0.;
-
-   long init_x0, init_y0;
-   int  clock_err = fd_clock_joint_read( _fd_tickcount, NULL, fd_log_wallclock_host, NULL, &init_x0, &init_y0, NULL );
-   if( FD_UNLIKELY( clock_err ) ) FD_LOG_ERR(( "fd_clock_joint_read failed (%i-%s)", clock_err, fd_clock_strerror( clock_err ) ));
-
-   /* spin for a bit */
-   long start_ticks = fd_tickcount();
-   while( fd_tickcount() < start_ticks + 20e6L ) FD_SPIN_PAUSE();
-
-   long init_x1, init_y1;
-   /**/ clock_err = fd_clock_joint_read( _fd_tickcount, NULL, fd_log_wallclock_host, NULL, &init_x1, &init_y1, NULL );
-   if( FD_UNLIKELY( clock_err ) ) FD_LOG_ERR(( "fd_clock_joint_read failed (%i-%s)", clock_err, fd_clock_strerror( clock_err ) ));
-
-   long init_dx = init_x1 - init_x0;
-   long init_dy = init_y1 - init_y0;
-   if( FD_UNLIKELY( !((init_dx>0L) & (init_dy>0L)) ) ) FD_LOG_ERR(( "initial calibration failed" ));
-
-   double init_w = (double)init_dx / (double)init_dy;
-
-   void * shclock = fd_clock_new( clock_mem, recal_avg, recal_jit, recal_hist, recal_frac, init_x1, init_y1, init_w );
-   if( FD_UNLIKELY( !shclock ) ) FD_LOG_ERR(( "fd_clock_new failed" ));
-
-   fd_clock_t * clock = fd_clock_join( clock_lmem, shclock, _fd_tickcount, NULL );
-   if( FD_UNLIKELY( !clock ) ) FD_LOG_ERR(( "fd_clock_join failed" ));
-   if( FD_UNLIKELY( clock!=clock_lmem ) ) FD_LOG_ERR(( "fd_clock_join did not return clock_lmem" ));
-}
-
-
-/* fd_clock_default_recal provides a default recalibration function to
-   accompany fd_clock_default_init. */
-
-static inline long
-fd_clock_default_recal( fd_clock_t * clock ) {
-  long x; long y;
-  int  err = fd_clock_joint_read( _fd_tickcount, NULL, fd_log_wallclock_host, NULL, &x, &y, NULL );
-  if( FD_UNLIKELY( err ) ) FD_LOG_WARNING(( "fd_clock_joint_read failed (%i-%s)", err, fd_clock_strerror( err ) ));
-  return fd_clock_recal( clock, x, y );
-}
-
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_util_clock_fd_clock_h */

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -1,8 +1,8 @@
 #include "../fd_quic_private.h"
 #include "fd_quic_test_helpers.h"
+#include "../../../disco/fd_clock_tile.h"
 
-static fd_clock_t clock[1];
-static fd_clock_shmem_t clock_shmem[1];
+static fd_clock_tile_t clock[1];
 
 uchar conn_final_cnt = 0;
 
@@ -66,14 +66,14 @@ void my_handshake_complete( fd_quic_conn_t * conn,
 __attribute__((noinline)) int
 service_client( fd_quic_t * quic ) {
   uchar buf[16] = {0}; FD_COMPILER_UNPREDICTABLE( buf[0] );
-  fd_quic_service( quic, fd_clock_now( clock ) );
+  fd_quic_service( quic, fd_clock_tile_now( clock ) );
   return 0;
 }
 
 __attribute__((noinline)) int
 service_server( fd_quic_t * quic ) {
   uchar buf[16] = {0}; FD_COMPILER_UNPREDICTABLE( buf[0] );
-  fd_quic_service( quic, fd_clock_now( clock ) );
+  fd_quic_service( quic, fd_clock_tile_now( clock ) );
   return 0;
 }
 
@@ -86,7 +86,7 @@ main( int     argc,
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  fd_clock_default_init( clock, clock_shmem );
+  fd_clock_tile_init( clock );
 
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
@@ -169,10 +169,10 @@ main( int     argc,
   FD_LOG_NOTICE(( "Initializing QUICs" ));
   FD_TEST( fd_quic_init( server_quic ) );
   FD_TEST( fd_quic_init( client_quic ) );
-  fd_quic_get_state( client_quic )->now = fd_quic_get_state( server_quic )->now = fd_clock_now( clock );
+  fd_quic_get_state( client_quic )->now = fd_quic_get_state( server_quic )->now = fd_clock_tile_now( clock );
 
   /* make a connection from client to server */
-  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0, fd_clock_now( clock ) );
+  fd_quic_conn_t * client_conn = fd_quic_connect( client_quic, 0U, 0, 0U, 0, fd_clock_tile_now( clock ) );
 
   FD_TEST( conn_final_cnt==0 );
 
@@ -208,13 +208,13 @@ main( int     argc,
   int rc = fd_quic_stream_send( client_stream, buf, sz, 1 );
   FD_LOG_INFO(( "fd_quic_stream_send returned %d", rc ));
 
-  long last_ts = fd_clock_now( clock );
+  long last_ts = fd_clock_tile_now( clock );
   long rprt_ts = last_ts + (long)1e9;
 
   long start_ts = last_ts;
   long end_ts   = start_ts + (long)(duration * 1e9f);
   while(1) {
-    long t = fd_clock_now( clock ); fd_quic_get_state( client_quic )->now = fd_quic_get_state( server_quic )->now = t;
+    long t = fd_clock_tile_now( clock ); fd_quic_get_state( client_quic )->now = fd_quic_get_state( server_quic )->now = t;
     service_client( client_quic );
     service_server( server_quic );
 
@@ -278,8 +278,8 @@ main( int     argc,
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( client_quic ) ) ) );
   fd_wksp_delete_anonymous( wksp );
-  fd_clock_leave( clock );
-  fd_clock_delete( clock_shmem );
+  fd_clock_leave( clock->clock );
+  fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -8,7 +8,7 @@
 
 #include "../../../ballet/sha512/fd_sha512.h"
 #include "../../../ballet/ed25519/fd_ed25519.h"
-#include "../../../tango/tempo/fd_tempo.h"
+#include "../../../disco/fd_clock_tile.h"
 #include "../../../waltz/quic/fd_quic_private.h"
 #include "../../../util/fd_util.h"
 #include "../../../util/net/fd_eth.h"
@@ -16,8 +16,7 @@
 
 static _Bool g_unreliable;
 
-static fd_clock_t clock[1];
-static fd_clock_shmem_t clock_shmem[1];
+static fd_clock_tile_t clock[1];
 
 int
 my_stream_rx_cb( fd_quic_conn_t * conn,
@@ -84,11 +83,11 @@ run_quic_client(
     FD_LOG_NOTICE(( "Starting QUIC client" ));
 
     /* make a connection from client to the server */
-    client_conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0, fd_clock_now( clock ) );
+    client_conn = fd_quic_connect( quic, dst_ip, dst_port, 0U, 0, fd_clock_tile_now( clock ) );
 
     /* do general processing */
     while( !client_complete ) {
-      fd_quic_service( quic, fd_clock_now( clock ) );
+      fd_quic_service( quic, fd_clock_tile_now( clock ) );
       fd_quic_udpsock_service( udpsock );
     }
 
@@ -156,7 +155,7 @@ run_quic_client(
 
   ulong stream_cnt = 0;
   ulong tot_sz     = 0;
-  long  t0         = fd_clock_now( clock );
+  long  t0         = fd_clock_tile_now( clock );
   ulong msg_sz     = MSG_SZ_MIN;
 
   /* Continually send data while we have a valid connection */
@@ -165,7 +164,7 @@ run_quic_client(
       break;
     }
 
-    fd_quic_service( quic, fd_clock_now( clock ) );
+    fd_quic_service( quic, fd_clock_tile_now( clock ) );
     fd_quic_udpsock_service( udpsock );
 
     /* obtain a free stream */
@@ -183,7 +182,7 @@ run_quic_client(
       msg_sz = fd_ulong_if( msg_sz>MSG_SZ_MAX, MSG_SZ_MIN, msg_sz );
     }
 
-    long t1 = fd_clock_now( clock );
+    long t1 = fd_clock_tile_now( clock );
     if( t1 >= t0 ) {
       printf( "streams=%lu sz=%g\n", stream_cnt, (double)tot_sz );
       stream_cnt = 0;
@@ -237,7 +236,7 @@ main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  fd_clock_default_init( clock, clock_shmem );
+  fd_clock_tile_init( clock );
 
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
@@ -300,8 +299,8 @@ main( int argc, char ** argv ) {
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( quic ) ) );
   fd_quic_udpsock_destroy( udpsock );
   fd_wksp_delete_anonymous( wksp );
-  fd_clock_leave( clock );
-  fd_clock_delete( clock_shmem );
+  fd_clock_leave( clock->clock );
+  fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_concurrency.c
+++ b/src/waltz/quic/tests/test_quic_concurrency.c
@@ -9,6 +9,7 @@
 #include "fd_quic_sandbox.h"
 #include "../fd_quic_proto.c"
 #include "../fd_quic_private.h"
+#include "../../../disco/fd_clock_tile.h"
 #include "../../../tango/tempo/fd_tempo.h"
 #include <string.h>
 
@@ -22,9 +23,8 @@ main( int     argc,
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
 
-  fd_clock_t clock[1];
-  fd_clock_shmem_t clock_shmem[1];
-  fd_clock_default_init( clock, clock_shmem );
+  fd_clock_tile_t clock[1];
+  fd_clock_tile_init( clock );
 
   char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"                   );
   ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                          );
@@ -74,7 +74,7 @@ main( int     argc,
   fd_quic_t * const quic = sandbox->quic;
   quic->config.idle_timeout = (ulong)100000e9;
   fd_quic_state_t * state = fd_quic_get_state( quic );
-  state->now = fd_clock_now( clock );
+  state->now = fd_clock_tile_now( clock );
 
   /* Create table of server-side conn objects to inject traffic into. */
 
@@ -93,13 +93,13 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "Test start (--conn-cnt %lu --duration %g s --conn-burst %lu)", conn_cnt, (double)duration, conn_burst ));
 
-  long test_finish = fd_clock_now( clock ) + (long)( duration * 1e9f );
+  long test_finish = fd_clock_tile_now( clock ) + (long)( duration * 1e9f );
 
   long  lazy        = 1e6; /* 1 ms */
   float tick_per_ns = (float)fd_tempo_tick_per_ns( NULL );
   ulong async_min   = fd_tempo_async_min( lazy, 1UL /*event_cnt*/, tick_per_ns );
 
-  long now  = fd_clock_now( clock );
+  long now  = fd_clock_tile_now( clock );
   long then = now;
 
   uchar frame_buf[ 1024 ];
@@ -111,7 +111,7 @@ main( int     argc,
   for(;;) {
 
     if( FD_UNLIKELY( (now-then)>=0L ) ) {
-      long ts = fd_clock_now( clock );
+      long ts = fd_clock_tile_now( clock );
       if( ts > test_finish ) break;
 
       if( ts-last_stat >= (long)1e9 ) {
@@ -124,7 +124,7 @@ main( int     argc,
       then = now + (long)fd_tempo_async_reload( rng, async_min );
     }
 
-    fd_quic_service( quic, fd_clock_now( clock ) );
+    fd_quic_service( quic, fd_clock_tile_now( clock ) );
 
     if( burst_idx==0UL ) {
       conn_idx  = fd_rng_ulong_roll( rng, conn_cnt );
@@ -143,7 +143,7 @@ main( int     argc,
     fd_quic_sandbox_send_lone_frame( sandbox, conn, frame_buf, sz );
     FD_TEST( conn->state==FD_QUIC_CONN_STATE_ACTIVE );
 
-    now = fd_clock_now( clock );
+    now = fd_clock_tile_now( clock );
     frame_cnt++;
 
   }
@@ -162,8 +162,8 @@ main( int     argc,
 
   fd_wksp_free_laddr( conn_list );
   fd_wksp_free_laddr( fd_quic_sandbox_delete( sandbox ) );
-  fd_clock_leave( clock );
-  fd_clock_delete( clock_shmem );
+  fd_clock_leave( clock->clock );
+  fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/waltz/quic/tests/test_quic_server.c
+++ b/src/waltz/quic/tests/test_quic_server.c
@@ -1,9 +1,8 @@
 #include "../fd_quic.h"
 #include "fd_quic_test_helpers.h"
-#include "../../../tango/tempo/fd_tempo.h"
+#include "../../../disco/fd_clock_tile.h"
 
-static fd_clock_t clock[1];
-static fd_clock_shmem_t clock_shmem[1];
+static fd_clock_tile_t clock[1];
 
 int
 main( int argc, char ** argv ) {
@@ -12,7 +11,7 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  fd_clock_default_init( clock, clock_shmem );
+  fd_clock_tile_init( clock );
 
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
@@ -89,7 +88,7 @@ main( int argc, char ** argv ) {
   /* do general processing */
   FD_LOG_NOTICE(( "Running" ));
   while(1) {
-    fd_quic_service( quic, fd_clock_now( clock ) );
+    fd_quic_service( quic, fd_clock_tile_now( clock ) );
     fd_quic_udpsock_service( udpsock );
   }
 
@@ -98,8 +97,8 @@ main( int argc, char ** argv ) {
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( quic ) ) );
   fd_quic_udpsock_destroy( udpsock );
   fd_wksp_delete_anonymous( wksp );
-  fd_clock_leave( clock );
-  fd_clock_delete( clock_shmem );
+  fd_clock_leave( clock->clock );
+  fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));


### PR DESCRIPTION
fd_clock_tile.h provides new APIs for fast arch-tickcount based
wallclock timestamps.

Overhauls the 'clock_default' API previously present in fd_clock.h:
- Fixes U.B. when calibration fails (invalid clock_joint_read)
- Greatly speeds up fd_clock_tile_now by avoiding expensive
  re-synchronziation and inlining timestamp calculation
- Polish clock recalibration API
