### PR TITLE
IBT and shadow stack support

### DIFF
--- a/config/extra/with-security.mk
+++ b/config/extra/with-security.mk
@@ -8,6 +8,13 @@ LDFLAGS+=-Wl,-z,relro,-z,now
 CPPFLAGS+=-fstack-protector-strong
 LDFLAGS+=-fstack-protector-strong
 
+ifdef FD_HAS_X86
+ifdef FD_HAS_LINUX
+CPPFLAGS+=-fcf-protection=full
+LDFLAGS_EXE+=-Wl,-z,ibt -Wl,-z,shstk -Wl,-z,cet-report=error
+endif
+endif
+
 # _FORTIFY_SOURCE only works when optimization is enabled
 ifeq ($(FD_DISABLE_OPTIMIZATION),)
 CPPFLAGS+=-D_FORTIFY_SOURCE=$(FORTIFY_SOURCE)

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -23,4 +23,5 @@ include config/extra/with-openssl.mk
 include config/extra/with-rocksdb.mk
 endif
 
+FD_HAS_X86:=1
 FD_ARCH_SUPPORTS_SANDBOX:=1

--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -46,11 +46,6 @@ BUILDDIR?=native/$(notdir $(CC))
 CPPFLAGS+=-march=native -mtune=native
 RUSTFLAGS+=-C target-cpu=native
 
-include config/extra/with-brutality.mk
-include config/extra/with-optimization.mk
-include config/extra/with-debug.mk
-include config/extra/with-security.mk
-
 $(call map-define,FD_HAS_SHANI, __SHA__)
 $(call map-define,FD_HAS_INT128, __SIZEOF_INT128__)
 FD_HAS_DOUBLE:=1
@@ -63,6 +58,11 @@ $(call map-define,FD_HAS_AVX, __AVX2__)
 $(call map-define,FD_HAS_GFNI, __GFNI__)
 $(call map-define,FD_IS_X86_64, __x86_64__)
 $(call map-define,FD_HAS_AESNI, __AES__)
+
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
 
 # Older version of GCC (<10) don't fully support AVX512, so we disable
 # it in those cases. Older versions of Clang (<8) don't support it

--- a/deps.sh
+++ b/deps.sh
@@ -37,8 +37,12 @@ DEVMODE=0
 MSAN=0
 _CC="${CC:=gcc}"
 _CXX="${CXX:=g++}"
-EXTRA_CFLAGS="-g3 -fno-omit-frame-pointer"
+EXTRA_CFLAGS="-g3"
 EXTRA_CXXFLAGS=""
+if [[ "$(uname -m)" == x86_64 ]]; then
+  EXTRA_CFLAGS+=" -fno-omit-frame-pointer -fcf-protection=full"
+  EXTRA_CXXFLAGS+=" -fno-omit-frame-pointer -fcf-protection=full"
+fi
 EXTRA_LDFLAGS=""
 
 help () {
@@ -401,6 +405,8 @@ install_libcxx () {
     -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
     -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-fcf-protection=full" \
+    -DCMAKE_CXX_FLAGS="-fcf-protection=full" \
     -DLLVM_DIR=".." \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     -DLLVM_USE_SANITIZER=Memory \
@@ -447,7 +453,11 @@ install_s2n () {
 
   echo "[+] Installing s2n-bignum to $PREFIX"
   if [[ "$(uname -m)" == x86_64 ]]; then
-    make -C x86
+    if [[ "$(uname -s)" == Linux ]]; then
+      make -C x86 PREPROCESS="$CC -E -fcf-protection=full -I../include -DWINDOWS_ABI=0 \$(SYMBOL_HIDING) -xassembler-with-cpp -"
+    else
+      make -C x86
+    fi
     cp x86/libs2nbignum.a "$PREFIX/lib"
   elif [[ "$(uname -m)" == aarch64 ]]; then
     make -C arm
@@ -462,7 +472,7 @@ install_blst () {
   cd "$PREFIX/git/blst"
 
   echo "[+] Building blst"
-  ./build.sh
+  CFLAGS="-O2 -fno-builtin -fPIC -Wall -Wextra -Werror $EXTRA_CFLAGS" ./build.sh
   echo "[+] Successfully built blst"
 
   echo "[+] Installing blst to $PREFIX"
@@ -543,7 +553,7 @@ install_openssl () {
     CONFIG_OPTS+=( enable-msan no-asm )
   fi
 
-  ./config "${CONFIG_OPTS[@]}"
+  CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CXXFLAGS" ./config "${CONFIG_OPTS[@]}"
   echo "[+] Configured OpenSSL"
 
   echo "[+] Building OpenSSL"

--- a/src/app/firedancer-dev/main.c
+++ b/src/app/firedancer-dev/main.c
@@ -2,10 +2,11 @@
 #include "../firedancer/topology.h"
 #include "../firedancer/config.h"
 #include "../shared_dev/boot/fd_dev_boot.h"
+#include "../../util/sandbox/fd_shstk.h"
 
 int
-main( int     argc,
-      char ** argv ) {
+main1( int     argc,
+       char ** argv ) {
   fd_config_file_t _default = fd_config_file_default();
   fd_config_file_t testnet = fd_config_file_testnet();
   fd_config_file_t devnet = fd_config_file_devnet();
@@ -24,4 +25,10 @@ main( int     argc,
   };
 
   return fd_dev_main( argc, argv, 1, configs, fd_topo_initialize );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_shstk_enter( main1, argc, argv );
 }

--- a/src/app/firedancer-dev/tests/test_firedancer_dev.c
+++ b/src/app/firedancer-dev/tests/test_firedancer_dev.c
@@ -10,6 +10,7 @@
 #include "../../shared_dev/boot/fd_dev_boot.h"
 #include "../../shared_dev/commands/wksp.h"
 #include "../../shared_dev/commands/dev.h"
+#include "../../../util/sandbox/fd_shstk.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -227,7 +228,13 @@ test_firedancer_dev( config_t * config ) {
 }
 
 int
+main1( int     argc,
+       char ** argv ) {
+  return firedancer_dev_test_run( argc, argv, test_firedancer_dev );
+}
+
+int
 main( int     argc,
       char ** argv ) {
-  return firedancer_dev_test_run( argc, argv, test_firedancer_dev );
+  fd_shstk_enter( main1, argc, argv );
 }

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #include "../shared/boot/fd_boot.h"
 #include "../shared/commands/configure/configure.h"
+#include "../../util/sandbox/fd_shstk.h"
 
 char const * FD_APP_NAME    = "Firedancer";
 char const * FD_BINARY_NAME = "firedancer";
@@ -178,8 +179,8 @@ action_t * ACTIONS[] = {
 };
 
 int
-main( int     argc,
-      char ** argv ) {
+main1( int     argc,
+       char ** argv ) {
   fd_config_file_t _default = fd_config_file_default();
   fd_config_file_t testnet = fd_config_file_testnet();
   fd_config_file_t devnet = fd_config_file_devnet();
@@ -194,6 +195,12 @@ main( int     argc,
   };
 
   return fd_main( argc, argv, 1, configs, fd_topo_initialize );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_shstk_enter( main1, argc, argv );
 }
 
 /* Kind of a hack for now, we sometimes want to view bench generation

--- a/src/ballet/aes/fd_aes_gcm_aesni.S
+++ b/src/ballet/aes/fd_aes_gcm_aesni.S
@@ -1143,3 +1143,21 @@ SYM_FUNC_END(aes_gcm_enc_final_aesni_avx)
 SYM_FUNC_START(aes_gcm_dec_final_aesni_avx)
 	_aes_gcm_final	0
 SYM_FUNC_END(aes_gcm_dec_final_aesni_avx)
+
+# Advertise IBT, SHSTK compliance
+.section ".note.gnu.property", "a"
+.p2align 3
+.long 1f - 0f
+.long 4f - 1f
+.long 5
+0:
+.byte 0x47, 0x4e, 0x55, 0
+1:
+.p2align 3
+.long 0xc0000002
+.long 3f - 2f
+2:
+.long 3
+3:
+.p2align 3
+4:

--- a/src/ballet/aes/fd_aes_gcm_avx10.S
+++ b/src/ballet/aes/fd_aes_gcm_avx10.S
@@ -1238,3 +1238,21 @@ SYM_FUNC_END(aes_gcm_enc_final_vaes_avx10)
 SYM_FUNC_START(aes_gcm_dec_final_vaes_avx10)
 	_aes_gcm_final	0
 SYM_FUNC_END(aes_gcm_dec_final_vaes_avx10)
+
+# Advertise IBT, SHSTK compliance
+.section ".note.gnu.property", "a"
+.p2align 3
+.long 1f - 0f
+.long 4f - 1f
+.long 5
+0:
+.byte 0x47, 0x4e, 0x55, 0
+1:
+.p2align 3
+.long 0xc0000002
+.long 3f - 2f
+2:
+.long 3
+3:
+.p2align 3
+4:

--- a/src/ballet/reedsol/fd_reedsol_gfni_32.S
+++ b/src/ballet/reedsol/fd_reedsol_gfni_32.S
@@ -17,6 +17,7 @@ gfni_const_tbl:
 fd_reedsol_private_encode_32_32:
 .globl fd_reedsol_private_encode_32_32
 .cfi_startproc
+endbr64
 
 # This file implements the FFT-like O(n log n) algorithm for computing Reed
 # Solomon parity as described in
@@ -412,3 +413,21 @@ ret
 .align 16
 
 .cfi_endproc
+
+# Advertise IBT, SHSTK compliance
+.section ".note.gnu.property", "a"
+.p2align 3
+.long 1f - 0f
+.long 4f - 1f
+.long 5
+0:
+.byte 0x47, 0x4e, 0x55, 0
+1:
+.p2align 3
+.long 0xc0000002
+.long 3f - 2f
+2:
+.long 3
+3:
+.p2align 3
+4:

--- a/src/ballet/sha512/fd_sha512_core_avx2.S
+++ b/src/ballet/sha512/fd_sha512_core_avx2.S
@@ -13,6 +13,7 @@
 .align	64
 fd_sha512_core_avx2:
 .cfi_startproc
+	endbr64
 	movq	%rsp,%rax
 .cfi_def_cfa_register	%rax
 	pushq	%rbx
@@ -1476,3 +1477,21 @@ fd_sha512_core_avx2_k:
 .quad	0x0001020304050607,0x08090a0b0c0d0e0f
 .quad	0x0001020304050607,0x08090a0b0c0d0e0f
 .byte	83,72,65,53,49,50,32,98,108,111,99,107,32,116,114,97,110,115,102,111,114,109,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
+
+# Advertise IBT, SHSTK compliance
+.section ".note.gnu.property", "a"
+.p2align 3
+.long 1f - 0f
+.long 4f - 1f
+.long 5
+0:
+.byte 0x47, 0x4e, 0x55, 0
+1:
+.p2align 3
+.long 0xc0000002
+.long 3f - 2f
+2:
+.long 3
+3:
+.p2align 3
+4:

--- a/src/util/sandbox/Local.mk
+++ b/src/util/sandbox/Local.mk
@@ -10,6 +10,13 @@ $(call add-hdrs,fd_pkeys.h)
 $(call add-objs,fd_pkeys,fd_util)
 $(call make-unit-test,test_pkeys,test_pkeys,fd_util)
 $(call run-unit-test,test_pkeys)
+
+$(call add-hdrs,fd_shstk.h)
+$(call add-objs,fd_shstk,fd_util)
+$(call make-unit-test,test_shstk,test_shstk,fd_util)
+$(call run-unit-test,test_shstk)
+$(call make-unit-test,test_rop,test_rop,fd_util)
+$(eval $(call _make-exe,test_rop_nocet,test_rop,fd_util,unit-test,unit-test,)) # no linker flags
 endif
 endif
 endif

--- a/src/util/sandbox/fd_shstk.c
+++ b/src/util/sandbox/fd_shstk.c
@@ -1,0 +1,88 @@
+#define _GNU_SOURCE
+#include "fd_shstk.h"
+#include "../fd_util.h"
+#include <errno.h>
+#include <stdlib.h>
+/* GCC 11 complains about "unused parameters" on naked functions */
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#if FD_HAS_HOSTED && defined(__linux__) && defined(__x86_64__) && !FD_HAS_ASAN && !FD_HAS_MSAN && !FD_HAS_UBSAN
+
+#ifndef ARCH_SHSTK_ENABLE
+#define ARCH_SHSTK_ENABLE 0x5001
+#endif
+
+#ifndef ARCH_SHSTK_LOCK
+#define ARCH_SHSTK_LOCK 0x5003
+#endif
+
+#ifndef ARCH_SHSTK_STATUS
+#define ARCH_SHSTK_STATUS 0x5005
+#endif
+
+#ifndef ARCH_SHSTK_SHSTK
+#define ARCH_SHSTK_SHSTK 1
+#endif
+
+#include <asm/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+__attribute__((noreturn))
+void
+fd_shstk_enter( int (* main_fn)( int     argc,
+                                 char ** argv ),
+                int     argc,
+                char ** argv ) {
+
+  ulong feature;
+  int status = (int)syscall( SYS_arch_prctl, ARCH_SHSTK_STATUS, &feature );
+  if( FD_UNLIKELY( status ) ) {
+    FD_LOG_WARNING(( "sandbox: could not detect if shadow stack is enabled (%i-%s), trying to enable them anyway", errno, fd_io_strerror( errno ) ));
+  } else if( feature & ARCH_SHSTK_SHSTK ) {
+    FD_LOG_INFO(( "sandbox: shadow stack enabled by libc" ));
+    /* Lock shadow stack feature in case libc did not */
+    (void)syscall( SYS_arch_prctl, ARCH_SHSTK_LOCK, ARCH_SHSTK_SHSTK );
+    exit( main_fn( argc, argv ) );
+  } else {
+    FD_LOG_INFO(( "sandbox: shadow stack not enabled by libc, enabling" ));
+  }
+
+  /* Dispatch a syscall without using the stack */
+
+  long enable_res;
+  __asm__ volatile (
+    "syscall"
+    : "=a" (enable_res)
+    : "a" ((ulong)SYS_arch_prctl),
+      "D" ((ulong)ARCH_SHSTK_ENABLE),
+      "S" ((ulong)ARCH_SHSTK_SHSTK)
+    : "rcx", "r11", "memory"
+  );
+
+  /* Now that shadow stack is enabled, we can no longer return from this
+     function, since that would cause a CET violation. */
+
+  if( FD_UNLIKELY( enable_res!=0 ) ) {
+    FD_LOG_WARNING(( "sandbox: failed to enable shadow stack (%ld-%s), running with weakened sandbox", -enable_res, fd_io_strerror( -(int)enable_res ) ));
+  } else {
+    int rc = (int)syscall( SYS_arch_prctl, ARCH_SHSTK_LOCK, ARCH_SHSTK_SHSTK );
+    if( FD_UNLIKELY( rc ) ) FD_LOG_WARNING(( "sandbox: failed to enforce shadow stack (arch_prctl(ARCH_SHSTK_LOCK,ARCH_SHSTK_SHSTK) failed (%i-%s))", errno, fd_io_strerror( errno ) ));
+    FD_LOG_INFO(( "sandbox: shadow stack enabled" ));
+  }
+  exit( main_fn( argc, argv ) );
+}
+
+#else /* portable variant */
+
+__attribute__((noreturn))
+void
+fd_shstk_enter( int (* main_fn)( int     argc,
+                                 char ** argv ),
+                int     argc,
+                char ** argv ) {
+  FD_LOG_INFO(( "sandbox: build does not support shadow stack" ));
+  exit( main_fn( argc, argv ) );
+}
+
+#endif

--- a/src/util/sandbox/fd_shstk.h
+++ b/src/util/sandbox/fd_shstk.h
@@ -1,0 +1,29 @@
+#ifndef HEADER_fd_src_util_sandbox_fd_shstk_h
+#define HEADER_fd_src_util_sandbox_fd_shstk_h
+
+/* fd_shstk.h enables x86 shadow stack even if the libc is too old to
+   support shadow stacks. */
+
+#include "../fd_util_base.h"
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_shstk_enter attempts to enable x86 shadow stack support, then
+   runs *main_fn.  The return value of main_fn is passed to exit(3).
+   If shadow stack enabling fails (due to lack of arch/kernel support),
+   logs warning, but continues running main_fn.  Should be run after
+   fd_boot.
+
+   WARNING: Incompatible with setjmp/longjmp, which may not support
+            shadow stacks. */
+
+__attribute__((noreturn))
+void
+fd_shstk_enter( int (* main_fn)( int     argc,
+                                 char ** argv ),
+                int     argc,
+                char ** argv );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_util_sandbox_fd_shstk_h */

--- a/src/util/sandbox/test_rop.c
+++ b/src/util/sandbox/test_rop.c
@@ -1,0 +1,33 @@
+#define _GNU_SOURCE
+#include "../fd_util.h"
+#include "fd_shstk.h"
+
+__attribute__((used,noinline,noreturn)) static void
+rop_target( void ) {
+  FD_LOG_ERR(( "ROP attack succeeded. IBT/SHSTK is not active" ));
+}
+
+__attribute__((naked,noinline,noreturn)) static void
+rop_attack( void ) {
+  __asm__(
+    "leaq rop_target(%rip), %rax\n\t"
+    "movq %rax, (%rsp)\n\t"
+    "ret\n\t"
+  );
+}
+
+static int
+main1( int     argc,
+       char ** argv ) {
+  (void)argc; (void)argv;
+  rop_attack();
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  int shstk = fd_env_strip_cmdline_contains( &argc, &argv, "--shstk" );
+  if( shstk ) fd_shstk_enter( main1, argc, argv );
+  else        return main1( argc, argv );
+}

--- a/src/util/sandbox/test_shstk.c
+++ b/src/util/sandbox/test_shstk.c
@@ -1,0 +1,54 @@
+#define _GNU_SOURCE
+#include "fd_shstk.h"
+#include "../fd_util.h"
+#include <asm/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef ARCH_SHSTK_ENABLE
+#define ARCH_SHSTK_ENABLE  (0x5001)
+#endif
+
+#ifndef ARCH_SHSTK_STATUS
+#define ARCH_SHSTK_STATUS  (0x5005)
+#endif
+
+#ifndef ARCH_SHSTK_SHSTK
+#define ARCH_SHSTK_SHSTK   (1ULL << 0)
+#endif
+
+static int
+test_shstk_enabled( void ) {
+  ulong features = 0UL;
+  if( FD_LIKELY( 0==syscall( SYS_arch_prctl, ARCH_SHSTK_STATUS, &features ) ) ) {
+    return !!(features & ARCH_SHSTK_SHSTK);
+  }
+  return 0;
+}
+
+static int
+main1( int     argc,
+       char ** argv ) {
+  (void)argc; (void)argv;
+#if !defined(__CET__)
+    FD_LOG_NOTICE(( "compiler CET support: no" ));
+#else
+#  if (__CET__ & 0x1) != 0
+     FD_LOG_NOTICE(( "compiler CET support: indirect branch" ));
+#  endif
+#  if (__CET__ & 0x2) != 0
+     FD_LOG_NOTICE(( "compiler CET support: return" ));
+#  endif
+#endif
+  FD_LOG_NOTICE(( "shadow stack enabled: %s", test_shstk_enabled() ? "yes" : "no" ));
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_shstk_enter( main1, argc, argv );
+}


### PR DESCRIPTION
Update all compile units in Firedancer to support IBT and shadow stack.
IBT attempts to prevent hijacking of indirect call / jmp, and shadow stack hardens against ROP attacks.

Add a `fd_shstk` API for enabling shadow stacks even on old libc versions.

IBT is only available on Intel CPUs. 
Shadow stack is available on Intel Skylake-SP or AMD Zen 3 and newer, but requires at least Linux 6.4. 
Linux 6.6 makes shadow stack protections stronger. 

-------------

- **ballet: mark asm code as IBT/SHSTK compliant**
- **deps.sh: IBT/SHSTK support**
- **config: enable x86 IBT, shadow stack**
- **sandbox: add shadow stack support**
- **app: enable shadow stack for full Firedancer**
