### PR TITLE
ballet: speedup fd_hex with simd

### DIFF
--- a/src/ballet/hex/Local.mk
+++ b/src/ballet/hex/Local.mk
@@ -1,5 +1,7 @@
 $(call add-hdrs,fd_hex.h)
 $(call add-objs,fd_hex,fd_ballet)
+$(call make-unit-test,test_hex,test_hex,fd_hex fd_ballet fd_util)
+$(call run-unit-test,test_hex)
 ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_hex,fuzz_hex,fd_ballet fd_util)
 endif

--- a/src/ballet/hex/fd_hex.c
+++ b/src/ballet/hex/fd_hex.c
@@ -1,6 +1,5 @@
 #include "fd_hex.h"
 
-/* FIXME use LUT instead? */
 static inline int
 fd_hex_unhex( int c ) {
   if( c>='0' && c<='9' ) return c-'0';
@@ -9,19 +8,96 @@ fd_hex_unhex( int c ) {
   return -1;
 }
 
-/* TODO: add AVX version */
+#if FD_HAS_AVX
+#include "../../util/simd/fd_sse.h"
+#include "../../util/simd/fd_avx.h"
+
+static inline wb_t
+decode_32( wb_t   c,
+           uint * invalid ) {
+  wb_t lower       = wb_or( c, wb_bcast( 0x20 ) );
+  wb_t alpha       = wb_and( wb_gt( lower, wb_bcast( '`' ) ), wb_gt( wb_bcast( 'g' ), lower ) );
+  wb_t digit       = wb_and( wb_gt( c, wb_bcast( '/' ) ),     wb_gt( wb_bcast( ':' ), c ) );
+  wb_t valid       = wb_or( digit, alpha );
+  wb_t nibbles     = wb_add( wb_and( c, wb_bcast( 0x0f ) ), wb_notczero( alpha, wb_bcast( 9 ) ) );
+  wb_t pairs       = _mm256_maddubs_epi16( nibbles, wh_bcast( 0x0110 ) );
+  wb_t compressed  = _mm256_shuffle_epi8( pairs, wb_bcast_hex( 0x00,0x02,0x04,0x06,0x08,0x0A,0x0C,0x0E,
+                                                               0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF ) );
+
+  *invalid = (uint)_mm256_movemask_epi8( wb_lnot( valid ) );
+  return _mm256_permute4x64_epi64( compressed, 0xd8 );
+}
+
+static inline wb_t
+encode_16( vb_t x ) {
+  wb_t expanded = _mm256_cvtepu8_epi16( x );
+  wb_t nibbles  = wb_and( wb_or( wh_shr( expanded, 4 ), wh_shl( expanded, 8 ) ), wb_bcast( 0x0f ) );
+  wb_t adjust   = wb_notczero( wb_gt( nibbles, wb_bcast( 9 ) ), wb_bcast( 39 ) );
+  return wb_add( wb_add( nibbles, adjust ), wb_bcast( '0' ) );
+}
+
+#endif
+
+#if FD_HAS_AVX512
+#include "../../util/simd/fd_avx512.h"
+
+static inline wb_t
+decode_64( wwb_t   c,
+           ulong * invalid ) {
+  wwb_t lower      = wwb_or( c, wwb_bcast( 0x20 ) );
+  ulong alpha      = wwb_gt( lower, wwb_bcast( '`' ) ) & wwb_gt( wwb_bcast( 'g' ), lower );
+  ulong digit      = wwb_gt( c, wwb_bcast( '/' ) )     & wwb_gt( wwb_bcast( ':' ), c );
+  ulong valid      = digit | alpha;
+  wwb_t nibbles    = wwb_add( wwb_and( c, wwb_bcast( 0x0f ) ), _mm512_maskz_set1_epi8( alpha, 9 ) );
+  wwb_t pairs      = _mm512_maddubs_epi16( nibbles, wwh_bcast( 0x0110 ) );
+  wwb_t compressed = _mm512_shuffle_epi8( pairs, wwb_bcast_hex( 0x00,0x02,0x04,0x06,0x08,0x0A,0x0C,0x0E,
+                                                                0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF ) );
+
+  *invalid = ~valid;
+  return _mm512_castsi512_si256( _mm512_maskz_compress_epi64( (__mmask8)0x55, compressed ) );
+}
+
+static inline wwb_t
+encode_32( wb_t x ) {
+  wwb_t expanded = _mm512_cvtepu8_epi16( x );
+  wwb_t nibbles  = wwb_and( wwb_or( wwh_shr( expanded, 4 ), wwh_shl( expanded, 8 ) ), wwb_bcast( 0x0f ) );
+  wwb_t adjust   = _mm512_maskz_set1_epi8( wwb_gt( nibbles, wwb_bcast( 9 ) ), 39 );
+  return wwb_add( wwb_add( nibbles, adjust ), wwb_bcast( '0' ) );
+}
+
+#endif
 
 ulong
 fd_hex_decode( void *       _dst,
                char const * hex,
                ulong        sz ) {
-
+  uchar const * src = (uchar const *)hex;
   uchar * dst = _dst;
 
-  ulong i;
-  for( i=0; i<sz; i++ ) {
-    int hi = fd_hex_unhex( *hex++ );
-    int lo = fd_hex_unhex( *hex++ );
+  ulong i=0UL;
+#if FD_HAS_AVX512
+  for( ; i+32UL<=sz; i+=32UL ) {
+    ulong invalid;
+    wb_t bytes = decode_64( wwb_ldu( src + 2UL*i ), &invalid );
+    if( FD_UNLIKELY( invalid ) ) return i + (ulong)fd_ulong_find_lsb( invalid )/2UL;
+    wb_stu( fd_type_pun( dst + i ), bytes );
+  }
+#endif
+#if FD_HAS_AVX
+  for( ; i+16UL<=sz; i+=16UL ) {
+    uint invalid;
+    wb_t bytes = decode_32( wb_ldu( src + 2UL*i ), &invalid );
+    if( FD_UNLIKELY( invalid ) ) return i + (ulong)fd_uint_find_lsb( invalid )/2UL;
+    vb_stu( fd_type_pun( dst + i ), _mm256_castsi256_si128( bytes ) );
+  }
+#endif
+
+  src += 2UL*i;
+  dst += i;
+
+  for( ; i<sz; i++ ) {
+    int hi = fd_hex_unhex( *src++ );
+    int lo = fd_hex_unhex( *src++ );
     if( FD_UNLIKELY( (hi<0) | (lo<0) ) ) return i;
     *dst++ = (uchar)( ((uint)hi<<4) | (uint)lo );
   }
@@ -33,10 +109,27 @@ char *
 fd_hex_encode( char *       dst,
                void const * _src,
                ulong        sz ) {
+
   uchar const * src = (uchar const *)_src;
-  static char const lut[ 16 ] = {
-    '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'
-  };
+  ulong j=0UL;
+#if FD_HAS_AVX512
+  for( ; j+32UL<=sz; j+=32UL ) {
+    wwb_t out = encode_32( wb_ldu( src + j ) );
+    wwb_stu( fd_type_pun( dst + 2UL*j ), out );
+  }
+#endif
+#if FD_HAS_AVX
+  for( ; j+16UL<=sz; j+=16UL ) {
+    wb_t out = encode_16( vb_ldu( fd_type_pun_const( src + j ) ) );
+    wb_stu( fd_type_pun( dst + 2UL*j ), out );
+  }
+#endif
+
+  src += j;
+  dst += 2UL*j;
+  sz  -= j;
+
+  static char const lut[ 16 ] = { '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' };
   for( ulong j=0UL; j<sz; j++ ) {
     ulong c = src[j];
     *dst++ = lut[ c >> 4UL ];
@@ -44,4 +137,3 @@ fd_hex_encode( char *       dst,
   }
   return dst;
 }
-

--- a/src/ballet/hex/test_hex.c
+++ b/src/ballet/hex/test_hex.c
@@ -1,0 +1,199 @@
+#include "fd_hex.h"
+#include "../fd_ballet.h"
+
+struct fd_hex_test_vec {
+  ulong        raw_len;
+  uchar const * raw;
+  char const *  hex;
+};
+
+typedef struct fd_hex_test_vec fd_hex_test_vec_t;
+
+static fd_hex_test_vec_t const test_vector[] = {
+  { 0UL, (uchar const *)"",
+    "" },
+  { 1UL, (uchar const *)"\x00",
+    "00" },
+  { 1UL, (uchar const *)"\xff",
+    "ff" },
+  { 1UL, (uchar const *)"\xab",
+    "ab" },
+  { 3UL, (uchar const *)"\xde\xad\xbe",
+    "deadbe" },
+  { 4UL, (uchar const *)"\xca\xfe\xba\xbe",
+    "cafebabe" },
+  { 8UL, (uchar const *)"\x01\x23\x45\x67\x89\xab\xcd\xef",
+    "0123456789abcdef" },
+  { 16UL, (uchar const *)"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
+    "00112233445566778899aabbccddeeff" },
+  { 32UL, (uchar const *)"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+                          "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" },
+  { .raw_len = ULONG_MAX }
+};
+
+static char const * const test_decode_upper[] = {
+  "DEADBEEF",
+  "0123456789ABCDEF",
+  "00112233445566778899AABBCCDDEEFF",
+  NULL
+};
+
+static uchar const test_decode_upper_raw[][16] = {
+  { 0xde, 0xad, 0xbe, 0xef },
+  { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef },
+  { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff },
+};
+
+static ulong const test_decode_upper_len[] = { 4, 8, 16 };
+
+static char const * const test_corrupt[] = {
+  "0g",
+  "g0",
+  "zz",
+  "0!",
+  " 0",
+  "0\n",
+  NULL
+};
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  for( fd_hex_test_vec_t const * test = test_vector; test->raw_len != ULONG_MAX; test++ ) {
+
+    ulong sz = test->raw_len;
+
+    do {
+      char enc[ 256 ];
+      char * end = fd_hex_encode( enc, test->raw, sz );
+      FD_TEST( (ulong)(end - enc) == sz*2UL );
+      FD_TEST( 0==memcmp( enc, test->hex, sz*2UL ) );
+    } while(0);
+
+    do {
+      uchar dec[ 128 ];
+      ulong ret = fd_hex_decode( dec, test->hex, sz );
+      FD_TEST( ret == sz );
+      FD_TEST( 0==memcmp( dec, test->raw, sz ) );
+    } while(0);
+  }
+
+  for( ulong i=0UL; test_decode_upper[i]; i++ ) {
+    uchar dec[ 128 ];
+    ulong sz  = test_decode_upper_len[i];
+    ulong ret = fd_hex_decode( dec, test_decode_upper[i], sz );
+    FD_TEST( ret == sz );
+    FD_TEST( 0==memcmp( dec, test_decode_upper_raw[i], sz ) );
+  }
+
+  for( char const * const * corrupt = test_corrupt; *corrupt; corrupt++ ) {
+    uchar dec[ 128 ];
+    ulong ret = fd_hex_decode( dec, *corrupt, 1UL );
+    if( FD_UNLIKELY( ret==1UL ) ) FD_LOG_ERR(( "decode should have failed: \"%s\"", *corrupt ));
+  }
+
+  for( ulong corrupt_idx=0UL; corrupt_idx<160UL; corrupt_idx++ ) {
+    char  enc[ 160 ];
+    uchar dec[ 80 ];
+    memset( enc, 'a', sizeof(enc) );
+    enc[ corrupt_idx ] = 'g';
+
+    ulong ret = fd_hex_decode( dec, enc, sizeof(dec) );
+    FD_TEST( ret == corrupt_idx/2UL );
+  }
+
+  for( ulong iter=0UL; iter<100000UL; iter++ ) {
+    uchar raw[ 256 ];
+    uchar dec[ 256 ];
+    char  enc[ 512 ];
+    ulong sz = fd_rng_uint_roll( rng, sizeof(raw) );
+    for( ulong j=0UL; j<sz; j++ ) raw[j] = (uchar)fd_rng_uchar( rng );
+    fd_hex_encode( enc, raw, sz );
+    ulong ret = fd_hex_decode( dec, enc, sz );
+    FD_TEST( ret == sz );
+    FD_TEST( fd_memeq( raw, dec, sz ) );
+  }
+
+  do {
+#if FD_HAS_AVX512
+#define BENCH_SIZE (32768UL)
+#else
+#define BENCH_SIZE (4096UL)
+#endif
+    static uchar raw[ BENCH_SIZE ];
+    static char  enc[ 2UL*BENCH_SIZE ];
+
+    for( ulong j=0; j<sizeof(raw); j++ ) raw[j] = (uchar)fd_rng_uchar( rng );
+    fd_hex_encode( enc, raw, sizeof(raw) );
+
+    ulong const sz = sizeof(raw);
+
+    /* Encode */
+    for( ulong rem=10000UL; rem; rem-- ) fd_hex_encode( enc, raw, sz );
+
+    ulong iter = 100000UL;
+    long  dt   = -fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) fd_hex_encode( enc, raw, sz );
+    dt += fd_log_wallclock();
+    double gbps = ((double)(8UL * sz * iter)) / ((double)dt);
+    double ns   = (double)dt / ((double)iter * (double)sz);
+    FD_LOG_NOTICE(( "encode %5lu B: ~%6.3f Gbps / core, ~%6.3f ns / byte", sz, gbps, ns ));
+
+    /* Decode */
+    for( ulong rem=10000UL; rem; rem-- ) fd_hex_decode( raw, enc, sz );
+
+    dt = -fd_log_wallclock();
+    for( ulong rem=iter; rem; rem-- ) fd_hex_decode( raw, enc, sz );
+    dt += fd_log_wallclock();
+    gbps = ((double)(8UL * sz * iter)) / ((double)dt);
+    ns   = (double)dt / ((double)iter * (double)sz);
+    FD_LOG_NOTICE(( "decode %5lu B: ~%6.3f Gbps / core, ~%6.3f ns / byte", sz, gbps, ns ));
+#undef BENCH_SIZE
+  } while(0);
+
+  do {
+#define MAX_SMALL_BENCH (512UL)
+    ulong const sizes[] = { 32UL, 64UL, 128UL, 256UL, 512UL };
+    ulong const n_sizes = sizeof(sizes) / sizeof(sizes[0]);
+
+    for( ulong si=0UL; si<n_sizes; si++ ) {
+      ulong sz = sizes[si];
+      uchar raw[ MAX_SMALL_BENCH ];
+      char  enc[ 2UL*MAX_SMALL_BENCH ];
+      for( ulong j=0; j<sz; j++ ) raw[j] = (uchar)fd_rng_uchar( rng );
+      fd_hex_encode( enc, raw, sz );
+
+      ulong iter = 1000000UL;
+
+      /* Encode */
+      for( ulong rem=10000UL; rem; rem-- ) fd_hex_encode( enc, raw, sz );
+      long dt = -fd_log_wallclock();
+      for( ulong rem=iter; rem; rem-- ) fd_hex_encode( enc, raw, sz );
+      dt += fd_log_wallclock();
+      double gbps = ((double)(8UL * sz * iter)) / ((double)dt);
+      double ns   = (double)dt / ((double)iter * (double)sz);
+      FD_LOG_NOTICE(( "encode %5lu B: ~%6.3f Gbps / core, ~%6.3f ns / byte", sz, gbps, ns ));
+
+      /* Decode */
+      for( ulong rem=10000UL; rem; rem-- ) fd_hex_decode( raw, enc, sz );
+      dt = -fd_log_wallclock();
+      for( ulong rem=iter; rem; rem-- ) fd_hex_decode( raw, enc, sz );
+      dt += fd_log_wallclock();
+      gbps = ((double)(8UL * sz * iter)) / ((double)dt);
+      ns   = (double)dt / ((double)iter * (double)sz);
+      FD_LOG_NOTICE(( "decode %5lu B: ~%6.3f Gbps / core, ~%6.3f ns / byte", sz, gbps, ns ));
+    }
+#undef MAX_SMALL_BENCH
+  } while(0);
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/util/simd/fd_avx512_wwb.h
+++ b/src/util/simd/fd_avx512_wwb.h
@@ -107,6 +107,7 @@ wwb_bcast_hex( uchar b0, uchar b1, uchar b2,  uchar b3,  uchar b4,  uchar b5,  u
 
 /* Arithmetic operations */
 
+#define wwb_add(a,b)  _mm512_add_epi8( (a), (b) )  /* [ a0+b0, a1+b1, ... a63+b63 ] */
 #define wwb_subs(a,b) _mm512_subs_epu8( (a), (b) ) /* [ a0-b0, a1-b1, ... a63-b63 ] */
 
 
@@ -115,6 +116,7 @@ wwb_bcast_hex( uchar b0, uchar b1, uchar b2,  uchar b3,  uchar b4,  uchar b5,  u
 
 #define wwb_eq(x,y) ((ulong)_mm512_cmpeq_epi8_mask(  (x), (y) )) /* mask( x0==y0, x1==y1, ... ) */
 #define wwb_ne(x,y) ((ulong)_mm512_cmpneq_epi8_mask( (x), (y) )) /* mask( x0!=y0, x1!=y1, ... ) */
+#define wwb_gt(x,y) ((ulong)_mm512_cmpgt_epu8_mask( (x), (y) ))  /* mask( x0>y0,  x1>y1,  ... ) */
 
 /* Memory operations */
 

--- a/src/util/simd/fd_avx512_wwh.h
+++ b/src/util/simd/fd_avx512_wwh.h
@@ -13,6 +13,13 @@
 
 #define wwh_t __m512i
 
+/* Constructors */
+
+/* Given the ushort values, return ... */
+
+#define wwh_bcast(b0) _mm512_set1_epi16( (ushort)(b0) ) /* [ b0 b0 ... b0 ] */
+
+
 /* Predefined constants */
 
 #define wwh_zero()           _mm512_setzero_si512()  /* wwh(0, 0, ... 0) */
@@ -32,3 +39,9 @@ static inline void  wwh_stu( void * m, wwh_t x ) { _mm512_storeu_epi32( m, x ); 
 
 #define wwh_add(x,y) _mm512_add_epi16( (x), (y) ) /* wwh( x0+y0, x1+y1, ... xf+y31 ) */
 #define wwh_sub(x,y) _mm512_sub_epi16( (x), (y) ) /* wwh( x0-y0, x1-y1, ... xf-y31 ) */
+
+
+/* Bit operations */
+
+#define wwh_shl(a,imm) _mm512_slli_epi16( (a), (imm) ) /* [ a0<<imm a1<<imm ... a31<<imm ] */
+#define wwh_shr(a,imm) _mm512_srli_epi16( (a), (imm) ) /* [ a0>>imm a1>>imm ... a31>>imm ] */


### PR DESCRIPTION
Before (GCC);
```
encode 32768 B: ~12.225 Gbps / core, ~ 0.654 ns / byte
decode 32768 B: ~ 4.278 Gbps / core, ~ 1.870 ns / byte
encode    32 B: ~11.275 Gbps / core, ~ 0.710 ns / byte
decode    32 B: ~ 6.009 Gbps / core, ~ 1.331 ns / byte
encode    64 B: ~11.801 Gbps / core, ~ 0.678 ns / byte
decode    64 B: ~ 6.127 Gbps / core, ~ 1.306 ns / byte
encode   128 B: ~12.072 Gbps / core, ~ 0.663 ns / byte
decode   128 B: ~ 5.972 Gbps / core, ~ 1.340 ns / byte
encode   256 B: ~11.761 Gbps / core, ~ 0.680 ns / byte
decode   256 B: ~ 5.908 Gbps / core, ~ 1.354 ns / byte
encode   512 B: ~12.044 Gbps / core, ~ 0.664 ns / byte
decode   512 B: ~ 4.991 Gbps / core, ~ 1.603 ns / byte
```
After:
```
encode 32768 B: ~127.380 Gbps / core, ~ 0.063 ns / byte
decode 32768 B: ~91.292 Gbps / core, ~ 0.088 ns / byte
encode    32 B: ~78.264 Gbps / core, ~ 0.102 ns / byte
decode    32 B: ~59.996 Gbps / core, ~ 0.133 ns / byte
encode    64 B: ~114.382 Gbps / core, ~ 0.070 ns / byte
decode    64 B: ~78.669 Gbps / core, ~ 0.102 ns / byte
encode   128 B: ~128.247 Gbps / core, ~ 0.062 ns / byte
decode   128 B: ~87.095 Gbps / core, ~ 0.092 ns / byte
encode   256 B: ~127.745 Gbps / core, ~ 0.063 ns / byte
decode   256 B: ~89.466 Gbps / core, ~ 0.089 ns / byte
encode   512 B: ~127.837 Gbps / core, ~ 0.063 ns / byte
decode   512 B: ~90.252 Gbps / core, ~ 0.089 ns / byte
```
9-14x speedup with avx512.