### PR TITLE
config: shuffle program code when linking

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -21,6 +21,16 @@ AUX_RULES:=clean distclean help run-unit-test run-integration-test cov-report di
 # Dry rules that should set up dependency targets, but not generate them
 DRY_RULES:=check show-deps proof
 
+# If LD_RANDOMIZE is requested, add the --shuffle-sections link flag
+ifeq ($(LD_RANDOMIZE),1)
+FD_LINKER_HELP:=$(shell $(LD) $(LDFLAGS) -Wl,--help 2>/dev/null)
+ifneq ($(findstring --shuffle-sections=<section-glob>=<seed>,$(FD_LINKER_HELP)),)
+LDFLAGS+=-Wl,--shuffle-sections='*=0'
+else ifneq ($(findstring --shuffle-sections[=SEED],$(FD_LINKER_HELP)),)
+LDFLAGS+=-Wl,--shuffle-sections
+endif
+endif
+
 all: info bin include lib unit-test fuzz-test
 
 help:
@@ -38,6 +48,7 @@ help:
 	# CXXFLAGS        = $(CXXFLAGS)
 	# LD              = $(LD)
 	# LDFLAGS         = $(LDFLAGS)
+	# LDFLAGS_EXE     = $(LDFLAGS_EXE)
 	# AR              = $(AR)
 	# ARFLAGS         = $(ARFLAGS)
 	# RANLIB          = $(RANLIB)

--- a/config/extra/with-security.mk
+++ b/config/extra/with-security.mk
@@ -12,3 +12,6 @@ LDFLAGS+=-fstack-protector-strong
 ifeq ($(FD_DISABLE_OPTIMIZATION),)
 CPPFLAGS+=-D_FORTIFY_SOURCE=$(FORTIFY_SOURCE)
 endif
+
+# Use --shuffle-sections if available to randomize binary content
+LD_RANDOMIZE:=1


### PR DESCRIPTION
Production Firedancer builds are linked into a single DSO which
reduces the effectiveness of ASLR at load-time.

This patch adds --shuffle-sections to lld/mold when the security
config extra is enabled (the default).  This causes offsets between
compile units to be different across each Firedancer build.

The goal of this patch is deep defense in depth: mitigate the
effectiveness of exploit chains that rely on static offsets between
pieces of victim code.

Another slight win is better isolation against performance issues
that arise from adverse alignment (as sometimes seen on AMD Zen).
