### PR TITLE
Fix firedancer-dev link fail without RocksDB

### DIFF
--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -17,10 +17,7 @@ $(call add-objs,commands/tower,fd_firedancer_dev)
 $(call add-objs,commands/ipecho_server,fd_firedancer_dev)
 $(call add-objs,commands/gossip_dump,fd_firedancer_dev)
 $(call add-objs,commands/reasm,fd_firedancer_dev)
-
-ifdef FD_HAS_ROCKSDB
 $(call add-objs,commands/forktest/forktest commands/forktest/fd_forktest_tile,fd_firedancer_dev)
-endif
 
 ifdef FD_HAS_SSE
 # ifdef FD_HAS_BLST -- will be a required dependency soon

--- a/src/app/firedancer-dev/main.h
+++ b/src/app/firedancer-dev/main.h
@@ -145,9 +145,7 @@ fd_topo_run_tile_t * TILES[] = {
   &fd_tile_tower,
   &fd_tile_shredcap,
   &fd_tile_backtest,
-# if FD_HAS_ROCKSDB
   &fd_tile_forktest,
-# endif
   &fd_tile_bencho,
   &fd_tile_benchg,
   &fd_tile_benchs,

--- a/src/discof/backtest/fd_backtest_src.c
+++ b/src/discof/backtest/fd_backtest_src.c
@@ -139,22 +139,26 @@ fd_backtest_src_create( fd_backtest_src_opts_t const * opts ) {
       FD_LOG_WARNING(( "cannot open ledger" ));
       return NULL;
     }
+#if FD_HAS_ROCKSDB
   } else if( 0==strcmp( opts->format, "rocksdb" ) ) {
     if( fmt!=FD_BACKT_SRC_FMT_ROCKSDB ) {
       FD_LOG_WARNING(( "cannot open ledger" ));
       return NULL;
     }
+#endif
   } else {
     FD_LOG_WARNING(( "unsupported opts.format \"%s\"", opts->format ));
     return NULL;
   }
 
   switch( fmt ) {
+#   if FD_HAS_ROCKSDB
     case FD_BACKT_SRC_FMT_ROCKSDB: return fd_backt_src_rocksdb_create( opts );
+#   endif
     case FD_BACKT_SRC_FMT_PCAP:
     case FD_BACKT_SRC_FMT_PCAPNG:  return fd_backt_src_pcap_create( opts, fmt, flags );
     default:
-      FD_LOG_WARNING(( "unsupported detected source type" ));
+      FD_LOG_WARNING(( "unsupported source type" ));
       return NULL;
   }
 }


### PR DESCRIPTION
Also remove stray rocksdb guard for forktest, which does not use
RocksDB at all
