### PR TITLE
config: UBSan requires libstdc++

### DIFF
--- a/config/extra/with-ubsan.mk
+++ b/config/extra/with-ubsan.mk
@@ -9,7 +9,10 @@ FD_UNALIGNED_ACCESS_STYLE:=0
 CPPFLAGS+=-DFD_UNALIGNED_ACCESS_STYLE=0
 
 LDFLAGS+=-fsanitize=undefined
-
+ifndef LIBCXX
+# UBSan runtime uses C++ RTTI
+LDFLAGS+=-lstdc++
+endif
 
 CPPFLAGS+=-fsanitize=undefined \
           -fsanitize=shift -fsanitize=shift-exponent -fsanitize=shift-base \


### PR DESCRIPTION
Some versions of UBSan use C++ RTTI which caused a link failure
when building Firedancer C unit tests without -lstdc++
