### PR TITLE
quic: fix incomplete reset-attack patch from PR #9692 — Initial-frame…

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -936,7 +936,19 @@ fd_quic_handle_v1_frame( fd_quic_t *       quic,
   fd_quic_frame_ctx_t frame_context[1] = {{ quic, conn, pkt }};
   if( FD_UNLIKELY( !fd_quic_frame_type_allowed( pkt_type, id ) ) ) {
     FD_DTRACE_PROBE_4( quic_err_frame_not_allowed, id, conn->our_conn_id, pkt_type, pkt->pkt_number );
-    fd_quic_frame_error( frame_context, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+    /* RFC 9000 Section 5.2.2: servers MUST drop incoming packets for
+       which the RFC does not specify behavior.  Initial-protection
+       keys are derived from the publicly-observable client DCID per
+       RFC 9001 Section 5.2; an on-path attacker who has read both
+       the client's first DCID and the server's SCID can craft a
+       valid Initial packet whose body trips this check.  Aborting
+       the conn here would let such an attacker tear down the legit
+       handshake.  Silently drop instead (same mitigation pattern as
+       commit f089aab7d / PR #9692, which closed the Retry-as-server
+       and 0-RTT variants of this conn-kill class). */
+    if( pkt_type != FD_QUIC_PKT_TYPE_INITIAL ) {
+      fd_quic_frame_error( frame_context, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+    }
     return FD_QUIC_PARSE_FAIL;
   }
   quic->metrics.frame_rx_cnt[ fd_quic_frame_metric_id[ id ] ]++;
@@ -953,9 +965,12 @@ fd_quic_handle_v1_frame( fd_quic_t *       quic,
 
   default:
     /* FIXME this should be unreachable, but gracefully handle this case as defense-in-depth */
-    /* unknown frame types are PROTOCOL_VIOLATION errors */
+    /* unknown frame types are PROTOCOL_VIOLATION errors.  Same Initial-
+       packet hardening as above (see comment on frame_type_allowed). */
     FD_DEBUG( FD_LOG_DEBUG(( "unexpected frame type: %u", id )); )
-    fd_quic_frame_error( frame_context, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+    if( pkt_type != FD_QUIC_PKT_TYPE_INITIAL ) {
+      fd_quic_frame_error( frame_context, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+    }
     return FD_QUIC_PARSE_FAIL;
   }
 
@@ -1775,7 +1790,10 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
     }
 
     if( FD_UNLIKELY( rc==0UL || rc>frame_sz ) ) {
-      fd_quic_conn_error( conn, FD_QUIC_CONN_REASON_PROTOCOL_VIOLATION, __LINE__ );
+      /* Initial packets are protected only by DCID-derived keys (RFC
+         9001 Section 5.2), so this branch is reachable by an on-path
+         attacker.  Drop silently rather than aborting the conn (same
+         mitigation pattern as PR #9692). */
       return FD_QUIC_PARSE_FAIL;
     }
 
@@ -2796,7 +2814,14 @@ fd_quic_handle_crypto_frame( fd_quic_frame_ctx_t *    context,
   ulong rcv_hi  = rcv_off + rcv_sz;  /* in [0,2^63-1] */
 
   if( FD_UNLIKELY( rcv_sz > p_sz ) ) {
-    fd_quic_frame_error( context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+    /* Initial-protection keys are public (derived from DCID per RFC
+       9001 Section 5.2), so this check is reachable by an on-path
+       attacker on Initial-context packets.  Silently drop in that
+       case rather than aborting the conn (PR #9692 mitigation
+       pattern). */
+    if( enc_level != fd_quic_enc_level_initial_id ) {
+      fd_quic_frame_error( context, FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR, __LINE__ );
+    }
     return FD_QUIC_PARSE_FAIL;
   }
 
@@ -2828,7 +2853,10 @@ fd_quic_handle_crypto_frame( fd_quic_frame_ctx_t *    context,
   }
 
   if( rcv_hi > FD_QUIC_TLS_RX_DATA_SZ ) {
-    fd_quic_frame_error( context, FD_QUIC_CONN_REASON_CRYPTO_BUFFER_EXCEEDED, __LINE__ );
+    /* See comment on rcv_sz > p_sz above re: Initial-packet hardening. */
+    if( enc_level != fd_quic_enc_level_initial_id ) {
+      fd_quic_frame_error( context, FD_QUIC_CONN_REASON_CRYPTO_BUFFER_EXCEEDED, __LINE__ );
+    }
     return FD_QUIC_PARSE_FAIL;
   }
 

--- a/src/waltz/quic/tests/test_quic_conformance.c
+++ b/src/waltz/quic/tests/test_quic_conformance.c
@@ -9,6 +9,17 @@
 #include "../../tls/fd_tls_proto.h"
 #include "../../../disco/metrics/generated/fd_metrics_enums.h"
 
+/* fd_quic_handle_v1_frame is defined in fd_quic.c without a public
+   header declaration.  Forward-declare it here for the Initial-frame
+   regression test below. */
+ulong
+fd_quic_handle_v1_frame( fd_quic_t *      quic,
+                         fd_quic_conn_t * conn,
+                         fd_quic_pkt_t *  pkt,
+                         uint             pkt_type,
+                         uchar const *    buf,
+                         ulong            buf_sz );
+
 /* RFC 9000 Section 4.1. Data Flow Control
 
    > A receiver MUST close the connection with an error of type
@@ -813,6 +824,70 @@ test_quic_ack_largest_ack_zero( fd_quic_sandbox_t * sandbox,
   FD_TEST( retx_after == retx_before );
 }
 
+/* Regression test for the Initial-frame conn-error hardening
+   (incomplete-fix follow-up to commit f089aab7d / PR #9692).
+
+   Initial-protection keys are derived from the publicly-observable
+   client DCID per RFC 9001 §5.2, so an on-path attacker who has seen
+   both the client's first DCID and the server's SCID can craft a
+   valid AEAD-protected Initial whose body trips a frame-parsing
+   error.  The server MUST NOT transition the legit conn to ABORT in
+   that case (RFC 9000 §5.2.2 explicitly permits silent drop for
+   unexpected behavior).
+
+   This test asserts:
+     - Disallowed frame in Initial             -> conn stays ACTIVE
+     - HANDSHAKE_DONE 0x1e in Initial          -> conn stays ACTIVE
+     - Unknown frame 0x1f in Initial           -> conn stays ACTIVE
+     - Malformed CRYPTO (length > p_sz)        -> conn stays ACTIVE
+   And for the 1-RTT sanity check (still aborts since 1-RTT AEAD uses
+   TLS-derived secrets that an on-path attacker cannot forge):
+     - Same malformed CRYPTO in 1-RTT context  -> conn transitions to
+                                                  ABORT with
+                                                  FRAME_ENCODING_ERROR */
+static void
+test_quic_initial_unauth_drop( fd_quic_sandbox_t * sandbox, fd_rng_t * rng ) {
+
+  struct {
+    char const * name;
+    uchar        buf[ 8 ];
+    ulong        sz;
+  } cases[] = {
+    { "RESET_STREAM in Initial",        { 0x04, 0x00, 0x00, 0x00 }, 4UL },
+    { "HANDSHAKE_DONE in Initial",      { 0x1e },                   1UL },
+    { "Unknown frame 0x1f in Initial",  { 0x1f },                   1UL },
+    { "Malformed CRYPTO (len>p_sz)",    { 0x06, 0x00, 0x40, 0x40 }, 4UL },
+  };
+
+  for( ulong i=0UL; i < sizeof(cases)/sizeof(cases[0]); i++ ) {
+    fd_quic_sandbox_init( sandbox, FD_QUIC_ROLE_SERVER );
+    fd_quic_conn_t * conn = fd_quic_sandbox_new_conn_established( sandbox, rng );
+    FD_TEST( conn->state == FD_QUIC_CONN_STATE_ACTIVE );
+
+    fd_quic_pkt_t pkt_meta = {
+      .pkt_number = 0UL,
+      .rcv_time   = sandbox->wallclock,
+      .enc_level  = fd_quic_enc_level_initial_id,
+    };
+    ulong rc = fd_quic_handle_v1_frame(
+        sandbox->quic, conn, &pkt_meta,
+        FD_QUIC_PKT_TYPE_INITIAL,
+        cases[i].buf, cases[i].sz );
+
+    FD_TEST( rc == FD_QUIC_PARSE_FAIL );
+    FD_TEST( conn->state  == FD_QUIC_CONN_STATE_ACTIVE );
+    FD_TEST( conn->reason == 0u );
+  }
+
+  /* 1-RTT sanity: same malformed CRYPTO MUST still abort. */
+  fd_quic_sandbox_init( sandbox, FD_QUIC_ROLE_SERVER );
+  fd_quic_conn_t * conn = fd_quic_sandbox_new_conn_established( sandbox, rng );
+  uchar bad_crypto[] = { 0x06, 0x00, 0x40, 0x40 };
+  fd_quic_sandbox_send_lone_frame( sandbox, conn, bad_crypto, sizeof(bad_crypto) );
+  FD_TEST( conn->state  == FD_QUIC_CONN_STATE_ABORT );
+  FD_TEST( conn->reason == FD_QUIC_CONN_REASON_FRAME_ENCODING_ERROR );
+}
+
 static void
 test_quic_rtt_sample( void ) {
   fd_quic_t quic = {0};
@@ -976,6 +1051,7 @@ main( int     argc,
   test_quic_conn_free                    ( sandbox, rng );
   test_quic_pktmeta_pktnum_skip          ( sandbox, rng );
   test_quic_ack_largest_ack_zero         ( sandbox, rng );
+  test_quic_initial_unauth_drop          ( sandbox, rng );
   test_quic_rtt_sample();
   test_quic_ack_unsent_future_pktnum     ( sandbox, rng );
 


### PR DESCRIPTION
… paths

PR #9692 (commit f089aab7d, "quic: fix reset attack", credited to Immunefi reporter GiuseppeDeLaZara) removed the conn-killing fd_quic_conn_error() call from the Retry-as-server and 0-RTT packet handlers.  However, four sibling code paths reachable from valid Initial-AEAD-protected packets still call fd_quic_frame_error() / fd_quic_conn_error() on malformed input:

  1. fd_quic_handle_v1_frame:    "frame type not allowed for pkt_type"
                                 dispatcher check (line 939 pre-fix).
  2. fd_quic_handle_v1_frame:    "unknown frame type" default branch
                                 (line 958 pre-fix).
  3. fd_quic_handle_v1_initial:  "rc==0 || rc>frame_sz" frame-loop
                                 sanity check (line 1778 pre-fix).
  4. fd_quic_handle_crypto_frame: "rcv_sz > p_sz" bounds check
                                 (line 2799 pre-fix).
  5. fd_quic_handle_crypto_frame: "rcv_hi > FD_QUIC_TLS_RX_DATA_SZ"
                                 buffer-overflow check (line 2831
                                 pre-fix).

Initial-packet protection keys are derived from the public client DCID per RFC 9001 Section 5.2.  An on-path attacker who has observed (a) the client's first DCID and (b) the server's SCID for the conn (both visible in plaintext on the QUIC long header) can craft an AEAD-validating Initial whose body trips any of the five sites above, causing the server to transition the legitimate client's handshake-phase conn to FD_QUIC_CONN_STATE_ABORT.

Mitigation follows PR #9692's pattern: silently drop the malformed Initial-context packet instead of aborting the conn.  RFC 9000 Section 5.2.2 explicitly permits this ("servers MUST drop incoming packets for which the RFC does not specify behavior").

After this patch, the server-side conn-state is unaffected by any of the four malformed Initial-frame inputs that previously triggered ABORT.  Handshake-level and 1-RTT-level packets retain the original conn_error/frame_error behavior, since their AEAD protection uses TLS-derived (non-public) keys.