### PR TITLE
h2/hpack: fix varint mis-call in Dynamic Table Size Update loops

### DIFF
--- a/src/waltz/h2/fd_hpack.c
+++ b/src/waltz/h2/fd_hpack.c
@@ -82,9 +82,36 @@ fd_hpack_rd_init( fd_hpack_rd_t * rd,
   while( FD_LIKELY( rd->src < rd->src_end ) ) {
     uint b0 = rd->src[0];
     if( FD_UNLIKELY( (b0&0xe0)==0x20 ) ) {
-      ulong max_sz = fd_hpack_rd_varint( rd, b0, 0x1f );
-      if( FD_UNLIKELY( max_sz!=0UL ) ) break; /* FIXME hacky */
+      /* Consume the prefix byte before calling fd_hpack_rd_varint:
+         the function reads continuation bytes from rd->src, so if we
+         leave rd->src pointing at the prefix byte, varint re-reads
+         the prefix as the first continuation byte for multi-byte
+         encodings (e.g. input 0x3f 0x00 = DT size update value 31
+         decoded as max_sz=94 with rd->src misaligned by 1 byte for
+         all subsequent parsing). */
+      uchar const * prefix_pos = rd->src;
       rd->src++;
+      ulong max_sz = fd_hpack_rd_varint( rd, b0, 0x1f );
+      if( FD_UNLIKELY( max_sz==ULONG_MAX ) ) {
+        /* fd_hpack_rd_init has no error return.  Restore rd->src to
+           the prefix byte so the first fd_hpack_rd_next call consumes
+           that byte as its first instruction byte.  The prefix's
+           top three bits (0x20) match no indexed-header / literal-
+           header encoding in fd_hpack_rd_next_raw, so the function
+           falls through to its "Unknown HPACK instruction" return
+           and surfaces FD_H2_ERR_COMPRESSION.  Note that the
+           DT-size-update loop at the end of fd_hpack_rd_next_raw is
+           not what surfaces the error — it only peeks at rd->src
+           AFTER the first byte has been consumed by *(rd->src++),
+           so it never re-examines the prefix byte.  Without this
+           restore, rd->src would land mid-varint at a continuation
+           byte (e.g. 0x81), which fd_hpack_rd_next_raw would mis-
+           parse as a valid indexed header (0x81 -> static-table
+           entry 1 = :authority). */
+        rd->src = prefix_pos;
+        break;
+      }
+      if( FD_UNLIKELY( max_sz!=0UL ) ) break; /* FIXME hacky */
     } else {
       break;
     }
@@ -185,9 +212,12 @@ fd_hpack_rd_next_raw( fd_hpack_rd_t * rd,
   while( FD_LIKELY( rd->src < end ) ) {
     b0 = rd->src[0];
     if( FD_UNLIKELY( (b0&0xe0)==0x20 ) ) {
-      ulong max_sz = fd_hpack_rd_varint( rd, b0, 0x1f );
-      if( FD_UNLIKELY( max_sz!=0UL ) ) return FD_H2_ERR_COMPRESSION;
+      /* Consume the prefix byte before calling fd_hpack_rd_varint —
+         see comment on the matching loop in fd_hpack_rd_init. */
       rd->src++;
+      ulong max_sz = fd_hpack_rd_varint( rd, b0, 0x1f );
+      if( FD_UNLIKELY( max_sz==ULONG_MAX ) ) return FD_H2_ERR_COMPRESSION;
+      if( FD_UNLIKELY( max_sz!=0UL       ) ) return FD_H2_ERR_COMPRESSION;
     } else {
       break;
     }

--- a/src/waltz/h2/fd_hpack_private.h
+++ b/src/waltz/h2/fd_hpack_private.h
@@ -26,8 +26,18 @@ fd_hpack_static_table[ 62 ];
 /* fd_hpack_rd_varint reads a varint with up to 8 bytes encoded length
    (not including prefix).  addend is (2^n)-1 where n is the varint
    prefix bit count.  prefix is the actual value of the varint prefix.
-   Returns a value in [0,2^56) on success.  Returns ULONG_MAX on decode
-   failure. */
+   Returns `result + addend` on success, where `result` is in
+   [0, 2^56); the maximum possible return value is therefore
+   2^56 - 1 + addend (so [0, 2^56 + 254] across the addend values
+   used by current callers, all of which are < 256).  Returns
+   ULONG_MAX on decode failure.
+
+   API contract: the caller MUST advance rd->src past the prefix byte
+   (e.g. via `b0 = *(rd->src++)`) before calling this function.  This
+   function reads continuation bytes starting at rd->src; if rd->src
+   still points at the prefix byte, the prefix is re-read as the
+   first continuation byte and both the decoded value and the final
+   rd->src position will be wrong. */
 
 static inline ulong
 fd_hpack_rd_varint( fd_hpack_rd_t * rd,

--- a/src/waltz/h2/test_hpack.c
+++ b/src/waltz/h2/test_hpack.c
@@ -176,6 +176,87 @@ test_hpack_rd_varint( void ) {
   }
 }
 
+/* Regression test for the fd_hpack_rd_varint mis-call in the Dynamic
+   Table Size Update loops of fd_hpack_rd_init / fd_hpack_rd_next_raw.
+   Before the fix, those loops peeked the prefix byte without
+   advancing rd->src, causing the varint helper to re-read the same
+   prefix byte as the first continuation byte.  For multi-byte
+   varints (DT size update value >= 31 with a 5-bit prefix) this
+   produced both a wrong decoded value AND a 1-byte cursor
+   misalignment that propagates into downstream HPACK parsing. */
+
+static void
+test_hpack_rd_dt_size_update( void ) {
+  /* DT size update value 0 (single-byte form: prefix 0x20, no
+     continuation).  rd->src must be advanced past the prefix byte. */
+  {
+    uchar const buf[] = { 0x20 };
+    fd_hpack_rd_t rd[1];
+    fd_hpack_rd_init( rd, buf, sizeof(buf) );
+    FD_TEST( rd->src == buf + sizeof(buf) );
+  }
+
+  /* DT size update value 31 (2-byte form: prefix 0x3f, single
+     continuation byte 0x00).  Pre-fix: varint mis-read 0x3f as the
+     continuation byte and returned 94, advancing rd->src by only 1
+     byte (leaving 0x00 unconsumed).  After fix: varint reads the
+     actual continuation byte 0x00 and returns 31, advancing rd->src
+     past both bytes. */
+  {
+    uchar const buf[] = { 0x3f, 0x00 };
+    fd_hpack_rd_t rd[1];
+    fd_hpack_rd_init( rd, buf, sizeof(buf) );
+    FD_TEST( rd->src == buf + sizeof(buf) );
+  }
+
+  /* DT size update value 1337 (3-byte form: prefix 0x3f, continuation
+     0x9a 0x0a — RFC 7541 §5.1 example).  rd->src must land past
+     all three bytes. */
+  {
+    uchar const buf[] = { 0x3f, 0x9a, 0x0a };
+    fd_hpack_rd_t rd[1];
+    fd_hpack_rd_init( rd, buf, sizeof(buf) );
+    FD_TEST( rd->src == buf + sizeof(buf) );
+  }
+
+  /* Mixed: a single-byte DT update (value 0) followed by a multi-byte
+     DT update (value 31) followed by a non-DT byte (0x80).  Loop must
+     consume both DT updates and break at the non-DT byte without
+     misaligning the cursor. */
+  {
+    uchar const buf[] = { 0x20, 0x3f, 0x00, 0x80 /* non-DT */ };
+    fd_hpack_rd_t rd[1];
+    fd_hpack_rd_init( rd, buf, sizeof(buf) );
+    FD_TEST( rd->src == buf + 3 );
+  }
+
+  /* Malformed / unterminated varint: prefix byte 0x3f followed by a
+     continuation byte 0x81 (top bit set => "more bytes follow") but
+     no further bytes.  fd_hpack_rd_varint returns ULONG_MAX.
+     fd_hpack_rd_init has no error return, so it must leave rd->src
+     at the prefix byte; the first fd_hpack_rd_next call then
+     consumes 0x3f as its first instruction byte, fails to match any
+     known HPACK encoding, and falls through to the "Unknown HPACK
+     instruction" return -> FD_H2_ERR_COMPRESSION.
+
+     Without the restore, rd->src would land mid-varint at 0x81,
+     which fd_hpack_rd_next_raw would mis-parse as a valid indexed
+     header (0x81 -> indexed entry 1 in the static table — :authority). */
+  {
+    uchar const buf[] = { 0x3f, 0x81 };
+    fd_hpack_rd_t rd[1];
+    fd_hpack_rd_init( rd, buf, sizeof(buf) );
+    FD_TEST( rd->src == buf ); /* restored to prefix */
+
+    fd_h2_hdr_t hdr[1];
+    uchar       scratch_buf[ 64 ];
+    uchar *     scratch     = scratch_buf;
+    uchar *     scratch_end = scratch_buf + sizeof(scratch_buf);
+    uint        err         = fd_hpack_rd_next( rd, hdr, &scratch, scratch_end );
+    FD_TEST( err == FD_H2_ERR_COMPRESSION );
+  }
+}
+
 static void
 test_hpack_wr_varint( void ) {
   for( test_hpack_case_t const * c=test_hpack_cases; c->bits; c++ ) {
@@ -200,5 +281,6 @@ test_hpack( void ) {
   test_hpack_rd( rfc7541_c51_bin, sizeof(rfc7541_c51_bin), rfc7541_c51_dec );
   test_hpack_rd( rfc7541_c61_bin, sizeof(rfc7541_c61_bin), rfc7541_c51_dec );
   test_hpack_rd_varint();
+  test_hpack_rd_dt_size_update();
   test_hpack_wr_varint();
 }


### PR DESCRIPTION
fd_hpack_rd_varint reads continuation bytes starting at rd->src, so the caller must advance rd->src past the prefix byte before invoking it.  Five of the seven call sites in fd_hpack.c do this correctly via `b0 = *(rd->src++)`, but the two Dynamic Table Size Update loops in fd_hpack_rd_init and fd_hpack_rd_next_raw peeked the prefix byte without advancing:

    uint b0 = rd->src[0];
    if( (b0&0xe0)==0x20 ) {
      ulong max_sz = fd_hpack_rd_varint( rd, b0, 0x1f );  /* bug */
      ...
    }

For multi-byte DT size update varints (any value >= 31 with the 5-bit prefix), the varint helper then re-read the same prefix byte as the first continuation byte.  Input `0x3f 0x00` (RFC 7541 §5.1 encoding of value 31) decoded as max_sz=94 with rd->src advanced by only 1 byte, leaving the 0x00 continuation byte to be re-interpreted as the start of the next HPACK instruction.  The downstream effect is header-parsing misalignment that turns malformed/inconsistent input into accepted (but wrong) headers, or into spurious FD_H2_ERR_COMPRESSION rejections.

Move the rd->src++ from after the varint call to before it, matching the convention the function's other five call sites already use. Also tighten the inline doc on fd_hpack_rd_varint to make the API contract explicit, and add a regression test
(test_hpack_rd_dt_size_update) covering the single-byte / multi-byte 2-byte / multi-byte 3-byte / mixed-with-followup cases.

A defensive bounds check landed in 88c71c494 ("h2/hpack: bounds-check varint return in rd_next_raw") that mitigates the worst symptoms of the misalignment but does not fix the root cause; this commit closes it.