### PR TITLE
keyguard: fix ineffective MADV_DONTDUMP in madvise

### DIFF
--- a/contrib/codeql/src/nightly/MadviseBitwise.ql
+++ b/contrib/codeql/src/nightly/MadviseBitwise.ql
@@ -1,0 +1,21 @@
+/**
+ * @name The `advice` argument of madvise doesn't accept bitwise arguments.
+ * @description `madvise` accepts only one `MADV_...` value in the `advice` argument. If you want to pass multiple advises, you need to call `madvise` multiple times.
+ * @kind problem
+ * @problem.severity warning
+ * @id asymmetric-research/madvise-wrong-bitwise
+ * @tags reliability
+ *       correctness
+ */
+
+import cpp
+
+private class MadviseCall extends FunctionCall {
+  MadviseCall() { this.getTarget().hasGlobalName("madvise") }
+
+  Expr getAdviceArgument() { result = this.getArgument(2) }
+}
+
+from MadviseCall mc
+where mc.getAdviceArgument() instanceof BinaryBitwiseOperation
+select mc, "The `advice` argument of madvise doesn't accept bitwise arguments."

--- a/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.c
+++ b/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.c
@@ -1,0 +1,22 @@
+typedef unsigned long size_t;
+
+#define MADV_DONTFORK    10
+#define MADV_DONTDUMP    16
+#define MADV_WIPEONFORK  18
+
+int
+madvise( void * addr, size_t length, int advise );
+
+int
+not_madvise( void * addr, size_t length, int advise );
+
+int
+test_madvise( void * addr, size_t length ) {
+  int rc = 0;
+
+  rc += madvise( addr, length, MADV_WIPEONFORK | MADV_DONTDUMP );   // $ Alert
+  rc += madvise( addr, length, MADV_WIPEONFORK );                   // NO Alert
+  rc += madvise( addr, length, MADV_DONTDUMP );                     // NO Alert
+
+  return rc;
+}

--- a/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.expected
+++ b/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.expected
@@ -1,0 +1,1 @@
+| MadviseBitwise.c:17:9:17:15 | call to madvise | The `advice` argument of madvise doesn't accept bitwise arguments. |

--- a/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.qlref
+++ b/contrib/codeql/test/query-tests/MadviseBitwise/MadviseBitwise.qlref
@@ -1,0 +1,2 @@
+query: MadviseBitwise.ql
+postprocess: InlineExpectationsTestQuery.ql

--- a/src/disco/keyguard/fd_keyload.c
+++ b/src/disco/keyguard/fd_keyload.c
@@ -136,7 +136,10 @@ fd_keyload_alloc_protected_pages( ulong page_cnt,
   /* Prevent the key page from showing up in core dumps. It shouldn't be
      possible to fork this process typically, but we also prevent any
      forked child from having this page. */
-  if( FD_UNLIKELY( madvise( middle_pages, page_cnt*PAGE_SZ, MADV_WIPEONFORK | MADV_DONTDUMP ) ) )
+  /* `madvise` supports only a single `advice` per call, so we cannot combine via bitwise or. */
+  if( FD_UNLIKELY( madvise( middle_pages, page_cnt*PAGE_SZ, MADV_WIPEONFORK ) ) )
+    FD_LOG_ERR(( "madvise failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( madvise( middle_pages, page_cnt*PAGE_SZ, MADV_DONTDUMP ) ) )
     FD_LOG_ERR(( "madvise failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
   return middle_pages;


### PR DESCRIPTION
madvise only accepts a single argument for advice that cannot
be advices being or-ed together.

Fixes #9800