### PR TITLE
accdb: fix account overallocation

### DIFF
--- a/src/flamenco/accdb/test_accdb_v1.c
+++ b/src/flamenco/accdb/test_accdb_v1.c
@@ -203,7 +203,11 @@ test_truncate_inplace( fd_accdb_admin_t * admin,
   ulong data_sz_0 = 56UL;
   FD_TEST( fd_accdb_open_rw( accdb, rw, &xid, &key, data_sz_0, FD_ACCDB_FLAG_CREATE ) );
   FD_TEST( rw->ref->ref_type==FD_ACCDB_REF_RW );
+  fd_pubkey_t owner = { .ul={ 1UL, 2UL, 3UL, 4UL } };
   fd_accdb_ref_lamports_set( rw, 32UL );
+  fd_accdb_ref_owner_set( rw, &owner );
+  fd_accdb_ref_exec_bit_set( rw, 1U );
+  fd_accdb_ref_slot_set( rw, 123UL );
   fd_accdb_ref_data_set( accdb, rw, "hello", 5UL );
   fd_funk_rec_t * rec = (void *)rw->ref->user_data;
   FD_TEST( rec->val_sz    == sizeof(fd_account_meta_t)+5UL );
@@ -218,6 +222,34 @@ test_truncate_inplace( fd_accdb_admin_t * admin,
   FD_TEST( rec->val_sz    == sizeof(fd_account_meta_t) );
   FD_TEST( rec->val_max   >= sizeof(fd_account_meta_t)+data_sz_1 );
   FD_TEST( rw->meta->dlen == 0UL );
+  ulong val_max_big = rec->val_max;
+  fd_accdb_close_rw( accdb, rw );
+
+  ulong data_sz_keep = val_max_big - sizeof(fd_account_meta_t) - 1UL;
+  FD_TEST( fd_accdb_open_rw( accdb, rw, &xid, &key, data_sz_keep, FD_ACCDB_FLAG_TRUNCATE ) );
+  FD_TEST( rw->ref->ref_type==FD_ACCDB_REF_RW );
+  rec = (void *)rw->ref->user_data;
+  FD_TEST( rec->val_sz    == sizeof(fd_account_meta_t) );
+  FD_TEST( rec->val_max   == val_max_big );
+  FD_TEST( rw->meta->dlen == 0UL );
+  fd_account_meta_t meta_keep = *rw->meta;
+  uchar val_keep[ sizeof(fd_account_meta_t) ];
+  fd_memcpy( val_keep, rw->meta, sizeof(fd_account_meta_t) );
+  fd_accdb_close_rw( accdb, rw );
+
+  FD_TEST( fd_accdb_open_rw( accdb, rw, &xid, &key, 0UL, FD_ACCDB_FLAG_TRUNCATE ) );
+  FD_TEST( rw->ref->ref_type==FD_ACCDB_REF_RW );
+  rec = (void *)rw->ref->user_data;
+  FD_TEST( rec->val_sz  == sizeof(fd_account_meta_t) );
+  FD_TEST( rec->val_max >= sizeof(fd_account_meta_t) );
+  FD_TEST( rec->val_max <  val_max_big );
+  FD_TEST( rw->meta->dlen == 0UL );
+  FD_TEST( !memcmp( rw->meta, val_keep, sizeof(fd_account_meta_t) ) );
+  FD_TEST( rw->meta->lamports   == meta_keep.lamports   );
+  FD_TEST( rw->meta->slot       == meta_keep.slot       );
+  FD_TEST( rw->meta->dlen       == meta_keep.dlen       );
+  FD_TEST( rw->meta->executable == meta_keep.executable );
+  FD_TEST( !memcmp( rw->meta->owner, meta_keep.owner, sizeof(meta_keep.owner) ) );
   fd_accdb_close_rw( accdb, rw );
 
   fd_accdb_advance_root( admin, &xid );

--- a/src/funk/fd_funk_val.c
+++ b/src/funk/fd_funk_val.c
@@ -30,13 +30,7 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
     fd_int_store_if( !!opt_err, opt_err, FD_FUNK_SUCCESS );
     return NULL;
 
-  } else if( FD_LIKELY( sz > val_max ) ) {
-
-    /* User requested to increase the value size.  We presume they are
-       asking for a specific size (as opposed to bumping up the size ala
-       append) so we don't build in extra padding to amortize the cost
-       of future truncates.  Note that new_val_sz is at least 1 at this
-       point but val_sz / val_gaddr could be zero / zero. */
+  } else if( FD_LIKELY( (sz > val_max) | fd_funk_val_shrink_compacts( sz, val_max ) ) ) {
 
     ulong   val_gaddr = rec->val_gaddr;
     uchar * val       = val_max ? fd_wksp_laddr_fast( wksp, val_gaddr ) : NULL; /* TODO: branchless */
@@ -50,8 +44,9 @@ fd_funk_val_truncate( fd_funk_rec_t * rec,
       return NULL;
     }
 
-    if( val_sz ) fd_memcpy( new_val, val, val_sz ); /* Copy the existing value */
-    fd_memset( new_val + val_sz, 0, new_val_max - val_sz ); /* Clear out trailing padding to be on the safe side */
+    ulong copy_sz = fd_ulong_min( val_sz, sz );
+    if( copy_sz ) fd_memcpy( new_val, val, copy_sz ); /* Copy the existing value */
+    fd_memset( new_val + copy_sz, 0, new_val_max - copy_sz ); /* Clear out trailing padding to be on the safe side */
 
     rec->val_gaddr = fd_wksp_gaddr_fast( wksp, new_val );
     rec->val_sz    = (uint)( sz & FD_FUNK_REC_VAL_MAX );

--- a/src/funk/fd_funk_val.h
+++ b/src/funk/fd_funk_val.h
@@ -11,6 +11,8 @@
 #define FD_FUNK_REC_VAL_MAX ((1UL<<28)-1UL)
 #define FD_FUNK_VAL_ALIGN   (8UL)
 
+#define FD_FUNK_VAL_SHRINK_FREE_THRESHOLD (512UL<<10) /* 512 KiB */
+
 FD_PROTOTYPES_BEGIN
 
 /* Accessors */
@@ -55,17 +57,20 @@ fd_funk_val_const( fd_funk_rec_t const * rec,     /* Assumes pointer in caller's
   return fd_wksp_laddr_fast( wksp, val_gaddr );
 }
 
+FD_FN_CONST static inline int
+fd_funk_val_shrink_compacts( ulong sz,
+                             ulong val_max ) {
+  return (sz<val_max) &&
+         ( ( (5UL*sz)<(4UL*val_max) ) |
+           ( (val_max-sz)>FD_FUNK_VAL_SHRINK_FREE_THRESHOLD ) );
+}
+
 /* fd_funk_val_truncate resizes a record to be new_val_sz bytes in
-   size.
+   size.  Invalidates val_gaddr.
 
-   This function is optimized for the user knowing the actual long term
-   record size when they call this.
-
-   Regardless of the current and new value sizes, this will
-   always attempt to resize the record in order to minimize the amount
-   of excess allocation used by the record.  So this function should be
-   assumed to kill any existing pointers into this record's value
-   storage.
+   If the requested size is larger than the current allocation, this
+   reallocates the record.  If the requested size is smaller than the
+   current allocation, reallocates if fd_funk_val_shrink_compacts()==1.
 
    Returns a pointer to the value memory on success and NULL on
    failure.  If opt_err is non-NULL, on return, *opt_err will hold

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -8,10 +8,71 @@ FD_STATIC_ASSERT( FD_FUNK_ALIGN    >=alignof(fd_funk_t), unit-test );
 
 FD_STATIC_ASSERT( FD_FUNK_MAGIC    ==0xf17eda2ce7fc2c02UL,  unit-test );
 
+static int
+test_funk_val_shrink_compacts_expected( ulong sz,
+                                        ulong val_max ) {
+  if( sz>=val_max ) return 0;
+
+  int below_80_pct = (5UL*sz)<(4UL*val_max);
+  int frees_big    = (val_max-sz)>FD_FUNK_VAL_SHRINK_FREE_THRESHOLD;
+  return below_80_pct | frees_big;
+}
+
+static void
+test_funk_val_shrink_compacts_case( ulong sz,
+                                    ulong val_max,
+                                    int   expected ) {
+  FD_TEST( sz<=FD_FUNK_REC_VAL_MAX );
+  FD_TEST( val_max<=FD_FUNK_REC_VAL_MAX );
+  FD_TEST( fd_funk_val_shrink_compacts( sz, val_max )==expected );
+}
+
+static void
+test_funk_val_shrink_compacts( void ) {
+  for( ulong val_max=0UL; val_max<=4096UL; val_max++ ) {
+    for( ulong sz=0UL; sz<=4096UL; sz++ ) {
+      test_funk_val_shrink_compacts_case( sz, val_max, test_funk_val_shrink_compacts_expected( sz, val_max ) );
+    }
+  }
+
+  ulong const T = FD_FUNK_VAL_SHRINK_FREE_THRESHOLD;
+  struct {
+    ulong sz;
+    ulong val_max;
+    int   expected;
+  } cases[] = {
+    { 0UL,                       0UL,                       0 },
+    { 1UL,                       1UL,                       0 },
+    { 2UL,                       1UL,                       0 },
+    { 0UL,                       1UL,                       1 },
+
+    { 79UL,                      100UL,                     1 },
+    { 80UL,                      100UL,                     0 },
+    { 81UL,                      100UL,                     0 },
+    { 80UL,                      101UL,                     1 },
+    { 81UL,                      101UL,                     0 },
+
+    { (8UL*T)-T,                 8UL*T,                     0 },
+    { (8UL*T)-T-1UL,             8UL*T,                     1 },
+    { (8UL*T)-T+1UL,             8UL*T,                     0 },
+
+    { FD_FUNK_REC_VAL_MAX-1UL,   FD_FUNK_REC_VAL_MAX,       0 },
+    { FD_FUNK_REC_VAL_MAX/2UL,   FD_FUNK_REC_VAL_MAX,       1 },
+    { 0UL,                       FD_FUNK_REC_VAL_MAX,       1 },
+    { FD_FUNK_REC_VAL_MAX,       FD_FUNK_REC_VAL_MAX,       0 }
+  };
+
+  for( ulong i=0UL; i<sizeof(cases)/sizeof(cases[0]); i++ ) {
+    test_funk_val_shrink_compacts_case( cases[i].sz, cases[i].val_max, cases[i].expected );
+  }
+}
+
 int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
+
+  test_funk_val_shrink_compacts();
 
   char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );


### PR DESCRIPTION
Fixes a vulnerability where an attacker can squat excessive accdb
heap space by creating a giant account and truncating it in the
same slot.
