### PR TITLE
fuzz: correctly propagate stack pop errors

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1093,9 +1093,9 @@ fd_instr_stack_pop( fd_runtime_t *          runtime,
    where we always pop the instruction stack no matter what the error code is.
    https://github.com/anza-xyz/agave/blob/v2.2.12/program-runtime/src/invoke_context.rs#L480 */
 int
-fd_execute_instr_end( fd_exec_instr_ctx_t * instr_ctx,
-                      fd_instr_info_t *     instr,
-                      int                   instr_exec_result ) {
+fd_execute_instr_end( fd_exec_instr_ctx_t *   instr_ctx,
+                      fd_instr_info_t const * instr,
+                      int                     instr_exec_result ) {
   int stack_pop_err = fd_instr_stack_pop( instr_ctx->runtime, instr_ctx->txn_out, instr );
 
   /* Only report the stack pop error on success */

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1092,7 +1092,7 @@ fd_instr_stack_pop( fd_runtime_t *          runtime,
 /* This function mimics Agave's `.and(self.pop())` functionality,
    where we always pop the instruction stack no matter what the error code is.
    https://github.com/anza-xyz/agave/blob/v2.2.12/program-runtime/src/invoke_context.rs#L480 */
-static inline int
+int
 fd_execute_instr_end( fd_exec_instr_ctx_t * instr_ctx,
                       fd_instr_info_t *     instr,
                       int                   instr_exec_result ) {

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -132,6 +132,11 @@ fd_instr_stack_pop( fd_runtime_t *          runtime,
                     fd_txn_out_t *          txn_out,
                     fd_instr_info_t const * instr );
 
+int
+fd_execute_instr_end( fd_exec_instr_ctx_t * instr_ctx,
+                      fd_instr_info_t *     instr,
+                      int                   instr_exec_result );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_fd_executor_h */

--- a/src/flamenco/runtime/fd_executor.h
+++ b/src/flamenco/runtime/fd_executor.h
@@ -133,9 +133,9 @@ fd_instr_stack_pop( fd_runtime_t *          runtime,
                     fd_instr_info_t const * instr );
 
 int
-fd_execute_instr_end( fd_exec_instr_ctx_t * instr_ctx,
-                      fd_instr_info_t *     instr,
-                      int                   instr_exec_result );
+fd_execute_instr_end( fd_exec_instr_ctx_t *   instr_ctx,
+                      fd_instr_info_t const * instr,
+                      int                     instr_exec_result );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/runtime/tests/fd_vm_harness.c
+++ b/src/flamenco/runtime/tests/fd_vm_harness.c
@@ -256,7 +256,7 @@ fd_solfuzz_pb_syscall_run( fd_solfuzz_runner_t * runner,
 
   /* Actually invoke the syscall */
   int syscall_err = syscall->func( vm, vm->reg[1], vm->reg[2], vm->reg[3], vm->reg[4], vm->reg[5], &vm->reg[0] );
-  int instr_end_err = fd_execute_instr_end( vm->instr_ctx, (fd_instr_info_t *)ctx->instr, syscall_err );
+  int instr_end_err = fd_execute_instr_end( vm->instr_ctx, ctx->instr, syscall_err );
   if( instr_end_err ) {
     fd_log_collector_program_failure( vm->instr_ctx );
   }

--- a/src/flamenco/runtime/tests/fd_vm_harness.c
+++ b/src/flamenco/runtime/tests/fd_vm_harness.c
@@ -256,19 +256,15 @@ fd_solfuzz_pb_syscall_run( fd_solfuzz_runner_t * runner,
 
   /* Actually invoke the syscall */
   int syscall_err = syscall->func( vm, vm->reg[1], vm->reg[2], vm->reg[3], vm->reg[4], vm->reg[5], &vm->reg[0] );
-  int stack_pop_err = fd_instr_stack_pop( ctx->runtime, ctx->txn_out, ctx->instr );
-  if( FD_UNLIKELY( stack_pop_err ) ) {
-      FD_LOG_WARNING(( "instr stack pop err" ));
-      goto error;
-  }
-  if( syscall_err ) {
+  int instr_end_err = fd_execute_instr_end( vm->instr_ctx, (fd_instr_info_t *)ctx->instr, syscall_err );
+  if( instr_end_err ) {
     fd_log_collector_program_failure( vm->instr_ctx );
   }
 
   /* Capture the effects */
   int exec_err = vm->instr_ctx->txn_out->err.exec_err;
   effects->error = 0;
-  if( syscall_err ) {
+  if( instr_end_err ) {
     if( exec_err==0 ) {
       FD_LOG_WARNING(( "TODO: syscall returns error, but exec_err not set. this is probably missing a log." ));
       effects->error = -1;
@@ -293,7 +289,7 @@ fd_solfuzz_pb_syscall_run( fd_solfuzz_runner_t * runner,
       }
     }
   }
-  effects->r0 = syscall_err ? 0 : vm->reg[0]; // Save only on success
+  effects->r0 = instr_end_err ? 0 : vm->reg[0]; // Save only on success
   effects->cu_avail = (ulong)vm->cu;
 
   if( vm->heap_max ) {


### PR DESCRIPTION
We don't want to reject the input if there is a stack pop error, instead we want to propagate this so that we can compare it.