### PR TITLE
flamenco, test: add ledger for disable_sbpf_v0_v1_v2_deployment

### DIFF
--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -137,3 +137,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l raise_block_limits_to_100m 
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l direct_account_pointers_in_program_input -y 1 -m 10000 -e 386
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l commission_rate_in_basis_points_boundary -y 1 -m 10000 -e 950
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l commission_rate_in_basis_points_snapshot -y 1 -m 10000 -e 950
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l disable_sbpf_v0_v1_v2_deployment -y 1 -m 10000 -e 617

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -137,4 +137,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l raise_block_limits_to_100m 
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l direct_account_pointers_in_program_input -y 1 -m 10000 -e 386
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l commission_rate_in_basis_points_boundary -y 1 -m 10000 -e 950
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l commission_rate_in_basis_points_snapshot -y 1 -m 10000 -e 950
-src/flamenco/runtime/tests/run_ledger_backtest.sh -l disable_sbpf_v0_v1_v2_deployment -y 1 -m 10000 -e 617
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l disable_sbpf_v0_v1_v2_deployment -y 1 -m 10000 -e 625


### PR DESCRIPTION
Add ledger for `disable_sbpf_v0_v1_v2_deployment`, which:

- Tests deployment of SBPF V0, V1, V2 and V3 programs pre-feature activation, which all succeed.
- Activates the feature at the boundary.
- Deploys/upgrades/finalizes SBPF V0, V1 and V2 programs - all fail.
- Tests deploying SBPF V3 programs still succeed.