### PR TITLE
restore: manifest array bounds constants

### DIFF
--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -1133,9 +1133,9 @@ fd_gui_peers_stage_snapshot_manifest( fd_gui_peers_ctx_t *           peers,
   fd_vote_stake_weight_t * vote_scratch = peers->scratch.manifest_vote_weights;
   ulong vote_scratch_cnt = 0UL;
   ulong vote_accounts_sz = manifest->vote_accounts_len;
-  if( FD_UNLIKELY( vote_accounts_sz>40200UL ) ) {
-    FD_LOG_WARNING(( "exceeded 40200UL vote accounts" ));
-    vote_accounts_sz = 40200UL;
+  if( FD_UNLIKELY( vote_accounts_sz>FD_VOTE_ACCOUNTS_MAX ) ) {
+    FD_LOG_WARNING(( "vote accounts %lu exceeds maximum %lu", vote_accounts_sz, FD_VOTE_ACCOUNTS_MAX ));
+    vote_accounts_sz = FD_VOTE_ACCOUNTS_MAX;
   }
   for( ulong i=0UL; i<vote_accounts_sz; i++ ) {
     if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -416,11 +416,11 @@ struct fd_gui_peers_ctx {
       ulong idxs   [ FD_CONTACT_INFO_TABLE_SIZE ];
     };
     struct {
-      ulong wfs_peers[ 40200UL ];
+      ulong wfs_peers[ FD_VOTE_ACCOUNTS_MAX ];
     };
     struct {
-      fd_stake_weight_t      manifest_id_weights  [ 40200UL ];
-      fd_vote_stake_weight_t manifest_vote_weights[ 40200UL ];
+      fd_stake_weight_t      manifest_id_weights  [ FD_VOTE_ACCOUNTS_MAX ];
+      fd_vote_stake_weight_t manifest_vote_weights[ FD_VOTE_ACCOUNTS_MAX ];
     };
     fd_gui_peers_voter_t voters_scratch[ MAX_COMPRESSED_STAKE_WEIGHTS ];
   } scratch;
@@ -432,7 +432,7 @@ struct fd_gui_peers_ctx {
   fd_gui_ip_db_t dbip;
 
   int                       wfs_enabled;
-  fd_gui_wfs_peer_t         wfs_peers[ 40200UL ];
+  fd_gui_wfs_peer_t         wfs_peers[ FD_VOTE_ACCOUNTS_MAX ];
   ulong                     wfs_peers_cnt;
   int                       wfs_peers_valid;
   int                       wfs_stakes_sent;

--- a/src/discof/gossip/fd_gossip_tile.c
+++ b/src/discof/gossip/fd_gossip_tile.c
@@ -392,7 +392,7 @@ returnable_frag( fd_gossip_tile_ctx_t * ctx,
       ctx->wfs_peers.total  = 0UL;
       memset( ctx->wfs_active, 0, sizeof(ctx->wfs_active) );
 
-      FD_TEST( manifest->vote_accounts_len<=40200UL );
+      FD_TEST( manifest->vote_accounts_len<=FD_VOTE_ACCOUNTS_MAX );
       for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
           if( FD_UNLIKELY( manifest->vote_accounts[ i ].stake==0UL ) ) continue;
           ctx->wfs_stake.total += manifest->vote_accounts[ i ].stake;

--- a/src/discof/gossip/fd_gossip_tile.h
+++ b/src/discof/gossip/fd_gossip_tile.h
@@ -59,13 +59,13 @@ struct fd_gossip_tile_ctx {
 
      We keep a copy of the snapshot bank's votes states in an array here
      for quick look up. */
-  fd_vote_stake_weight_t wfs_stakes_scratch[ 40200UL ];
-  fd_stake_weight_t      wfs_stakes        [ 40200UL ];
+  fd_vote_stake_weight_t wfs_stakes_scratch[ FD_VOTE_ACCOUNTS_MAX ];
+  fd_stake_weight_t      wfs_stakes        [ FD_VOTE_ACCOUNTS_MAX ];
   ulong                  wfs_stakes_cnt;
 
   /* wfs_active is used to keep track of nodes we've already labeled as
      being active on gossip, so we don't double count their stake. */
-  uchar             wfs_active[ 40200UL ];
+  uchar             wfs_active[ FD_VOTE_ACCOUNTS_MAX ];
   int               wfs_state;
 
   struct {

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -195,7 +195,7 @@ verify_epoch_stakes( fd_snapshot_manifest_t const * manifest ) {
   /* ensure all required epochs are present in epoch stakes */
   for( ulong i=min_required_epoch; i<=max_required_epoch; i++ ) {
     int found = 0;
-    for( ulong j=0UL; j<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN; j++ ) {
+    for( ulong j=0UL; j<FD_EPOCH_STAKES_LEN; j++ ) {
       if( manifest->epoch_stakes[j].epoch==i ) {
         found = 1;
         break;
@@ -293,7 +293,7 @@ transition_malformed( fd_snapin_tile_t *  ctx,
 
 static int
 populate_txncache( fd_snapin_tile_t *                     ctx,
-                   fd_snapshot_manifest_blockhash_t const blockhashes[ static 301UL ],
+                   fd_snapshot_manifest_blockhash_t const blockhashes[ static FD_BLOCKHASHES_MAX ],
                    ulong                                  blockhashes_len ) {
   /* Our txncache internally contains the fork structure for the chain,
      which we need to recreate here.  Because snapshots are only served
@@ -374,8 +374,8 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     offset for each slot, and stick it into the appropriate bank in
     our chain. */
 
-  if( FD_UNLIKELY( blockhashes_len>301UL ) ) {
-    FD_LOG_WARNING(( "corrupt snapshot: blockhash queue length %lu exceeds maximum 301", blockhashes_len ));
+  if( FD_UNLIKELY( blockhashes_len>FD_BLOCKHASHES_MAX ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: blockhash queue length %lu exceeds maximum %lu", blockhashes_len, FD_BLOCKHASHES_MAX ));
     return 1;
   }
   if( FD_UNLIKELY( !blockhashes_len ) ) {
@@ -400,7 +400,7 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
     uchar blockhash[ 32UL ];
     fd_txncache_fork_id_t fork_id;
     ulong txnhash_offset;
-  } banks[ 301UL ] = {0};
+  } banks[ FD_BLOCKHASHES_MAX ] = {0};
 
   for( ulong i=0UL; i<blockhashes_len; i++ ) {
     fd_snapshot_manifest_blockhash_t const * elem = &blockhashes[ i ];

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -5,6 +5,13 @@
 #include "fd_ssmsg.h"
 
 FD_STATIC_ASSERT( FD_HARD_FORKS_MAX==sizeof(((fd_snapshot_manifest_t *)0)->hard_forks)/sizeof(fd_hard_fork_t), hard_forks_max );
+FD_STATIC_ASSERT( FD_BLOCKHASHES_MAX==sizeof(((fd_snapshot_manifest_t *)0)->blockhashes)/sizeof(fd_snapshot_manifest_blockhash_t), blockhashes_max );
+FD_STATIC_ASSERT( FD_VOTE_ACCOUNTS_MAX==sizeof(((fd_snapshot_manifest_t *)0)->vote_accounts)/sizeof(fd_snapshot_manifest_vote_account_t), vote_accounts_max );
+FD_STATIC_ASSERT( FD_STAKE_DELEGATIONS_MAX==sizeof(((fd_snapshot_manifest_t *)0)->stake_delegations)/sizeof(fd_snapshot_manifest_stake_delegation_t), stake_delegations_max );
+FD_STATIC_ASSERT( FD_EPOCH_STAKES_LEN==sizeof(((fd_snapshot_manifest_t *)0)->epoch_stakes)/sizeof(fd_snapshot_manifest_epoch_stakes_t), epoch_stakes_len );
+FD_STATIC_ASSERT( FD_EPOCH_VOTE_STAKES_MAX==sizeof(((fd_snapshot_manifest_epoch_stakes_t *)0)->vote_stakes)/sizeof(fd_snapshot_manifest_vote_stakes_t), epoch_vote_stakes_max );
+FD_STATIC_ASSERT( FD_EPOCH_CREDITS_MAX==sizeof(((fd_snapshot_manifest_vote_account_t *)0)->epoch_credits)/sizeof(epoch_credits_t), vote_account_epoch_credits_max );
+FD_STATIC_ASSERT( FD_EPOCH_CREDITS_MAX==sizeof(((fd_snapshot_manifest_vote_stakes_t *)0)->epoch_credits)/sizeof(epoch_credits_t), vote_stakes_epoch_credits_max );
 
 void
 blockhashes_recover( fd_blockhashes_t *                       blockhashes,
@@ -246,7 +253,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
 
   FD_TEST( leader_schedule_epoch >= epoch_stakes_base );
   ulong t_1_idx = leader_schedule_epoch - epoch_stakes_base;
-  FD_TEST( t_1_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
+  FD_TEST( t_1_idx < FD_EPOCH_STAKES_LEN );
 
   int   has_t_2 = (t_1_idx > 0UL);
   ulong t_2_idx = has_t_2 ? t_1_idx - 1UL : 0UL;

--- a/src/discof/restore/utils/fd_ssmanifest_parser.c
+++ b/src/discof/restore/utils/fd_ssmanifest_parser.c
@@ -1414,8 +1414,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
   /* Lengths must be valid */
   switch( parser->state ) {
     case STATE_BLOCKHASH_QUEUE_AGES_LENGTH: {
-      if( FD_UNLIKELY( !manifest->blockhashes_len || manifest->blockhashes_len>sizeof(manifest->blockhashes)/sizeof(manifest->blockhashes[0]) ) ) {
-        FD_LOG_WARNING(( "invalid blockhash_queue_ages length %lu", manifest->blockhashes_len ));
+      if( FD_UNLIKELY( !manifest->blockhashes_len || manifest->blockhashes_len>FD_BLOCKHASHES_MAX ) ) {
+        FD_LOG_WARNING(( "invalid blockhash_queue_ages length %lu (max %lu)", manifest->blockhashes_len, FD_BLOCKHASHES_MAX ));
         return -1;
       }
       break;
@@ -1433,22 +1433,22 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
       break;
     }
     case STATE_HARD_FORKS_LENGTH: {
-      if( FD_UNLIKELY( manifest->hard_fork_cnt>sizeof(manifest->hard_forks)/sizeof(manifest->hard_forks[0]) ) ) {
-        FD_LOG_WARNING(( "invalid hard_forks length %lu", manifest->hard_fork_cnt ));
+      if( FD_UNLIKELY( manifest->hard_fork_cnt>FD_HARD_FORKS_MAX ) ) {
+        FD_LOG_WARNING(( "invalid hard_forks length %lu (max %lu)", manifest->hard_fork_cnt, FD_HARD_FORKS_MAX ));
         return -1;
       }
       break;
     }
     case STATE_STAKES_VOTE_ACCOUNTS_LENGTH: {
-      if( FD_UNLIKELY( manifest->vote_accounts_len>sizeof(manifest->vote_accounts)/sizeof(manifest->vote_accounts[0]) ) ) {
-        FD_LOG_WARNING(( "invalid vote_accounts_len %lu", manifest->vote_accounts_len ));
+      if( FD_UNLIKELY( manifest->vote_accounts_len>FD_VOTE_ACCOUNTS_MAX ) ) {
+        FD_LOG_WARNING(( "invalid vote_accounts_len %lu (max %lu)", manifest->vote_accounts_len, FD_VOTE_ACCOUNTS_MAX ));
         return -1;
       }
       break;
     }
     case STATE_STAKES_STAKE_DELEGATIONS_LENGTH: {
-      if( FD_UNLIKELY( manifest->stake_delegations_len>sizeof(manifest->stake_delegations)/sizeof(manifest->stake_delegations[0]) ) ) {
-        FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu", manifest->stake_delegations_len ));
+      if( FD_UNLIKELY( manifest->stake_delegations_len>FD_STAKE_DELEGATIONS_MAX ) ) {
+        FD_LOG_WARNING(( "invalid stakes_stake_delegations length %lu (max %lu)", manifest->stake_delegations_len, FD_STAKE_DELEGATIONS_MAX ));
         return -1;
       }
       break;
@@ -1464,8 +1464,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V3_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
-      if( FD_UNLIKELY( manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len>64UL ) ) {
-        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu", manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len ));
+      if( FD_UNLIKELY( manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len>FD_EPOCH_CREDITS_MAX ) ) {
+        FD_LOG_WARNING(( "invalid vote_accounts value data current epoch credits length %lu (max %lu)", manifest->vote_accounts[ parser->idx1 ].epoch_credits_history_len, FD_EPOCH_CREDITS_MAX ));
         return -1;
       }
       break;
@@ -1531,9 +1531,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_EPOCH_STAKES_VOTE_ACCOUNTS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_LENGTH: {
       ulong stakes_len = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes_len : parser->length2;
-      ulong stakes_cap = sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes)/sizeof(manifest->epoch_stakes[ 0UL ].vote_stakes[ 0UL ]);
-      if( FD_UNLIKELY( stakes_len>stakes_cap ) ) {
-        FD_LOG_WARNING(( "invalid versioned epoch stakes vote accounts length %lu", stakes_len ));
+      if( FD_UNLIKELY( stakes_len>FD_EPOCH_VOTE_STAKES_MAX ) ) {
+        FD_LOG_WARNING(( "invalid versioned epoch stakes vote accounts length %lu (max %lu)", stakes_len, FD_EPOCH_VOTE_STAKES_MAX ));
         return -1;
       }
       break;
@@ -1570,8 +1569,8 @@ state_validate( fd_ssmanifest_parser_t * parser ) {
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V11411_EPOCH_CREDITS_LENGTH:
     case STATE_VERSIONED_EPOCH_STAKES_STAKES_VOTE_ACCOUNTS_VALUE_DATA_V0235_EPOCH_CREDITS_LENGTH: {
       ulong length = parser->epoch_idx!=ULONG_MAX ? manifest->epoch_stakes[ parser->epoch_idx ].vote_stakes[ parser->idx2 ].epoch_credits_history_len : parser->length4;
-      if( FD_UNLIKELY( length>64UL ) ) {
-        FD_LOG_WARNING(( "invalid version_epoch_stakes.vote_accounts value data current epoch credits length %lu", length ));
+      if( FD_UNLIKELY( length>FD_EPOCH_CREDITS_MAX ) ) {
+        FD_LOG_WARNING(( "invalid version_epoch_stakes.vote_accounts value data current epoch credits length %lu (max %lu)", length, FD_EPOCH_CREDITS_MAX ));
         return -1;
       }
       break;
@@ -1734,7 +1733,7 @@ state_process( fd_ssmanifest_parser_t * parser,
        https://github.com/anza-xyz/agave/blob/v4.0.0-beta.1/runtime/src/serde_snapshot.rs#L174 */
     parser->epoch                    = fd_slot_to_epoch( &epoch_schedule, manifest->slot, NULL );
     parser->leader_schedule_epoch    = fd_slot_to_leader_schedule_epoch( &epoch_schedule, manifest->slot );
-    ulong const epoch_stakes_ele_cnt = sizeof(parser->manifest->epoch_stakes)/sizeof(fd_snapshot_manifest_epoch_stakes_t);
+    ulong const epoch_stakes_ele_cnt = FD_EPOCH_STAKES_LEN;
 
     ulong const epoch_stakes_base = parser->epoch>0UL ? parser->epoch-1UL : 0UL;
     if( FD_UNLIKELY( parser->leader_schedule_epoch-epoch_stakes_base>=epoch_stakes_ele_cnt ) ) {
@@ -2016,7 +2015,7 @@ fd_ssmanifest_parser_init( fd_ssmanifest_parser_t * parser,
   parser->dst_cur  = 0UL;
   parser->manifest = manifest;
 
-  for( ulong i=0UL; i<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN; i++ ) {
+  for( ulong i=0UL; i<FD_EPOCH_STAKES_LEN; i++ ) {
     manifest->epoch_stakes[i].epoch           = ULONG_MAX;  /* sentinel: not populated */
     manifest->epoch_stakes[i].total_stake     = 0UL;
     manifest->epoch_stakes[i].vote_stakes_len = 0UL;

--- a/src/discof/restore/utils/fd_ssmsg.h
+++ b/src/discof/restore/utils/fd_ssmsg.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_discof_restore_utils_fd_ssmsg_h
 
 #include "../../../flamenco/runtime/fd_runtime_const.h"
+#include "../../../flamenco/runtime/fd_blockhashes.h"
 
 #define FD_SSMSG_MANIFEST_FULL        (0) /* A snapshot manifest message from the full snapshot */
 #define FD_SSMSG_MANIFEST_INCREMENTAL (1) /* A snapshot manifest message from the incremental snapshot */
@@ -142,8 +143,6 @@ struct fd_snapshot_manifest_vote_stakes {
 
 typedef struct fd_snapshot_manifest_vote_stakes fd_snapshot_manifest_vote_stakes_t;
 
-#define FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN 3UL
-
 struct fd_snapshot_manifest_epoch_stakes {
    /* The epoch for which these vote accounts and stakes are valid for */
   ulong                              epoch;
@@ -153,7 +152,7 @@ struct fd_snapshot_manifest_epoch_stakes {
   /* The vote accounts and their stakes for a given epoch.
      FIXME: Snapshot manifest has to support a much larger bound. */
   ulong                              vote_stakes_len;
-  fd_snapshot_manifest_vote_stakes_t vote_stakes[ 40200UL ];
+  fd_snapshot_manifest_vote_stakes_t vote_stakes[ FD_EPOCH_VOTE_STAKES_MAX ];
 };
 
 typedef struct fd_snapshot_manifest_epoch_stakes fd_snapshot_manifest_epoch_stakes_t;
@@ -371,7 +370,7 @@ struct fd_snapshot_manifest {
   uchar epoch_account_hash[ 32UL ];
 
   ulong blockhashes_len;
-  fd_snapshot_manifest_blockhash_t blockhashes[ 301UL ];
+  fd_snapshot_manifest_blockhash_t blockhashes[ FD_BLOCKHASHES_MAX ];
 
   /* The fork_id in the status cache for the root slot. */
   ushort txncache_fork_id;
@@ -456,11 +455,11 @@ struct fd_snapshot_manifest {
      uptime, which is measured by vote account vote credits.
      FIXME: Make this unbounded or support a much larger bound. */
   ulong                               vote_accounts_len;
-  fd_snapshot_manifest_vote_account_t vote_accounts[ 40200UL ];
+  fd_snapshot_manifest_vote_account_t vote_accounts[ FD_VOTE_ACCOUNTS_MAX ];
 
   /* FIXME: Make this unbounded or support a much larger bound. */
   ulong stake_delegations_len;
-  fd_snapshot_manifest_stake_delegation_t stake_delegations[ 3000000UL ];
+  fd_snapshot_manifest_stake_delegation_t stake_delegations[ FD_STAKE_DELEGATIONS_MAX ];
 
   /* Epoch stakes represent the exact amount staked to each vote
      account at the beginning of a previous epoch.  They are primarily
@@ -490,7 +489,7 @@ struct fd_snapshot_manifest {
        epoch_stakes[0] = epoch E-1
        epoch_stakes[1] = epoch E
        epoch_stakes[2] = epoch E+1 */
-  fd_snapshot_manifest_epoch_stakes_t epoch_stakes[ 3UL ];
+  fd_snapshot_manifest_epoch_stakes_t epoch_stakes[ FD_EPOCH_STAKES_LEN ];
 };
 
 typedef struct fd_snapshot_manifest fd_snapshot_manifest_t;

--- a/src/discof/shredcap/fd_shredcap_tile.c
+++ b/src/discof/shredcap/fd_shredcap_tile.c
@@ -221,7 +221,7 @@ verify_epoch_stakes( fd_snapshot_manifest_t const * manifest ) {
   /* ensure all required epochs are present in epoch stakes */
   for( ulong i=min_required_epoch; i<=max_required_epoch; i++ ) {
     int found = 0;
-    for( ulong j=0UL; j<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN; j++ ) {
+    for( ulong j=0UL; j<FD_EPOCH_STAKES_LEN; j++ ) {
       if( manifest->epoch_stakes[j].epoch==i ) {
         found = 1;
         break;
@@ -287,7 +287,7 @@ publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
   ulong epoch_stakes_base = epoch > 0UL ? epoch - 1UL : 0UL;
   ulong leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( schedule, manifest->slot );
   ulong cur_idx = epoch - epoch_stakes_base;
-  FD_TEST( cur_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
+  FD_TEST( cur_idx < FD_EPOCH_STAKES_LEN );
 
   /* current epoch */
   ulong * stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
@@ -300,7 +300,7 @@ publish_stake_weights_manifest( fd_capture_tile_ctx_t * ctx,
   /* next epoch */
   if( leader_schedule_epoch >= epoch + 1UL ) {
     ulong next_idx = epoch + 1UL - epoch_stakes_base;
-    FD_TEST( next_idx < FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN );
+    FD_TEST( next_idx < FD_EPOCH_STAKES_LEN );
 
     stake_weights_msg = fd_chunk_to_laddr( ctx->stake_out->mem, ctx->stake_out->chunk );
     stake_weights_sz = generate_epoch_info_msg_manifest( epoch + 1, schedule, &manifest->epoch_stakes[next_idx], stake_weights_msg );
@@ -445,7 +445,7 @@ after_credit( fd_capture_tile_ctx_t * ctx,
       /* Spad memory is not zeroed.  Initialize epoch_stakes sentinels so
          that verify_epoch_stakes can reliably detect unpopulated entries
          even if the parser does not write all slots. */
-      for( ulong i=0UL; i<FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN; i++ ) {
+      for( ulong i=0UL; i<FD_EPOCH_STAKES_LEN; i++ ) {
         manifest->epoch_stakes[i].epoch = ULONG_MAX;
       }
 

--- a/src/flamenco/runtime/fd_blockhashes.h
+++ b/src/flamenco/runtime/fd_blockhashes.h
@@ -10,7 +10,7 @@
 
    See solana_accounts_db::blockhash_queue::BlockhashQueue. */
 
-#define FD_BLOCKHASHES_MAX 301
+#define FD_BLOCKHASHES_MAX (301UL)
 
 /* See solana_accounts_db::blockhash_queue::HashInfo. */
 

--- a/src/flamenco/runtime/fd_runtime_const.h
+++ b/src/flamenco/runtime/fd_runtime_const.h
@@ -240,9 +240,15 @@ FD_PROTOTYPES_BEGIN
 #define BPF_LOADER_SERIALIZATION_FOOTPRINT (671764016UL)
 FD_STATIC_ASSERT( BPF_LOADER_SERIALIZATION_FOOTPRINT==FD_BPF_LOADER_INPUT_REGION_FOOTPRINT(64UL, 0), bpf_loader_serialization_footprint );
 
-#define FD_EPOCH_CREDITS_MAX (64UL)
-
 #define FD_HARD_FORKS_MAX (64UL)
+
+/* Snapshot manifest array bounds.  They are used to size arrays and
+   validate parsed lengths throughout the entire architecture. */
+
+#define FD_VOTE_ACCOUNTS_MAX     (40200UL)
+#define FD_STAKE_DELEGATIONS_MAX (3000000UL)
+#define FD_EPOCH_STAKES_LEN      (3UL)
+#define FD_EPOCH_VOTE_STAKES_MAX (40200UL)
 
 static const FD_FN_UNUSED fd_account_meta_t FD_ACCOUNT_META_DEFAULT = {0};
 


### PR DESCRIPTION
- Replaced hardcoded snapshot manifest constant values (40200, 301, 3000000, 64, 3) with named constants (`FD_BLOCKHASHES_MAX`, `FD_VOTE_ACCOUNTS_MAX`, `FD_STAKE_DELEGATIONS_MAX`, `FD_EPOCH_STAKES_LEN`, `FD_EPOCH_VOTE_STAKES_MAX`).
- Added compile-time static asserts in `fd_ssload.c`.
- Removed deduplicate `FD_EPOCH_CREDITS_MAX` and relocate `FD_SNAPSHOT_MANIFEST_EPOCH_STAKES_LEN` from `fd_ssmsg.h` to `fd_runtime_const.h`.
- Improved log messages to include limits.

This is a prerequisite before further addressing https://github.com/firedancer-io/firedancer/issues/9588.