### PR TITLE
quic: fix tx_ack off-by-one

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -1097,7 +1097,7 @@ fd_quic_conn_new_stream( fd_quic_conn_t * conn ) {
   stream->state        = FD_QUIC_STREAM_STATE_RX_FIN;
   stream->stream_flags = 0u;
 
-  memset( stream->tx_ack, 0, stream->tx_buf.cap >> 3ul );
+  memset( stream->tx_ack, 0, fd_quic_stream_tx_ack_bufsz( stream ) );
 
   /* insert into used streams */
   FD_QUIC_STREAM_LIST_REMOVE( stream );

--- a/src/waltz/quic/fd_quic_stream.c
+++ b/src/waltz/quic/fd_quic_stream.c
@@ -57,7 +57,7 @@ fd_quic_stream_footprint( ulong tx_buf_sz ) {
   ulong align           = fd_quic_stream_align();
   ulong offs            = 0ul;
 
-  ulong tx_ack_sz       = (tx_buf_sz >> 3ul)+1UL;
+  ulong tx_ack_sz       = fd_quic_tx_ack_bufsz( tx_buf_sz );
   ulong align_stream_sz = fd_ulong_align_up( sizeof( fd_quic_stream_t ), align );
   ulong align_tx_ack_sz = fd_ulong_align_up( tx_ack_sz, align );
   ulong align_tx_buf_sz = fd_ulong_align_up( tx_buf_sz, align );
@@ -69,17 +69,11 @@ fd_quic_stream_footprint( ulong tx_buf_sz ) {
   return offs;
 }
 
-/* returns a newly initialized stream
-
-   args
-     mem          the memory aligned to fd_quic_stream_align, and at least fd_quic_stream_footprint
-                    bytes
-     tx_buf_sz    the size of the tx buffer */
 fd_quic_stream_t *
 fd_quic_stream_new( void * mem, fd_quic_conn_t * conn, ulong tx_buf_sz ) {
   ulong align = fd_quic_stream_align();
 
-  ulong tx_ack_sz       = (tx_buf_sz >> 3ul)+1UL;
+  ulong tx_ack_sz       = fd_quic_tx_ack_bufsz( tx_buf_sz );
   ulong align_stream_sz = fd_ulong_align_up( sizeof( fd_quic_stream_t ), align );
   ulong align_tx_buf_sz = fd_ulong_align_up( tx_buf_sz, align );
   ulong align_tx_ack_sz = fd_ulong_align_up( tx_ack_sz, align );
@@ -114,39 +108,4 @@ fd_quic_stream_new( void * mem, fd_quic_conn_t * conn, ulong tx_buf_sz ) {
   stream->next = stream->prev = stream;
 
   return stream;
-}
-
-/* delete a stream
-
-   args
-     stream       the stream to free */
-void
-fd_quic_stream_delete( fd_quic_stream_t * stream ) {
-  /* stream pointing to itself is not a member of any list */
-  stream->next = stream->prev = stream;
-  stream->list_memb = FD_QUIC_STREAM_LIST_MEMB_NONE;
-}
-
-
-/* set stream context
-
-   args
-     stream      the stream with which to associate the context
-     context     the user-defined context associated with the stream */
-void
-fd_quic_stream_set_context( fd_quic_stream_t * stream, void * context ) {
-  stream->context = context;
-}
-
-
-/* get stream context
-
-   args
-     stream      the stream from which to obtain the context
-
-   returns
-     context     the user defined context associated with the stream */
-void *
-fd_quic_stream_get_context( fd_quic_stream_t * stream ) {
-  return stream->context;
 }

--- a/src/waltz/quic/fd_quic_stream.h
+++ b/src/waltz/quic/fd_quic_stream.h
@@ -172,57 +172,28 @@ fd_quic_buffer_load( fd_quic_buffer_t * buf,
                      uchar *            data,
                      ulong              data_sz );
 
-/* returns the alignment of the fd_quic_stream_t */
-FD_FN_CONST inline
-ulong
+FD_FN_CONST inline ulong
 fd_quic_stream_align( void ) {
   return 128ul;
 }
 
-/* returns the required footprint of fd_quic_stream_t
-
-   args
-     tx_buf_sz    the size of the tx buffer */
-FD_FN_CONST
-ulong
+FD_FN_CONST ulong
 fd_quic_stream_footprint( ulong tx_buf_sz );
 
-/* returns a newly initialized stream
-
-   args
-     mem          the memory aligned to fd_quic_stream_align, and at least fd_quic_stream_footprint
-                    bytes
-     tx_buf_sz    the size of the tx buffer */
 fd_quic_stream_t *
-fd_quic_stream_new( void * mem, fd_quic_conn_t * conn, ulong tx_buf_sz );
+fd_quic_stream_new( void *           mem,
+                    fd_quic_conn_t * conn,
+                    ulong            tx_buf_sz );
 
-/* delete a stream
+static inline ulong
+fd_quic_tx_ack_bufsz( ulong tx_bufsz ) {
+  return (tx_bufsz >> 3UL) + 1UL;
+}
 
-   args
-     stream       the stream to free */
-void
-fd_quic_stream_delete( fd_quic_stream_t * stream );
-
-
-/* set stream context
-
-   args
-     stream      the stream with which to associate the context
-     context     the user-defined context associated with the stream */
-void
-fd_quic_stream_set_context( fd_quic_stream_t * stream, void * context );
-
-
-/* get stream context
-
-   args
-     stream      the stream from which to obtain the context
-
-   returns
-     context     the user defined context associated with the stream */
-void *
-fd_quic_stream_get_context( fd_quic_stream_t * stream );
-
+static inline ulong
+fd_quic_stream_tx_ack_bufsz( fd_quic_stream_t const * stream ) {
+  return fd_quic_tx_ack_bufsz( stream->tx_buf.cap );
+}
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Fixes an off-by-one bug when creating a stream resulting in 7 bits
of uninitialized memory in the 'tx_ack' buffer. This can cause
QUIC clients to mistakenly think data was ACKed when it wasn't
yet in extremely rare edge cases.

Reported-by: https://v12.sh/
