### PR TITLE
events: fix circq correctness issue

### DIFF
--- a/src/disco/events/fd_circq.c
+++ b/src/disco/events/fd_circq.c
@@ -85,6 +85,16 @@ verify( fd_circq_t * circq ) {
   }
 }
 
+/* Recover from eviction logic removing elements at the cursor */
+
+static inline void
+overrun_recover( fd_circq_t * circq ) {
+  if( FD_UNLIKELY( circq->cursor==ULONG_MAX ) ) return;
+
+  ulong oldest_seq = circq->cursor_push_seq - circq->cnt;
+  if( FD_UNLIKELY( circq->cursor_seq<=oldest_seq ) ) circq->cursor = ULONG_MAX;
+}
+
 static void
 evict( fd_circq_t * circq,
        ulong        from,
@@ -104,6 +114,7 @@ evict( fd_circq_t * circq,
       circq->metrics.drop_cnt++;
       if( FD_LIKELY( !circq->cnt ) ) circq->head = circq->tail = 0UL;
       else                           circq->head = head->next;
+      overrun_recover( circq );
     } else {
       break;
     }
@@ -155,6 +166,7 @@ fd_circq_push_back( fd_circq_t * circq,
   fd_circq_message_t * next_message = (fd_circq_message_t *)(buf+circq->tail);
   next_message->align = align;
   next_message->footprint = footprint;
+  next_message->next = ULONG_MAX;
   circq->cursor_push_seq++;
   return (uchar *)(next_message+1);
 }
@@ -219,6 +231,7 @@ fd_circq_pop_until( fd_circq_t * circq,
   }
 
   if( FD_UNLIKELY( !circq->cnt ) ) circq->cursor = ULONG_MAX;
+  overrun_recover( circq );
   return 0;
 }
 

--- a/src/disco/events/test_circq.c
+++ b/src/disco/events/test_circq.c
@@ -194,6 +194,67 @@ test_stale_cursor_handling( void ) {
   FD_TEST( msg );
 }
 
+/* push so many elements that the cursor head got evicted */
+
+static void
+test_overrun_recover( void ) {
+  uchar buf[ 192UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 192UL ) );
+  ulong msg_sz = 0UL;
+
+  uchar * a = fd_circq_push_back( circq, 1UL, 8UL );
+  uchar * b = fd_circq_push_back( circq, 1UL, 8UL );
+  FD_TEST( a && b );
+  a[0] = 'A';
+  b[0] = 'B';
+
+  uchar const * first = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( first );
+  FD_TEST( first[0]=='A' );
+  FD_TEST( msg_sz==8UL );
+
+  uchar * c = fd_circq_push_back( circq, 1UL, 112UL );
+  FD_TEST( c );
+  c[0] = 'C';
+
+  FD_TEST( circq->cnt==1UL );
+  FD_TEST( circq->cursor==ULONG_MAX );
+
+  uchar const * survivor = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( survivor );
+  /* B skipped */
+  FD_TEST( survivor[0]=='C' );
+  FD_TEST( msg_sz==112UL );
+  FD_TEST( !fd_circq_cursor_advance( circq, &msg_sz ) );
+}
+
+/* manually pop so much that cursor gets evicted */
+
+static void
+test_pop_recover( void ) {
+  uchar buf[ 256UL+4096UL ];
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
+  ulong msg_sz = 0UL;
+
+  for( ulong i=0UL; i<3UL; i++ ) {
+    uchar * msg = fd_circq_push_back( circq, 1UL, 8UL );
+    FD_TEST( msg );
+    msg[0] = (uchar)('A' + i);
+  }
+
+  uchar const * first = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( first );
+  FD_TEST( first[0]=='A' );
+
+  ulong cursor_a = circq->cursor_seq - 1UL;
+  FD_TEST( fd_circq_pop_until( circq, cursor_a )==0 );
+  FD_TEST( circq->cursor==ULONG_MAX );
+
+  uchar const * next = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( next );
+  FD_TEST( next[0]=='B' );
+}
+
 static void
 test_cursor_sequence_monotonicity( void ) {
   uchar buf[ 512UL+4096UL ];
@@ -279,6 +340,8 @@ main( int     argc,
   test_wraparound_iteration();         FD_LOG_NOTICE(( "pass: wraparound_iteration" ));
   test_interleaved_ops();              FD_LOG_NOTICE(( "pass: interleaved_ops" ));
   test_stale_cursor_handling();        FD_LOG_NOTICE(( "pass: stale_cursor_handling" ));
+  test_overrun_recover();              FD_LOG_NOTICE(( "pass: overrun_recover" ));
+  test_pop_recover();                  FD_LOG_NOTICE(( "pass: pop_recover" ));
   test_cursor_sequence_monotonicity(); FD_LOG_NOTICE(( "pass: cursor_sequence_monotonicity" ));
   test_edge_cases();                   FD_LOG_NOTICE(( "pass: edge_cases" ));
   test_bounds();                       FD_LOG_NOTICE(( "pass: bounds" ));


### PR DESCRIPTION
Fixes a bug where circq did not correctly recover from loss due
to cache eviction or manual removals.
