### PR TITLE
ci: faster checkouts

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Check Proofs
         run: |

--- a/.github/workflows/check_seccomp.yml
+++ b/.github/workflows/check_seccomp.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout current commit
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Python environment
         run: |

--- a/.github/workflows/proto_check.yml
+++ b/.github/workflows/proto_check.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/trailing_whitespace.yml
+++ b/.github/workflows/trailing_whitespace.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Get changed files
         id: changes


### PR DESCRIPTION
Fixes several unnecessary 'full commit history' checkouts.
Shallow checkout (the GitHub Actions default) is enough for most
purposes.
