### PR TITLE
reasm: simplify eviction to leaf nodes only

### DIFF
--- a/src/discof/reasm/fd_reasm.c
+++ b/src/discof/reasm/fd_reasm.c
@@ -422,166 +422,76 @@ fd_reasm_pool_idx( fd_reasm_t * reasm, fd_reasm_fec_t * ele ) {
   return pool_idx( reasm_pool( reasm ), ele );
 }
 
-fd_reasm_fec_t *
-fd_reasm_remove( fd_reasm_t     * reasm,
-                 fd_reasm_fec_t * head,
-                 fd_store_t     * opt_store ) {
-  /* see fd_forest.c clear_leaf */
+/* remove_leaf removes a leaf node. This function cannot return
+   NULL. It is assumed that the passed `head` exists in reasm. */
 
-  fd_reasm_fec_t *    pool     = reasm_pool( reasm );
-  orphaned_t *        orphaned = reasm->orphaned;
-  frontier_t *        frontier = reasm->frontier;
-  ancestry_t *        ancestry = reasm->ancestry;
-  subtrees_t *        subtrees = reasm->subtrees;
-  subtreel_t *        subtreel = reasm->subtreel;
+static fd_reasm_fec_t *
+remove_leaf( fd_reasm_t     * reasm,
+             fd_reasm_fec_t * head,
+             fd_store_t     * opt_store ) {
+  fd_reasm_fec_t * pool     = reasm_pool( reasm );
+  orphaned_t *     orphaned = reasm->orphaned;
+  frontier_t *     frontier = reasm->frontier;
+  ancestry_t *     ancestry = reasm->ancestry;
+  subtrees_t *     subtrees = reasm->subtrees;
+  subtreel_t *     subtreel = reasm->subtreel;
 
-  FD_TEST( head );
-
-  fd_reasm_fec_t * tail = head;
-
-
-
-  if( FD_LIKELY( orphaned_ele_query( orphaned, &head->key, NULL, pool ) ||
-                 subtrees_ele_query( subtrees, &head->key, NULL, pool ) ) ) {
-    FD_TEST( head->child == ULONG_MAX ); /* must be a leaf node */
-  } else {
-    /* Node is in frontier or ancestry.  If the leaf is in the frontier,
-       we could be removing something that has been executed.  Move the
-       head pointer up to where we begin evicting.
-
-       We search up the tree until the theoretical boundary of a bank.
-       This is usually when we jump to a parent slot, but if an
-       equivocation occured, this could also be the middle of the slot.
-
-       0 ── 32 ──  64 ──  96          (confirmed)
-              └──  64' ── 96' ── 128' (eqvoc)
-
-        Note we only have execute a slot twice (have 2 bank idxs for it)
-        if the slot equivocated, we replayed the wrong version, and then
-        replayed the confirmed version afterwards.
-
-        The state after executing the wrong version first is:
-
-              0  ────  32 ────  64 ────  96 ──── 128
-        (bank_idx=1) (bank_idx=1) .... (all bank_idx=1)
-
-        After receiving and executing the confirmed version, the state
-        looks like:
-
-        0 (b=2) ── 32 (b=2) ──  64  (b=2) ──  96  (b=2)               (confirmed)
-                           └──  64' (b=1) ──  96' (b=1) ── 128' (b=1) (eqvoc)
-
-        Here we want to evict only until fec 64'. Or let's say we are
-        getting around to executing the confirmed version, but we haven't
-        executed it yet.
-
-        0 (b=1) ── 32 (b=1) ──  64  (b=ULONG_MAX) ── 96  (b=ULONG_MAX)           (confirmed, but not executed yet)
-                           └──  64' (b=1)         ── 96' (b=1) ── 128'(b=1)      (eqvoc)
-
-        Now we know we should evict until the max(parent has > 1 child, or fec set idx == 0) */
-
-    while( FD_LIKELY( head ) ) {
-      fd_reasm_fec_t * parent = fd_reasm_parent( reasm, head ); /* parent must exist.  It's not possible to walk up past root */
-      FD_TEST( head->bank_idx == tail->bank_idx );
-
-      if( FD_UNLIKELY( head->fec_set_idx==0  ) )                   break;
-      if( FD_UNLIKELY( head->sibling != pool_idx_null( pool ) ) )  break; /* if the parent has more than 1 child, we know for sure the parent is a slot boundary or eqvoc point, so we can stop here. */
-      if( FD_UNLIKELY( parent->child != pool_idx( pool, head ) ) ) break; /* if the parent has more than 1 child, we know for sure the parent is a slot boundary or eqvoc point, so we can stop here. */
-      if( FD_UNLIKELY( parent->slot_complete ) )                   break; /* specifically catches case where slot complete is in middle of slot. */
-      head = parent;
-    }
-  }
-  FD_LOG_INFO(( "evicting reasm slot %lu, fec idx %u, down to %u bank_idx %lu", head->slot, head->fec_set_idx, tail->fec_set_idx, head->bank_idx ));
-
-  /* Orphan the entire subtree from the tail :( */
-  if( FD_UNLIKELY( fd_reasm_child( reasm, tail ) ) ) {
-    /* subtree this child.  This code path should only be hit if this is
-       banks-driven eviction, so children are guaranteed to be in main
-       tree right now. */
-    ulong * bfs = reasm->bfs;
-    bfs_push_tail( bfs, pool_idx( pool, tail ) );
-    while( FD_LIKELY( !bfs_empty( bfs ) ) ) {
-      fd_reasm_fec_t * ele   = pool_ele( pool, bfs_pop_head( bfs ) );
-      fd_reasm_fec_t * child = fd_reasm_child( reasm, ele );
-      while( FD_LIKELY( child ) ) {
-        bfs_push_tail( bfs, pool_idx( pool, child ) );
-        child = pool_ele( pool, child->sibling );
-      }
-
-      if( FD_UNLIKELY( ele == tail ) ) continue;
-      /* remove each child from the maps */
-      if( FD_UNLIKELY( !ancestry_ele_remove( ancestry, &ele->key, NULL, pool ) ) ) frontier_ele_remove( frontier, &ele->key, NULL, pool );
-      if( FD_LIKELY( ele->in_out ) ) { out_ele_remove( reasm->out, ele, pool ); ele->in_out = 0; }
-
-      if( FD_UNLIKELY( ele->parent == pool_idx( pool, tail ) ) ) {
-        subtrees_ele_insert( subtrees, ele, pool );
-        subtreel_ele_push_tail( reasm->subtreel, ele, pool );
-        ele->parent  = ULONG_MAX;
-        ele->sibling = ULONG_MAX;
-      } else {
-        orphaned_ele_insert( orphaned, ele, pool );
-      }
-    }
-    /* unlink the leaf from its children. */
-    tail->child = ULONG_MAX;
-  }
+  FD_TEST( head && head->child == ULONG_MAX ); /* must be a leaf node */
+  FD_LOG_INFO(( "evicting reasm slot %lu fec idx %u bank_idx %lu", head->slot, head->fec_set_idx, head->bank_idx ));
 
   fd_reasm_fec_t * parent = fd_reasm_parent( reasm, head );
-  if( FD_LIKELY( parent ) ) {
-   /* Clean up the parent pointing to this head, and remove block from the maps
-      remove the block from the parent's child list */
-
-    fd_reasm_fec_t * child = pool_ele( pool, parent->child );
-    if( FD_LIKELY( 0==memcmp( &child->key, &head->key, sizeof(fd_hash_t) ) ) ) { /* evicted is left-child (or only child) */
-      parent->child = child->sibling;
-    } else {
-      /* evicted is a right-sibling */
-      fd_reasm_fec_t * sibling = pool_ele( pool, child->sibling );
-      fd_reasm_fec_t * prev    = child;
-      while( FD_LIKELY( sibling && memcmp( &sibling->key, &head->key, sizeof(fd_hash_t) ) ) ) {
-        prev = sibling;
-        sibling = pool_ele( pool, sibling->sibling );
-      }
-      prev->sibling = sibling->sibling;
-    }
-
-    /* remove the chain itself from the maps */
-
-    fd_reasm_fec_t * removed_orphan = NULL;
-    if( FD_LIKELY  ( removed_orphan = orphaned_ele_remove( orphaned, &head->key, NULL, pool ) ) ) {
-      clear_slot_metadata( reasm, head );
-      if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
-      return head;
-    }
-
-    /* remove from ancestry and frontier */
-    fd_reasm_fec_t * curr = head;
-    while( FD_LIKELY( curr ) ) {
-      fd_reasm_fec_t * removed = ancestry_ele_remove( ancestry, &curr->key, NULL, pool );
-      if( !removed )   removed = frontier_ele_remove( frontier, &curr->key, NULL, pool );
-      if( FD_LIKELY( removed->in_out ) ) { out_ele_remove( reasm->out, removed, pool ); removed->in_out = 0; }
-
-      curr = fd_reasm_child( reasm, curr );  /* guaranteed only one child */
-      clear_slot_metadata( reasm, removed );
-      if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &removed->key );
-    }
-
-    /* We removed from the main tree, so we might need to insert parent into the frontier.
-        Only need to add parent to the frontier if it doesn't have any other children. */
-
-    if( parent->child == pool_idx_null( pool ) ) {
-      parent = ancestry_ele_remove( ancestry, &parent->key, NULL, pool );
-      FD_TEST( parent );
-      frontier_ele_insert( frontier, parent, pool );
-    }
+  if( FD_UNLIKELY( !parent ) ) {
+    /* No parent, remove from subtrees and subtree list */
+    subtrees_ele_remove( subtrees, &head->key, NULL, pool );
+    subtreel_ele_remove( subtreel,  head,            pool );
+    clear_slot_metadata( reasm, head );
+    if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
     return head;
   }
 
-  /* No parent, remove from subtrees and subtree list */
-  subtrees_ele_remove( subtrees, &head->key, NULL, pool );
-  subtreel_ele_remove( subtreel,  head,            pool );
+  /* Else this node is connected to a parent. Clean up the parent
+     pointing to this head, remove block from the maps. */
+
+  fd_reasm_fec_t * child = pool_ele( pool, parent->child );
+  if( FD_LIKELY( 0==memcmp( &child->key, &head->key, sizeof(fd_hash_t) ) ) ) {
+    /* evicted is left-child (or only child) */
+    parent->child = child->sibling;
+  } else {
+    /* evicted is a right-sibling */
+    fd_reasm_fec_t * sibling = pool_ele( pool, child->sibling );
+    fd_reasm_fec_t * prev    = child;
+    while( FD_LIKELY( sibling && memcmp( &sibling->key, &head->key, sizeof(fd_hash_t) ) ) ) {
+      prev = sibling;
+      sibling = pool_ele( pool, sibling->sibling );
+    }
+    prev->sibling = sibling->sibling;
+  }
+
+  /* remove the node itself from the maps */
+
+  fd_reasm_fec_t * removed = orphaned_ele_remove( orphaned, &head->key, NULL, pool );
+  if( FD_LIKELY( removed ) ) {
+    clear_slot_metadata( reasm, removed );
+    if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &removed->key );
+    return head;
+  }
+
+  /* Early exit if node was an orphan. Now we know it's in ancestry or frontier. */
+
+  removed = ancestry_ele_remove( ancestry, &head->key, NULL, pool );
+  removed = fd_ptr_if( !removed, frontier_ele_remove( frontier, &head->key, NULL, pool ), removed );
+  if( FD_LIKELY( removed->in_out ) ) { out_ele_remove( reasm->out, removed, pool ); removed->in_out = 0; }
   clear_slot_metadata( reasm, head );
   if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
+
+  /* We removed from the main tree, so we might need to insert parent into the frontier.
+      Only need to add parent to the frontier if it doesn't have any other children. */
+
+  if( parent->child == pool_idx_null( pool ) ) {
+    parent = ancestry_ele_remove( ancestry, &parent->key, NULL, pool );
+    FD_TEST( parent );
+    frontier_ele_insert( frontier, parent, pool );
+  }
   return head;
 }
 
@@ -637,9 +547,9 @@ evict( fd_reasm_t      * reasm,
   subtreel_t *     subtreel = reasm->subtreel;
 
   /* Generally, best policy for eviction is to evict in the order of:
-    1. Highest unconfirmed orphan leaf                   - furthest from root
-    2. Highest incomplete, unconfirmed leaf in ancestry  - furthest from tip of execution
-    3. Highest confirmed orphan leaf                     - evictable, since unrelated to banks, but less ideal */
+    1. Highest unconfirmed orphan leaf       - furthest from root
+    2. Highest unconfirmed leaf in ancestry  - furthest from tip of execution
+    3. Highest confirmed orphan leaf         - evictable, since unrelated to banks, but less ideal */
 
   fd_reasm_fec_t * unconfrmd_orphan = NULL; /* 1st best candidate for eviction is the highest unconfirmed orphan. */
   fd_reasm_fec_t * confirmed_orphan = NULL; /* 3rd best candidate for eviction is the highest confirmed orphan.   */
@@ -661,24 +571,23 @@ evict( fd_reasm_t      * reasm,
   }
 
   if( FD_UNLIKELY( unconfrmd_orphan )) {
-    return fd_reasm_remove( reasm, unconfrmd_orphan, opt_store );
+    return remove_leaf( reasm, unconfrmd_orphan, opt_store );
   }
 
-  fd_reasm_fec_t * unconfrmd_leaf = NULL; /* 2nd best candidate for eviction is the highest unconfirmed, incomplete slot. */
+  fd_reasm_fec_t * unconfrmd_leaf = NULL; /* 2nd best candidate for eviction is the highest unconfirmed fec. */
   for( frontier_iter_t iter = frontier_iter_init( frontier, pool );
-                              !frontier_iter_done( iter, frontier, pool );
-                        iter = frontier_iter_next( iter, frontier, pool ) ) {
+                             !frontier_iter_done( iter, frontier, pool );
+                       iter = frontier_iter_next( iter, frontier, pool ) ) {
     fd_reasm_fec_t * ele = frontier_iter_ele( iter, frontier, pool );
     if( iter.ele_idx == reasm->root
         || 0==memcmp( &ele->key, parent_root, sizeof(fd_hash_t) )
         || ele->confirmed
-        || ele->slot_complete
         || ele->is_leader ) continue; /* not a candidate */
     unconfrmd_leaf = fd_ptr_if( !unconfrmd_leaf || ele->slot > unconfrmd_leaf->slot, ele, unconfrmd_leaf );
   }
 
   if( FD_UNLIKELY( unconfrmd_leaf )) {
-    return fd_reasm_remove( reasm, unconfrmd_leaf, opt_store );
+    return remove_leaf( reasm, unconfrmd_leaf, opt_store );
   }
 
   /* Already did traversal to find best confirmed orphan candidate,
@@ -687,7 +596,7 @@ evict( fd_reasm_t      * reasm,
   if( FD_UNLIKELY( confirmed_orphan )) {
     fd_reasm_fec_t * parent = fd_reasm_query( reasm, parent_root );
     if( !parent ) {
-      return fd_reasm_remove( reasm, confirmed_orphan, opt_store );
+      return remove_leaf( reasm, confirmed_orphan, opt_store );
     }
   /* for any subtree:
       0 ── 1 ── 2 ── 3 (confirmed) ── 4(confirmed) ── 5 ── 6 ──> add 7 here is valid.
@@ -706,7 +615,7 @@ evict( fd_reasm_t      * reasm,
 
     fd_reasm_fec_t * latest_confirmed_leaf = latest_confirmed_fec( reasm, subtree_root );
     if( !latest_confirmed_leaf || latest_confirmed_leaf == gca( reasm, latest_confirmed_leaf, parent )) {
-      return fd_reasm_remove( reasm, confirmed_orphan, opt_store );
+      return remove_leaf( reasm, confirmed_orphan, opt_store );
     }
     /* is a useless new fork. */
     return NULL;

--- a/src/discof/reasm/fd_reasm.h
+++ b/src/discof/reasm/fd_reasm.h
@@ -317,15 +317,15 @@ fd_reasm_init( fd_reasm_t *      reasm,
    Insert can fail before acquiring a pool element, in which case it
    returns NULL and *evicted remains NULL.  If the reasm is full
    (fd_reasm_free() returns 1 [sic!]), reasm_insert will evict a FEC set
-   by the policy outlined in the evict function.  The evicted FEC set(s)
+   by the policy outlined in the evict function.  The evicted FEC set
    will be removed from reasm, but will remain in the pool.  If no FEC
    set was able to be evicted after the insert reaches the eviction
    path, then evicted will be set to a pool element that is populated
    with data of the failed insert.
 
-   It is the caller's responsibility to read, traverse, and release back
-   to the pool the evicted reasm_fec_t chain before the next
-   fd_reasm_insert or fd_reasm_remove call.
+   It is the caller's responsibility to read and release back to the
+   pool the evicted reasm_fec_t before the next fd_reasm_insert or
+   fd_reasm_remove call.
 
    See top-level documentation for further details on insertion. */
 
@@ -342,36 +342,6 @@ fd_reasm_insert( fd_reasm_t *      reasm,
                  int               leader,
                  fd_store_t      * opt_store,
                  fd_reasm_fec_t ** evicted );
-
-/* fd_reasm_remove removes a leaf node or a chain of nodes that
-   terminates with the provided node from reasm.  Returns the start of
-   the chain of evicted fd_reasm_fec_t.  This function cannot return
-   NULL.
-
-   It is assumed that the passed `head` exists in reasm.  If `head` is
-   in orphans, it is assumed that it is a leaf node, and only `head`
-   will be cleared.  If `head` is in ancestry, a chain of nodes will be
-   cleared starting from `head` and walking up the tree until one of the
-   following conditions is met: we reach fec_set_idx 0, we reach a fec
-   set with an equivocating sibling.  Any children nodes of `head` will
-   be appropriately orphaned.
-
-   Note that an invariant reasm_remove guarantees is that from the
-   returned head to the end of the chain, it is a linear chain of nodes
-   with no branches.  This is important because it allows the caller to
-   traverse the chain without needing to BFS.
-
-   The evicted fd_reasm_fec_t will be returned as a pointer to a pool
-   element. At this point the evicted pool element will still be
-   acquired in the pool, but no longer in any map.  It is the caller's
-   responsibility to read, traverse, and release back to the pool the
-   evicted reasm_fec_t chain before the next fd_reasm_insert or
-   fd_reasm_remove call. */
-
-fd_reasm_fec_t *
-fd_reasm_remove( fd_reasm_t     * reasm,
-                 fd_reasm_fec_t * head,
-                 fd_store_t     * opt_store );
 
 /* fd_reasm_pool_release releases a reasm_fec element back to the pool.
    Assumes ele is a valid pointer to a pool element inside reasm.  This

--- a/src/discof/reasm/test_reasm.c
+++ b/src/discof/reasm/test_reasm.c
@@ -552,9 +552,9 @@ test_evict( fd_wksp_t * wksp ) {
 
   FD_TEST( fd_reasm_insert( reasm, mr10, mr9,  10,    0,       2,     32,     0, 0,        0, NULL, evicted ) );
 
-  FD_TEST( fd_reasm_query( reasm, mr5 ) ); /* Evicts slot 4, because slot 5 is complete  */
-  FD_TEST( !fd_reasm_query( reasm, mr3 ) );
-  FD_TEST( (*evicted)->slot == 4 && (*evicted)->fec_set_idx == 0 );
+  FD_TEST( fd_reasm_query( reasm, mr3 ) );  /* mr3 still present */
+  FD_TEST( !fd_reasm_query( reasm, mr5 ) ); /* mr5 evicted (highest unconfirmed frontier leaf) */
+  FD_TEST( (*evicted)->slot == 5 && (*evicted)->fec_set_idx == 32 );
   fd_reasm_pool_release( reasm, *evicted );
 }
 
@@ -1050,141 +1050,161 @@ test_confirm_out_ordering( fd_wksp_t * wksp ) {
 }
 
 void
-test_remove_bank_eviction( fd_wksp_t * wksp ) {
-  /* Tree structure after all inserts:
+test_evict_unconfirmed_orphan( fd_wksp_t * wksp ) {
+  /* Category 1: Highest unconfirmed orphan leaf is evicted.
 
-     root(0,0) ── (1,0) ── (1,32) ── (1,64)[slot_complete]
-                                        ├── (2,0) ── (2,32) ── (2,64) ── (2,96)
-                                        └── (3,0) ── (3,32)
+     Tree: root(0) -- a(1) -- b(2) -- c(3) -- d(4) -- e(5)
+     Orphan: f(10) [unconfirmed subtree root leaf]
 
-     Simulate the replay tile having popped and replayed the first 2
-     FECs of slot 1 ((1,0) and (1,32)).  Then simulate bank eviction
-     by calling fd_reasm_remove on (1,32) — the latest FEC that was
-     replayed on this bank */
+     Insert g(6) as child of e → triggers eviction.
+     Expected: f(10) evicted. */
 
-  ulong        fec_max = 32;
+  ulong        fec_max = 8;
   void *       mem     = fd_wksp_alloc_laddr( wksp, fd_reasm_align(), fd_reasm_footprint( fec_max ), 1UL );
   fd_reasm_t * reasm   = fd_reasm_join( fd_reasm_new( mem, fec_max, 0UL ) );
   FD_TEST( reasm );
 
-  fd_reasm_fec_t * pool     = reasm_pool( reasm );
-  frontier_t *     frontier = reasm->frontier;
-  subtrees_t *     subtrees = reasm->subtrees;
-  orphaned_t *     orphaned = reasm->orphaned;
+  fd_hash_t mr_root[1] = {{{ 0 }}};
+  fd_hash_t mr_a[1]    = {{{ 1 }}};
+  fd_hash_t mr_b[1]    = {{{ 2 }}};
+  fd_hash_t mr_c[1]    = {{{ 3 }}};
+  fd_hash_t mr_d[1]    = {{{ 4 }}};
+  fd_hash_t mr_e[1]    = {{{ 5 }}};
+  fd_hash_t mr_f[1]    = {{{ 6 }}};
+  fd_hash_t mr_fp[1]   = {{{ 60 }}};
+  fd_hash_t mr_g[1]    = {{{ 7 }}};
 
   fd_reasm_fec_t * ev[1];
 
-  /* Merkle roots for each FEC. */
-  fd_hash_t mr_root[1] = {{{ 99 }}};
-
-  fd_hash_t mr1_0 [1] = {{{ 10 }}};
-  fd_hash_t mr1_32[1] = {{{ 11 }}};
-  fd_hash_t mr1_64[1] = {{{ 12 }}};
-
-  fd_hash_t mr2_0 [1] = {{{ 20 }}};
-  fd_hash_t mr2_32[1] = {{{ 21 }}};
-  fd_hash_t mr2_64[1] = {{{ 22 }}};
-  fd_hash_t mr2_96[1] = {{{ 23 }}};
-
-  fd_hash_t mr3_0 [1] = {{{ 30 }}};
-  fd_hash_t mr3_32[1] = {{{ 31 }}};
-
-  /* Insert root (snapshot slot). */
   fd_reasm_init( reasm, mr_root, 0 );
 
-  /* Insert slot 1: 3 FECs. (1,64) has slot_complete. */
-  /*                                mr       cmr       slot fec_idx p_off data_cnt dc   sc   ldr        */
-  fd_reasm_insert( reasm, mr1_0,  mr_root, 1,   0,     1,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr1_32, mr1_0,   1,   32,    1,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr1_64, mr1_32,  1,   64,    1,   32,     0,   1,   0, NULL, ev );
+  fd_reasm_insert( reasm, mr_a,   mr_root, 1,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_b,   mr_a,    2,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_c,   mr_b,    3,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_d,   mr_c,    4,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_e,   mr_d,    5,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_f,   mr_fp,  10,  0, 1, 32, 0, 1, 0, NULL, ev );
 
-  /* Insert slot 2: 4 FECs chaining off slot 1. */
-  fd_reasm_insert( reasm, mr2_0,  mr1_64,  2,   0,     1,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr2_32, mr2_0,   2,   32,    1,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr2_64, mr2_32,  2,   64,    1,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr2_96, mr2_64,  2,   96,    1,   32,     0,   1,   0, NULL, ev );
+  FD_TEST( *ev == NULL );
 
-  /* Insert slot 3: 2 FECs chaining off slot 1 (fork). */
-  fd_reasm_insert( reasm, mr3_0,  mr1_64,  3,   0,     2,   32,     0,   0,   0, NULL, ev );
-  fd_reasm_insert( reasm, mr3_32, mr3_0,   3,   32,    2,   32,     0,   1,   0, NULL, ev );
+  FD_TEST( fd_reasm_insert( reasm, mr_g, mr_e, 6, 0, 1, 32, 0, 1, 0, NULL, ev ) );
+  FD_TEST( *ev );
+  FD_TEST( !fd_reasm_query( reasm, mr_f ) );
+  FD_TEST( (*ev)->slot == 10 && (*ev)->fec_set_idx == 0 );
+  fd_reasm_pool_release( reasm, *ev );
 
-  verify_out_invariants( reasm );
-
-  /* Simulate replay: pop the first 2 FECs in slot 1.
-     In the replay tile, this means the bank has replayed (1,0) and
-     (1,32).  The replay tile's latest_mr would be mr1_32. */
-
-  fd_reasm_fec_t * popped1 = fd_reasm_pop( reasm );
-  FD_TEST( popped1 );
-  FD_TEST( 0==memcmp( &popped1->key, mr1_0, sizeof(fd_hash_t) ) );
-  popped1->bank_idx = 1; /* simulate bank assignment */
-
-  fd_reasm_fec_t * popped2 = fd_reasm_pop( reasm );
-  FD_TEST( popped2 );
-  FD_TEST( 0==memcmp( &popped2->key, mr1_32, sizeof(fd_hash_t) ) );
-  popped2->bank_idx = 1; /* same bank */
-
-  /* Simulate bank eviction: call fd_reasm_remove on the second FEC
-     that was popped ((1,32)), mimicking the replay tile querying
-     latest_mr and passing the result to remove. */
-
-  fd_reasm_fec_t * fec_to_evict = fd_reasm_query( reasm, mr1_32 );
-  FD_TEST( fec_to_evict );
-  FD_TEST( fec_to_evict->child != ULONG_MAX );                  /* NOT a leaf  */
-
-  fd_reasm_fec_t * evicted_head = fd_reasm_remove( reasm, fec_to_evict, NULL );
-  FD_TEST( evicted_head );
-
-  /* The evicted chain should be (1,0) -> (1,32).  head walks up from
-     (1,32) to (1,0) because fec_set_idx 0 is the stop condition. */
-
-  FD_TEST( 0==memcmp( &evicted_head->key, mr1_0, sizeof(fd_hash_t) ) );
-  fd_reasm_fec_t * evicted_child = fd_reasm_child( reasm, evicted_head );
-  FD_TEST( 0==memcmp( &evicted_child->key, mr1_32, sizeof(fd_hash_t) ) );
-
-  /* (1,0) and (1,32) should no longer be in any map. */
-
-  FD_TEST( !fd_reasm_query( reasm, mr1_0  ) );
-  FD_TEST( !fd_reasm_query( reasm, mr1_32 ) );
-
-  /* (1,64) should now be a subtree root — it was the direct child of
-     tail=(1,32) and became orphaned by the removal. */
-
-  FD_TEST( subtrees_ele_query( subtrees, mr1_64, NULL, pool ) );
-
-  /* (1,64)'s children from slot 2 and slot 3 should be in orphaned. */
-
-  FD_TEST( orphaned_ele_query( orphaned, mr2_0,  NULL, pool ) );
-  FD_TEST( orphaned_ele_query( orphaned, mr2_32, NULL, pool ) );
-  FD_TEST( orphaned_ele_query( orphaned, mr2_64, NULL, pool ) );
-  FD_TEST( orphaned_ele_query( orphaned, mr2_96, NULL, pool ) );
-  FD_TEST( orphaned_ele_query( orphaned, mr3_0,  NULL, pool ) );
-  FD_TEST( orphaned_ele_query( orphaned, mr3_32, NULL, pool ) );
-
-  /* Slot 2's first FEC and slot 3's first FEC should be subtree roots
-     (they are direct children of (1,64) which is the tail's child, so
-     actually (2,0) and (3,0) should be subtree roots if the code
-     re-roots each direct child of tail). */
-
-  /* The out dlist should be empty — all previously connected FECs
-     were either popped ((1,0), (1,32)) or orphaned ((1,64) and
-     descendants). */
-
-  FD_TEST( out_is_empty( reasm->out, pool ) );
-
-  /* The root should now be a frontier leaf (its only child (1,0) was
-     evicted, so it has no children). */
-
-  FD_TEST( frontier_ele_query( frontier, mr_root, NULL, pool ) );
-
-  /* Clean up: release evicted elements back to pool. */
-
-  fd_reasm_pool_release( reasm, evicted_child );
-  fd_reasm_pool_release( reasm, evicted_head );
+  FD_TEST( fd_reasm_query( reasm, mr_g ) );
 
   fd_wksp_free_laddr( fd_reasm_delete( fd_reasm_leave( reasm ) ) );
+  FD_LOG_NOTICE(( "test_evict_unconfirmed_orphan passed" ));
+}
 
-  FD_LOG_NOTICE(( "test_remove_bank_eviction passed" ));
+void
+test_evict_unconfirmed_frontier( fd_wksp_t * wksp ) {
+  /* Category 2: Highest unconfirmed frontier leaf is evicted when
+     there are no unconfirmed orphan candidates.
+
+     Tree: root(0) -- a(1) -- b(2) -- c(3) -- d(4)  [frontier, slot 4]
+                                   \-- e(5)          [frontier, slot 5]
+                                   \-- f(7)          [frontier, slot 7]
+
+     No orphans. Insert g(8) with nonexistent parent → orphan.
+     Expected: f(7) evicted (highest unconfirmed frontier leaf). */
+
+  ulong        fec_max = 8;
+  void *       mem     = fd_wksp_alloc_laddr( wksp, fd_reasm_align(), fd_reasm_footprint( fec_max ), 1UL );
+  fd_reasm_t * reasm   = fd_reasm_join( fd_reasm_new( mem, fec_max, 0UL ) );
+  FD_TEST( reasm );
+
+  fd_hash_t mr_root[1] = {{{ 0 }}};
+  fd_hash_t mr_a[1]    = {{{ 1 }}};
+  fd_hash_t mr_b[1]    = {{{ 2 }}};
+  fd_hash_t mr_c[1]    = {{{ 3 }}};
+  fd_hash_t mr_d[1]    = {{{ 4 }}};
+  fd_hash_t mr_e[1]    = {{{ 5 }}};
+  fd_hash_t mr_f[1]    = {{{ 6 }}};
+  fd_hash_t mr_g[1]    = {{{ 7 }}};
+  fd_hash_t mr_gp[1]   = {{{ 70 }}};
+
+  fd_reasm_fec_t * ev[1];
+  fd_reasm_init( reasm, mr_root, 0 );
+  fd_reasm_insert( reasm, mr_a,   mr_root, 1,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_b,   mr_a,    2,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_c,   mr_b,    3,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_d,   mr_c,    4,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_e,   mr_b,    5,  0, 3, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_f,   mr_b,    7,  0, 5, 32, 0, 1, 0, NULL, ev );
+
+  FD_TEST( *ev == NULL );
+
+  FD_TEST( fd_reasm_insert( reasm, mr_g, mr_gp, 8, 0, 1, 32, 0, 0, 0, NULL, ev ) );
+  FD_TEST( *ev );
+  FD_TEST( !fd_reasm_query( reasm, mr_f ) );
+  FD_TEST( (*ev)->slot == 7 && (*ev)->fec_set_idx == 0 );
+  fd_reasm_pool_release( reasm, *ev );
+
+  FD_TEST( fd_reasm_query( reasm, mr_d ) );
+  FD_TEST( fd_reasm_query( reasm, mr_e ) );
+
+  fd_wksp_free_laddr( fd_reasm_delete( fd_reasm_leave( reasm ) ) );
+  FD_LOG_NOTICE(( "test_evict_unconfirmed_frontier passed" ));
+}
+
+void
+test_evict_confirmed_orphan( fd_wksp_t * wksp ) {
+  /* Category 3: Highest confirmed orphan leaf is evicted when there
+     are no unconfirmed orphan or frontier candidates.
+
+     Tree: root(0) -- a(1) -- b(2) -- c(3) -- d(4) -- e(5, is_leader)
+     Orphan: f(10, confirmed=1) [subtree root leaf]
+
+     Insert g(11) with nonexistent parent.
+     Category 1: f is confirmed → skip.
+     Category 2: e is_leader → skip.
+     Category 3: parent not found → evict confirmed orphan f. */
+
+  ulong        fec_max = 8;
+  void *       mem     = fd_wksp_alloc_laddr( wksp, fd_reasm_align(), fd_reasm_footprint( fec_max ), 1UL );
+  fd_reasm_t * reasm   = fd_reasm_join( fd_reasm_new( mem, fec_max, 0UL ) );
+  FD_TEST( reasm );
+
+  fd_hash_t mr_root[1] = {{{ 0 }}};
+  fd_hash_t mr_a[1]    = {{{ 1 }}};
+  fd_hash_t mr_b[1]    = {{{ 2 }}};
+  fd_hash_t mr_c[1]    = {{{ 3 }}};
+  fd_hash_t mr_d[1]    = {{{ 4 }}};
+  fd_hash_t mr_e[1]    = {{{ 5 }}};
+  fd_hash_t mr_f[1]    = {{{ 6 }}};
+  fd_hash_t mr_fp[1]   = {{{ 60 }}};
+  fd_hash_t mr_g[1]    = {{{ 7 }}};
+  fd_hash_t mr_gp[1]   = {{{ 70 }}};
+
+  fd_reasm_fec_t * ev[1];
+
+  fd_reasm_init( reasm, mr_root, 0 );
+  fd_reasm_insert( reasm, mr_a,   mr_root, 1,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_b,   mr_a,    2,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_c,   mr_b,    3,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_d,   mr_c,    4,  0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_insert( reasm, mr_e,   mr_d,    5,  0, 1, 32, 0, 1, 1, NULL, ev );
+  fd_reasm_insert( reasm, mr_f,   mr_fp,  10,  0, 1, 32, 0, 1, 0, NULL, ev );
+
+  fd_reasm_fec_t * fec_f = fd_reasm_query( reasm, mr_f );
+  FD_TEST( fec_f );
+  fec_f->confirmed = 1;
+
+  FD_TEST( *ev == NULL );
+
+  FD_TEST( fd_reasm_insert( reasm, mr_g, mr_gp, 11, 0, 1, 32, 0, 0, 0, NULL, ev ) );
+  FD_TEST( *ev );
+  FD_TEST( !fd_reasm_query( reasm, mr_f ) );
+  FD_TEST( (*ev)->slot == 10 && (*ev)->fec_set_idx == 0 );
+  fd_reasm_pool_release( reasm, *ev );
+
+  FD_TEST( fd_reasm_query( reasm, mr_e ) );
+
+  fd_wksp_free_laddr( fd_reasm_delete( fd_reasm_leave( reasm ) ) );
+  FD_LOG_NOTICE(( "test_evict_confirmed_orphan passed" ));
 }
 
 void
@@ -1247,7 +1267,9 @@ main( int argc, char ** argv ) {
   test_validate_cross_slot( wksp );
   test_remove_deep_orphan_subtree( wksp );
   test_confirm_out_ordering( wksp );
-  test_remove_bank_eviction( wksp );
+  test_evict_unconfirmed_orphan( wksp );
+  test_evict_unconfirmed_frontier( wksp );
+  test_evict_confirmed_orphan( wksp );
   test_insert_rejects_when_full_and_nothing_is_evictable( wksp );
 
   fd_halt();


### PR DESCRIPTION
fixes https://github.com/firedancer-io/firedancer/issues/9735

Closing because we want to 
1. prevent against evicting completed slots -- this way replay can only deliver up to two slot_completeds to tower
2. prevent against losing equivocation detection -- i.e. 0, 32, 64 arrive, we replay. if we evict 64, and then get 64', we lose eqvoc detection. So its better to just evict all 0, 32, 64.