### PR TITLE
rewards: validate stake_rewards max_fork_width

### DIFF
--- a/src/flamenco/rewards/fd_stake_rewards.c
+++ b/src/flamenco/rewards/fd_stake_rewards.c
@@ -2,8 +2,6 @@
 #include "fd_rewards_base.h"
 #include "../../ballet/siphash13/fd_siphash13.h"
 
-#define MAX_SUPPORTED_FORKS (128UL)
-
 #define FD_STAKE_REWARDS_MAGIC (0xF17EDA2CE757A4E0) /* FIREDANCER STAKE V0 */
 
 struct index_key {
@@ -68,7 +66,7 @@ struct fd_stake_rewards {
   ulong       magic;
   uint        total_ele_used;
   ulong       max_stake_accounts;
-  fork_info_t fork_info[MAX_SUPPORTED_FORKS];
+  fork_info_t fork_info[FD_STAKE_REWARDS_MAX_FORK_WIDTH];
   ulong       fork_pool_offset;
   ulong       index_pool_offset;
   ulong       index_map_offset;
@@ -140,6 +138,10 @@ fd_stake_rewards_new( void * shmem,
   }
   if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_stake_rewards_align() ) ) ) {
     FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+  if( FD_UNLIKELY( max_fork_width>FD_STAKE_REWARDS_MAX_FORK_WIDTH ) ) {
+    FD_LOG_WARNING(( "max_fork_width is too large" ));
     return NULL;
   }
 
@@ -225,7 +227,11 @@ fd_stake_rewards_init( fd_stake_rewards_t * stake_rewards,
     stake_rewards->total_ele_used = 0UL;
   }
 
-  uchar fork_idx = (uchar)fork_pool_idx_acquire( fork_pool );
+  if( FD_UNLIKELY( !fork_pool_free( fork_pool ) ) ) {
+    FD_LOG_CRIT(( "invariant violation: stake rewards fork pool is full" ));
+  }
+
+  ulong fork_idx = fork_pool_idx_acquire( fork_pool );
 
   stake_rewards->parent_blockhash = *parent_blockhash;
 
@@ -236,7 +242,7 @@ fd_stake_rewards_init( fd_stake_rewards_t * stake_rewards,
   memset( stake_rewards->fork_info[fork_idx].partition_idxs_head, 0xFF, sizeof(stake_rewards->fork_info[fork_idx].partition_idxs_head) );
   memset( stake_rewards->fork_info[fork_idx].partition_idxs_tail, 0xFF, sizeof(stake_rewards->fork_info[fork_idx].partition_idxs_tail) );
 
-  return fork_idx;
+  return (uchar)fork_idx;
 }
 
 void

--- a/src/flamenco/rewards/fd_stake_rewards.h
+++ b/src/flamenco/rewards/fd_stake_rewards.h
@@ -53,6 +53,8 @@
 
 #define FD_STAKE_REWARDS_ALIGN (128UL)
 
+#define FD_STAKE_REWARDS_MAX_FORK_WIDTH (128UL)
+
 struct fd_stake_rewards;
 typedef struct fd_stake_rewards fd_stake_rewards_t;
 

--- a/src/flamenco/runtime/tests/test_inflation_rewards.c
+++ b/src/flamenco/runtime/tests/test_inflation_rewards.c
@@ -807,6 +807,17 @@ test_epoch_rewards_sysvar_lifecycle( fd_svm_mini_t * mini ) {
 }
 
 static void
+test_stake_rewards_invalid_max_fork_width( void ) {
+  ulong oversz_fork_cnt = FD_STAKE_REWARDS_MAX_FORK_WIDTH + 1UL;
+  ulong footprint = fd_stake_rewards_footprint( 1UL, 1UL, oversz_fork_cnt );
+  FD_TEST( footprint > 0UL );
+  void * mem = aligned_alloc( fd_stake_rewards_align(), footprint );
+  FD_TEST( mem );
+  FD_TEST( !fd_stake_rewards_new( mem, 1UL, 1UL, oversz_fork_cnt, 42UL ) );
+  free( mem );
+}
+
+static void
 test_hash_rewards_into_partitions( void ) {
   ulong max_accs  = 16384UL;
   ulong exp_accs  = 12345UL;
@@ -1361,6 +1372,7 @@ main( int     argc,
   test_multi_validator_proportional( mini );
   test_calculate_points_typical_values( mini );
   test_epoch_rewards_sysvar_lifecycle( mini );
+  test_stake_rewards_invalid_max_fork_width();
   test_hash_rewards_into_partitions();
   test_hash_rewards_into_partitions_empty();
   test_distribute_rewards_capitalization( mini );


### PR DESCRIPTION
fd_stake_rewards_new did not validate the max_fork_width param
despite low internal limits. Fixes a bug where a config file with
max_fork_width > 128 could cause data corruption.

Reported-by: https://v12.sh/
