### PR TITLE
restore: ssload recoverable errors

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1251,12 +1251,19 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
       if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
         FD_LOG_ERR(( "chunk %lu from in %d corrupt, not in range [%lu,%lu]", chunk, ctx->in_kind[ in_idx ], ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
 
-      fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
-                         ctx->banks,
-                         fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ ),
-                         msg==FD_SSMSG_MANIFEST_INCREMENTAL );
+      /* Malformed manifests are rejected recoverably by snapin via
+         fd_ssload_manifest_validate.  If recover fails here, then the
+         bank is partially mutated, and we must abort. */
+      if( FD_UNLIKELY( fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
+                                          ctx->banks,
+                                          fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ ),
+                                          msg==FD_SSMSG_MANIFEST_INCREMENTAL,
+                                          ctx->blockhash_seed ) ) ) {
+        FD_LOG_ERR(( "Snapshot manifest recovery failed, aborting." ));
+      }
 
       fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
+      /* hard_fork_cnt already validated by fd_ssload_recover. */
       ctx->hard_fork_cnt = manifest->hard_fork_cnt;
       for( ulong i=0UL; i<manifest->hard_fork_cnt; i++ ) {
         ctx->hard_forks[ i ] = manifest->hard_forks[ i ];
@@ -2430,6 +2437,10 @@ privileged_init( fd_topo_t *      topo,
   }
 
   FD_TEST( fd_rng_secure( &ctx->rng_seed, sizeof(ctx->rng_seed) ) );
+
+  if( FD_UNLIKELY( !fd_rng_secure( &ctx->blockhash_seed, sizeof(ulong) ) ) ) {
+    FD_LOG_CRIT(( "fd_rng_secure failed" ));
+  }
 
   if( FD_UNLIKELY( !fd_rng_secure( &ctx->reasm_seed, sizeof(ulong) ) ) ) {
     FD_LOG_CRIT(( "fd_rng_secure failed" ));

--- a/src/discof/replay/fd_replay_tile_private.h
+++ b/src/discof/replay/fd_replay_tile_private.h
@@ -100,6 +100,7 @@ struct fd_replay_tile {
 
   fd_hash_t expected_bank_hash;
 
+  ulong            blockhash_seed;
   ulong            reasm_seed;
   fd_reasm_t     * reasm;
   fd_reasm_fec_t * reasm_evicted; /* evicted FEC by reasm_insert must be stored in returnable_frag, and then drained in after_credit */

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -26,12 +26,14 @@ endif
 $(call make-unit-test,test_slot_delta_parser,utils/test_slot_delta_parser,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_sspeer_selector,utils/test_sspeer_selector,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_ssping,utils/test_ssping,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_ssload,utils/test_ssload,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_ssarchive,utils/test_ssarchive,fd_discof fdctl_platform fd_ballet fd_util)
 $(call make-unit-test,test_ssparse,utils/test_ssparse,fd_discof fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_slot_delta_parser)
 $(call run-unit-test,test_sspeer_selector)
 $(call run-unit-test,test_ssarchive)
 $(call run-unit-test,test_ssparse)
+$(call run-unit-test,test_ssload)
 
 $(call make-fuzz-test,fuzz_snapshot_parser,utils/fuzz_snapshot_parser,fd_discof fd_flamenco fd_ballet fd_util)
 ifdef FD_HAS_INT128

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -1,5 +1,6 @@
 #include "fd_snapin_tile_private.h"
 #include "utils/fd_ssctrl.h"
+#include "utils/fd_ssload.h"
 #include "utils/fd_ssmsg.h"
 
 #include "../../disco/topo/fd_topo.h"
@@ -560,6 +561,13 @@ process_manifest( fd_snapin_tile_t * ctx ) {
     transition_malformed( ctx, ctx->stem );
     return;
   }
+
+  if( FD_UNLIKELY( fd_ssload_manifest_validate( manifest, FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS ) ) ) {
+    FD_LOG_WARNING(( "snapshot manifest validation failed" ));
+    transition_malformed( ctx, ctx->stem );
+    return;
+  }
+
   fd_epoch_schedule_t epoch_schedule = (fd_epoch_schedule_t){
     .slots_per_epoch             = manifest->epoch_schedule_params.slots_per_epoch,
     .leader_schedule_slot_offset = manifest->epoch_schedule_params.leader_schedule_slot_offset,

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -1,6 +1,7 @@
 #include "fd_ssload.h"
 
 #include "../../../disco/genesis/fd_genesis_cluster.h"
+#include "../../../flamenco/runtime/fd_runtime_const.h"
 #include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "fd_ssmsg.h"
 
@@ -13,64 +14,318 @@ FD_STATIC_ASSERT( FD_EPOCH_VOTE_STAKES_MAX==sizeof(((fd_snapshot_manifest_epoch_
 FD_STATIC_ASSERT( FD_EPOCH_CREDITS_MAX==sizeof(((fd_snapshot_manifest_vote_account_t *)0)->epoch_credits)/sizeof(epoch_credits_t), vote_account_epoch_credits_max );
 FD_STATIC_ASSERT( FD_EPOCH_CREDITS_MAX==sizeof(((fd_snapshot_manifest_vote_stakes_t *)0)->epoch_credits)/sizeof(epoch_credits_t), vote_stakes_epoch_credits_max );
 
-void
-blockhashes_recover( fd_blockhashes_t *                       blockhashes,
-                     fd_snapshot_manifest_blockhash_t const * ages,
-                     ulong                                    age_cnt,
-                     ulong                                    seed ) {
-  FD_TEST( fd_blockhashes_init( blockhashes, seed ) );
-  FD_TEST( age_cnt && age_cnt<=FD_BLOCKHASHES_MAX );
+int
+fd_ssload_manifest_validate( fd_snapshot_manifest_t const * manifest,
+                             ulong                          max_vote_accounts,
+                             ulong                          max_stake_accounts ) {
 
-  /* For depressing reasons, the ages array is not sorted when ingested
-     from a snapshot.  The hash_index field is also not validated.
-     Firedancer assumes that the sequence of hash_index numbers is
-     gapless and does not wrap around. */
+  if( FD_UNLIKELY( max_vote_accounts!=FD_RUNTIME_MAX_VOTE_ACCOUNTS ||
+                   max_stake_accounts!=FD_RUNTIME_MAX_STAKE_ACCOUNTS ) ) {
+    FD_LOG_WARNING(( "banks capacity mismatch: max_vote_accounts=%lu (expected %lu) max_stake_accounts=%lu (expected %lu)",
+                     max_vote_accounts,  FD_RUNTIME_MAX_VOTE_ACCOUNTS,
+                     max_stake_accounts, FD_RUNTIME_MAX_STAKE_ACCOUNTS ));
+    return -1;
+  }
 
-  ulong seq_min = ULONG_MAX-1;
+  /* slots_per_epoch must be at least FD_EPOCH_LEN_MIN, so that
+     fd_slot_to_epoch and related functions produce valid data.
+     This check must come before any epoch computation. */
+
+  if( FD_UNLIKELY( manifest->epoch_schedule_params.slots_per_epoch<FD_EPOCH_LEN_MIN ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: slots_per_epoch %lu below minimum %lu",
+                     manifest->epoch_schedule_params.slots_per_epoch, FD_EPOCH_LEN_MIN ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( manifest->epoch_schedule_params.warmup>1 ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: warmup %u is not boolean", (uint)manifest->epoch_schedule_params.warmup ));
+    return -1;
+  }
+
+  /* Validate that the manifest's first_normal_{epoch,slot} are
+     consistent with the derivation from slots_per_epoch and warmup. */
+
+  fd_epoch_schedule_t derived;
+  if( FD_UNLIKELY( !fd_epoch_schedule_derive( &derived,
+                                              manifest->epoch_schedule_params.slots_per_epoch,
+                                              manifest->epoch_schedule_params.leader_schedule_slot_offset,
+                                              manifest->epoch_schedule_params.warmup ) ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: fd_epoch_schedule_derive failed" ));
+    return -1;
+  }
+  if( FD_UNLIKELY( derived.first_normal_epoch!=manifest->epoch_schedule_params.first_normal_epoch ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: first_normal_epoch mismatch (manifest=%lu derived=%lu)",
+                     manifest->epoch_schedule_params.first_normal_epoch, derived.first_normal_epoch ));
+    return -1;
+  }
+  if( FD_UNLIKELY( derived.first_normal_slot!=manifest->epoch_schedule_params.first_normal_slot ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: first_normal_slot mismatch (manifest=%lu derived=%lu)",
+                     manifest->epoch_schedule_params.first_normal_slot, derived.first_normal_slot ));
+    return -1;
+  }
+
+  /* Blockhash queue structural validation */
+
+  ulong const age_cnt = manifest->blockhashes_len;
+  fd_snapshot_manifest_blockhash_t const * ages = manifest->blockhashes;
+
+  if( FD_UNLIKELY( !age_cnt || age_cnt>FD_BLOCKHASHES_MAX ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: invalid blockhash age count %lu (max %lu)", age_cnt, FD_BLOCKHASHES_MAX ));
+    return -1;
+  }
+
+  ulong seq_min = ULONG_MAX;
   for( ulong i=0UL; i<age_cnt; i++ ) {
     seq_min = fd_ulong_min( seq_min, ages[ i ].hash_index );
   }
   ulong seq_max;
   if( FD_UNLIKELY( __builtin_uaddl_overflow( seq_min, age_cnt, &seq_max ) ) ) {
-    /* TODO: Move to snapin validations so we can retry */
-    FD_LOG_ERR(( "Corrupt snapshot: blockhash queue sequence number wraparound (seq_min=%lu age_cnt=%lu)", seq_min, age_cnt ));
+    FD_LOG_WARNING(( "corrupt snapshot: blockhash queue sequence number wraparound (seq_min=%lu age_cnt=%lu)", seq_min, age_cnt ));
+    return -1;
+  }
+
+  /* Check for gaps and duplicates using a bitset (max 301 entries). */
+
+  ulong seen[ (FD_BLOCKHASHES_MAX+63UL)/64UL ];
+  fd_memset( seen, 0, sizeof(seen) );
+  for( ulong i=0UL; i<age_cnt; i++ ) {
+    ulong idx;
+    if( FD_UNLIKELY( __builtin_usubl_overflow( ages[ i ].hash_index, seq_min, &idx ) || idx>=age_cnt ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: gap in blockhash queue (seq=[%lu,%lu) hash_index=%lu)",
+                       seq_min, seq_max, ages[ i ].hash_index ));
+      return -1;
+    }
+    ulong word = idx/64UL;
+    ulong bit  = idx%64UL;
+    if( FD_UNLIKELY( seen[ word ] & (1UL<<bit) ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: duplicate blockhash queue hash_index=%lu (relative_idx=%lu seq_min=%lu)",
+                       ages[ i ].hash_index, idx, seq_min ));
+      return -1;
+    }
+    seen[ word ] |= (1UL<<bit);
+  }
+
+  /* Array bounds checks, reject manifests whose counts exceed the
+     fixed-size arrays in fd_snapshot_manifest_t.  Validating here
+     enables early recovery from malformed snapshots. */
+
+  if( FD_UNLIKELY( manifest->hard_fork_cnt>FD_HARD_FORKS_MAX ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: hard_fork_cnt %lu exceeds max %lu",
+                     manifest->hard_fork_cnt, FD_HARD_FORKS_MAX ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( manifest->stake_delegations_len>FD_STAKE_DELEGATIONS_MAX ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: stake_delegations_len %lu exceeds max %lu",
+                     manifest->stake_delegations_len, FD_STAKE_DELEGATIONS_MAX ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( manifest->stake_delegations_len>max_stake_accounts ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: stake_delegations_len %lu exceeds max_stake_accounts %lu",
+                     manifest->stake_delegations_len, max_stake_accounts ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( manifest->vote_accounts_len>FD_VOTE_ACCOUNTS_MAX ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: vote_accounts_len %lu exceeds max %lu",
+                     manifest->vote_accounts_len, FD_VOTE_ACCOUNTS_MAX ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( manifest->vote_accounts_len>max_vote_accounts ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: vote_accounts_len %lu exceeds max_vote_accounts %lu",
+                     manifest->vote_accounts_len, max_vote_accounts ));
+    return -1;
+  }
+
+  /* Epoch credits downcasting only happens on epoch_stakes entries,
+     not vote_accounts.  Validated here for consistency. */
+
+  for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
+    if( FD_UNLIKELY( manifest->vote_accounts[i].epoch_credits_history_len>FD_EPOCH_CREDITS_MAX ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: vote_accounts[%lu].epoch_credits_history_len %lu exceeds max %lu",
+                       i, manifest->vote_accounts[i].epoch_credits_history_len, FD_EPOCH_CREDITS_MAX ));
+      return -1;
+    }
+    ulong ec_base = manifest->vote_accounts[i].epoch_credits_history_len>0UL
+                  ? manifest->vote_accounts[i].epoch_credits[0].prev_credits : 0UL;
+    for( ulong j=0UL; j<manifest->vote_accounts[i].epoch_credits_history_len; j++ ) {
+      epoch_credits_t const * epc = &manifest->vote_accounts[i].epoch_credits[j];
+      if( FD_UNLIKELY( epc->epoch>(ulong)USHORT_MAX ) ) {
+        FD_LOG_WARNING(( "corrupt snapshot: vote_accounts[%lu].epoch_credits[%lu].epoch %lu exceeds USHORT_MAX",
+                         i, j, epc->epoch ));
+        return -1;
+      }
+      if( FD_UNLIKELY( epc->credits<ec_base || epc->credits-ec_base>(ulong)UINT_MAX ) ) {
+        FD_LOG_WARNING(( "corrupt snapshot: vote_accounts[%lu].epoch_credits[%lu].credits %lu out of range (base %lu)",
+                         i, j, epc->credits, ec_base ));
+        return -1;
+      }
+      if( FD_UNLIKELY( epc->prev_credits<ec_base || epc->prev_credits-ec_base>(ulong)UINT_MAX ) ) {
+        FD_LOG_WARNING(( "corrupt snapshot: vote_accounts[%lu].epoch_credits[%lu].prev_credits %lu out of range (base %lu)",
+                         i, j, epc->prev_credits, ec_base ));
+        return -1;
+      }
+    }
+  }
+
+  /* Epoch credits downcasting validation */
+
+  for( ulong i=0UL; i<FD_EPOCH_STAKES_LEN; i++ ) {
+    if( FD_UNLIKELY( manifest->epoch_stakes[i].vote_stakes_len>FD_EPOCH_VOTE_STAKES_MAX ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes_len %lu exceeds max %lu",
+                       i, manifest->epoch_stakes[i].vote_stakes_len, FD_EPOCH_VOTE_STAKES_MAX ));
+      return -1;
+    }
+    if( FD_UNLIKELY( manifest->epoch_stakes[i].vote_stakes_len>max_vote_accounts ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes_len %lu exceeds max_vote_accounts %lu",
+                       i, manifest->epoch_stakes[i].vote_stakes_len, max_vote_accounts ));
+      return -1;
+    }
+    for( ulong j=0UL; j<manifest->epoch_stakes[i].vote_stakes_len; j++ ) {
+      fd_snapshot_manifest_vote_stakes_t const * vs = &manifest->epoch_stakes[i].vote_stakes[j];
+      if( FD_UNLIKELY( vs->epoch_credits_history_len>FD_EPOCH_CREDITS_MAX ) ) {
+        FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes[%lu].epoch_credits_history_len %lu exceeds max %lu",
+                         i, j, vs->epoch_credits_history_len, FD_EPOCH_CREDITS_MAX ));
+        return -1;
+      }
+      ulong ec_base = vs->epoch_credits_history_len>0UL ? vs->epoch_credits[0].prev_credits : 0UL;
+      for( ulong k=0UL; k<vs->epoch_credits_history_len; k++ ) {
+        epoch_credits_t const * epc = &vs->epoch_credits[k];
+        if( FD_UNLIKELY( epc->epoch>(ulong)USHORT_MAX ) ) {
+          FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes[%lu].epoch_credits[%lu].epoch %lu exceeds USHORT_MAX",
+                           i, j, k, epc->epoch ));
+          return -1;
+        }
+        if( FD_UNLIKELY( epc->credits<ec_base || epc->credits-ec_base>(ulong)UINT_MAX ) ) {
+          FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes[%lu].epoch_credits[%lu].credits %lu out of range (base %lu)",
+                           i, j, k, epc->credits, ec_base ));
+          return -1;
+        }
+        if( FD_UNLIKELY( epc->prev_credits<ec_base || epc->prev_credits-ec_base>(ulong)UINT_MAX ) ) {
+          FD_LOG_WARNING(( "corrupt snapshot: epoch_stakes[%lu].vote_stakes[%lu].epoch_credits[%lu].prev_credits %lu out of range (base %lu)",
+                           i, j, k, epc->prev_credits, ec_base ));
+          return -1;
+        }
+      }
+    }
+  }
+
+  /* Epoch stakes index validation.  fd_slot_to_leader_schedule_epoch
+     is inlined here with overflow-safe arithmetic. */
+
+  fd_epoch_schedule_t epoch_schedule = (fd_epoch_schedule_t){
+    .slots_per_epoch             = manifest->epoch_schedule_params.slots_per_epoch,
+    .leader_schedule_slot_offset = manifest->epoch_schedule_params.leader_schedule_slot_offset,
+    .warmup                      = manifest->epoch_schedule_params.warmup,
+    .first_normal_epoch          = manifest->epoch_schedule_params.first_normal_epoch,
+    .first_normal_slot           = manifest->epoch_schedule_params.first_normal_slot,
+  };
+
+  ulong epoch = fd_slot_to_epoch( &epoch_schedule, manifest->slot, NULL );
+
+  /* Compute leader_schedule_epoch with overflow safety.  Mirrors
+     fd_slot_to_leader_schedule_epoch but rejects overflow instead
+     of silently wrapping. */
+
+  ulong leader_schedule_epoch;
+  if( FD_UNLIKELY( manifest->slot<epoch_schedule.first_normal_slot ) ) {
+    if( FD_UNLIKELY( __builtin_uaddl_overflow( epoch, 1UL, &leader_schedule_epoch ) ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: leader_schedule_epoch overflow (epoch=%lu)", epoch ));
+      return -1;
+    }
+  } else {
+    ulong delta = manifest->slot-epoch_schedule.first_normal_slot;
+    ulong sum;
+    if( FD_UNLIKELY( __builtin_uaddl_overflow( delta, epoch_schedule.leader_schedule_slot_offset, &sum ) ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: leader_schedule_slot_offset overflow "
+                       "(slot_delta=%lu leader_schedule_slot_offset=%lu)",
+                       delta, epoch_schedule.leader_schedule_slot_offset ));
+      return -1;
+    }
+    ulong n_epochs = sum/epoch_schedule.slots_per_epoch;
+    if( FD_UNLIKELY( __builtin_uaddl_overflow( epoch_schedule.first_normal_epoch, n_epochs, &leader_schedule_epoch ) ) ) {
+      FD_LOG_WARNING(( "corrupt snapshot: leader_schedule_epoch overflow "
+                       "(first_normal_epoch=%lu n_epochs=%lu)",
+                       epoch_schedule.first_normal_epoch, n_epochs ));
+      return -1;
+    }
+  }
+
+  ulong epoch_stakes_base = epoch>0UL ? epoch-1UL : 0UL;
+
+  if( FD_UNLIKELY( leader_schedule_epoch<epoch_stakes_base ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: leader_schedule_epoch %lu < epoch_stakes_base %lu",
+                     leader_schedule_epoch, epoch_stakes_base ));
+    return -1;
+  }
+  ulong t_1_idx = leader_schedule_epoch-epoch_stakes_base;
+  if( FD_UNLIKELY( t_1_idx>=FD_EPOCH_STAKES_LEN ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: epoch stakes index %lu out of range (max %lu)",
+                     t_1_idx, FD_EPOCH_STAKES_LEN ));
+    return -1;
+  }
+
+  return 0;
+}
+
+static int
+blockhashes_recover( fd_blockhashes_t *                       blockhashes,
+                     fd_snapshot_manifest_blockhash_t const * ages,
+                     ulong                                    age_cnt,
+                     ulong                                    seed ) {
+
+  /* The caller must guarantee that fd_ssload_manifest_validate has
+     already been invoked, verifying that age_cnt is in the range
+     (0, FD_BLOCKHASHES_MAX], that there are no gaps or duplicates in
+     the sequence numbers, and that seq_min+age_cnt does not overflow. */
+
+  if( FD_UNLIKELY( !fd_blockhashes_init( blockhashes, seed ) ) ) {
+    FD_LOG_WARNING(( "failed to initialize blockhash queue" ));
+    return -1;
+  }
+
+  ulong seq_min = ULONG_MAX;
+  for( ulong i=0UL; i<age_cnt; i++ ) {
+    seq_min = fd_ulong_min( seq_min, ages[ i ].hash_index );
   }
 
   /* Reset */
 
   for( ulong i=0UL; i<age_cnt; i++ ) {
     fd_blockhash_info_t * ele = fd_blockhash_deq_push_tail_nocopy( blockhashes->d.deque );
-    memset( ele, 0, sizeof(fd_blockhash_info_t) );
+    fd_memset( ele, 0, sizeof(fd_blockhash_info_t) );
   }
 
   /* Load hashes */
 
   for( ulong i=0UL; i<age_cnt; i++ ) {
     fd_snapshot_manifest_blockhash_t const * elem = &ages[ i ];
-    ulong idx;
-    if( FD_UNLIKELY( __builtin_usubl_overflow( elem->hash_index, seq_min, &idx ) ) ) {
-      /* TODO: Move to snapin validations so we can retry */
-      FD_LOG_ERR(( "Corrupt snapshot: gap in blockhash queue (seq=[%lu,%lu) idx=%lu)",
-                   seq_min, seq_max, elem->hash_index ));
-    }
+    ulong idx = elem->hash_index - seq_min;
     fd_blockhash_info_t * info = &blockhashes->d.deque[ idx ];
-    if( FD_UNLIKELY( info->exists ) ) {
-      /* TODO: Move to snapin validations so we can retry */
-      FD_LOG_HEXDUMP_NOTICE(( "info", info, sizeof(fd_blockhash_info_t) ));
-      FD_LOG_ERR(( "Corrupt snapshot: duplicate blockhash queue index %lu", idx ));
-    }
     info->exists = 1;
     fd_memcpy( info->hash.uc, elem->hash, 32UL );
     info->lamports_per_signature = elem->lamports_per_signature;
     fd_blockhash_map_idx_insert( blockhashes->map, idx, blockhashes->d.deque );
   }
+
+  return 0;
 }
 
-void
+int
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_banks_t *             banks,
                    fd_bank_t *              bank,
-                   int                      is_incremental ) {
+                   int                      is_incremental,
+                   ulong                    blockhash_seed ) {
+
+  /* Validate manifest before mutating the bank. */
+  if( FD_UNLIKELY( fd_ssload_manifest_validate( manifest, banks->max_vote_accounts, banks->max_stake_accounts ) ) ) {
+    FD_LOG_WARNING(( "snapshot manifest validation failed" ));
+    return -1;
+  }
+
   /* Slot */
 
   bank->f.slot = manifest->slot;
@@ -132,7 +387,10 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   fd_bank_lthash_end_locking_modify( bank );
 
   fd_blockhashes_t * blockhashes = &bank->f.block_hash_queue;
-  blockhashes_recover( blockhashes, manifest->blockhashes, manifest->blockhashes_len, 42UL /* TODO */ );
+  if( FD_UNLIKELY( blockhashes_recover( blockhashes, manifest->blockhashes, manifest->blockhashes_len, blockhash_seed ) ) ) {
+    FD_LOG_WARNING(( "blockhash queue recovery failed" ));
+    return -1;
+  }
 
   /* PoH */
   fd_blockhashes_t const * bhq = &bank->f.block_hash_queue;
@@ -250,10 +508,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
 
   ulong leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( epoch_schedule, manifest->slot );
   ulong epoch_stakes_base     = epoch > 0UL ? epoch - 1UL : 0UL;
-
-  FD_TEST( leader_schedule_epoch >= epoch_stakes_base );
   ulong t_1_idx = leader_schedule_epoch - epoch_stakes_base;
-  FD_TEST( t_1_idx < FD_EPOCH_STAKES_LEN );
 
   int   has_t_2 = (t_1_idx > 0UL);
   ulong t_2_idx = has_t_2 ? t_1_idx - 1UL : 0UL;
@@ -266,6 +521,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
      snapshot is in epoch T. */
   for( ulong i=0UL; i<manifest->epoch_stakes[t_1_idx].vote_stakes_len; i++ ) {
     fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[t_1_idx].vote_stakes[i];
+
     fd_vote_stakes_root_insert_key(
         vote_stakes,
         (fd_pubkey_t *)elem->vote,
@@ -321,4 +577,6 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   }
 
   bank->txncache_fork_id = (fd_txncache_fork_id_t){ .val = manifest->txncache_fork_id };
+
+  return 0;
 }

--- a/src/discof/restore/utils/fd_ssload.h
+++ b/src/discof/restore/utils/fd_ssload.h
@@ -2,21 +2,40 @@
 #define HEADER_fd_src_discof_restore_utils_fd_ssload_h
 
 #include "fd_ssmsg.h"
-#include "../../../flamenco//runtime/fd_blockhashes.h"
+#include "../../../flamenco/runtime/fd_blockhashes.h"
 
 FD_PROTOTYPES_BEGIN
 
-void
-blockhashes_recover( fd_blockhashes_t *                       blockhashes,
-                     fd_snapshot_manifest_blockhash_t const * ages,
-                     ulong                                    age_cnt,
-                     ulong                                    seed );
+/* fd_ssload_manifest_validate checks the snapshot manifest for
+   structural issues that the parser does not catch: epoch schedule
+   consistency, blockhash queue ordering (gaps, duplicates, wraparound),
+   array bounds (hard forks, stake delegations, vote accounts,
+   epoch stakes), epoch credits downcasting safety (epoch fits ushort,
+   credit deltas fit uint), and epoch stakes index bounds.
+   max_vote_accounts and max_stake_accounts must equal
+   FD_RUNTIME_MAX_VOTE_ACCOUNTS and FD_RUNTIME_MAX_STAKE_ACCOUNTS
+   respectively; mismatches are rejected as a configuration error.
+   Returns 0 on success, -1 on failure (corrupt manifest or
+   configuration mismatch).  This function only reads the manifest
+   and has no side effects. */
+int
+fd_ssload_manifest_validate( fd_snapshot_manifest_t const * manifest,
+                             ulong                          max_vote_accounts,
+                             ulong                          max_stake_accounts );
 
-void
+/* Returns 0 on success, -1 on failure (corrupt manifest or
+   configuration mismatch).  If manifest validation fails, bank and
+   associated structures are left unmodified.  If failure occurs after
+   mutation begins, bank and associated structures may be left partially
+   mutated.  Caller must treat such failures as unrecoverable (e.g.
+   abort or discard the bank).  blockhash_seed seeds the internal
+   blockhash hash map. */
+int
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_banks_t *             banks,
                    fd_bank_t *              bank,
-                   int                      is_incremental );
+                   int                      is_incremental,
+                   ulong                    blockhash_seed );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -1,0 +1,555 @@
+#include "fd_ssload.h"
+#include "../../../util/fd_util.h"
+#include "../../../flamenco/runtime/fd_runtime_const.h"
+#include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include <limits.h>
+
+/* Shorthand for the common validate call pattern using the production
+   capacity limits.  fd_ssload_manifest_validate rejects calls where
+   the limits differ from FD_RUNTIME_MAX_{VOTE,STAKE}_ACCOUNTS. */
+#define VALIDATE_MANIFEST(m) fd_ssload_manifest_validate( (m), FD_RUNTIME_MAX_VOTE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS )
+
+/* Set up the minimum valid manifest state so that all validation
+   stages can be reached.  Adds 1 blockhash with hash_index=0 and
+   sets valid epoch schedule params.
+   With defaults (slot=0, warmup=0, first_normal_epoch=0,
+   first_normal_slot=0): epoch=0, leader_schedule_epoch=1,
+   epoch_stakes_base=0, t_1_idx=1 (valid). */
+static void
+setup_valid_manifest_base( fd_snapshot_manifest_t * manifest ) {
+  manifest->blockhashes_len = 1UL;
+  manifest->blockhashes[0].hash_index = 0UL;
+  manifest->epoch_schedule_params.slots_per_epoch             = 432000UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = 432000UL;
+}
+
+static void
+test_valid_base_manifest( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing valid base manifest" ));
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_capacity_mismatch( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing capacity mismatch" ));
+
+  /* Mismatched max_vote_accounts. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  FD_TEST( fd_ssload_manifest_validate( manifest, 100UL, FD_RUNTIME_MAX_STAKE_ACCOUNTS )==-1 );
+
+  /* Mismatched max_stake_accounts. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  FD_TEST( fd_ssload_manifest_validate( manifest, FD_RUNTIME_MAX_VOTE_ACCOUNTS, 100UL )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_epoch_schedule( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing epoch schedule" ));
+
+  /* Exactly min slots_per_epoch. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = FD_EPOCH_LEN_MIN;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = FD_EPOCH_LEN_MIN;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Zero slots_per_epoch. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Below min slots_per_epoch. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch = FD_EPOCH_LEN_MIN - 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* slots_per_epoch too large with warmup (would cause 1UL<<64 UB in
+     fd_epoch_schedule_derive without the upper-bound guard). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = (1UL<<63) + 1UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = (1UL<<63) + 1UL;
+  manifest->epoch_schedule_params.warmup                      = 1;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* slots_per_epoch exactly at 2^63 with warmup (valid, no UB). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = 1UL<<63;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = 1UL<<63;
+  manifest->epoch_schedule_params.warmup                      = 1;
+  fd_epoch_schedule_t huge_derived;
+  FD_TEST( fd_epoch_schedule_derive( &huge_derived, 1UL<<63, 1UL<<63, 1 ) );
+  manifest->epoch_schedule_params.first_normal_epoch = huge_derived.first_normal_epoch;
+  manifest->epoch_schedule_params.first_normal_slot  = huge_derived.first_normal_slot;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Invalid warmup. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.warmup = 2;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Invalid first_normal_epoch/slot rejected (warmup=0). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.warmup             = 0;
+  manifest->epoch_schedule_params.first_normal_epoch = ULONG_MAX;
+  manifest->epoch_schedule_params.first_normal_slot  = ULONG_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Invalid first_normal_epoch/slot rejected (warmup=1). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.warmup             = 1;
+  manifest->epoch_schedule_params.first_normal_epoch = 0UL;
+  manifest->epoch_schedule_params.first_normal_slot  = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Invalid first_normal_epoch rejected by consistency check
+     (derived first_normal_epoch=0 does not match ULONG_MAX). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.first_normal_epoch = ULONG_MAX;
+  manifest->epoch_schedule_params.first_normal_slot  = 0UL;
+  manifest->slot = 432000UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Correct derived first_normal values accepted (warmup=0). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.warmup             = 0;
+  manifest->epoch_schedule_params.first_normal_epoch = 0UL;
+  manifest->epoch_schedule_params.first_normal_slot  = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Correct derived first_normal values accepted (warmup=1). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.warmup = 1;
+  fd_epoch_schedule_t expected;
+  FD_TEST( fd_epoch_schedule_derive( &expected,
+                                     manifest->epoch_schedule_params.slots_per_epoch,
+                                     manifest->epoch_schedule_params.leader_schedule_slot_offset,
+                                     1 ) );
+  manifest->epoch_schedule_params.first_normal_epoch = expected.first_normal_epoch;
+  manifest->epoch_schedule_params.first_normal_slot  = expected.first_normal_slot;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Valid warmup-region slot (slot < first_normal_slot).  Exercises
+     the warmup branch of epoch stakes index validation. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = 64UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = 64UL;
+  manifest->epoch_schedule_params.warmup                      = 1;
+  fd_epoch_schedule_t warmup_derived;
+  FD_TEST( fd_epoch_schedule_derive( &warmup_derived, 64UL, 64UL, 1 ) );
+  manifest->epoch_schedule_params.first_normal_epoch = warmup_derived.first_normal_epoch;
+  manifest->epoch_schedule_params.first_normal_slot  = warmup_derived.first_normal_slot;
+  manifest->slot = 16UL; /* 16 < first_normal_slot(32), enters warmup branch */
+  manifest->blockhashes_len = 1UL;
+  manifest->blockhashes[0].hash_index = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* leader_schedule_slot_offset overflow. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->slot = 432000UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = ULONG_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Large leader_schedule_slot_offset without addition overflow
+     but t_1_idx exceeds FD_EPOCH_STAKES_LEN. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = 64UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = ULONG_MAX - 32UL;
+  manifest->epoch_schedule_params.warmup                      = 1;
+  manifest->slot = 32UL;
+  fd_epoch_schedule_t derived;
+  FD_TEST( fd_epoch_schedule_derive( &derived, 64UL, ULONG_MAX - 32UL, 1 ) );
+  manifest->epoch_schedule_params.first_normal_epoch = derived.first_normal_epoch;
+  manifest->epoch_schedule_params.first_normal_slot  = derived.first_normal_slot;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Epoch stakes index out of range. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_schedule_params.slots_per_epoch             = 432000UL;
+  manifest->epoch_schedule_params.leader_schedule_slot_offset = 432000UL * 3UL;
+  manifest->slot = 432000UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_blockhash_queue( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing blockhash queue" ));
+
+  /* Valid sorted blockhashes. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 3UL;
+  manifest->blockhashes[0].hash_index = 0UL;
+  manifest->blockhashes[1].hash_index = 1UL;
+  manifest->blockhashes[2].hash_index = 2UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Valid unsorted blockhashes. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 3UL;
+  manifest->blockhashes[0].hash_index = 2UL;
+  manifest->blockhashes[1].hash_index = 0UL;
+  manifest->blockhashes[2].hash_index = 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Empty blockhashes. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Count exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = FD_BLOCKHASHES_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Count exactly at max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = FD_BLOCKHASHES_MAX;
+  for( ulong i=0UL; i<FD_BLOCKHASHES_MAX; i++ ) {
+    manifest->blockhashes[i].hash_index = i;
+  }
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Gap in sequence. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 3UL;
+  manifest->blockhashes[0].hash_index = 0UL;
+  manifest->blockhashes[1].hash_index = 1UL;
+  manifest->blockhashes[2].hash_index = 3UL; /* gap at 2 */
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Duplicate index. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 3UL;
+  manifest->blockhashes[0].hash_index = 0UL;
+  manifest->blockhashes[1].hash_index = 1UL;
+  manifest->blockhashes[2].hash_index = 1UL; /* duplicate */
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Sequence wraparound (seq_min+age_cnt overflows). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 2UL;
+  manifest->blockhashes[0].hash_index = ULONG_MAX - 1UL;
+  manifest->blockhashes[1].hash_index = ULONG_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Single blockhash with near-max index (valid). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 1UL;
+  manifest->blockhashes[0].hash_index = ULONG_MAX - 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Single blockhash with hash_index=ULONG_MAX (wraparound). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->blockhashes_len = 1UL;
+  manifest->blockhashes[0].hash_index = ULONG_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_hard_forks( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing hard forks" ));
+
+  /* Exactly at max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->hard_fork_cnt = FD_HARD_FORKS_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->hard_fork_cnt = FD_HARD_FORKS_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_stake_delegations( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing stake delegations" ));
+
+  /* Exactly at max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->stake_delegations_len = FD_STAKE_DELEGATIONS_MAX;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->stake_delegations_len = FD_STAKE_DELEGATIONS_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Exceeds runtime max_stake_accounts. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->stake_delegations_len = FD_RUNTIME_MAX_STAKE_ACCOUNTS + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_vote_accounts( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing vote accounts" ));
+
+  /* vote_accounts_len exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = FD_VOTE_ACCOUNTS_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* vote_accounts epoch_credits_history_len exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = FD_EPOCH_CREDITS_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* vote_accounts_len exceeds runtime max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = FD_RUNTIME_MAX_VOTE_ACCOUNTS + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* epoch_stakes vote_stakes_len exceeds runtime max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = FD_RUNTIME_MAX_VOTE_ACCOUNTS + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* epoch_stakes vote_stakes_len exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = FD_EPOCH_VOTE_STAKES_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* epoch_stakes epoch_credits_history_len exceeds max. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = FD_EPOCH_CREDITS_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
+test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing epoch credits downcasting" ));
+
+  /* Valid epoch credits (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 2UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = 100UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  manifest->vote_accounts[0].epoch_credits[1].epoch        = 2UL;
+  manifest->vote_accounts[0].epoch_credits[1].credits      = 200UL;
+  manifest->vote_accounts[0].epoch_credits[1].prev_credits = 100UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Epoch at USHORT_MAX boundary (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = (ulong)USHORT_MAX;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = 100UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Credits delta at UINT_MAX boundary (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = (ulong)UINT_MAX;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Epoch exceeds USHORT_MAX (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = (ulong)USHORT_MAX + 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = 100UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Credits delta exceeds UINT_MAX (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = (ulong)UINT_MAX + 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Prev credits delta exceeds UINT_MAX (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 2UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = 100UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 0UL;
+  manifest->vote_accounts[0].epoch_credits[1].epoch        = 2UL;
+  manifest->vote_accounts[0].epoch_credits[1].credits      = 200UL;
+  manifest->vote_accounts[0].epoch_credits[1].prev_credits = (ulong)UINT_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Credits below base (vote_accounts path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->vote_accounts_len = 1UL;
+  manifest->vote_accounts[0].epoch_credits_history_len = 2UL;
+  manifest->vote_accounts[0].epoch_credits[0].epoch        = 1UL;
+  manifest->vote_accounts[0].epoch_credits[0].credits      = 600UL;
+  manifest->vote_accounts[0].epoch_credits[0].prev_credits = 500UL;
+  manifest->vote_accounts[0].epoch_credits[1].epoch        = 2UL;
+  manifest->vote_accounts[0].epoch_credits[1].credits      = 400UL;
+  manifest->vote_accounts[0].epoch_credits[1].prev_credits = 500UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Valid epoch credits (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 2UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].epoch        = 2UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].credits      = 200UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].prev_credits = 100UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Epoch at USHORT_MAX boundary (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = (ulong)USHORT_MAX;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Credits delta at UINT_MAX boundary (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = (ulong)UINT_MAX;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  /* Epoch exceeds USHORT_MAX (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = (ulong)USHORT_MAX + 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Credits delta exceeds UINT_MAX (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = (ulong)UINT_MAX + 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  /* Prev credits delta exceeds UINT_MAX (epoch_stakes path). */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 2UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].prev_credits = 0UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].epoch        = 2UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].credits      = 200UL;
+  manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[1].prev_credits = (ulong)UINT_MAX + 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong  page_cnt = 1;
+  char * _page_sz = "gigantic";
+  ulong  numa_idx = fd_shmem_numa_idx( 0 );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_TEST( wksp );
+
+  fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );
+  FD_TEST( manifest );
+  fd_memset( manifest, 0, sizeof(*manifest) );
+
+  test_valid_base_manifest( manifest );
+  test_capacity_mismatch( manifest );
+  test_epoch_schedule( manifest );
+  test_blockhash_queue( manifest );
+  test_hard_forks( manifest );
+  test_stake_delegations( manifest );
+  test_vote_accounts( manifest );
+  test_epoch_credits_downcasting( manifest );
+
+  fd_wksp_free_laddr( manifest );
+  fd_wksp_delete_anonymous( wksp );
+
+  FD_LOG_NOTICE(( "all ssload tests passed" ));
+
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.c
@@ -27,6 +27,12 @@ fd_epoch_schedule_derive( fd_epoch_schedule_t * schedule,
 
   if( warmup ) {
     ulong ceil_log2_epoch   = (ulong)fd_ulong_find_msb( epoch_len-1UL ) + 1UL;
+
+    if( FD_UNLIKELY( ceil_log2_epoch>=64UL ) ) {
+      FD_LOG_WARNING(( "epoch_len too large (ceil_log2_epoch %lu)", ceil_log2_epoch ));
+      return NULL;
+    }
+
     ulong ceil_log2_len_min = (ulong)fd_ulong_find_msb( FD_EPOCH_LEN_MIN );
 
     schedule->first_normal_epoch = fd_ulong_sat_sub( ceil_log2_epoch, ceil_log2_len_min );


### PR DESCRIPTION
Making `fd_ssload` able to recover on manifest / snapshot errors, by introducing `fd_ssload_manifest_validate()`. 
- `snapin` calls `fd_ssload_manifest_validate()` and `transition_malformed()` on failure.
- `fd_ssload_recover`, currently run in `replay` tile, invokes `fd_ssload_manifest_validate()` as well, but crashes on error (last line of defense).

Replacing hardcoded `fd_blockhashes_init` seed from 42UL to  fd_rng_secure.
Adding a guard to `fd_epoch_schedule_derive` against `1UL << 64` UB.
Introducing `test_ssload` unit test.

Partially addresses https://github.com/firedancer-io/firedancer/issues/9588.