### PR TITLE
reasm: update xid on eviction, remove post EOS eqvoc

### DIFF
--- a/src/discof/reasm/fd_reasm.c
+++ b/src/discof/reasm/fd_reasm.c
@@ -219,13 +219,6 @@ fd_reasm_confirm( fd_reasm_t      * reasm,
   while( FD_LIKELY( fec && !fec->confirmed ) ) {
     fec->confirmed = 1;
 
-    xid_t * xid = xid_query( reasm->xid, (fec->slot << 32) | fec->fec_set_idx, NULL );
-    xid->idx    = pool_idx( pool, fec );
-    if( FD_UNLIKELY( fec->slot_complete ) ) {
-      xid_t * bid = xid_query( reasm->xid, ( fec->slot << 32 ) | UINT_MAX, NULL );
-      bid->idx    = pool_idx( pool, fec );
-    }
-
     if( FD_LIKELY( !fec->popped && !fec->in_out ) ) {
       /* Let's say that the delivery queue already contains A, and
          we confirm A - B - C.  We walk upwards from C, but we need to
@@ -348,15 +341,21 @@ link( fd_reasm_t     * reasm,
   }
 }
 
-/* Assumes caller is de-duplicating FEC sets of the same merkle root. */
+/* Assumes caller is de-duplicating FEC sets of the same merkle root.
+   Updates the xid map and inserts the new FEC into the head of the
+   xid list. */
 static xid_t *
 xid_update( fd_reasm_t * reasm, ulong slot, uint fec_set_idx, ulong pool_idx ) {
-  xid_t * xid = xid_query( reasm->xid, (slot << 32) | fec_set_idx, NULL );
+  fd_reasm_fec_t * new_fec = pool_ele( reasm_pool( reasm ), pool_idx );
+  xid_t          * xid     = xid_query( reasm->xid, (slot << 32) | fec_set_idx, NULL );
   if( FD_UNLIKELY( xid ) ) {
+    if( FD_UNLIKELY( fec_set_idx==UINT_MAX ) ) new_fec->bid_next = xid->idx;
+    else                                       new_fec->xid_next = xid->idx;
+    xid->idx = pool_idx; /* updates head ptr */
     xid->cnt++;
   } else {
     xid = xid_insert( reasm->xid, (slot << 32) | fec_set_idx );
-    if( FD_UNLIKELY( !xid ) ) FD_LOG_CRIT(( "xid map full, slot=%lu fec_set_idx=%u", slot, fec_set_idx )); // TODO remove after reasm eviction is implemented
+    if( FD_UNLIKELY( !xid ) ) FD_LOG_CRIT(( "xid map full, slot=%lu fec_set_idx=%u", slot, fec_set_idx ));
     xid->idx = pool_idx;
     xid->cnt = 1;
   }
@@ -364,17 +363,36 @@ xid_update( fd_reasm_t * reasm, ulong slot, uint fec_set_idx, ulong pool_idx ) {
 }
 
 static fd_reasm_fec_t *
-clear_slot_metadata( fd_reasm_t     * reasm,
+clear_xid_metadata( fd_reasm_t     * reasm,
                      fd_reasm_fec_t * fec ) {
-  /* remove from bid and xid */
+  fd_reasm_fec_t * pool = reasm_pool( reasm );
+  ulong fec_idx = pool_idx( pool, fec );
+
   if( FD_UNLIKELY( fec->slot_complete ) ) {
     xid_t * bid = xid_query( reasm->xid, (fec->slot << 32)|UINT_MAX, NULL );
     bid->cnt--;
-    if( FD_LIKELY( !bid->cnt ) ) xid_remove( reasm->xid, bid );
+    if( FD_LIKELY( !bid->cnt ) ) {
+      xid_remove( reasm->xid, bid );
+    } else if( FD_LIKELY( bid->idx==fec_idx ) ) {
+      bid->idx = fec->bid_next;
+    } else {
+      fd_reasm_fec_t * prev = pool_ele( pool, bid->idx );
+      while( prev->bid_next!=fec_idx ) prev = pool_ele( pool, prev->bid_next );
+      prev->bid_next = fec->bid_next;
+    }
   }
-  xid_t * xid = xid_query( reasm->xid, ( fec->slot << 32 ) | fec->fec_set_idx, NULL );
+
+  xid_t * xid = xid_query( reasm->xid, (fec->slot << 32)|fec->fec_set_idx, NULL );
   xid->cnt--;
-  if( FD_LIKELY( !xid->cnt ) ) xid_remove( reasm->xid, xid );
+  if( FD_LIKELY( !xid->cnt ) ) {
+    xid_remove( reasm->xid, xid );
+  } else if( xid->idx==fec_idx ) {
+    xid->idx = fec->xid_next;
+  } else {
+    fd_reasm_fec_t * prev = pool_ele( pool, xid->idx );
+    while( prev->xid_next!=fec_idx ) prev = pool_ele( pool, prev->xid_next );
+    prev->xid_next = fec->xid_next;
+  }
 
   return fec;
 }
@@ -404,7 +422,7 @@ remove_orphan_subtree( fd_reasm_t     * reasm,
       FD_TEST( orphaned_ele_remove( reasm->orphaned, &ele->key, NULL, pool )==ele );
     }
 
-    clear_slot_metadata( reasm, ele );
+    clear_xid_metadata( reasm, ele );
     if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &ele->key );
     pool_ele_release( pool, ele );
   }
@@ -549,7 +567,7 @@ fd_reasm_remove( fd_reasm_t     * reasm,
 
     fd_reasm_fec_t * removed_orphan = NULL;
     if( FD_LIKELY  ( removed_orphan = orphaned_ele_remove( orphaned, &head->key, NULL, pool ) ) ) {
-      clear_slot_metadata( reasm, head );
+      clear_xid_metadata( reasm, head );
       if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
       return head;
     }
@@ -562,7 +580,7 @@ fd_reasm_remove( fd_reasm_t     * reasm,
       if( FD_LIKELY( removed->in_out ) ) { out_ele_remove( reasm->out, removed, pool ); removed->in_out = 0; }
 
       curr = fd_reasm_child( reasm, curr );  /* guaranteed only one child */
-      clear_slot_metadata( reasm, removed );
+      clear_xid_metadata( reasm, removed );
       if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &removed->key );
     }
 
@@ -580,7 +598,7 @@ fd_reasm_remove( fd_reasm_t     * reasm,
   /* No parent, remove from subtrees and subtree list */
   subtrees_ele_remove( subtrees, &head->key, NULL, pool );
   subtreel_ele_remove( subtreel,  head,            pool );
-  clear_slot_metadata( reasm, head );
+  clear_xid_metadata( reasm, head );
   if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
   return head;
 }
@@ -878,11 +896,12 @@ fd_reasm_insert( fd_reasm_t *      reasm,
   fec->out.next = null;
   fec->out.prev = null;
   fec->in_out   = 0;
+  fec->xid_next = null;
+  fec->bid_next = null;
   fec->subtreel.next = null;
   fec->subtreel.prev = null;
 
   fec->cmr = *chained_merkle_root;
-  FD_TEST( memcmp( &fec->cmr, chained_merkle_root, sizeof(fd_hash_t) ) == 0 );
 
   if( FD_UNLIKELY( slot_complete ) ) {
     xid_t * bid = xid_query( reasm->xid, (slot << 32) | UINT_MAX, NULL );
@@ -993,68 +1012,13 @@ fd_reasm_insert( fd_reasm_t *      reasm,
   xid_t * xid = xid_query( reasm->xid, (slot<<32) | fec_set_idx, NULL );
   if( FD_UNLIKELY( xid ) ) {
     eqvoc( reasm, fec );
-    eqvoc( reasm, pool_ele( pool, xid->idx ) ); /* first appearance of this xid */
+    eqvoc( reasm, pool_ele( pool, xid->idx ) ); /* most recent appearance of this xid */
+    /* We can call eqvoc on the head of the xid list because we maintain
+       the order of most recent to least recent. Inductively, this marks
+       all FECs with the same xid as equivocating. */
   }
   xid_update( reasm, slot, fec_set_idx, pool_idx( pool, fec ) );
   if( FD_UNLIKELY( parent && parent->eqvoc && !parent->confirmed ) ) eqvoc( reasm, fec );
-
-  /* 3. this FEC's parent is a slot_complete, but this FEC is part of
-        the same slot.  Or this fec is a slot_complete, but it's child
-        is part of the same slot. i.e.
-
-             A - B - C (slot cmpl) - D - E - F (slot cmpl)
-
-        We do not want to deliver this entire slot if possible. The
-        block has TWO slot complete flags. This is not honest behavior.
-
-         Two ways this can happen:
-          scenario 1: A - B - C (slot cmpl) - D - E - F (slot cmpl)
-
-          scenario 2: A - B - C (slot cmpl)
-                           \
-                            D - E - F (slot cmpl)   [true equivocation case]
-
-        Scenario 2 is handled first-class in reasm, and we will only
-        replay this slot if one version gets confirmed (or we did not
-        see evidence of the other version until after we replayed the
-        first).
-
-        In scenario 1, it is impossible for the cluster to converge on
-        ABC(slot cmpl)DEF(slot cmpl), but depending on the order in
-        which each node receives the FEC sets, the cluster could either
-        confirm ABC(slot cmpl), or mark the slot dead.  In general, if
-        the majority of nodes received and replayed the shorter version
-        before seeing the second half, the slot could still end up
-        getting confirmed. Whereas if the majority of nodes saw shreds
-        from DEF before finishing replay and voting on ABC, the slot
-        would likely be marked dead.
-
-        Firedancer handles this case by marking the slot eqvoc upon
-        detecting a slot complete in the middle of a slot.  reasm will
-        mark the earliest FEC possible in the slot as eqvoc, but may not
-        be able to detect fec 0 because the FEC may be orphaned, or fec
-        0 may not exist yet.  Thus, it is possible for Firedancer to
-        replay ABC(slot cmpl), but it is impossible for reasm to deliver
-        fecs D, E, or F. The node would then vote for ABC(slot cmpl).
-
-        If the node sees D before replaying A, B, or C, then it would be
-        able to mark ABCD as eqvoc, and prevent the corresponding FECs
-        from being delivered. In this case, the Firedancer node would
-        have an incompletely executed bank that eventually gets pruned
-        away.
-
-        Agave's handling differs because they key by slot, but our
-        handling is compatible with the protocol. */
-
-  if( FD_UNLIKELY( (parent && parent->slot_complete && parent->slot == slot) ||
-                   (fec->slot_complete && min_descendant == slot) ) ) {
-    /* walk up to the earliest fec in slot */
-    fd_reasm_fec_t * curr = fec;
-    while( FD_LIKELY( curr->parent != pool_idx_null( pool ) && pool_ele( pool, curr->parent )->slot == slot ) ) {
-      curr = pool_ele( pool, curr->parent );
-    }
-    eqvoc( reasm, curr );
-  }
 
   /* Finally, return the newly inserted FEC. */
   return fec;
@@ -1115,7 +1079,7 @@ fd_reasm_publish( fd_reasm_t      * reasm,
       }
       child = pool_ele( pool, child->sibling );                                         /* right-sibling */
     }
-    clear_slot_metadata( reasm, head );
+    clear_xid_metadata( reasm, head );
     if( FD_LIKELY( opt_store ) ) fd_store_remove( opt_store, &head->key );
     if( FD_LIKELY( head->in_out ) ) { out_ele_remove( reasm->out, head, pool ); head->in_out = 0; }
     pool_ele_release( pool, head );

--- a/src/discof/reasm/fd_reasm.h
+++ b/src/discof/reasm/fd_reasm.h
@@ -188,6 +188,9 @@ struct __attribute__((aligned(128UL))) fd_reasm_fec {
   int    popped;        /* whether this FEC has been previously delivered by fd_reasm_pop */
   int    in_out;        /* whether this FEC is currently present in the out dlist */
 
+  ulong  xid_next;     /* pool idx of next FEC with same (slot, fec_set_idx). ULONG_MAX if no next. Maintain the order of most recent to least recent. */
+  ulong  bid_next;     /* pool idx of next FEC with same (slot, UINT_MAX). ULONG_MAX if no next. Maintain the order of most recent to least recent. */
+
   /* Data (set by caller) */
 
   ulong bank_dead;

--- a/src/discof/reasm/test_reasm.c
+++ b/src/discof/reasm/test_reasm.c
@@ -334,11 +334,11 @@ test_eqvoc_xidbid( fd_wksp_t * wksp ) {
   FD_TEST( xid_query( reasm->xid, last_xid, NULL )->cnt == 1 );
   FD_TEST( xid_query( reasm->xid, last_xid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec3 ) );
 
-  fd_reasm_fec_t * fec4 = fd_reasm_insert( reasm, mr4, mr2,  1, 64, 1, 32, 0, 1, 0, NULL, ev ); /* equivocate on last fec set idx */
+  fd_reasm_fec_t * fec4 = fd_reasm_insert( reasm, mr4, mr2,  1, 64, 1, 32, 0, 1, 0, NULL, ev ); /* equivocate on last fec set idx, gets placed at head of list*/
   FD_TEST( xid_query( reasm->xid, bid, NULL )->cnt == 2 );
-  FD_TEST( xid_query( reasm->xid, bid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec3 ) );
+  FD_TEST( xid_query( reasm->xid, bid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
   FD_TEST( xid_query( reasm->xid, last_xid, NULL )->cnt == 2 );
-  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec3 ) );
+  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
 
   fd_reasm_confirm( reasm, mr4 );
   FD_TEST( xid_query( reasm->xid, bid, NULL )->cnt == 2 );
@@ -1222,6 +1222,106 @@ test_insert_rejects_when_full_and_nothing_is_evictable( fd_wksp_t * wksp ) {
   FD_LOG_NOTICE(( "test_insert_rejects_when_full_and_nothing_is_evictable passed" ));
 }
 
+void
+test_eqvoc_xid_evict( fd_wksp_t * wksp ) {
+  /* Verify xid->idx correctly tracks the surviving FEC after eviction
+     when equivocation has occurred (cnt > 1). */
+
+  ulong        fec_max = 32;
+  void *       mem     = fd_wksp_alloc_laddr( wksp, fd_reasm_align(), fd_reasm_footprint( fec_max ), 1UL );
+  fd_reasm_t * reasm   = fd_reasm_join( fd_reasm_new( mem, fec_max, 0UL ) );
+  FD_TEST( reasm );
+  fd_reasm_fec_t * ev[1];
+
+  fd_hash_t mr0[1] = {{{ 1, 0 }}};
+  fd_reasm_init( reasm, mr0, 0 );
+
+  fd_hash_t mr1[1] = {{{ 1, 1 }}};
+  fd_hash_t mr2[1] = {{{ 1, 2 }}};
+  fd_hash_t mr3[1] = {{{ 1, 3 }}};
+  fd_hash_t mr4[1] = {{{ 1, 4 }}};
+
+  /*                              mr    cmr   slot fecidx p_off data_cnt d_cmpl s_cmpl ldr */
+                          fd_reasm_insert( reasm, mr1, mr0,  1, 0,  1, 32, 0, 0, 0, NULL, ev );
+                          fd_reasm_insert( reasm, mr2, mr1,  1, 32, 1, 32, 0, 0, 0, NULL, ev );
+                          fd_reasm_insert( reasm, mr3, mr2,  1, 64, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_fec_t * fec4 = fd_reasm_insert( reasm, mr4, mr2,  1, 64, 1, 32, 0, 1, 0, NULL, ev );
+
+  ulong last_xid = (1UL << 32) | 64UL;
+  ulong bid      = (1UL << 32) | UINT_MAX;
+
+  FD_TEST( xid_query( reasm->xid, bid,      NULL )->cnt == 2 );
+  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->cnt == 2 );
+
+  /* Confirm fec4 (the second equivocating FEC). This moves fec4 to
+     the head of the xid/bid linked lists. */
+  fd_reasm_confirm( reasm, mr4 );
+  FD_TEST( xid_query( reasm->xid, bid,      NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
+  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
+
+  /* Publish to mr4.  This prunes fec3 (the unconfirmed equivocating
+     FEC) via clear_slot_metadata.  After publish, cnt should be 1 and
+     idx should still point to fec4 (the confirmed survivor). */
+  fd_reasm_publish( reasm, mr4, NULL );
+  FD_TEST( xid_query( reasm->xid, bid,      NULL )->cnt == 1 );
+  FD_TEST( xid_query( reasm->xid, bid,      NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
+  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->cnt == 1 );
+  FD_TEST( xid_query( reasm->xid, last_xid, NULL )->idx == pool_idx( reasm_pool( reasm ), fec4 ) );
+
+  fd_wksp_free_laddr( fd_reasm_delete( fd_reasm_leave( reasm ) ) );
+  mem   = fd_wksp_alloc_laddr( wksp, fd_reasm_align(), fd_reasm_footprint( fec_max ), 1UL );
+  reasm = fd_reasm_join( fd_reasm_new( mem, fec_max, 0UL ) );
+  FD_TEST( reasm );
+
+  fd_hash_t mra[1] = {{{ 2, 0 }}};
+  fd_reasm_init( reasm, mra, 0 );
+
+  fd_hash_t mrb[1] = {{{ 2, 1 }}};
+  fd_hash_t mrc[1] = {{{ 2, 2 }}};
+  fd_hash_t mrd[1] = {{{ 2, 3 }}};
+  fd_hash_t mre[1] = {{{ 2, 4 }}};
+  fd_hash_t mrf[1] = {{{ 2, 5 }}};
+  fd_hash_t mrg[1] = {{{ 2, 6 }}};
+
+  /*                              mr    cmr   slot fecidx p_off data_cnt d_cmpl s_cmpl ldr */
+                          fd_reasm_insert( reasm, mrb, mra,  1, 0,  1, 32, 0, 0, 0, NULL, ev );
+                          fd_reasm_insert( reasm, mrc, mrb,  1, 32, 1, 32, 0, 0, 0, NULL, ev );
+  /* fece */              fd_reasm_insert( reasm, mre, mrc,  1, 64, 1, 32, 0, 1, 0, NULL, ev ); /* third in list */
+  fd_reasm_fec_t * fecd = fd_reasm_insert( reasm, mrd, mrc,  1, 64, 1, 32, 0, 1, 0, NULL, ev ); /* second in list */
+  fd_reasm_fec_t * fecf = fd_reasm_insert( reasm, mrf, mrc,  1, 64, 1, 32, 0, 1, 0, NULL, ev ); /* first in list */
+
+  ulong xid2 = (1UL << 32) | 64UL;
+  ulong bid2 = (1UL << 32) | UINT_MAX;
+
+  FD_TEST( xid_query( reasm->xid, xid2, NULL )->cnt == 3 );
+  FD_TEST( xid_query( reasm->xid, bid2, NULL )->cnt == 3 );
+
+  /* Confirm fecd (the first equivocating FEC this time). Should not move head of list. */
+  fd_reasm_confirm( reasm, mrd );
+  FD_TEST( xid_query( reasm->xid, xid2, NULL )->idx == pool_idx( reasm_pool( reasm ), fecf ) );
+  FD_TEST( xid_query( reasm->xid, bid2, NULL )->idx == pool_idx( reasm_pool( reasm ), fecf ) );
+
+  /* simulate eviction of fecf */
+  fd_reasm_remove( reasm, fecf, NULL );
+  fd_reasm_pool_release( reasm, fecf );
+
+  FD_TEST( xid_query( reasm->xid, xid2, NULL )->cnt == 2 );
+  FD_TEST( xid_query( reasm->xid, bid2, NULL )->cnt == 2 );
+  FD_TEST( xid_query( reasm->xid, xid2, NULL )->idx == pool_idx( reasm_pool( reasm ), fecd ) );
+  FD_TEST( xid_query( reasm->xid, bid2, NULL )->idx == pool_idx( reasm_pool( reasm ), fecd ) );
+
+  /* Build forward from fecd so publish prunes fece, fec f */
+  fd_reasm_insert( reasm, mrg, mrd,  2, 0, 1, 32, 0, 1, 0, NULL, ev );
+  fd_reasm_publish( reasm, mrg, NULL );
+
+  /* fece should have been pruned.  fecd survives at cnt 1. */
+  FD_TEST( !xid_query( reasm->xid, xid2, NULL ) );
+  FD_TEST( !xid_query( reasm->xid, bid2, NULL ) );
+
+  fd_wksp_free_laddr( fd_reasm_delete( fd_reasm_leave( reasm ) ) );
+  FD_LOG_NOTICE(( "test_eqvoc_xid_evict passed" ));
+}
+
 int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
@@ -1243,6 +1343,7 @@ main( int argc, char ** argv ) {
   test_fec_after_eos( wksp );
   test_eqvoc_transitive( wksp );
   test_eqvoc_xidbid( wksp );
+  test_eqvoc_xid_evict( wksp );
   test_evict( wksp );
   test_validate_cross_slot( wksp );
   test_remove_deep_orphan_subtree( wksp );


### PR DESCRIPTION
closes https://github.com/firedancer-io/firedancer/issues/9721 (needs to be merged after validate)
closes https://github.com/firedancer-io/firedancer/issues/9667

not tracking only up to two FECs per xid because theres no way in repair to guarantee delivery of only two FECs, since repair can evict independently
