### PR TITLE
progcache: introduce dedicated xid/key types and lineage

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -276,7 +276,9 @@ replay_block_start( fd_replay_tile_t *  ctx,
   fd_funk_txn_xid_t xid        = fd_bank_xid( bank        );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
-  fd_progcache_attach_child( ctx->progcache,   &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( ctx->progcache,   &pc_parent_xid, &pc_xid );
 
   /* Update required runtime state and handle potential boundary. */
 
@@ -573,7 +575,9 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   fd_funk_txn_xid_t xid        = fd_bank_xid( ctx->leader_bank );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank      );
   fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
-  fd_progcache_attach_child( ctx->progcache,   &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( ctx->progcache,   &pc_parent_xid, &pc_xid );
 
   int is_epoch_boundary = 0;
   fd_runtime_block_execute_prepare( ctx->banks, ctx->leader_bank, ctx->accdb, ctx->runtime_stack, ctx->capture_ctx, &is_epoch_boundary );
@@ -733,8 +737,10 @@ init_funk( fd_replay_tile_t * ctx,
 
   fd_funk_txn_xid_t last_publish = fd_accdb_root_get( ctx->accdb_admin );
   fd_funk_txn_xid_t root = { .ul = { ULONG_MAX, ULONG_MAX } };
-  fd_progcache_attach_child( ctx->progcache, &root, &last_publish );
-  fd_progcache_advance_root( ctx->progcache,        &last_publish );
+  fd_progcache_xid_t pc_root         = fd_progcache_xid_from_funk( &root );
+  fd_progcache_xid_t pc_last_publish = fd_progcache_xid_from_funk( &last_publish );
+  fd_progcache_attach_child( ctx->progcache, &pc_root, &pc_last_publish );
+  fd_progcache_advance_root( ctx->progcache,           &pc_last_publish );
 }
 
 static void
@@ -1737,7 +1743,8 @@ accdb_advance_root( fd_replay_tile_t * ctx,
   fd_histf_sample( ctx->metrics.root_slot_dur,    (ulong)root_accounts_dt );
   fd_histf_sample( ctx->metrics.root_account_dur, (ulong)root_accounts_dt / (ulong)fd_long_max( rooted_accounts, 1L ) );
 
-  fd_progcache_advance_root( ctx->progcache, xid );
+  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( xid );
+  fd_progcache_advance_root( ctx->progcache, &pc_xid );
   long t2 = fd_tickcount();
   FD_MCNT_INC( REPLAY, PROGCACHE_TIME_SECONDS, (ulong)( t2-t1 ) );
 }
@@ -1842,7 +1849,8 @@ after_credit( fd_replay_tile_t *  ctx,
     fd_txncache_cancel_fork( ctx->txncache, cancel_info->txncache_fork_id );
     fd_funk_txn_xid_t xid = { .ul = { cancel_info->slot, cancel_info->bank_seq } };
     fd_accdb_cancel    ( ctx->accdb_admin, &xid );
-    fd_progcache_cancel( ctx->progcache,   &xid );
+    fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
+    fd_progcache_cancel( ctx->progcache,   &pc_xid );
     *charge_busy = 1;
     *opt_poll_in = 0;
     return;

--- a/src/flamenco/progcache/Local.mk
+++ b/src/flamenco/progcache/Local.mk
@@ -12,6 +12,8 @@ $(call add-objs,fd_progcache_admin,fd_flamenco)
 $(call add-hdrs,fd_progcache_user.h)
 $(call add-objs,fd_progcache_user,fd_flamenco)
 
+$(call add-hdrs,fd_progcache_xid.h fd_progcache_lineage.h)
+
 $(call add-objs,fd_progcache_clock,fd_flamenco)
 $(call add-objs,fd_progcache_rec,fd_flamenco)
 $(call add-objs,fd_progcache_reclaim,fd_flamenco)

--- a/src/flamenco/progcache/fd_progcache.c
+++ b/src/flamenco/progcache/fd_progcache.c
@@ -10,10 +10,10 @@
 
 #define MAP_NAME              fd_prog_recm
 #define MAP_ELE_T             fd_progcache_rec_t
-#define MAP_KEY_T             fd_funk_xid_key_pair_t
+#define MAP_KEY_T             fd_progcache_xid_key_pair_t
 #define MAP_KEY               pair
-#define MAP_KEY_EQ(k0,k1)     fd_funk_xid_key_pair_eq((k0),(k1))
-#define MAP_KEY_HASH(k0,seed) fd_funk_xid_key_pair_hash((k0),(seed))
+#define MAP_KEY_EQ(k0,k1)     fd_progcache_xid_key_pair_eq((k0),(k1))
+#define MAP_KEY_HASH(k0,seed) fd_progcache_xid_key_pair_hash((k0),(seed))
 #define MAP_IDX_T             uint
 #define MAP_NEXT              map_next
 #define MAP_MAGIC             (0xf173da2ce77ecdb8UL)
@@ -29,10 +29,10 @@
 
 #define  MAP_NAME              fd_prog_txnm
 #define  MAP_ELE_T             fd_progcache_txn_t
-#define  MAP_KEY_T             fd_xid_t
+#define  MAP_KEY_T             fd_progcache_xid_t
 #define  MAP_KEY               xid
-#define  MAP_KEY_EQ(k0,k1)     fd_funk_txn_xid_eq((k0),(k1))
-#define  MAP_KEY_HASH(k0,seed) fd_funk_txn_xid_hash((k0),(seed))
+#define  MAP_KEY_EQ(k0,k1)     fd_progcache_txn_xid_eq((k0),(k1))
+#define  MAP_KEY_HASH(k0,seed) fd_progcache_txn_xid_hash((k0),(seed))
 #define  MAP_IDX_T             uint
 #define  MAP_NEXT              map_next
 #define  MAP_MAGIC             (0xf173da2ce77ecdb9UL)
@@ -149,7 +149,7 @@ fd_progcache_shmem_new( void * shmem,
   pc->txn.max = txn_max;
   pc->txn.child_head_idx = UINT_MAX;
   pc->txn.child_tail_idx = UINT_MAX;
-  fd_funk_txn_xid_set_root( pc->txn.last_publish );
+  fd_progcache_txn_xid_set_root( pc->txn.last_publish );
   for( ulong i=0UL; i<txn_max; i++ ) {
     fd_rwlock_new( &txn_ele[ i ].lock );
   }

--- a/src/flamenco/progcache/fd_progcache.h
+++ b/src/flamenco/progcache/fd_progcache.h
@@ -6,7 +6,8 @@
    Lock ordering:
    global txn lock, txn lock, clock lock, recm chain_lock, rec.lock */
 
-#include "fd_progcache_rec.h" /* includes fd_progcache_base.h fd_funk_base.h */
+#include "fd_progcache_rec.h" /* includes fd_progcache_base.h */
+#include "fd_progcache_xid.h"
 #include "fd_progcache_clock.h"
 #include "../fd_rwlock.h"
 #include "../runtime/fd_runtime_const.h"
@@ -15,8 +16,6 @@
    of the progcache. */
 
 #define FD_PROGCACHE_SHMEM_MAGIC (0xf17eda2ce7fc2c03UL)
-
-#define FD_PROGCACHE_DEPTH_MAX (8192UL)
 
 #define FD_PROGCACHE_SPAD_MAX (FD_MAX_INSTRUCTION_STACK_DEPTH * (20UL<<20))
 
@@ -36,14 +35,14 @@ struct fd_progcache_shmem {
   } rec;
 
   struct __attribute__((aligned(64))) {
-    fd_rwlock_t       rwlock;
-    ulong             max;
-    ulong             map_gaddr;
-    ulong             pool_gaddr;
-    ulong             ele_gaddr;
-    uint              child_head_idx;
-    uint              child_tail_idx;
-    fd_xid_t last_publish[1];  /* root XID (initially ULONG_MAX:ULONG_MAX) */
+    fd_rwlock_t rwlock;
+    ulong       max;
+    ulong       map_gaddr;
+    ulong       pool_gaddr;
+    ulong       ele_gaddr;
+    uint        child_head_idx;
+    uint        child_tail_idx;
+    fd_progcache_xid_t last_publish[1];  /* root XID (initially ULONG_MAX:ULONG_MAX) */
   } txn;
 
   struct {
@@ -76,10 +75,10 @@ FD_STATIC_ASSERT( FD_PROGCACHE_SPAD_MAX<=UINT_MAX, "layout" );
 
 #define MAP_NAME              fd_prog_recm
 #define MAP_ELE_T             fd_progcache_rec_t
-#define MAP_KEY_T             fd_funk_xid_key_pair_t
+#define MAP_KEY_T             fd_progcache_xid_key_pair_t
 #define MAP_KEY               pair
-#define MAP_KEY_EQ(k0,k1)     fd_funk_xid_key_pair_eq((k0),(k1))
-#define MAP_KEY_HASH(k0,seed) fd_funk_xid_key_pair_hash((k0),(seed))
+#define MAP_KEY_EQ(k0,k1)     fd_progcache_xid_key_pair_eq((k0),(k1))
+#define MAP_KEY_HASH(k0,seed) fd_progcache_xid_key_pair_hash((k0),(seed))
 #define MAP_IDX_T             uint
 #define MAP_NEXT              map_next
 #define MAP_MAGIC             (0xf173da2ce77ecdb8UL)
@@ -90,7 +89,7 @@ FD_STATIC_ASSERT( FD_PROGCACHE_SPAD_MAX<=UINT_MAX, "layout" );
    synchronized) */
 
 struct __attribute__((aligned(64))) fd_progcache_txn {
-  fd_xid_t    xid;
+  fd_progcache_xid_t xid;
   uint        map_next;
   fd_rwlock_t lock;
   ushort      tag : 2;
@@ -114,10 +113,10 @@ struct __attribute__((aligned(64))) fd_progcache_txn {
 
 #define  MAP_NAME              fd_prog_txnm
 #define  MAP_ELE_T             fd_progcache_txn_t
-#define  MAP_KEY_T             fd_xid_t
+#define  MAP_KEY_T             fd_progcache_xid_t
 #define  MAP_KEY               xid
-#define  MAP_KEY_EQ(k0,k1)     fd_funk_txn_xid_eq((k0),(k1))
-#define  MAP_KEY_HASH(k0,seed) fd_funk_txn_xid_hash((k0),(seed))
+#define  MAP_KEY_EQ(k0,k1)     fd_progcache_txn_xid_eq((k0),(k1))
+#define  MAP_KEY_HASH(k0,seed) fd_progcache_txn_xid_hash((k0),(seed))
 #define  MAP_IDX_T             uint
 #define  MAP_NEXT              map_next
 #define  MAP_MAGIC             (0xf173da2ce77ecdb9UL)

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -33,9 +33,9 @@ fd_progcache_est_rec_max( ulong wksp_footprint,
    txn_map. */
 
 void
-fd_progcache_attach_child( fd_progcache_join_t * cache,
-                           fd_xid_t const *      xid_parent,
-                           fd_xid_t const *      xid_new ) {
+fd_progcache_attach_child( fd_progcache_join_t *      cache,
+                           fd_progcache_xid_t const * xid_parent,
+                           fd_progcache_xid_t const * xid_new ) {
   fd_rwlock_write( &cache->shmem->txn.rwlock );
 
   if( FD_UNLIKELY( fd_prog_txnm_idx_query_const( cache->txn.map, xid_new, ULONG_MAX, cache->txn.pool )!=ULONG_MAX ) ) {
@@ -51,9 +51,9 @@ fd_progcache_attach_child( fd_progcache_join_t * cache,
   uint * _child_head_idx;
   uint * _child_tail_idx;
 
-  if( FD_UNLIKELY( fd_funk_txn_xid_eq( xid_parent, cache->shmem->txn.last_publish ) ) ) {
+  if( FD_UNLIKELY( fd_progcache_txn_xid_eq( xid_parent, cache->shmem->txn.last_publish ) ) ) {
 
-    parent_idx = FD_FUNK_TXN_IDX_NULL;
+    parent_idx = FD_PROGCACHE_TXN_IDX_NULL;
 
     _child_head_idx = &cache->shmem->txn.child_head_idx;
     _child_tail_idx = &cache->shmem->txn.child_tail_idx;
@@ -76,7 +76,7 @@ fd_progcache_attach_child( fd_progcache_join_t * cache,
   uint txn_idx = (uint)fd_prog_txnp_idx_acquire( cache->txn.pool );
   if( FD_UNLIKELY( txn_idx==UINT_MAX ) ) FD_LOG_ERR(( "fd_progcache_attach_child failed: transaction object pool out of memory" ));
   fd_progcache_txn_t * txn = &cache->txn.pool[ txn_idx ];
-  fd_funk_txn_xid_copy( &txn->xid, xid_new );
+  fd_progcache_txn_xid_copy( &txn->xid, xid_new );
 
   uint sibling_prev_idx = *_child_tail_idx;
 
@@ -160,7 +160,7 @@ fd_progcache_cancel_one( fd_progcache_join_t * cache,
   /* Remove transaction from index */
 
   if( FD_UNLIKELY( !fd_prog_txnm_ele_remove( cache->txn.map, &txn->xid, NULL, cache->txn.pool ) ) ) {
-    FD_LOG_CRIT(( "fd_progcache_cancel failed: fd_funk_txn_map_remove(%lu:%lu) failed",
+    FD_LOG_CRIT(( "fd_progcache_cancel failed: fd_prog_txnm_ele_remove(%lu:%lu) failed",
                   txn->xid.ul[0], txn->xid.ul[1] ));
   }
 
@@ -252,9 +252,9 @@ fd_progcache_txn_publish_release( fd_progcache_join_t * cache,
     }
 
     /* Evict previous root value */
-    fd_funk_xid_key_pair_t pair[1];
-    fd_funk_rec_key_copy( pair->key, rec->pair.key );
-    fd_funk_txn_xid_set_root( pair->xid );
+    fd_progcache_xid_key_pair_t pair[1];
+    fd_progcache_rec_key_copy( pair->key, rec->pair.key );
+    fd_progcache_txn_xid_set_root( pair->xid );
     if( fd_prog_delete_rec_by_key( cache, pair, 0 )>=0 ) {
       fd_progcache_admin_metrics_g.gc_root_cnt++;
     }
@@ -270,8 +270,8 @@ fd_progcache_txn_publish_release( fd_progcache_join_t * cache,
     rec->prev_idx = UINT_MAX;
     rec->next_idx = UINT_MAX;
     atomic_store_explicit( &rec->txn_idx, UINT_MAX, memory_order_release );
-    fd_xid_t const root = { .ul = { ULONG_MAX, ULONG_MAX } };
-    fd_funk_txn_xid_st_atomic( rec->pair.xid, &root );
+    fd_progcache_xid_t const root = { .ul = { ULONG_MAX, ULONG_MAX } };
+    fd_progcache_txn_xid_st_atomic( rec->pair.xid, &root );
     fd_rwlock_unwrite( &rec->lock );
     fd_progcache_admin_metrics_g.root_cnt++;
 
@@ -293,12 +293,12 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
 
   /* Phase 1: Mark transaction as "last published" */
 
-  fd_xid_t const xid = txn->xid;
+  fd_progcache_xid_t const xid = txn->xid;
   if( FD_UNLIKELY( txn->parent_idx!=UINT_MAX ) ) {
     FD_LOG_CRIT(( "fd_progcache_publish failed: txn with xid %lu:%lu is not a child of the last published txn", xid.ul[0], xid.ul[1] ));
   }
   fd_racesan_hook( "prog_publish_one:pre_xid_store" );
-  fd_funk_txn_xid_st_atomic( cache->shmem->txn.last_publish, &xid );
+  fd_progcache_txn_xid_st_atomic( cache->shmem->txn.last_publish, &xid );
 
   /* Phase 2: Drain inserters from transaction */
 
@@ -333,7 +333,7 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
   /* Phase 5: Remove transaction from index */
 
   if( FD_UNLIKELY( fd_prog_txnm_idx_remove( cache->txn.map, &txn->xid, ULONG_MAX, cache->txn.pool )==ULONG_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_publish failed: fd_funk_txn_map_remove(%lu:%lu) failed",
+    FD_LOG_CRIT(( "fd_progcache_publish failed: fd_prog_txnm_idx_remove(%lu:%lu) failed",
                   xid.ul[0], xid.ul[1] ));
   }
 
@@ -351,8 +351,8 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
 }
 
 void
-fd_progcache_advance_root( fd_progcache_join_t * cache,
-                           fd_xid_t const *      xid ) {
+fd_progcache_advance_root( fd_progcache_join_t *      cache,
+                           fd_progcache_xid_t const * xid ) {
 
   /* Detach records from txns without acquiring record locks */
 
@@ -390,8 +390,8 @@ fd_progcache_advance_root( fd_progcache_join_t * cache,
 }
 
 void
-fd_progcache_cancel( fd_progcache_join_t * cache,
-                     fd_xid_t const *      xid ) {
+fd_progcache_cancel( fd_progcache_join_t *      cache,
+                     fd_progcache_xid_t const * xid ) {
 
   fd_rwlock_write( &cache->shmem->txn.rwlock );
   fd_progcache_txn_t * txn = fd_prog_txnm_ele_query( cache->txn.map, xid, NULL, cache->txn.pool );
@@ -422,7 +422,7 @@ reset_txn_list( fd_progcache_join_t * cache,
   }
 }
 
-/* reset_rec_map frees all records in a funk instance. */
+/* reset_rec_map frees all records in a progcache instance. */
 
 static void
 reset_rec_map( fd_progcache_join_t * cache ) {

--- a/src/flamenco/progcache/fd_progcache_admin.h
+++ b/src/flamenco/progcache/fd_progcache_admin.h
@@ -3,9 +3,6 @@
 
 #include "fd_progcache.h"
 
-struct fd_account_meta;
-typedef struct fd_account_meta fd_account_meta_t;
-
 union fd_features;
 typedef union fd_features fd_features_t;
 
@@ -22,7 +19,7 @@ FD_PROTOTYPES_BEGIN
 
 /* Constructors *******************************************************/
 
-/* fd_progcache_est_rec_max estimates the fd_funk rec_max parameter
+/* fd_progcache_est_rec_max estimates the progcache rec_max parameter
    given the cache's wksp footprint and mean cache entry heap
    utilization. */
 
@@ -39,9 +36,9 @@ fd_progcache_est_rec_max( ulong wksp_footprint,
    this is called. */
 
 void
-fd_progcache_attach_child( fd_progcache_join_t * cache,
-                           fd_xid_t const *      xid_parent,
-                           fd_xid_t const *      xid_new );
+fd_progcache_attach_child( fd_progcache_join_t *      cache,
+                           fd_progcache_xid_t const * xid_parent,
+                           fd_progcache_xid_t const * xid_new );
 
 /* fd_progcache_advance_root advances the fork graph root to the
    given xid.  (In funk terminology, this is the "last publish")
@@ -49,15 +46,15 @@ fd_progcache_attach_child( fd_progcache_join_t * cache,
    Assumes that the xid's parent is the fork graph root. */
 
 void
-fd_progcache_advance_root( fd_progcache_join_t * cache,
-                           fd_xid_t const *      xid );
+fd_progcache_advance_root( fd_progcache_join_t *      cache,
+                           fd_progcache_xid_t const * xid );
 
 /* fd_progcache_cancel removes a fork graph node by XID and its
    children (recursively). */
 
 void
-fd_progcache_cancel( fd_progcache_join_t * cache,
-                     fd_xid_t const *      xid );
+fd_progcache_cancel( fd_progcache_join_t *      cache,
+                     fd_progcache_xid_t const * xid );
 
 /* Reset operations ***************************************************/
 

--- a/src/flamenco/progcache/fd_progcache_base.h
+++ b/src/flamenco/progcache/fd_progcache_base.h
@@ -1,8 +1,6 @@
 #ifndef HEADER_fd_src_flamenco_progcache_fd_progcache_base_h
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_base_h
 
-#include "../../funk/fd_funk_base.h"
-
 typedef struct fd_progcache fd_progcache_t;
 
 typedef struct fd_progcache_shmem fd_progcache_shmem_t;
@@ -12,5 +10,7 @@ typedef struct fd_progcache_join fd_progcache_join_t;
 typedef struct fd_progcache_rec fd_progcache_rec_t;
 
 typedef struct fd_progcache_txn fd_progcache_txn_t;
+
+#define FD_PROGCACHE_DEPTH_MAX (8192UL)
 
 #endif /* HEADER_fd_src_flamenco_progcache_fd_progcache_base_h */

--- a/src/flamenco/progcache/fd_progcache_clock.h
+++ b/src/flamenco/progcache/fd_progcache_clock.h
@@ -27,7 +27,9 @@
    - An additional "exists" bit is interleaved with the "visited" bit,
      to disambiguate an existing idle entry from a free entry */
 
+#include "../../util/bits/fd_bits.h"
 #include "fd_progcache_base.h"
+
 #include <stdatomic.h>
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/progcache/fd_progcache_lineage.h
+++ b/src/flamenco/progcache/fd_progcache_lineage.h
@@ -1,0 +1,46 @@
+#ifndef HEADER_fd_src_flamenco_progcache_fd_progcache_lineage_h
+#define HEADER_fd_src_flamenco_progcache_fd_progcache_lineage_h
+
+/* fd_progcache_lineage.h provides an API for filtering program cache
+   records by fork graph lineage. */
+
+#include "fd_progcache_base.h"
+#include "fd_progcache_xid.h"
+
+struct fd_progcache_lineage {
+
+  /* Current fork cache */
+  fd_progcache_xid_t fork[ FD_PROGCACHE_DEPTH_MAX ];
+  ulong             fork_depth;
+
+  uint txn_idx[ FD_PROGCACHE_DEPTH_MAX ];
+
+  /* Current funk txn cache */
+  ulong tip_txn_idx; /* ==ULONG_MAX if tip is root */
+
+  ulong max_depth;
+};
+
+#define FD_PROGCACHE_LINEAGE_FOOTPRINT (sizeof(fd_progcache_lineage_t))
+
+typedef struct fd_progcache_lineage fd_progcache_lineage_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_progcache_lineage_has_xid returns 1 if the given record XID is part of
+   the current lineage, otherwise 0. */
+
+FD_FN_UNUSED static int
+fd_progcache_lineage_has_xid( fd_progcache_lineage_t const * lineage,
+                              fd_progcache_xid_t const *     rec_xid ) {
+  ulong const fork_depth = lineage->fork_depth;
+  if( fd_progcache_txn_xid_eq_root( rec_xid ) ) return 1;
+  for( ulong i=0UL; i<fork_depth; i++ ) {
+    if( fd_progcache_txn_xid_eq( &lineage->fork[i], rec_xid ) ) return 1;
+  }
+  return 0;
+}
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_progcache_fd_progcache_lineage_h */

--- a/src/flamenco/progcache/fd_progcache_rec.h
+++ b/src/flamenco/progcache/fd_progcache_rec.h
@@ -2,9 +2,11 @@
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_rec_h
 
 #include "fd_progcache_base.h"
+#include "fd_progcache_xid.h"
 #include "../../ballet/sbpf/fd_sbpf_loader.h"
 #include "../fd_flamenco_base.h"
 #include "../fd_rwlock.h"
+
 #include <stdatomic.h>
 
 /* fd_progcache_rec_t is the fixed size header of a program cache entry
@@ -15,7 +17,7 @@
    segment, control flow metadata, ...). */
 
 struct __attribute__((aligned(64))) fd_progcache_rec {
-  fd_funk_xid_key_pair_t pair;  /* Transaction id and record key pair */
+  fd_progcache_xid_key_pair_t pair;  /* Transaction id and record key pair */
 
   ulong revision_key;
 

--- a/src/flamenco/progcache/fd_progcache_reclaim.c
+++ b/src/flamenco/progcache/fd_progcache_reclaim.c
@@ -118,9 +118,9 @@ fd_prog_delete_rec( fd_progcache_join_t * cache,
 }
 
 long
-fd_prog_delete_rec_by_key( fd_progcache_join_t *          cache,
-                           fd_funk_xid_key_pair_t const * key,
-                           _Bool                          lock ) {
+fd_prog_delete_rec_by_key( fd_progcache_join_t *               cache,
+                           fd_progcache_xid_key_pair_t const * key,
+                           _Bool                               lock ) {
   fd_prog_recm_query_t query[1];
   int rm_err;
   if( lock ) rm_err = fd_prog_recm_remove    ( cache->rec.map, key, NULL, query, FD_MAP_FLAG_BLOCKING );

--- a/src/flamenco/progcache/fd_progcache_reclaim.h
+++ b/src/flamenco/progcache/fd_progcache_reclaim.h
@@ -1,7 +1,9 @@
 #ifndef HEADER_fd_src_flamenco_progcache_fd_progcache_reclaim_h
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_reclaim_h
 
+#include "../../util/fd_util_base.h"
 #include "fd_progcache_base.h"
+#include "fd_progcache_xid.h"
 
 FD_PROTOTYPES_BEGIN
 
@@ -15,9 +17,9 @@ fd_prog_delete_rec( fd_progcache_join_t * cache,
                     fd_progcache_rec_t *  rec );
 
 long
-fd_prog_delete_rec_by_key( fd_progcache_join_t *          cache,
-                           fd_funk_xid_key_pair_t const * key,
-                           _Bool                          lock );
+fd_prog_delete_rec_by_key( fd_progcache_join_t *               cache,
+                           fd_progcache_xid_key_pair_t const * key,
+                           _Bool                               lock );
 
 /* Internal API */
 

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -1,6 +1,7 @@
 #include "fd_prog_load.h"
 #include "fd_progcache_user.h"
 #include "fd_progcache_reclaim.h"
+#include "fd_progcache_clock.h"
 #include "../../util/racesan/fd_racesan_target.h"
 
 FD_TL fd_progcache_metrics_t fd_progcache_metrics_default;
@@ -63,16 +64,16 @@ fd_progcache_leave( fd_progcache_t *        cache,
    For any given xid, the epoch_slot0 is assumed to stay constant. */
 
 static void
-fd_progcache_load_fork_slow( fd_progcache_t * cache,
-                             fd_xid_t const * xid ) {
-  fd_accdb_lineage_t *        lineage = cache->lineage;
+fd_progcache_load_fork_slow( fd_progcache_t *           cache,
+                             fd_progcache_xid_t const * xid ) {
+  fd_progcache_lineage_t *    lineage = cache->lineage;
   fd_progcache_join_t const * ljoin   = cache->join;
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
   lineage->fork_depth = 0UL;
   lineage->tip_txn_idx = ULONG_MAX;
 
   ulong txn_max = fd_prog_txnp_max( ljoin->txn.pool );
-  fd_xid_t next_xid = *xid;
+  fd_progcache_xid_t next_xid = *xid;
   ulong i;
   for( i=0UL;; i++ ) {
     if( FD_UNLIKELY( i>=FD_PROGCACHE_DEPTH_MAX ) ) {
@@ -104,11 +105,11 @@ fd_progcache_load_fork_slow( fd_progcache_t * cache,
 }
 
 static inline void
-fd_progcache_load_fork( fd_progcache_t * cache,
-                        fd_xid_t const * xid ) {
+fd_progcache_load_fork( fd_progcache_t *           cache,
+                        fd_progcache_xid_t const * xid ) {
   /* Skip if already on the correct fork */
-  fd_accdb_lineage_t * lineage = cache->lineage;
-  if( FD_LIKELY( (!!lineage->fork_depth) & (!!fd_funk_txn_xid_eq( &lineage->fork[ 0 ], xid ) ) ) ) return;
+  fd_progcache_lineage_t * lineage = cache->lineage;
+  if( FD_LIKELY( (!!lineage->fork_depth) & (!!fd_progcache_txn_xid_eq( &lineage->fork[ 0 ], xid ) ) ) ) return;
   fd_progcache_load_fork_slow( cache, xid ); /* switch fork */
 }
 
@@ -116,15 +117,15 @@ fd_progcache_load_fork( fd_progcache_t * cache,
    fork.  Stops short of an epoch boundary. */
 
 static int
-fd_progcache_search_chain( fd_progcache_t const *    cache,
-                           ulong                     chain_idx,
-                           fd_funk_rec_key_t const * key,
-                           ulong                     revision_key,
-                           fd_progcache_rec_t **     out_rec ) { /* read locked */
+fd_progcache_search_chain( fd_progcache_t const *         cache,
+                           ulong                          chain_idx,
+                           fd_progcache_rec_key_t const * key,
+                           ulong                          revision_key,
+                           fd_progcache_rec_t **          out_rec ) { /* read locked */
   *out_rec = NULL;
 
   fd_progcache_join_t const *                ljoin     = cache->join;
-  fd_accdb_lineage_t const *                 lineage   = cache->lineage;
+  fd_progcache_lineage_t const *             lineage   = cache->lineage;
   fd_prog_recm_shmem_t *                     shmap     = ljoin->rec.map->map;
   fd_prog_recm_shmem_private_chain_t const * chain_tbl = fd_prog_recm_shmem_private_chain_const( shmap, 0UL );
   fd_prog_recm_shmem_private_chain_t const * chain     = chain_tbl + chain_idx;
@@ -149,13 +150,13 @@ fd_progcache_search_chain( fd_progcache_t const *    cache,
     fd_progcache_rec_t * rec = &rec_tbl[ ele_idx ];
 
     /* Skip over unrelated records (hash collision) */
-    if( FD_UNLIKELY( !fd_funk_rec_key_eq( rec->pair.key, key ) ) ) continue;
+    if( FD_UNLIKELY( !fd_progcache_rec_key_eq( rec->pair.key, key ) ) ) continue;
 
     /* Skip over other revisions */
     if( FD_UNLIKELY( rec->revision_key != revision_key ) ) continue;
-    fd_xid_t rec_xid[1];
-    fd_funk_txn_xid_ld_atomic( rec_xid, rec->pair.xid );
-    if( FD_UNLIKELY( !fd_accdb_lineage_has_xid( lineage, rec_xid ) ) ) continue;
+    fd_progcache_xid_t rec_xid[1];
+    fd_progcache_txn_xid_ld_atomic( rec_xid, rec->pair.xid );
+    if( FD_UNLIKELY( !fd_progcache_lineage_has_xid( lineage, rec_xid ) ) ) continue;
 
     if( FD_UNLIKELY( rec->map_next==ele_idx ) ) return FD_MAP_ERR_AGAIN;
     if( FD_UNLIKELY( rec->map_next!=UINT_MAX && rec->map_next>=rec_max ) ) return FD_MAP_ERR_AGAIN;
@@ -179,16 +180,16 @@ fd_progcache_search_chain( fd_progcache_t const *    cache,
 }
 
 static fd_progcache_rec_t * /* read locked */
-fd_progcache_query( fd_progcache_t *          cache,
-                    fd_xid_t const *          xid,
-                    fd_funk_rec_key_t const * key,
-                    ulong                     revision_key ) {
+fd_progcache_query( fd_progcache_t *               cache,
+                    fd_progcache_xid_t const *     xid,
+                    fd_progcache_rec_key_t const * key,
+                    ulong                          revision_key ) {
   /* Hash key to chain */
-  fd_funk_xid_key_pair_t pair[1];
-  fd_funk_txn_xid_copy( pair->xid, xid );
-  fd_funk_rec_key_copy( pair->key, key );
+  fd_progcache_xid_key_pair_t pair[1];
+  fd_progcache_txn_xid_copy( pair->xid, xid );
+  fd_progcache_rec_key_copy( pair->key, key );
   fd_prog_recm_t const * rec_map = cache->join->rec.map;
-  ulong hash      = fd_funk_rec_key_hash( pair->key, rec_map->map->seed );
+  ulong hash      = fd_progcache_rec_key_hash( pair->key, rec_map->map->seed );
   ulong chain_idx = (hash & (rec_map->map->chain_cnt-1UL) );
 
   /* Traverse chain for candidate */
@@ -205,13 +206,13 @@ fd_progcache_query( fd_progcache_t *          cache,
 }
 
 fd_progcache_rec_t * /* read locked */
-fd_progcache_peek( fd_progcache_t    * cache,
-                   fd_xid_t    const * xid,
-                   fd_pubkey_t const * prog_addr,
-                   ulong               revision_key ) {
+fd_progcache_peek( fd_progcache_t *           cache,
+                   fd_progcache_xid_t const * xid,
+                   fd_pubkey_t const *        prog_addr,
+                   ulong                      revision_key ) {
   if( FD_UNLIKELY( !cache || !cache->join->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
   fd_progcache_load_fork( cache, xid );
-  fd_funk_rec_key_t key[1]; fd_memcpy( key->uc, prog_addr->hash, 32UL );
+  fd_progcache_rec_key_t key[1]; fd_memcpy( key->uc, prog_addr->hash, 32UL );
   fd_progcache_rec_t * rec = fd_progcache_query( cache, xid, key, revision_key );
   if( FD_UNLIKELY( !rec ) ) return NULL;
   return rec;
@@ -255,7 +256,7 @@ fd_progcache_push( fd_progcache_join_t * cache,
   rec->next_idx = UINT_MAX;
   memcpy( rec->pair.key, prog_addr, 32UL );
   if( FD_UNLIKELY( !txn ) ) FD_LOG_CRIT(( "NULL txn" ));
-  fd_funk_txn_xid_copy( rec->pair.xid, &txn->xid );
+  fd_progcache_txn_xid_copy( rec->pair.xid, &txn->xid );
 
   /* Lock rec_map chain, entering critical section */
 
@@ -339,7 +340,7 @@ typedef struct insert_params insert_params_t;
 
 static insert_params_t *
 insert_params( insert_params_t *          p,
-               fd_xid_t const *           load_xid,
+               fd_progcache_xid_t const * load_xid,
                void const *               prog_addr,
                fd_prog_load_env_t const * env,
                fd_accdb_ro_t *            prog_ro,
@@ -543,7 +544,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
 
 fd_progcache_rec_t * /* read locked */
 fd_progcache_pull( fd_progcache_t           * cache,
-                   fd_xid_t           const * xid,
+                   fd_progcache_xid_t const * xid,
                    fd_pubkey_t        const * prog_addr,
                    fd_prog_load_env_t const * env,
                    fd_accdb_ro_t            * prog_ro ) {

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -22,7 +22,7 @@
    (typically only zero or one, in rare cases where the program content
    differs across forks multiple).
 
-   A cache entry consists of a funk_rec object (from a preallocated
+   A cache entry consists of a progcache_rec object (from a preallocated
    object pool), and a variable-sized fd_progcache_entry struct
    (from an fd_alloc heap).
 
@@ -52,6 +52,7 @@
 
 #include "fd_progcache.h"
 #include "fd_prog_load.h"
+#include "fd_progcache_lineage.h"
 #include "../runtime/fd_runtime_const.h"
 
 struct fd_progcache_metrics {
@@ -72,13 +73,13 @@ struct fd_progcache_metrics {
 
 typedef struct fd_progcache_metrics fd_progcache_metrics_t;
 
-/* fd_progcache_t is a thread-local client to a program cache funk
-   instance.  This struct is quite large and therefore not local/stack
+/* fd_progcache_t is a thread-local client to a program cache instance.
+   This struct is quite large and therefore not local/stack
    declaration-friendly. */
 
 struct fd_progcache {
   fd_progcache_join_t join[1];
-  fd_accdb_lineage_t  lineage[1];
+  fd_progcache_lineage_t lineage[1];
 
   fd_progcache_metrics_t * metrics;
 
@@ -142,10 +143,10 @@ fd_progcache_revision_key_slot( ulong revision_key ) {
    fd_progcache_rec_close. */
 
 fd_progcache_rec_t * /* read locked */
-fd_progcache_peek( fd_progcache_t    * cache,
-                   fd_xid_t    const * xid,
-                   fd_pubkey_t const * prog_addr,
-                   ulong               revision_key );
+fd_progcache_peek( fd_progcache_t *           cache,
+                   fd_progcache_xid_t const * xid,
+                   fd_pubkey_t const *        prog_addr,
+                   ulong                      revision_key );
 
 /* fd_progcache_pull loads a program from cache, filling the cache if
    necessary.  The load operation can have a number of outcomes:
@@ -164,7 +165,7 @@ fd_progcache_peek( fd_progcache_t    * cache,
 
 fd_progcache_rec_t * /* read locked */
 fd_progcache_pull( fd_progcache_t           * cache,
-                   fd_xid_t const           * xid,
+                   fd_progcache_xid_t const * xid,
                    fd_pubkey_t        const * prog_addr,
                    fd_prog_load_env_t const * env,
                    fd_accdb_ro_t            * progdata_ro );

--- a/src/flamenco/progcache/fd_progcache_xid.h
+++ b/src/flamenco/progcache/fd_progcache_xid.h
@@ -1,0 +1,287 @@
+#ifndef HEADER_fd_src_flamenco_progcache_fd_progcache_xid_h
+#define HEADER_fd_src_flamenco_progcache_fd_progcache_xid_h
+
+#include "../../util/bits/fd_bits.h"
+#include "../../funk/fd_funk_base.h"
+
+#if FD_HAS_X86
+#include <immintrin.h>
+#endif
+
+#define FD_PROGCACHE_TXN_IDX_NULL ((ulong)UINT_MAX)
+
+/* FD_PROGCACHE_REC_KEY_{ALIGN,FOOTPRINT} describe the alignment and
+   footprint of a fd_progcache_rec_key_t.  ALIGN is a positive integer power
+   of 2.  FOOTPRINT is a multiple of ALIGN.  These are provided to
+   facilitate compile time declarations. */
+
+#define FD_PROGCACHE_REC_KEY_ALIGN     (8UL)
+#define FD_PROGCACHE_REC_KEY_FOOTPRINT (32UL)
+
+/* A fd_progcache_rec_key_t identifies a progcache record.  Compact binary keys
+   are encouraged but a cstr can be used so long as it has
+   strlen(cstr)<FD_PROGCACHE_REC_KEY_FOOTPRINT and the characters c[i] for i
+   in [strlen(cstr),FD_PROGCACHE_REC_KEY_FOOTPRINT) zero.  (Also, if encoding
+   a cstr in a key, recommend using first byte to encode the strlen for
+   accelerating cstr operations further but this is up to the user.) */
+
+union __attribute__((aligned(FD_PROGCACHE_REC_KEY_ALIGN))) fd_progcache_rec_key {
+  uchar uc[ FD_PROGCACHE_REC_KEY_FOOTPRINT ];
+  uint  ui[ 8 ];
+  ulong ul[ 4 ];
+};
+
+typedef union fd_progcache_rec_key fd_progcache_rec_key_t;
+
+#define FD_PROGCACHE_TXN_XID_ALIGN     (16UL)
+#define FD_PROGCACHE_TXN_XID_FOOTPRINT (16UL)
+
+union __attribute__((aligned(FD_PROGCACHE_TXN_XID_ALIGN))) fd_progcache_xid {
+  uchar uc[ FD_PROGCACHE_TXN_XID_FOOTPRINT ];
+  ulong ul[ FD_PROGCACHE_TXN_XID_FOOTPRINT / sizeof(ulong) ];
+#if FD_HAS_INT128
+  uint128 uf[1];
+#endif
+#if FD_HAS_X86
+  __m128i xmm[1];
+#endif
+};
+
+typedef union fd_progcache_xid fd_progcache_xid_t;
+
+/* FD_PROGCACHE_XID_KEY_PAIR_{ALIGN,FOOTPRINT} describe the alignment and
+   footprint of a fd_progcache_xid_key_pair_t.  ALIGN is a positive integer
+   power of 2.  FOOTPRINT is a multiple of ALIGN.  These are provided to
+   facilitate compile time declarations. */
+
+#define FD_PROGCACHE_XID_KEY_PAIR_ALIGN     (16UL)
+#define FD_PROGCACHE_XID_KEY_PAIR_FOOTPRINT (48UL)
+
+/* A fd_progcache_xid_key_pair_t identifies a progcache record.  It is just
+   xid and key packed into the same structure. */
+
+struct fd_progcache_xid_key_pair {
+  fd_progcache_xid_t xid[1];
+  fd_progcache_rec_key_t key[1];
+};
+
+typedef struct fd_progcache_xid_key_pair fd_progcache_xid_key_pair_t;
+
+/* fd_progcache_rec_key_hash provides a family of hashes that hash the key
+   pointed to by k to a uniform quasi-random 64-bit integer.  seed
+   selects the particular hash function to use and can be an arbitrary
+   64-bit value.  Returns the hash.  The hash functions are high quality
+   but not cryptographically secure.  Assumes k is in the caller's
+   address space and valid. */
+
+#if FD_HAS_INT128
+
+/* If the target supports uint128, fd_progcache_rec_key_hash is seeded
+   xxHash3 with 64-bit output size. (open source BSD licensed) */
+
+static inline ulong
+fd_pc_xxh3_mul128_fold64( ulong lhs, ulong rhs ) {
+  uint128 product = (uint128)lhs * (uint128)rhs;
+  return (ulong)product ^ (ulong)( product>>64 );
+}
+
+static inline ulong
+fd_pc_xxh3_mix16b( ulong i0, ulong i1,
+                ulong s0, ulong s1,
+                ulong seed ) {
+  return fd_pc_xxh3_mul128_fold64( i0 ^ (s0 + seed), i1 ^ (s1 - seed) );
+}
+
+FD_FN_PURE static inline ulong
+fd_progcache_rec_key_hash1( uchar const key[ 32 ],
+                            ulong       seed ) {
+  ulong k0 = FD_LOAD( ulong, key+ 0 );
+  ulong k1 = FD_LOAD( ulong, key+ 8 );
+  ulong k2 = FD_LOAD( ulong, key+16 );
+  ulong k3 = FD_LOAD( ulong, key+24 );
+  ulong acc = 32 * 0x9E3779B185EBCA87ULL;
+  acc += fd_pc_xxh3_mix16b( k0, k1, 0xbe4ba423396cfeb8UL, 0x1cad21f72c81017cUL, seed );
+  acc += fd_pc_xxh3_mix16b( k2, k3, 0xdb979083e96dd4deUL, 0x1f67b3b7a4a44072UL, seed );
+  acc = acc ^ (acc >> 37);
+  acc *= 0x165667919E3779F9ULL;
+  acc = acc ^ (acc >> 32);
+  return acc;
+}
+
+FD_FN_PURE static inline ulong
+fd_progcache_rec_key_hash( fd_progcache_rec_key_t const * k,
+                           ulong                          seed ) {
+  return fd_progcache_rec_key_hash1( k->uc, seed );
+}
+
+#else
+
+/* If the target does not support xxHash3, fallback to the 'old' key
+   hash function.
+
+   FIXME This version is vulnerable to HashDoS */
+
+FD_FN_PURE static inline ulong
+fd_progcache_rec_key_hash1( uchar const key[ 32 ],
+                            ulong       seed ) {
+  /* tons of ILP */
+  return (fd_ulong_hash( seed ^ (1UL<<0) ^ FD_LOAD( ulong, key+ 0 ) )   ^
+          fd_ulong_hash( seed ^ (1UL<<1) ^ FD_LOAD( ulong, key+ 8 ) ) ) ^
+         (fd_ulong_hash( seed ^ (1UL<<2) ^ FD_LOAD( ulong, key+16 ) ) ^
+          fd_ulong_hash( seed ^ (1UL<<3) ^ FD_LOAD( ulong, key+24 ) ) );
+}
+
+FD_FN_PURE static inline ulong
+fd_progcache_rec_key_hash( fd_progcache_rec_key_t const * k,
+                           ulong                          seed ) {
+  return fd_progcache_rec_key_hash1( k->uc, seed );
+}
+
+#endif /* FD_HAS_INT128 */
+
+/* fd_progcache_rec_key_copy copies the key pointed to by ks into the key
+   pointed to by kd and returns kd.  Assumes kd and ks are in the
+   caller's address space and valid. */
+
+static inline fd_progcache_rec_key_t *
+fd_progcache_rec_key_copy( fd_progcache_rec_key_t *       kd,
+                           fd_progcache_rec_key_t const * ks ) {
+  ulong *       d = kd->ul;
+  ulong const * s = ks->ul;
+  d[0] = s[0]; d[1] = s[1]; d[2] = s[2]; d[3] = s[3];
+  return kd;
+}
+
+/* fd_progcache_txn_xid_copy copies the transaction id pointed to by xs into
+   the transaction id pointed to by xd and returns xd.  Assumes xd and
+   xs are in the caller's address space and valid. */
+
+static inline fd_progcache_xid_t *
+fd_progcache_txn_xid_copy( fd_progcache_xid_t *       xd,
+                           fd_progcache_xid_t const * xs ) {
+  ulong *       d = xd->ul;
+  ulong const * s = xs->ul;
+  d[0] = s[0]; d[1] = s[1];
+  return xd;
+}
+
+static inline fd_progcache_xid_t *
+fd_progcache_txn_xid_ld_atomic( fd_progcache_xid_t *       xd,
+                                fd_progcache_xid_t const * xs ) {
+# if FD_HAS_X86
+  xd->xmm[0] = FD_VOLATILE_CONST( xs->xmm[0] );
+# elif FD_HAS_INT128
+  xd->uf[0] = FD_VOLATILE_CONST( xs->uf[0] );
+# else
+  fd_progcache_txn_xid_copy( xd, xs );
+# endif
+  return xd;
+}
+
+static inline fd_progcache_xid_t *
+fd_progcache_txn_xid_st_atomic( fd_progcache_xid_t *       xd,
+                                fd_progcache_xid_t const * xs ) {
+# if FD_HAS_X86
+  FD_VOLATILE( xd->xmm[0] ) = xs->xmm[0];
+# elif FD_HAS_INT128
+  FD_VOLATILE( xd->uf[0] ) = xs->uf[0];
+# else
+  fd_progcache_txn_xid_copy( xd, xs );
+# endif
+  return xd;
+}
+
+/* fd_progcache_xid_key_pair_hash produces a 64-bit hash case for a
+   xid_key_pair. Assumes p is in the caller's address space and valid. */
+
+FD_FN_PURE static inline ulong
+fd_progcache_xid_key_pair_hash( fd_progcache_xid_key_pair_t const * p,
+                                ulong                               seed ) {
+  /* We ignore the xid part of the key because we need all the instances
+     of a given record key to appear in the same hash
+     chain. fd_progcache_rec_query_global depends on this. */
+  return fd_progcache_rec_key_hash( p->key, seed );
+}
+
+/* fd_progcache_txn_xid_hash provides a family of hashes that hash the xid
+   pointed to by x to a uniform quasi-random 64-bit integer.  seed
+   selects the particular hash function to use and can be an arbitrary
+   64-bit value.  Returns the hash.  The hash functions are high quality
+   but not cryptographically secure.  Assumes x is in the caller's
+   address space and valid. */
+
+FD_FN_UNUSED FD_FN_PURE static ulong /* Work around -Winline */
+fd_progcache_txn_xid_hash( fd_progcache_xid_t const * x,
+                           ulong                      seed ) {
+  return ( fd_ulong_hash( seed ^ (1UL<<0) ^ x->ul[0] ) ^ fd_ulong_hash( seed ^ (1UL<<1) ^ x->ul[1] ) ); /* tons of ILP */
+}
+
+/* fd_progcache_txn_xid_eq returns 1 if transaction id pointed to by xa and
+   xb are equal and 0 otherwise.  Assumes xa and xb are in the caller's
+   address space and valid. */
+
+FD_FN_PURE static inline int
+fd_progcache_txn_xid_eq( fd_progcache_xid_t const * xa,
+                         fd_progcache_xid_t const * xb ) {
+  ulong const * a = xa->ul;
+  ulong const * b = xb->ul;
+  return !( (a[0]^b[0]) | (a[1]^b[1]) );
+}
+
+/* fd_progcache_txn_xid_eq_root returns 1 if transaction id pointed to by x
+   is the root transaction.  Assumes x is in the caller's address space
+   and valid. */
+
+FD_FN_PURE static inline int
+fd_progcache_txn_xid_eq_root( fd_progcache_xid_t const * x ) {
+  ulong const * a = x->ul;
+  return ((a[0] == ULONG_MAX) & (a[1] == ULONG_MAX));
+}
+
+/* fd_progcache_rec_key_eq returns 1 if keys pointed to by ka and kb are
+   equal and 0 otherwise.  Assumes ka and kb are in the caller's address
+   space and valid. */
+
+FD_FN_UNUSED FD_FN_PURE static int /* Workaround -Winline */
+fd_progcache_rec_key_eq( fd_progcache_rec_key_t const * ka,
+                         fd_progcache_rec_key_t const * kb ) {
+  ulong const * a = ka->ul;
+  ulong const * b = kb->ul;
+  return !( ((a[0]^b[0]) | (a[1]^b[1])) | ((a[2]^b[2]) | (a[3]^b[3])) ) ;
+}
+
+/* fd_progcache_xid_key_pair_eq returns 1 if (xid,key) pair pointed to by pa
+   and pb are equal and 0 otherwise.  Assumes pa and pb are in the
+   caller's address space and valid. */
+
+FD_FN_UNUSED FD_FN_PURE static int /* Work around -Winline */
+fd_progcache_xid_key_pair_eq( fd_progcache_xid_key_pair_t const * pa,
+                              fd_progcache_xid_key_pair_t const * pb ) {
+  return fd_progcache_txn_xid_eq( pa->xid, pb->xid ) & fd_progcache_rec_key_eq( pa->key, pb->key );
+}
+
+/* fd_progcache_txn_xid_set_root sets transaction id pointed to by x to the
+   root transaction and returns x.  Assumes x is in the caller's address
+   space and valid. */
+
+static inline fd_progcache_xid_t *
+fd_progcache_txn_xid_set_root( fd_progcache_xid_t * x ) {
+  ulong * a = x->ul;
+  a[0] = ULONG_MAX; a[1] = ULONG_MAX;
+  return x;
+}
+
+/* fd_progcache_xid_from_funk converts a funk transaction id into a
+   progcache transaction id.  fd_progcache_xid_t and fd_funk_txn_xid_t
+   are byte-compatible 16-byte identifiers; this helper exists to make
+   the type boundary explicit at progcache API call sites. */
+
+FD_FN_PURE static inline fd_progcache_xid_t
+fd_progcache_xid_from_funk( fd_funk_txn_xid_t const * src ) {
+  fd_progcache_xid_t out;
+  out.ul[0] = src->ul[0];
+  out.ul[1] = src->ul[1];
+  return out;
+}
+
+#endif /* HEADER_fd_src_flamenco_progcache_fd_progcache_xid_h */

--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -56,12 +56,12 @@ test_env_destroy( test_env_t * env ) {
    parent with the given xid, in both accdb and progcache. */
 
 static void
-test_env_txn_prepare( test_env_t *     env,
-                      fd_xid_t const * parent,
-                      fd_xid_t const * xid ) {
-  fd_xid_t root[1];
+test_env_txn_prepare( test_env_t *               env,
+                      fd_progcache_xid_t const * parent,
+                      fd_progcache_xid_t const * xid ) {
+  fd_progcache_xid_t root[1];
   if( !parent ) {
-    fd_funk_txn_xid_set_root( root );
+    fd_progcache_txn_xid_set_root( root );
     parent = root;
   }
   fd_progcache_attach_child( env->progcache->join, parent, xid );
@@ -71,8 +71,8 @@ test_env_txn_prepare( test_env_t *     env,
    with root 'xid', in both accdb and progcache. */
 
 static void
-test_env_txn_cancel( test_env_t *     env,
-                     fd_xid_t const * xid ) {
+test_env_txn_cancel( test_env_t *               env,
+                     fd_progcache_xid_t const * xid ) {
   fd_progcache_cancel( env->progcache->join, xid );
 }
 
@@ -80,8 +80,8 @@ test_env_txn_cancel( test_env_t *     env,
    transactions with root 'xid', in both accdb and progcache. */
 
 static void
-test_env_txn_publish( test_env_t *     env,
-                      fd_xid_t const * xid ) {
+test_env_txn_publish( test_env_t *               env,
+                      fd_progcache_xid_t const * xid ) {
   fd_progcache_advance_root( env->progcache->join, xid );
 }
 
@@ -92,11 +92,11 @@ FD_IMPORT_BINARY( invalid_program_data,      "src/ballet/sbpf/fixtures/malformed
 /* query_rec_exact fetches a funk record at a precise xid:key pair. */
 
 static fd_progcache_rec_t const *
-query_rec_exact( test_env_t *           env,
-                 fd_xid_t const *       xid,
-                 fd_pubkey_t const *    key ) {
-  fd_funk_xid_key_pair_t pair[1];
-  fd_funk_txn_xid_copy( pair->xid, xid );
+query_rec_exact( test_env_t *               env,
+                 fd_progcache_xid_t const * xid,
+                 fd_pubkey_t const *        key ) {
+  fd_progcache_xid_key_pair_t pair[1];
+  fd_progcache_txn_xid_copy( pair->xid, xid );
   memcpy( pair->key, key, 32 );
 
   fd_prog_recm_query_t query[1];
@@ -113,11 +113,11 @@ query_rec_exact( test_env_t *           env,
    by cancel/publish/destroy. */
 
 static fd_progcache_rec_t *
-test_peek1( fd_progcache_t *    cache,
-            fd_xid_t const *    xid,
-            fd_pubkey_t const * prog_addr,
-            ulong               epoch_slot0,
-            ulong               deploy_slot ) {
+test_peek1( fd_progcache_t *           cache,
+            fd_progcache_xid_t const * xid,
+            fd_pubkey_t const *        prog_addr,
+            ulong                      epoch_slot0,
+            ulong                      deploy_slot ) {
   ulong key = fd_progcache_revision_key( epoch_slot0, deploy_slot );
   fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, key );
   if( rec ) fd_progcache_rec_close( cache, rec );
@@ -125,10 +125,10 @@ test_peek1( fd_progcache_t *    cache,
 }
 
 static fd_progcache_rec_t *
-test_peek( fd_progcache_t *    cache,
-           fd_xid_t const *    xid,
-           fd_pubkey_t const * prog_addr,
-           ulong               epoch_slot0 ) {
+test_peek( fd_progcache_t *           cache,
+           fd_progcache_xid_t const * xid,
+           fd_pubkey_t const *        prog_addr,
+           ulong                      epoch_slot0 ) {
   ulong key = fd_progcache_revision_key( epoch_slot0, 0UL );
   fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, key );
   if( rec ) fd_progcache_rec_close( cache, rec );
@@ -138,7 +138,7 @@ test_peek( fd_progcache_t *    cache,
 static fd_progcache_rec_t *
 test_pull( fd_progcache_t *           cache,
            fd_accdb_ro_t *            prog_ro,
-           fd_xid_t const *           xid,
+           fd_progcache_xid_t const * xid,
            fd_pubkey_t const *        prog_addr,
            fd_prog_load_env_t const * env ) {
   fd_progcache_rec_t * rec = fd_progcache_pull( cache, xid, prog_addr, env, prog_ro );
@@ -152,7 +152,7 @@ test_pull( fd_progcache_t *           cache,
 static void
 test_account_does_not_exist( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   (void)test_env_txn_publish;
@@ -166,7 +166,7 @@ test_account_does_not_exist( fd_wksp_t * wksp ) {
 static void
 test_invalid_owner( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -190,7 +190,7 @@ test_invalid_owner( fd_wksp_t * wksp ) {
 static void
 test_invalid_program( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -200,7 +200,7 @@ test_invalid_program( fd_wksp_t * wksp ) {
 
   FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_funk_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
+  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
 
   fd_prog_load_env_t load_env = {
     .features    = env->features,
@@ -221,7 +221,7 @@ test_invalid_program( fd_wksp_t * wksp ) {
 static void
 test_valid_program( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -231,7 +231,7 @@ test_valid_program( fd_wksp_t * wksp ) {
 
   FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_funk_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
+  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
 
   fd_prog_load_env_t load_env = {
     .features    = env->features,
@@ -244,7 +244,7 @@ test_valid_program( fd_wksp_t * wksp ) {
   FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL )==rec );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
 
-  fd_xid_t fork_b = { .ul = { 64UL, 2UL } };
+  fd_progcache_xid_t fork_b = { .ul = { 64UL, 2UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
   FD_TEST( test_peek( env->progcache, &fork_b, &key, 0UL )==rec );
   FD_TEST( env->progcache->lineage->fork_depth==2UL );
@@ -265,7 +265,7 @@ test_valid_program( fd_wksp_t * wksp ) {
 static void
 test_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -275,7 +275,7 @@ test_epoch_boundary( fd_wksp_t * wksp ) {
 
   FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_funk_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
+  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
 
   fd_prog_load_env_t load_env = {
     .features    = env->features,
@@ -287,7 +287,7 @@ test_epoch_boundary( fd_wksp_t * wksp ) {
   FD_TEST( rec->data_gaddr );
   FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL )==rec );
 
-  fd_xid_t fork_b = { .ul = { 64UL, 2UL } };
+  fd_progcache_xid_t fork_b = { .ul = { 64UL, 2UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
   load_env.epoch       =  1UL;
   load_env.epoch_slot0 = 64UL;
@@ -305,7 +305,7 @@ test_epoch_boundary( fd_wksp_t * wksp ) {
 static void
 test_epoch_boundary2( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t prog_key       = test_key( 1UL );
@@ -341,7 +341,7 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
     .epoch       = 1UL,
     .epoch_slot0 = 64UL,
   };
-  fd_xid_t fork_b = { .ul = { 64UL, 2UL } };
+  fd_progcache_xid_t fork_b = { .ul = { 64UL, 2UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
   fd_progcache_rec_t const * rec2 = test_pull( env->progcache, prog0_data.ro, &fork_b, &prog_key, &load_env2 );
   FD_TEST( rec1!=rec2 );
@@ -356,7 +356,7 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
       bigger_valid_program_data, bigger_valid_program_data_sz,
       64UL
   );
-  fd_xid_t fork_c = { .ul = { 65UL, 2UL } };
+  fd_progcache_xid_t fork_c = { .ul = { 65UL, 2UL } };
   test_env_txn_prepare( env, &fork_b, &fork_c );
   fd_progcache_rec_t const * rec3 = test_pull( env->progcache, prog1_data.ro, &fork_c, &prog_key, &load_env2 );
   FD_TEST( rec3!=rec1 && rec3!=rec2 );
@@ -374,7 +374,7 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
 static void
 test_publish_gc( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -391,7 +391,7 @@ test_publish_gc( fd_wksp_t * wksp ) {
   FD_TEST( rec_a );
   FD_TEST( rec_a->data_gaddr );
 
-  fd_xid_t fork_b = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t fork_b = { .ul = { 2UL, 1UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
   fd_prog_load_env_t load_env_b = {
     .features    = env->features,
@@ -402,7 +402,7 @@ test_publish_gc( fd_wksp_t * wksp ) {
   FD_TEST( rec_b );
   FD_TEST( rec_b->data_gaddr );
 
-  fd_xid_t fork_c = { .ul = { 3UL, 2UL } };
+  fd_progcache_xid_t fork_c = { .ul = { 3UL, 2UL } };
   test_env_txn_prepare( env, &fork_b, &fork_c );
   fd_prog_load_env_t load_env_c = {
     .features    = env->features,
@@ -423,7 +423,7 @@ test_publish_gc( fd_wksp_t * wksp ) {
   FD_TEST( frec_a ); FD_TEST( frec_b ); FD_TEST( frec_c );
   FD_TEST( frec_a!=frec_b && frec_a!=frec_c && frec_b!=frec_c );
 
-  fd_xid_t root; fd_funk_txn_xid_set_root( &root );
+  fd_progcache_xid_t root; fd_progcache_txn_xid_set_root( &root );
   test_env_txn_publish( env, &fork_a );
   FD_TEST( query_rec_exact( env, &fork_a, &key )==NULL   );
   FD_TEST( query_rec_exact( env, &root,   &key )==frec_a );
@@ -460,8 +460,8 @@ test_publish_trivial( fd_wksp_t * wksp ) {
 
   test_env_t * env = test_env_create( wksp );
 
-  fd_xid_t root; fd_funk_txn_xid_set_root( &root );
-  fd_xid_t fork_368528500 = { .ul = { 368528500UL, 368528500UL } };
+  fd_progcache_xid_t root; fd_progcache_txn_xid_set_root( &root );
+  fd_progcache_xid_t fork_368528500 = { .ul = { 368528500UL, 368528500UL } };
   fd_progcache_attach_child( env->progcache->join, &root, &fork_368528500 );
   fd_progcache_advance_root( env->progcache->join,        &fork_368528500 );
 
@@ -474,10 +474,10 @@ test_publish_trivial( fd_wksp_t * wksp ) {
 static void
 test_root_nonroot_prio( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_1 = { .ul = { 1UL, 1UL } }; /* account deployed here */
-  fd_xid_t fork_2 = { .ul = { 2UL, 1UL } }; /* root */
-  fd_xid_t fork_3 = { .ul = { 3UL, 2UL } }; /* account redeployed here */
-  fd_xid_t fork_4 = { .ul = { 4UL, 2UL } }; /* tip */
+  fd_progcache_xid_t fork_1 = { .ul = { 1UL, 1UL } }; /* account deployed here */
+  fd_progcache_xid_t fork_2 = { .ul = { 2UL, 1UL } }; /* root */
+  fd_progcache_xid_t fork_3 = { .ul = { 3UL, 2UL } }; /* account redeployed here */
+  fd_progcache_xid_t fork_4 = { .ul = { 4UL, 2UL } }; /* tip */
 
   test_env_txn_prepare( env, NULL, &fork_1 );
   fd_pubkey_t key = test_key( 1UL );
@@ -522,10 +522,10 @@ static void
 test_reattach_after_cancel_all( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
 
-  fd_xid_t parent  = { .ul = { 1UL, 1UL } };
-  fd_xid_t child_a = { .ul = { 2UL, 2UL } };
-  fd_xid_t child_b = { .ul = { 3UL, 2UL } };
-  fd_xid_t child_c = { .ul = { 4UL, 2UL } };
+  fd_progcache_xid_t parent  = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t child_a = { .ul = { 2UL, 2UL } };
+  fd_progcache_xid_t child_b = { .ul = { 3UL, 2UL } };
+  fd_progcache_xid_t child_c = { .ul = { 4UL, 2UL } };
   test_env_txn_prepare( env, NULL,    &parent  );
   test_env_txn_prepare( env, &parent, &child_a );
   test_env_txn_prepare( env, &parent, &child_b );
@@ -544,7 +544,7 @@ test_reattach_after_cancel_all( fd_wksp_t * wksp ) {
   FD_TEST( parent_txn->child_head_idx==UINT_MAX );
   FD_TEST( parent_txn->child_tail_idx==UINT_MAX );
 
-  fd_xid_t child_d = { .ul = { 5UL, 2UL } };
+  fd_progcache_xid_t child_d = { .ul = { 5UL, 2UL } };
   test_env_txn_prepare( env, &parent, &child_d );
 
   FD_TEST( parent_txn->child_head_idx!=UINT_MAX );
@@ -552,7 +552,7 @@ test_reattach_after_cancel_all( fd_wksp_t * wksp ) {
   FD_TEST( parent_txn->child_head_idx==parent_txn->child_tail_idx );
 
   fd_progcache_txn_t * child_d_txn = &env->progcache->join->txn.pool[ parent_txn->child_head_idx ];
-  FD_TEST( fd_funk_txn_xid_eq( &child_d_txn->xid, &child_d ) );
+  FD_TEST( fd_progcache_txn_xid_eq( &child_d_txn->xid, &child_d ) );
   FD_TEST( child_d_txn->parent_idx==parent_idx );
   FD_TEST( child_d_txn->sibling_prev_idx==UINT_MAX );
   FD_TEST( child_d_txn->sibling_next_idx==UINT_MAX );
@@ -582,7 +582,7 @@ test_reclaim_empty( fd_wksp_t * wksp ) {
 static void
 test_reclaim_no_readers( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -616,7 +616,7 @@ test_reclaim_no_readers( fd_wksp_t * wksp ) {
 static void
 test_reclaim_active_reader( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -652,7 +652,7 @@ test_reclaim_active_reader( fd_wksp_t * wksp ) {
 static void
 test_reclaim_txn_unlink( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -742,8 +742,8 @@ test_shmem_delete_fast( fd_wksp_t * wksp ) {
   fd_progcache_t cache[1];
   FD_TEST( fd_progcache_join( cache, progcache_mem, scratch, sizeof(scratch) ) );
 
-  fd_xid_t root; fd_funk_txn_xid_set_root( &root );
-  fd_xid_t fork = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t root; fd_progcache_txn_xid_set_root( &root );
+  fd_progcache_xid_t fork = { .ul = { 1UL, 1UL } };
   fd_progcache_attach_child( cache->join, &root, &fork );
 
   fd_pubkey_t key = test_key( 1UL );
@@ -773,7 +773,7 @@ test_shmem_delete_fast( fd_wksp_t * wksp ) {
 static void
 test_reclaim_mixed( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key1 = test_key( 1UL );
@@ -816,7 +816,7 @@ test_reclaim_mixed( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_ok( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 42UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 42UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   uchar buf[ 655536 ];
@@ -849,7 +849,7 @@ test_loader_v3_ok( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_wrong_account_type( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   ulong data_sz = PROGRAMDATA_METADATA_SIZE + valid_program_data_sz;
@@ -884,7 +884,7 @@ test_loader_v3_wrong_account_type( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_undersize( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   uchar data[ PROGRAMDATA_METADATA_SIZE-1 ];
@@ -910,7 +910,7 @@ test_loader_v3_undersize( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_corrupt( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   uchar data[ PROGRAMDATA_METADATA_SIZE+1 ];
@@ -936,7 +936,7 @@ test_loader_v3_corrupt( fd_wksp_t * wksp ) {
 static void
 test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t fork_a = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t fork_a = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a );
 
   uchar buf[ 655536 ];
@@ -960,7 +960,7 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   FD_TEST( rec1->data_gaddr );
   FD_TEST( fd_progcache_revision_key_slot( rec1->revision_key )==42UL );
 
-  fd_xid_t fork_b = { .ul = { 100UL, 2UL } };
+  fd_progcache_xid_t fork_b = { .ul = { 100UL, 2UL } };
   test_env_txn_prepare( env, &fork_a, &fork_b );
 
   load_env.epoch       = 1UL;
@@ -1016,13 +1016,13 @@ test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
     .epoch_slot0 = e0
   };
 
-  fd_xid_t root; fd_funk_txn_xid_set_root( &root );
+  fd_progcache_xid_t root; fd_progcache_txn_xid_set_root( &root );
 
   /* Fork A upgraded the program at e0-1 and invokes after skipped slot e0. */
-  fd_xid_t fork_a_deploy = { .ul = { e0-1UL, 1UL } };
+  fd_progcache_xid_t fork_a_deploy = { .ul = { e0-1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &fork_a_deploy );
 
-  fd_xid_t fork_a_invoke = { .ul = { e0+1UL, 2UL } };
+  fd_progcache_xid_t fork_a_invoke = { .ul = { e0+1UL, 2UL } };
   test_env_txn_prepare( env, &fork_a_deploy, &fork_a_invoke );
 
   fd_progcache_rec_t const * rec_a = test_pull( env->progcache, fork_a_acc.ro, &fork_a_invoke, &key, &load_env );
@@ -1036,7 +1036,7 @@ test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
   /* Fork B crosses the same skipped epoch boundary without fork A's
      upgrade.  It supplies different loader-v3 ProgramData bytes, so it
      must not receive fork A's loaded program record. */
-  fd_xid_t fork_b_invoke = { .ul = { e0+1UL, 3UL } };
+  fd_progcache_xid_t fork_b_invoke = { .ul = { e0+1UL, 3UL } };
   test_env_txn_prepare( env, NULL, &fork_b_invoke );
 
   fd_progcache_rec_t const * rec_b = test_pull( env->progcache, fork_b_acc.ro, &fork_b_invoke, &key, &load_env );
@@ -1058,7 +1058,7 @@ test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_all_visited( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key1 = test_key( 1UL );
@@ -1110,7 +1110,7 @@ test_clock_evict_all_visited( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_wraps_around( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key1 = test_key( 1UL );
@@ -1169,7 +1169,7 @@ test_clock_evict_empty_cache( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key1 = test_key( 1UL );
@@ -1227,7 +1227,7 @@ test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_heap_only( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_xid_t xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t xid = { .ul = { 1UL, 1UL } };
   test_env_txn_prepare( env, NULL, &xid );
 
   fd_pubkey_t key1 = test_key( 1UL );

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -19,7 +19,7 @@ static fd_features_t g_features[1];
 #define ITER_DEFAULT    (4096UL)
 #define STEP_MAX        (100000UL)
 
-#define ROOT_XID ( (fd_xid_t) { .ul={1UL,0UL} } )
+#define ROOT_XID ( (fd_progcache_xid_t) { .ul={1UL,0UL} } )
 
 /* Declare fibers */
 
@@ -37,7 +37,7 @@ struct fiber {
 
     struct {
       fd_progcache_t *   cache;
-      fd_xid_t           xid;
+      fd_progcache_xid_t           xid;
       fd_pubkey_t        prog_addr;
       fd_prog_load_env_t load_env;
       fd_accdb_ro_t *    prog_ro;
@@ -45,7 +45,7 @@ struct fiber {
 
     struct {
       fd_progcache_t * cache;
-      fd_xid_t         xid;
+      fd_progcache_xid_t         xid;
       fd_pubkey_t      prog_addr;
       ulong            revision_key;
     } peek;
@@ -58,12 +58,12 @@ struct fiber {
 
     struct {
       fd_progcache_join_t * cache;
-      fd_xid_t              xid;
+      fd_progcache_xid_t              xid;
     } advance_root;
 
     struct {
       fd_progcache_join_t * cache;
-      fd_xid_t              xid;
+      fd_progcache_xid_t              xid;
     } cancel;
 
   };
@@ -90,7 +90,7 @@ fiber_pull_exec( void * _ctx ) {
 static fd_racesan_async_t *
 fiber_pull( fiber_t *                  fiber,
             void *                     shmem,
-            fd_xid_t const *           xid,
+            fd_progcache_xid_t const * xid,
             void const *               prog_addr,
             fd_prog_load_env_t const * load_env,
             fd_accdb_ro_t *            prog_ro ) {
@@ -113,10 +113,10 @@ fiber_peek_exec( void * _ctx ) {
 }
 
 static fd_racesan_async_t *
-fiber_peek( fiber_t *        fiber,
-            void *           shmem,
-            fd_xid_t const * xid,
-            void const *     prog_addr ) {
+fiber_peek( fiber_t *                  fiber,
+            void *                     shmem,
+            fd_progcache_xid_t const * xid,
+            void const *               prog_addr ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->peek.cache     = fiber->cache;
   fiber->peek.xid       = *xid;
@@ -152,9 +152,9 @@ fiber_advance_root_exec( void * _ctx ) {
 }
 
 static fd_racesan_async_t *
-fiber_advance_root( fiber_t *        fiber,
-                    void *           shmem,
-                    fd_xid_t const * xid ) {
+fiber_advance_root( fiber_t *                  fiber,
+                    void *                     shmem,
+                    fd_progcache_xid_t const * xid ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->advance_root.cache = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
   fiber->advance_root.xid   = *xid;
@@ -169,9 +169,9 @@ fiber_cancel_exec( void * _ctx ) {
 }
 
 static fd_racesan_async_t *
-fiber_cancel( fiber_t *        fiber,
-              void *           shmem,
-              fd_xid_t const * xid ) {
+fiber_cancel( fiber_t *                  fiber,
+              void *                     shmem,
+              fd_progcache_xid_t const * xid ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->cancel.cache = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
   fiber->cancel.xid   = *xid;
@@ -224,7 +224,7 @@ static void
 test_pull_pull( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t    xid = { .ul = { 1UL, 1UL } };
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -267,7 +267,7 @@ static void
 test_pull_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t    xid = { .ul = { 1UL, 1UL } };
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -310,9 +310,9 @@ static void
 test_cancel_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -363,8 +363,8 @@ static void
 test_publish_evict( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -412,8 +412,8 @@ static void
 test_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -462,8 +462,8 @@ static void
 test_peek_cancel( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -512,8 +512,8 @@ static void
 test_peek_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid = ROOT_XID;
-  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t    xid = ROOT_XID;
+  fd_progcache_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -563,9 +563,9 @@ static void
 test_peek_root_sibling( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_xid_t    xid2 = { .ul = { 3UL, 2UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid2 = { .ul = { 3UL, 2UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -616,9 +616,9 @@ static void
 test_peek_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_xid_t    xid2 = { .ul = { 3UL, 2UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid2 = { .ul = { 3UL, 2UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -672,8 +672,8 @@ static void
 test_inject_at_hook( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -713,8 +713,8 @@ static void
 test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
 
@@ -762,9 +762,9 @@ static void
 test_root_evict_two( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
-  fd_xid_t    xid2 = { .ul = { 3UL, 2UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid2 = { .ul = { 3UL, 2UL } };
   fd_pubkey_t ka   = test_key( 1UL );
   fd_pubkey_t kb   = test_key( 2UL );
   fd_prog_load_env_t load_env = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };
@@ -820,9 +820,9 @@ static void
 test_publish_evict_stale( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_xid_t    xid0 = ROOT_XID;
-  fd_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
-  fd_xid_t    xid1 = { .ul = { 2UL, 1UL } };
+  fd_progcache_xid_t    xid0 = ROOT_XID;
+  fd_progcache_xid_t    xid_pre = { .ul = { 1UL, 1UL } };
+  fd_progcache_xid_t    xid1 = { .ul = { 2UL, 1UL } };
   fd_pubkey_t key  = test_key( 42UL );
 
   fd_prog_load_env_t load_env_root  = { .features = g_features, .epoch = 0UL, .epoch_slot0 = 0UL };

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2219,9 +2219,10 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
 
   fd_prog_load_env_t load_env[1]; fd_prog_load_env_from_bank( load_env, ctx->bank );
   fd_funk_txn_xid_t xid = fd_bank_xid( ctx->bank );
+  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
   fd_progcache_t * progcache = ctx->runtime->progcache;
   fd_progcache_rec_t * cache_entry =
-      fd_progcache_pull( progcache, &xid, program_id, load_env, progdata_ro );
+      fd_progcache_pull( progcache, &pc_xid, program_id, load_env, progdata_ro );
   if( FD_UNLIKELY( !cache_entry ) ) {
     fd_log_collector_msg_literal( ctx, "Program is not deployed" );
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -166,7 +166,9 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   fd_funk_txn_xid_set_root( root );
   env->xid = fd_bank_xid( env->bank );
   fd_accdb_attach_child    ( env->accdb_admin,     root, &env->xid );
-  fd_progcache_attach_child( env->progcache->join, root, &env->xid );
+  fd_progcache_xid_t pc_root = fd_progcache_xid_from_funk( root );
+  fd_progcache_xid_t pc_xid  = fd_progcache_xid_from_funk( &env->xid );
+  fd_progcache_attach_child( env->progcache->join, &pc_root, &pc_xid );
 
   init_rent_sysvar( env );
   init_epoch_schedule_sysvar( env );
@@ -211,7 +213,8 @@ test_env_cleanup( test_env_t * env ) {
   }
 
   fd_accdb_cancel    ( env->accdb_admin,     &env->xid );
-  fd_progcache_cancel( env->progcache->join, &env->xid );
+  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &env->xid );
+  fd_progcache_cancel( env->progcache->join, &pc_xid );
 
   if( env->runtime ) {
     if( env->runtime->acc_pool ) {
@@ -260,7 +263,9 @@ process_slot( test_env_t * env, ulong slot ) {
   fd_funk_txn_xid_t xid        = fd_bank_xid( new_bank    );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
   fd_accdb_attach_child    ( env->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_attach_child( env->progcache->join, &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( env->progcache->join, &pc_parent_xid, &pc_xid );
 
   env->xid  = xid;
   env->bank = new_bank;

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -134,7 +134,9 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
   /* Create temporary funk transaction and slot / epoch contexts */
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
   fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, xid );
-  fd_progcache_attach_child( runner->progcache->join, &parent_xid, xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_parent_xid, &pc_xid );
 
   /* Initialize bank from input block bank */
   FD_TEST( test_ctx->has_bank );
@@ -301,7 +303,9 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
   /* Make a new funk transaction since we're done loading in accounts for context */
   fd_funk_txn_xid_t fork_xid = fd_bank_xid( bank );
   fd_accdb_attach_child    ( runner->accdb_admin,     xid, &fork_xid );
-  fd_progcache_attach_child( runner->progcache->join, xid, &fork_xid );
+  fd_progcache_xid_t pc_xid2     = fd_progcache_xid_from_funk( xid );
+  fd_progcache_xid_t pc_fork_xid = fd_progcache_xid_from_funk( &fork_xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_xid2, &pc_fork_xid );
   xid[0] = fork_xid;
 
   /* Set the initial lthash from the input since we're in a new Funk txn */

--- a/src/flamenco/runtime/tests/fd_bundle_harness.c
+++ b/src/flamenco/runtime/tests/fd_bundle_harness.c
@@ -44,7 +44,9 @@ fd_solfuzz_pb_bundle_ctx_create( fd_solfuzz_runner_t *                 runner,
   fd_funk_txn_xid_t xid = fd_bank_xid( runner->bank );
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
   fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_attach_child( runner->progcache->join, &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_parent_xid, &pc_xid );
 
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -28,7 +28,9 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
 
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
   fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, xid );
-  fd_progcache_attach_child( runner->progcache->join, &parent_xid, xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_parent_xid, &pc_xid );
 
   fd_txn_in_t *  txn_in  = fd_spad_alloc( runner->spad, alignof(fd_txn_in_t), sizeof(fd_txn_in_t) );
   fd_txn_out_t * txn_out = fd_spad_alloc( runner->spad, alignof(fd_txn_out_t), sizeof(fd_txn_out_t) );
@@ -233,7 +235,9 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
 
   fd_funk_txn_xid_t exec_xid[1] = { fd_bank_xid( runner->bank ) };
   fd_accdb_attach_child    ( runner->accdb_admin,     xid, exec_xid );
-  fd_progcache_attach_child( runner->progcache->join, xid, exec_xid );
+  fd_progcache_xid_t pc_xid2      = fd_progcache_xid_from_funk( xid );
+  fd_progcache_xid_t pc_exec_xid = fd_progcache_xid_from_funk( exec_xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_xid2, &pc_exec_xid );
 
   fd_epoch_schedule_t epoch_schedule_[1];
   fd_epoch_schedule_t * epoch_schedule = fd_sysvar_cache_epoch_schedule_read( ctx->sysvar_cache, epoch_schedule_ );

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -396,7 +396,8 @@ fd_svm_mini_reset( fd_svm_mini_t *        mini,
   fd_xid_t root_xid = fd_bank_xid( bank );
   fd_funk_t * funk = fd_accdb_user_v1_funk( mini->accdb );
   fd_funk_txn_xid_copy( funk->shmem->last_publish, &root_xid );
-  fd_funk_txn_xid_copy( mini->progcache->join->shmem->txn.last_publish, &root_xid );
+  fd_progcache_xid_t pc_root_xid = fd_progcache_xid_from_funk( &root_xid );
+  fd_progcache_txn_xid_copy( mini->progcache->join->shmem->txn.last_publish, &pc_root_xid );
 
   if( params->clock ) {
     bank->f.slot  = params->clock->slot;
@@ -570,7 +571,9 @@ fd_svm_mini_attach_child( fd_svm_mini_t * mini,
   fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_attach_child    ( mini->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_attach_child( mini->progcache->join, &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( mini->progcache->join, &pc_parent_xid, &pc_xid );
 
   int is_epoch_boundary = 0;
   fd_runtime_block_execute_prepare( mini->banks, bank, mini->accdb, mini->runtime_stack, NULL, &is_epoch_boundary );
@@ -598,7 +601,8 @@ fd_svm_mini_cancel_fork( fd_svm_mini_t * mini,
   fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_cancel    ( mini->accdb_admin,     &xid );
-  fd_progcache_cancel( mini->progcache->join, &xid );
+  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_cancel( mini->progcache->join, &pc_xid );
 }
 
 void
@@ -610,7 +614,8 @@ fd_svm_mini_advance_root( fd_svm_mini_t * mini,
   fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_advance_root    ( mini->accdb_admin,     &xid );
-  fd_progcache_advance_root( mini->progcache->join, &xid );
+  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_advance_root( mini->progcache->join, &pc_xid );
   fd_banks_advance_root    ( mini->banks, bank_idx );
 }
 

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -55,7 +55,9 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   fd_xid_t xid = fd_bank_xid( runner->bank );
   fd_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
   fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_attach_child( runner->progcache->join, &parent_xid, &xid );
+  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
+  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
+  fd_progcache_attach_child( runner->progcache->join, &pc_parent_xid, &pc_xid );
 
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;


### PR DESCRIPTION
Split progcache's identifier types from funk's. progcache now has its own fd_progcache_xid_t, fd_progcache_rec_key_t, fd_progcache_xid_key_pair_t and fd_progcache_lineage_t, decoupling its public API from fd_funk. A converter fd_progcache_xid_from_funk() is provided for call sites that bridge accdb/funk and progcache.

Also sweeps a stale "fd_funk rec_max" doc comment in fd_progcache_admin.h.