### PR TITLE
restore: snapin data_len bounds check for non-batch account headers

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -734,6 +734,11 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
         break;
       }
       case FD_SSPARSE_ADVANCE_ACCOUNT_HEADER:
+        if( FD_UNLIKELY( result->account_header.data_len > FD_RUNTIME_ACC_SZ_MAX ) ) {
+          FD_LOG_WARNING(( "Found unusually large account (data_sz=%lu)", result->account_header.data_len ));
+          transition_malformed( ctx, stem );
+          return 0;
+        }
         early_exit = fd_snapin_process_account_header( ctx, result );
         if( FD_UNLIKELY( early_exit<0 ) ) {
           transition_malformed( ctx, stem );


### PR DESCRIPTION
Adding `data_len` bounds check for non-batch account headers in `snapin` tile.

Partially addresses https://github.com/firedancer-io/firedancer/issues/9588.