### PR TITLE
restore: ssload recover always reset on new manifest

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1264,7 +1264,6 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
       if( FD_UNLIKELY( fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
                                           ctx->banks,
                                           fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ ),
-                                          msg==FD_SSMSG_MANIFEST_INCREMENTAL,
                                           ctx->blockhash_seed ) ) ) {
         FD_LOG_ERR(( "Snapshot manifest recovery failed, aborting." ));
       }

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -24,7 +24,7 @@ endif
 $(call make-unit-test,test_slot_delta_parser,utils/test_slot_delta_parser,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_sspeer_selector,utils/test_sspeer_selector,fd_discof fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_ssping,utils/test_ssping,fd_discof fd_flamenco fd_ballet fd_util)
-$(call make-unit-test,test_ssload,utils/test_ssload,fd_discof fd_flamenco fd_ballet fd_util)
+$(call make-unit-test,test_ssload,utils/test_ssload,fd_discof fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 $(call make-unit-test,test_ssarchive,utils/test_ssarchive,fd_discof fdctl_platform fd_ballet fd_util)
 $(call make-unit-test,test_ssparse,utils/test_ssparse,fd_discof fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_slot_delta_parser)

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -314,17 +314,16 @@ blockhashes_recover( fd_blockhashes_t *                       blockhashes,
 }
 
 int
-fd_ssload_recover( fd_snapshot_manifest_t * manifest,
-                   fd_banks_t *             banks,
-                   fd_bank_t *              bank,
-                   int                      is_incremental,
-                   ulong                    blockhash_seed ) {
+fd_ssload_recover_validate( fd_snapshot_manifest_t const * manifest,
+                            fd_banks_t const *             banks ) {
+  return fd_ssload_manifest_validate( manifest, banks->max_vote_accounts, banks->max_stake_accounts );
+}
 
-  /* Validate manifest before mutating the bank. */
-  if( FD_UNLIKELY( fd_ssload_manifest_validate( manifest, banks->max_vote_accounts, banks->max_stake_accounts ) ) ) {
-    FD_LOG_WARNING(( "snapshot manifest validation failed" ));
-    return -1;
-  }
+int
+fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
+                         fd_banks_t *             banks,
+                         fd_bank_t *              bank,
+                         ulong                    blockhash_seed ) {
 
   /* Slot */
 
@@ -453,7 +452,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
 
   /* Stake delegations for the current epoch. */
   fd_stake_delegations_t * stake_delegations = fd_banks_stake_delegations_root_query( banks );
-  if( is_incremental ) fd_stake_delegations_reset( stake_delegations );
+  fd_stake_delegations_reset( stake_delegations );
   for( ulong i=0UL; i<manifest->stake_delegations_len; i++ ) {
     fd_snapshot_manifest_stake_delegation_t const * elem = &manifest->stake_delegations[ i ];
     if( FD_UNLIKELY( elem->stake_delegation==0UL ) ) {
@@ -472,7 +471,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   }
 
   fd_new_votes_t * new_votes = fd_bank_new_votes( bank );
-  if( is_incremental ) fd_new_votes_reset_root( new_votes );
+  fd_new_votes_reset_root( new_votes );
   for( ulong i=0UL; i<manifest->vote_accounts_len; i++ ) {
     fd_snapshot_manifest_vote_account_t const * elem = &manifest->vote_accounts[ i ];
     if( FD_UNLIKELY( elem->stake==0UL ) ) fd_new_votes_root_insert( new_votes, (fd_pubkey_t *)elem->vote_account_pubkey );
@@ -499,7 +498,7 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
      in fd_ssmanifest_parser.c. */
 
   fd_vote_stakes_t * vote_stakes = fd_bank_vote_stakes( bank );
-  if( is_incremental ) fd_vote_stakes_reset( vote_stakes );
+  fd_vote_stakes_reset( vote_stakes );
 
   fd_top_votes_t * top_votes_t_1 = fd_bank_top_votes_t_1_modify( bank );
   fd_top_votes_t * top_votes_t_2 = fd_bank_top_votes_t_2_modify( bank );
@@ -579,4 +578,18 @@ fd_ssload_recover( fd_snapshot_manifest_t * manifest,
   bank->txncache_fork_id = (fd_txncache_fork_id_t){ .val = manifest->txncache_fork_id };
 
   return 0;
+}
+
+int
+fd_ssload_recover( fd_snapshot_manifest_t * manifest,
+                   fd_banks_t *             banks,
+                   fd_bank_t *              bank,
+                   ulong                    blockhash_seed ) {
+
+  if( FD_UNLIKELY( fd_ssload_recover_validate( manifest, banks ) ) ) {
+    FD_LOG_WARNING(( "snapshot manifest validation failed" ));
+    return -1;
+  }
+
+  return fd_ssload_recover_apply( manifest, banks, bank, blockhash_seed );
 }

--- a/src/discof/restore/utils/fd_ssload.h
+++ b/src/discof/restore/utils/fd_ssload.h
@@ -23,18 +23,41 @@ fd_ssload_manifest_validate( fd_snapshot_manifest_t const * manifest,
                              ulong                          max_vote_accounts,
                              ulong                          max_stake_accounts );
 
-/* Returns 0 on success, -1 on failure (corrupt manifest or
-   configuration mismatch).  If manifest validation fails, bank and
-   associated structures are left unmodified.  If failure occurs after
-   mutation begins, bank and associated structures may be left partially
-   mutated.  Caller must treat such failures as unrecoverable (e.g.
-   abort or discard the bank).  blockhash_seed seeds the internal
-   blockhash hash map. */
+/* fd_ssload_recover_validate checks that the manifest is structurally
+   valid for use with banks.  Equivalent to calling
+   fd_ssload_manifest_validate with the banks' capacity limits;
+   see fd_ssload_manifest_validate for capacity constraints.
+   Returns 0 on success, -1 on failure.  This function only reads the
+   manifest and banks metadata and has no side effects. */
+int
+fd_ssload_recover_validate( fd_snapshot_manifest_t const * manifest,
+                            fd_banks_t const *             banks );
+
+/* fd_ssload_recover_apply applies manifest-derived state to bank.
+   Caller MUST have validated the manifest before calling (e.g. via
+   fd_ssload_recover_validate).  All resettable data structures are
+   unconditionally reset before repopulation.  Returns 0 on success,
+   -1 on failure.  On failure, bank and associated structures may be
+   left partially mutated; caller must treat this as unrecoverable.
+   blockhash_seed seeds the internal blockhash hash map. */
+int
+fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
+                         fd_banks_t *             banks,
+                         fd_bank_t *              bank,
+                         ulong                    blockhash_seed );
+
+/* fd_ssload_recover validates the manifest and applies it to bank.
+   Equivalent to fd_ssload_recover_validate followed by
+   fd_ssload_recover_apply.  Returns 0 on success, -1 on failure.
+   If manifest validation fails, bank and associated structures are
+   left unmodified.  If failure occurs after mutation begins, bank and
+   associated structures may be left partially mutated.  Caller must
+   treat such failures as unrecoverable (e.g. abort or discard the
+   bank).  blockhash_seed seeds the internal blockhash hash map. */
 int
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_banks_t *             banks,
                    fd_bank_t *              bank,
-                   int                      is_incremental,
                    ulong                    blockhash_seed );
 
 FD_PROTOTYPES_END

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -1,7 +1,11 @@
 #include "fd_ssload.h"
 #include "../../../util/fd_util.h"
+#include "../../../flamenco/runtime/fd_bank.h"
 #include "../../../flamenco/runtime/fd_runtime_const.h"
 #include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../../flamenco/stakes/fd_stake_delegations.h"
+#include "../../../flamenco/stakes/fd_vote_stakes.h"
+#include "../../../flamenco/stakes/fd_new_votes.h"
 #include <limits.h>
 
 /* Shorthand for the common validate call pattern using the production
@@ -521,6 +525,160 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   FD_LOG_NOTICE(( "... pass" ));
 }
 
+static void
+test_recover_back_to_back_reset( fd_wksp_t * wksp, fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing recover back-to-back reset" ));
+
+  /* Set up a tiny-capacity fd_banks_t.  Call fd_ssload_recover_apply
+     directly (bypassing fd_ssload_recover_validate) because the
+     validate step requires production-sized capacities outside the
+     scope of this test. */
+
+  ulong max_banks = 16UL;
+  ulong max_forks =  4UL;
+  ulong max_stake = 64UL;
+  ulong max_vote  = 64UL;
+  ulong seed      = 42UL;
+
+  ulong banks_footprint = fd_banks_footprint( max_banks, max_forks,
+                                              max_stake, max_vote );
+  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(),
+                                          banks_footprint, 2UL );
+  FD_TEST( banks_mem );
+
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( banks_mem, max_banks, max_forks,
+                                                    max_stake, max_vote,
+                                                    0 /* larger_max_cost_per_block */, seed ) );
+  FD_TEST( banks );
+
+  fd_bank_t * bank = fd_banks_init_bank( banks );
+  FD_TEST( bank );
+
+  /* Manifest A: one stake delegation (pubkey_A), one vote stake
+    (pubkey_X).  With slot=0, epoch=0, leader_schedule_epoch=1,
+     epoch_stakes_base=0, t_1_idx=1. */
+
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+
+  uchar pubkey_a[32]; fd_memset( pubkey_a, 0xAA, 32 );
+  uchar vote_a[32];   fd_memset( vote_a,   0xA1, 32 );
+  manifest->stake_delegations_len = 1UL;
+  fd_memcpy( manifest->stake_delegations[0].stake_pubkey, pubkey_a, 32 );
+  fd_memcpy( manifest->stake_delegations[0].vote_pubkey,  vote_a,   32 );
+  manifest->stake_delegations[0].stake_delegation   = 1000UL;
+  manifest->stake_delegations[0].activation_epoch   = 0UL;
+  manifest->stake_delegations[0].deactivation_epoch = ULONG_MAX;
+
+  uchar pubkey_x[32]; fd_memset( pubkey_x, 0xBB, 32 );
+  uchar ident_x[32];  fd_memset( ident_x,  0xB1, 32 );
+  manifest->epoch_stakes[1].vote_stakes_len = 1UL;
+  fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].vote,     pubkey_x, 32 );
+  fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].identity, ident_x,  32 );
+  manifest->epoch_stakes[1].vote_stakes[0].stake      = 5000UL;
+  manifest->epoch_stakes[1].vote_stakes[0].commission = 10;
+  manifest->epoch_stakes[1].total_stake               = 5000UL;
+
+  /* Also add a new_votes entry (vote account with stake==0). */
+  uchar nv_pubkey_a[32]; fd_memset( nv_pubkey_a, 0xE1, 32 );
+  manifest->vote_accounts_len = 1UL;
+  fd_memcpy( manifest->vote_accounts[0].vote_account_pubkey, nv_pubkey_a, 32 );
+  manifest->vote_accounts[0].stake = 0UL;
+
+  /* First apply: simulate initial full snapshot load. */
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed )==0 );
+
+  /* Verify entries from first apply are present. */
+  fd_stake_delegations_t * sd = fd_banks_stake_delegations_root_query( banks );
+  FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_a )!=NULL );
+  FD_TEST( fd_stake_delegations_cnt( sd )==1UL );
+
+  fd_vote_stakes_t * vs = fd_bank_vote_stakes( bank );
+  ushort root_idx = fd_vote_stakes_get_root_idx( vs );
+  FD_TEST( fd_vote_stakes_ele_cnt( vs, root_idx )==1 );
+
+  fd_new_votes_t * nv = fd_bank_new_votes( bank );
+  FD_TEST( fd_new_votes_cnt( nv )==1UL );
+
+  /* Manifest B: different stake delegation (pubkey_B),
+     different vote stake (pubkey_Y), different new_votes entry. */
+
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+
+  uchar pubkey_b[32]; fd_memset( pubkey_b, 0xCC, 32 );
+  uchar vote_b[32];   fd_memset( vote_b,   0xC1, 32 );
+  manifest->stake_delegations_len = 1UL;
+  fd_memcpy( manifest->stake_delegations[0].stake_pubkey, pubkey_b, 32 );
+  fd_memcpy( manifest->stake_delegations[0].vote_pubkey,  vote_b,   32 );
+  manifest->stake_delegations[0].stake_delegation   = 2000UL;
+  manifest->stake_delegations[0].activation_epoch   = 0UL;
+  manifest->stake_delegations[0].deactivation_epoch = ULONG_MAX;
+
+  uchar pubkey_y[32]; fd_memset( pubkey_y, 0xDD, 32 );
+  uchar ident_y[32];  fd_memset( ident_y,  0xD1, 32 );
+  manifest->epoch_stakes[1].vote_stakes_len = 1UL;
+  fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].vote,     pubkey_y, 32 );
+  fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].identity, ident_y,  32 );
+  manifest->epoch_stakes[1].vote_stakes[0].stake      = 7000UL;
+  manifest->epoch_stakes[1].vote_stakes[0].commission = 5;
+  manifest->epoch_stakes[1].total_stake               = 7000UL;
+
+  uchar nv_pubkey_b[32]; fd_memset( nv_pubkey_b, 0xE2, 32 );
+  manifest->vote_accounts_len = 1UL;
+  fd_memcpy( manifest->vote_accounts[0].vote_account_pubkey, nv_pubkey_b, 32 );
+  manifest->vote_accounts[0].stake = 0UL;
+
+  /* Second apply: simulate back-to-back retry after a failed first
+     attempt.  Stale entries must be cleared. */
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed )==0 );
+
+  /* Stake delegations: pubkey_A must have been removed, pubkey_B must
+     be present, exactly 1 entry (not 2). */
+  FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_a )==NULL );
+  FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_b )!=NULL );
+  FD_TEST( fd_stake_delegations_cnt( sd )==1UL );
+
+  /* Vote stakes: pubkey_X must have been removed, pubkey_Y must be
+     present, exactly 1 entry (not 2). */
+  root_idx = fd_vote_stakes_get_root_idx( vs );
+  FD_TEST( fd_vote_stakes_ele_cnt( vs, root_idx )==1 );
+
+  ulong stake_out;
+  FD_TEST( fd_vote_stakes_query_t_1( vs, root_idx, (fd_pubkey_t *)pubkey_x, &stake_out, NULL, NULL )==0 );
+  FD_TEST( fd_vote_stakes_query_t_1( vs, root_idx, (fd_pubkey_t *)pubkey_y, &stake_out, NULL, NULL )==1 );
+  FD_TEST( stake_out==7000UL );
+
+  /* New votes: old entry must have been removed, new entry must be
+     present, exactly 1 entry (not 2). */
+  FD_TEST( fd_new_votes_cnt( nv )==1UL );
+  fd_pubkey_t nv_pk_a; fd_memcpy( nv_pk_a.uc, nv_pubkey_a, 32UL );
+  fd_pubkey_t nv_pk_b; fd_memcpy( nv_pk_b.uc, nv_pubkey_b, 32UL );
+  uchar __attribute__((aligned(FD_NEW_VOTES_ITER_ALIGN))) iter_mem[ FD_NEW_VOTES_ITER_FOOTPRINT ];
+  fd_new_votes_iter_t * it = fd_new_votes_iter_init( nv, NULL, 0UL, iter_mem );
+  ulong nv_cnt = 0UL;
+  int saw_a = 0;
+  int saw_b = 0;
+  for( ; !fd_new_votes_iter_done( it ); fd_new_votes_iter_next( it ) ) {
+    int is_tombstone = 0;
+    fd_pubkey_t const * pk = fd_new_votes_iter_ele( it, &is_tombstone );
+    if( FD_UNLIKELY( is_tombstone ) ) continue;
+    nv_cnt++;
+    saw_a |= fd_pubkey_eq( pk, &nv_pk_a );
+    saw_b |= fd_pubkey_eq( pk, &nv_pk_b );
+  }
+  fd_new_votes_iter_fini( it );
+  FD_TEST( nv_cnt==1UL );
+  FD_TEST( !saw_a );
+  FD_TEST(  saw_b );
+
+  fd_wksp_free_laddr( banks_mem );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -544,8 +702,10 @@ main( int     argc,
   test_stake_delegations( manifest );
   test_vote_accounts( manifest );
   test_epoch_credits_downcasting( manifest );
+  test_recover_back_to_back_reset( wksp, manifest );
 
   fd_wksp_free_laddr( manifest );
+
   fd_wksp_delete_anonymous( wksp );
 
   FD_LOG_NOTICE(( "all ssload tests passed" ));


### PR DESCRIPTION
Remove the `is_incremental` parameter from `fd_ssload_recover` and unconditionally reset `vote_stakes`, `stake_delegations`, and `new_votes` before repopulating from any manifest (full or incremental). This solves the issue of stale entries after a failed full manifest + retry.

In order to add a subtest to the unit test (`test_recover_back_to_back_reset`) with a reasonable memory footprint, `fd_ssload_recover` is split into `fd_ssload_recover_validate` and `fd_ssload_recover_apply`. This is because `fd_ssload_recover_validate` invokes `fd_ssload_manifest_validate`, which rejects banks with `max_vote_accounts != 19M` or `max_stake_accounts != 241M`, requiring a 50+ GB workspace.

Addresses https://github.com/firedancer-io/firedancer/issues/9577.