### PR TITLE
neigh: fix prober rate calculation

### DIFF
--- a/src/waltz/fd_token_bucket.h
+++ b/src/waltz/fd_token_bucket.h
@@ -5,10 +5,10 @@
 #include <math.h>
 
 struct fd_token_bucket {
-  long  ts;
-  float rate;
-  float burst;
-  float balance;
+  long  ts;       /* timestamp in ticks (see fd_tickcount()) */
+  float rate;     /* tokens per tick, how often do we probe */
+  float burst;    /* in tokens, how many probes can we send at once */
+  float balance;  /* in tokens, can be negative if bucket is overdrawn */
 };
 
 typedef struct fd_token_bucket fd_token_bucket_t;

--- a/src/waltz/neigh/fd_neigh4_probe.c
+++ b/src/waltz/neigh/fd_neigh4_probe.c
@@ -42,7 +42,7 @@ fd_neigh4_prober_init( fd_neigh4_prober_t * prober,
     .probe_delay = (long)( tick_per_ns * probe_delay_seconds * 1e9f ),
     .rate_limit  = (fd_token_bucket_t) {
       .ts      = fd_tickcount(),
-      .rate    = tick_per_ns * (max_probes_per_second / 1e9f),
+      .rate    = max_probes_per_second / (tick_per_ns * 1e9f),
       .burst   = (float)max_probe_burst,
       .balance = 0.f
     },


### PR DESCRIPTION
rate is tokens/tick, previously we probed to much by a factor of tick_per_ns**2