### PR TITLE
stem: armv8.4-a support

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Run build
         env:
-          MACHINE: linux_gcc_arm_n1
+          MACHINE: linux_gcc_neoverse_n2
         run: |
           if [ "${{ matrix.gcc_version }}" != "8" ]; then
             source /opt/rh/gcc-toolset-${{ matrix.gcc_version }}/enable

--- a/.github/workflows/on_nightly.yml
+++ b/.github/workflows/on_nightly.yml
@@ -18,7 +18,7 @@ jobs:
       gcc_exceptions: |
         ALL,linux_gcc_riscv,ALL;
         ALL,linux_gcc_power9,ALL;
-        ALL,linux_gcc_arm_n1,ALL;
+        ALL,linux_gcc_neoverse_n2,ALL;
         ALL,linux_gcc_icelake,ALL;
         ALL,linux_gcc_x86_64,ALL;
         ALL,linux_gcc_zen2,ALL;

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -42,7 +42,7 @@ jobs:
         gcc-12.4.0,linux_gcc_zen2,ALL;
         ALL,linux_gcc_riscv,ALL;
         ALL,linux_gcc_power9,ALL;
-        ALL,linux_gcc_arm_n1,ALL;
+        ALL,linux_gcc_neoverse_n2,ALL;
         ALL,linux_gcc_zen3,ALL;
         ALL,linux_gcc_zen4,ALL;
         ALL,linux_gcc_zen5,ALL;

--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -1,3 +1,6 @@
+# Experimental Arm support.
+# Requires at least Armv8.4-a (LSE2 and RCPC3)
+
 ifneq ($(filter-out aarch64 arm64,$(shell uname -m)),)
 # uname -m is not empty and is neither aarch64 nor arm64
 CROSS=1

--- a/config/machine/linux_gcc_neoverse_n2.mk
+++ b/config/machine/linux_gcc_neoverse_n2.mk
@@ -1,9 +1,5 @@
-BUILDDIR?=linux/gcc/arm_n1
+BUILDDIR?=linux/gcc/neoverse_n2
 
-# This machine target is compatible with generic ARMv8.4-A server CPUs
-# like Neoverse V1 (ca 2020-Sep) or AWS Graviton3.
-
-# Experimental! Firedancer does not yet support Arm CPU, expect bugs.
 
 include config/extra/with-gcc-pre.mk
 include config/base.mk
@@ -15,7 +11,7 @@ include config/extra/with-debug.mk
 include config/extra/with-security.mk
 include config/extra/with-threads.mk
 
-CPPFLAGS+=-mcpu=neoverse-n1
+CPPFLAGS+=-mcpu=neoverse-n2+lse+rcpc3
 CPPFLAGS+=-DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1
 
 FD_HAS_INT128:=1

--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -613,10 +613,16 @@ STEM_(run1)( ulong                        in_cnt,
     __m128i seq_sig = fd_frag_meta_seq_sig_query( this_in_mline );
     ulong seq_found = fd_frag_meta_sse0_seq( seq_sig );
     ulong sig       = fd_frag_meta_sse0_sig( seq_sig );
+#elif FD_HAS_ARM
+    ulong seq_found, sig;
+    fd_arm_ldp16_acq_pc( this_in_mline->ul, seq_found, sig );
+    ulong ul2, ul3;
+    fd_arm_ldp16( this_in_mline->ul+2, ul2, ul3 );
 #else
-    /* Without SSE, seq and sig might be read from different frags (due
-       to overrun), which results in a before_frag and during_frag being
-       issued with incorrect arguments, but not after_frag. */
+    /* Without 128-bit atomic load, seq and sig might be read from
+       different frags (due to overrun), which results in a before_frag
+       and during_frag being issued with incorrect arguments, but not
+       after_frag. */
     ulong seq_found = FD_VOLATILE_CONST( this_in_mline->seq );
     ulong sig       = FD_VOLATILE_CONST( this_in_mline->sig );
 #endif
@@ -687,6 +693,12 @@ STEM_(run1)( ulong                        in_cnt,
     ulong ctl      = fd_frag_meta_avx_ctl   ( yline ); (void)ctl;
     ulong tsorig   = fd_frag_meta_avx_tsorig( yline ); (void)tsorig;
     ulong tspub    = fd_frag_meta_avx_tspub ( yline ); (void)tspub;
+#elif FD_HAS_ARM
+    ulong chunk    = fd_frag_meta_ul2_chunk ( ul2 ); (void)chunk;
+    ulong sz       = fd_frag_meta_ul2_sz    ( ul2 ); (void)sz;
+    ulong ctl      = fd_frag_meta_ul2_ctl   ( ul2 ); (void)ctl;
+    ulong tsorig   = fd_frag_meta_ul3_tsorig( ul3 ); (void)tsorig;
+    ulong tspub    = fd_frag_meta_ul3_tspub ( ul3 ); (void)tspub;
 #else
     ulong chunk    = (ulong)this_in_mline->chunk;  (void)chunk;
     ulong sz       = (ulong)this_in_mline->sz;     (void)sz;
@@ -695,14 +707,11 @@ STEM_(run1)( ulong                        in_cnt,
     ulong tspub    = (ulong)this_in_mline->tspub;  (void)tspub;
 #endif
 
-#ifdef STEM_CALLBACK_DURING_FRAG1
-    STEM_CALLBACK_DURING_FRAG1( ctx, (ulong)this_in->idx, seq_found, sig, chunk, sz, ctl, tsorig, tspub );
-#endif
 #ifdef STEM_CALLBACK_DURING_FRAG
     STEM_CALLBACK_DURING_FRAG( ctx, (ulong)this_in->idx, seq_found, sig, chunk, sz, ctl );
 #endif
 
-    FD_COMPILER_MFENCE();
+    FD_HW_MFENCE_LD();
     ulong seq_test = FD_VOLATILE_CONST( this_in_mline->seq );
     FD_COMPILER_MFENCE();
 

--- a/src/disco/stem/fd_stem.h
+++ b/src/disco/stem/fd_stem.h
@@ -41,12 +41,16 @@ fd_stem_publish( fd_stem_context_t * stem,
                  ulong               ctl,
                  ulong               tsorig,
                  ulong               tspub ) {
-  ulong * seqp = &stem->seqs[ out_idx ];
-  ulong   seq  = *seqp;
+  fd_frag_meta_t * mcache = stem->mcaches[ out_idx ];
+  ulong            depth  = stem->depths [ out_idx ];
+  ulong *          seqp   = &stem->seqs  [ out_idx ];
+  ulong            seq    = *seqp;
 # if FD_HAS_AVX
-  fd_mcache_publish_avx( stem->mcaches[ out_idx ], stem->depths[ out_idx ], seq, sig, chunk, sz, ctl, tsorig, tspub );
+  fd_mcache_publish_avx( mcache, depth, seq, sig, chunk, sz, ctl, tsorig, tspub );
+# elif FD_HAS_ARM
+  fd_mcache_publish_arm( mcache, depth, seq, sig, chunk, sz, ctl, tsorig, tspub );
 # else
-  fd_mcache_publish( stem->mcaches[ out_idx ], stem->depths[ out_idx ], seq, sig, chunk, sz, ctl, tsorig, tspub );
+  fd_mcache_publish    ( mcache, depth, seq, sig, chunk, sz, ctl, tsorig, tspub );
 # endif
   if( FD_LIKELY( stem->out_reliable[ out_idx ] ) ) {
     if( FD_UNLIKELY( stem->cr_avail[ out_idx ]<stem->cr_decrement_amount ) ) { /* Ensure producer BURST is set correctly */

--- a/src/flamenco/progcache/fd_progcache_xid.h
+++ b/src/flamenco/progcache/fd_progcache_xid.h
@@ -114,6 +114,8 @@ fd_progcache_xid_ld_atomic( fd_progcache_xid_t *       xd,
                             fd_progcache_xid_t const * xs ) {
 # if FD_HAS_X86
   xd->xmm[0] = FD_VOLATILE_CONST( xs->xmm[0] );
+# elif FD_HAS_ARM
+  fd_arm_ldp16( &xs->slot, xd->slot, xd->bank_seq );
 # elif FD_HAS_ATOMIC
   xd->uf[0] = __atomic_load_n( &xs->uf[0], __ATOMIC_RELAXED );
 # else
@@ -127,6 +129,8 @@ fd_progcache_xid_st_atomic( fd_progcache_xid_t *       xd,
                             fd_progcache_xid_t const * xs ) {
 # if FD_HAS_X86
   FD_VOLATILE( xd->xmm[0] ) = xs->xmm[0];
+# elif FD_HAS_ARM
+  fd_arm_stp16( &xd->slot, xs->slot, xs->bank_seq );
 # elif FD_HAS_ATOMIC
   __atomic_store_n( &xd->uf[0], xs->uf[0], __ATOMIC_RELEASE );
 # else

--- a/src/tango/fd_tango_base.h
+++ b/src/tango/fd_tango_base.h
@@ -198,6 +198,10 @@ union __attribute__((aligned(FD_FRAG_META_ALIGN))) fd_frag_meta {
   __m256i avx; /* Possibly non-atomic but can hold the metadata in a single register */
 # endif
 
+# if FD_HAS_ARM
+  ulong ul[4];
+# endif
+
 };
 
 typedef union fd_frag_meta fd_frag_meta_t;
@@ -359,6 +363,29 @@ FD_FN_CONST static inline ulong fd_frag_meta_avx_tsorig( __m256i avx ) { return 
 FD_FN_CONST static inline ulong fd_frag_meta_avx_tspub ( __m256i avx ) { return (ulong)(uint  )_mm256_extract_epi32( avx,  7 ); }
 
 #endif
+
+#if FD_HAS_ARM
+
+FD_FN_CONST static inline ulong
+fd_frag_meta_ul2( ulong chunk,
+                  ulong sz,
+                  ulong ctl ) {
+  return chunk | (sz<<32) | (ctl<<48);
+}
+
+FD_FN_CONST static inline ulong
+fd_frag_meta_ul3( ulong tsorig,
+                  ulong tspub ) {
+  return tsorig | (tspub<<32);
+}
+
+FD_FN_CONST static inline ulong fd_frag_meta_ul2_chunk ( ulong ul2 ) { return (ulong)(uint  )( ul2      & 0xFFFFFFFFUL); }
+FD_FN_CONST static inline ulong fd_frag_meta_ul2_sz    ( ulong ul2 ) { return (ulong)(ushort)((ul2>>32) &     0xFFFFUL); }
+FD_FN_CONST static inline ulong fd_frag_meta_ul2_ctl   ( ulong ul2 ) { return (ulong)(ushort)((ul2>>48) &     0xFFFFUL); }
+FD_FN_CONST static inline ulong fd_frag_meta_ul3_tsorig( ulong ul3 ) { return (ulong)(uint  )( ul3      & 0xFFFFFFFFUL); }
+FD_FN_CONST static inline ulong fd_frag_meta_ul3_tspub ( ulong ul3 ) { return (ulong)(uint  )( ul3>>32 );                }
+
+#endif /* FD_HAS_ARM */
 
 /* fd_frag_meta_ts_{comp,decomp}:  Given the longs ts and tsref that
    are reasonably close to each other (|ts-tsref| < 2^31 ... about

--- a/src/tango/mcache/fd_mcache.h
+++ b/src/tango/mcache/fd_mcache.h
@@ -381,6 +381,32 @@ fd_mcache_publish_avx( fd_frag_meta_t * mcache,   /* Assumed a current local joi
 
 #endif
 
+#if FD_HAS_ARM
+
+static inline void
+fd_mcache_publish_arm( fd_frag_meta_t * mcache,   /* Assumed a current local join */
+                       ulong            depth,    /* Assumed an integer power-of-2 >= BLOCK */
+                       ulong            seq,
+                       ulong            sig,
+                       ulong            chunk,    /* Assumed in [0,UINT_MAX] */
+                       ulong            sz,       /* Assumed in [0,USHORT_MAX] */
+                       ulong            ctl,      /* Assumed in [0,USHORT_MAX] */
+                       ulong            tsorig,   /* Assumed in [0,UINT_MAX] */
+                       ulong            tspub ) { /* Assumed in [0,UINT_MAX] */
+  /* stp   seq-1, sig, [meta]
+     stp   ul2,   ul3, [meta, #16]
+     stlr  seq,        [meta] */
+  fd_frag_meta_t * meta = mcache + fd_mcache_line_idx( seq, depth );
+  ulong ul2 = fd_frag_meta_ul2( chunk, sz, ctl );
+  ulong ul3 = fd_frag_meta_ul3( tsorig, tspub );
+  fd_arm_stp16( meta->ul, fd_seq_dec( seq, 1UL ), sig );
+  FD_HW_MFENCE_ST();
+  fd_arm_stp16( meta->ul+2, ul2, ul3 );
+  __atomic_store_n( &meta->seq, seq, __ATOMIC_RELEASE );
+}
+
+#endif
+
 /* FD_MCACHE_WAIT does a bounded wait for a producer to transmit a
    particular frag.
 

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -762,11 +762,17 @@ fd_type_pun_const( void const * p ) {
    a dependent load on this core (StoreLoad barrier). */
 
 #if FD_HAS_X86
-#define FD_HW_MFENCE() __asm__ __volatile__( "lock addl $0, (%%rsp)" ::: "memory", "cc" )
+#define FD_HW_MFENCE()    __asm__ __volatile__( "lock addl $0, (%%rsp)" ::: "memory", "cc" )
+#define FD_HW_MFENCE_LD() FD_COMPILER_MFENCE()
+#define FD_HW_MFENCE_ST() FD_COMPILER_MFENCE()
 #elif FD_HAS_ARM
-#define FD_HW_MFENCE() __asm__ __volatile__( "dmb ish" ::: "memory" )
+#define FD_HW_MFENCE()    __asm__ __volatile__( "dmb ish" ::: "memory" )
+#define FD_HW_MFENCE_LD() __asm__ __volatile__( "dmb ishld" ::: "memory" )
+#define FD_HW_MFENCE_ST() __asm__ __volatile__( "dmb ishst" ::: "memory" )
 #else
-#define FD_HW_MFENCE() __sync_synchronize()
+#define FD_HW_MFENCE()    __sync_synchronize()
+#define FD_HW_MFENCE_LD() __sync_synchronize()
+#define FD_HW_MFENCE_ST() __sync_synchronize()
 #endif
 
 /* FD_SPIN_PAUSE():  Yields the logical core of the calling thread to
@@ -781,6 +787,8 @@ fd_type_pun_const( void const * p ) {
 
 #if FD_HAS_X86
 #define FD_SPIN_PAUSE() __builtin_ia32_pause()
+#elif FD_HAS_ARM
+#define FD_SPIN_PAUSE() __asm__ __volatile__( "yield" ::: "memory" )
 #else
 #define FD_SPIN_PAUSE() ((void)0)
 #endif
@@ -1367,6 +1375,47 @@ void
 fd_yield( void );
 
 #endif
+
+#if FD_HAS_ARM
+
+/* fd_arm_stp16 stores two ulongs to a 16-byte memory location.
+   If LSE2 and p is aligned, is single-copy atomic. */
+
+static inline void
+fd_arm_stp16( ulong * p,
+              ulong   a,
+              ulong   b ) {
+  __asm__(
+      "stp %x[a], %x[b], [%[p]]"
+      :
+      : [a] "r"(a), [b] "r"(b), [p] "r"(p)
+      : "memory"
+  );
+}
+
+/* fd_arm_ldp16 loads two ulongs from a 16-byte memory location.
+   If LSE2 and p is aligned, is single-copy atomic. */
+
+#define fd_arm_ldp16(p_,a_,b_)     \
+  __asm__(                         \
+      "ldp %x[a], %x[b], [%[p]]"   \
+      : [a] "=r"(a_), [b] "=r"(b_) \
+      : [p] "r"(p_)                \
+      : "memory"                   \
+  )
+
+/* fd_arm_ldp16_acq_pc is like fd_arm_ldp16, but with Load-AcquirePC
+   semantics.  Requires RCPC3. */
+
+#define fd_arm_ldp16_acq_pc(p_,a_,b_) \
+  __asm__(                            \
+      "ldiapp %x[a], %x[b], [%[p]]"   \
+      : [a] "=r"(a_), [b] "=r"(b_)    \
+      : [p] "r"(p_)                   \
+      : "memory"                      \
+  )
+
+#endif /* FD_HAS_ARM */
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Use LSE2 (128-bit relaxed atomic load/store) to implement stem support similar to x86-SSE.
