### PR TITLE
ARM-optimized cryptography using NEON SIMD intrinsics

### DIFF
--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -44,3 +44,27 @@ FD_ARCH_SUPPORTS_SANDBOX:=1
 
 CPPFLAGS+=-DFD_HAS_ARM=1
 FD_HAS_ARM:=1
+
+CPPFLAGS+=-DFD_HAS_NEON=1
+FD_HAS_NEON:=1
+
+define _arm_map_define
+  ifeq ($(shell echo | $(CC) $(CPPFLAGS) -E -dM - | grep -c $(2)),1)
+    CPPFLAGS+=-D$(1)=1
+    $(1):=1
+  endif
+endef
+
+arm-map-define = $(eval $(call _arm_map_define,$(1),$(2)))
+
+$(call arm-map-define,FD_HAS_ARM_AES,__ARM_FEATURE_AES)
+$(call arm-map-define,FD_HAS_ARM_CRYPTO,__ARM_FEATURE_CRYPTO)
+$(call arm-map-define,FD_HAS_ARM_SHA256,__ARM_FEATURE_SHA2)
+$(call arm-map-define,FD_HAS_ARM_SHA512,__ARM_FEATURE_SHA512)
+
+ifdef FD_HAS_ARM_AES
+ifndef FD_HAS_ARM_CRYPTO
+CPPFLAGS+=-DFD_HAS_ARM_CRYPTO=1
+FD_HAS_ARM_CRYPTO:=1
+endif
+endif

--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -63,6 +63,12 @@ $(call map-define,FD_HAS_AVX, __AVX2__)
 $(call map-define,FD_HAS_GFNI, __GFNI__)
 $(call map-define,FD_IS_X86_64, __x86_64__)
 $(call map-define,FD_HAS_AESNI, __AES__)
+$(call map-define,FD_HAS_ARM, __aarch64__)
+$(call map-define,FD_HAS_NEON, __ARM_NEON)
+$(call map-define,FD_HAS_ARM_CRYPTO, __ARM_FEATURE_CRYPTO)
+$(call map-define,FD_HAS_ARM_SHA256, __ARM_FEATURE_SHA2)
+$(call map-define,FD_HAS_ARM_SHA512, __ARM_FEATURE_SHA512)
+$(call map-define,FD_HAS_ARM_AES, __ARM_FEATURE_AES)
 
 # Older version of GCC (<10) don't fully support AVX512, so we disable
 # it in those cases. Older versions of Clang (<8) don't support it
@@ -83,6 +89,13 @@ ifdef FD_HAS_THREADS
 include config/extra/with-threads.mk
 endif
 
+ifdef FD_HAS_ARM_AES
+ifndef FD_HAS_ARM_CRYPTO
+CPPFLAGS+=-DFD_HAS_ARM_CRYPTO=1
+FD_HAS_ARM_CRYPTO:=1
+endif
+endif
+
 ifdef FD_IS_X86_64
 include config/extra/with-x86-64.mk
 $(info Using FD_HAS_SSE=$(FD_HAS_SSE))
@@ -91,4 +104,12 @@ $(info Using FD_HAS_AVX512=$(FD_HAS_AVX512) $(FD_HAS_AVX512_MESSAGE))
 $(info Using FD_HAS_GFNI=$(FD_HAS_GFNI))
 $(info Using FD_HAS_SHANI=$(FD_HAS_SHANI))
 $(info Using FD_HAS_AESNI=$(FD_HAS_AESNI))
+endif
+
+ifdef FD_HAS_ARM
+$(info Using FD_HAS_NEON=$(FD_HAS_NEON))
+$(info Using FD_HAS_ARM_CRYPTO=$(FD_HAS_ARM_CRYPTO))
+$(info Using FD_HAS_ARM_SHA256=$(FD_HAS_ARM_SHA256))
+$(info Using FD_HAS_ARM_SHA512=$(FD_HAS_ARM_SHA512))
+$(info Using FD_HAS_ARM_AES=$(FD_HAS_ARM_AES))
 endif

--- a/src/ballet/blake3/Local.mk
+++ b/src/ballet/blake3/Local.mk
@@ -3,6 +3,9 @@ $(call add-objs,fd_blake3 fd_blake3_ref,fd_ballet)
 ifdef FD_HAS_SSE
 $(call add-objs,fd_blake3_sse41,fd_ballet)
 endif
+ifdef FD_HAS_NEON
+$(call add-objs,fd_blake3_neon,fd_ballet)
+endif
 ifdef FD_HAS_AVX512
 $(call add-objs,fd_blake3_avx512,fd_ballet)
 endif

--- a/src/ballet/blake3/fd_blake3.c
+++ b/src/ballet/blake3/fd_blake3.c
@@ -585,6 +585,8 @@ fd_blake3_single_hash( fd_blake3_pos_t * s,
                       op->sz, s->layer, op->counter, op->flags ));
 #   if FD_HAS_SSE
     fd_blake3_sse_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
+#   elif FD_HAS_NEON
+    fd_blake3_neon_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
 #   else
     fd_blake3_ref_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
 #   endif
@@ -645,6 +647,8 @@ fd_blake3_fini_xof_compress( fd_blake3_t * sha,
       FD_LOG_ERR(( "fd_blake3_fini_xof_compress invariant violation: failed to prepare compression of <=1024 byte message (duplicate call to fini?)" ));
 #if FD_HAS_SSE
     fd_blake3_sse_compress1( root_msg, op->msg, op->sz, op->counter, op->flags, root_cv_pre, NULL );
+#elif FD_HAS_NEON
+    fd_blake3_neon_compress1( root_msg, op->msg, op->sz, op->counter, op->flags, root_cv_pre, NULL );
 #else
     fd_blake3_ref_compress1( root_msg, op->msg, op->sz, op->counter, op->flags, root_cv_pre, NULL );
 #endif
@@ -679,6 +683,8 @@ fd_blake3_fini_xof_compress( fd_blake3_t * sha,
       break;
 #   if FD_HAS_SSE
     fd_blake3_sse_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
+#   elif FD_HAS_NEON
+    fd_blake3_neon_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
 #   else
     fd_blake3_ref_compress1( op->out, op->msg, op->sz, op->counter, op->flags, NULL, NULL );
 #   endif
@@ -747,6 +753,8 @@ fd_blake3_fini_2048( fd_blake3_t * sha,
     fd_blake3_avx_compress8( 8UL, batch_data, batch_sz, batch_ctr, batch_flags, batch_hash, NULL, 64U, batch_cv );
 #elif FD_HAS_SSE
     fd_blake3_sse_compress1( (uchar *)hash+i*64, root_msg, last_block_sz, ctr0+i, last_block_flags, NULL, root_cv_pre );
+#elif FD_HAS_NEON
+    fd_blake3_neon_compress1( (uchar *)hash+i*64, root_msg, last_block_sz, ctr0+i, last_block_flags, NULL, root_cv_pre );
 #else
     fd_blake3_ref_compress1( (uchar *)hash+i*64, root_msg, last_block_sz, ctr0+i, last_block_flags, NULL, root_cv_pre );
 #endif

--- a/src/ballet/blake3/fd_blake3_neon.c
+++ b/src/ballet/blake3/fd_blake3_neon.c
@@ -1,0 +1,162 @@
+/* BLAKE3 single-block compress using ARM NEON, ported from
+   src/ballet/blake3/fd_blake3_sse41.c. */
+
+#include "fd_blake3.h"
+#include "fd_blake3_private.h"
+
+#if FD_HAS_NEON
+
+#include <arm_neon.h>
+#include <assert.h>
+
+static inline void
+fd_blake3_g1( uint32x4_t * row0,
+              uint32x4_t * row1,
+              uint32x4_t * row2,
+              uint32x4_t * row3,
+              uint32x4_t   m ) {
+  *row0 = vaddq_u32( vaddq_u32( *row0, m ), *row1 );
+  *row3 = veorq_u32( *row3, *row0 );
+  *row3 = vorrq_u32( vshlq_n_u32( *row3, 16 ), vshrq_n_u32( *row3, 16 ) );
+  *row2 = vaddq_u32( *row2, *row3 );
+  *row1 = veorq_u32( *row1, *row2 );
+  *row1 = vorrq_u32( vshrq_n_u32( *row1, 12 ), vshlq_n_u32( *row1, 20 ) );
+}
+
+static inline void
+fd_blake3_g2( uint32x4_t * row0,
+              uint32x4_t * row1,
+              uint32x4_t * row2,
+              uint32x4_t * row3,
+              uint32x4_t   m ) {
+  *row0 = vaddq_u32( vaddq_u32( *row0, m ), *row1 );
+  *row3 = veorq_u32( *row3, *row0 );
+  *row3 = vreinterpretq_u32_u8( vqtbl1q_u8( vreinterpretq_u8_u32( *row3 ),
+                                            (uint8x16_t){ 1,2,3,0, 5,6,7,4, 9,10,11,8, 13,14,15,12 } ) );
+  *row2 = vaddq_u32( *row2, *row3 );
+  *row1 = veorq_u32( *row1, *row2 );
+  *row1 = vorrq_u32( vshrq_n_u32( *row1, 7 ), vshlq_n_u32( *row1, 25 ) );
+}
+
+static inline void
+fd_blake3_diagonalize( uint32x4_t * row1,
+                       uint32x4_t * row2,
+                       uint32x4_t * row3 ) {
+  *row1 = vextq_u32( *row1, *row1, 1 );
+  *row2 = vextq_u32( *row2, *row2, 2 );
+  *row3 = vextq_u32( *row3, *row3, 3 );
+}
+
+static inline void
+fd_blake3_undiagonalize( uint32x4_t * row1,
+                         uint32x4_t * row2,
+                         uint32x4_t * row3 ) {
+  *row1 = vextq_u32( *row1, *row1, 3 );
+  *row2 = vextq_u32( *row2, *row2, 2 );
+  *row3 = vextq_u32( *row3, *row3, 1 );
+}
+
+static inline uint32x4_t
+fd_blake3_msg( uint const         msg[ static 16 ],
+               uchar const        schedule[ static 16 ],
+               int                base ) {
+  uint lane[ 4 ] = {
+    msg[ schedule[ base     ] ],
+    msg[ schedule[ base + 2 ] ],
+    msg[ schedule[ base + 4 ] ],
+    msg[ schedule[ base + 6 ] ]
+  };
+  return vld1q_u32( lane );
+}
+
+static inline void
+fd_blake3_compress_pre( uint32x4_t      rows[ static 4 ],
+                        uint const       cv[ static 8 ],
+                        uchar const      block[ static FD_BLAKE3_BLOCK_SZ ],
+                        uint             block_len,
+                        ulong            ctr,
+                        uint             flags ) {
+  uint msg[ 16 ];
+  fd_memcpy( msg, block, FD_BLAKE3_BLOCK_SZ );
+
+  rows[0] = vld1q_u32( cv   );
+  rows[1] = vld1q_u32( cv+4 );
+  rows[2] = (uint32x4_t){ FD_BLAKE3_IV[0], FD_BLAKE3_IV[1], FD_BLAKE3_IV[2], FD_BLAKE3_IV[3] };
+  rows[3] = (uint32x4_t){ (uint)(ctr & UINT_MAX), (uint)(ctr >> 32), block_len, flags };
+
+  for( ulong round=0UL; round<7UL; round++ ) {
+    uchar const * sched = FD_BLAKE3_MSG_SCHEDULE[ round ];
+    fd_blake3_g1( &rows[0], &rows[1], &rows[2], &rows[3], fd_blake3_msg( msg, sched, 0 ) );
+    fd_blake3_g2( &rows[0], &rows[1], &rows[2], &rows[3], fd_blake3_msg( msg, sched, 1 ) );
+    fd_blake3_diagonalize( &rows[1], &rows[2], &rows[3] );
+    fd_blake3_g1( &rows[0], &rows[1], &rows[2], &rows[3], fd_blake3_msg( msg, sched, 8 ) );
+    fd_blake3_g2( &rows[0], &rows[1], &rows[2], &rows[3], fd_blake3_msg( msg, sched, 9 ) );
+    fd_blake3_undiagonalize( &rows[1], &rows[2], &rows[3] );
+  }
+}
+
+void
+fd_blake3_neon_compress1( uchar * restrict       out,
+                          uchar const * restrict msg,
+                          uint                   msg_sz,
+                          ulong                  counter,
+                          uint                   flags,
+                          uchar * restrict       out_chain,
+                          uchar const * restrict in_chain ) {
+  FD_BLAKE3_TRACE(( "fd_blake3_neon_compress1(out=%p,msg=%p,sz=%u,counter=%lu,flags=%02x)",
+                    (void *)out, (void *)msg, msg_sz, counter, flags ));
+  assert( msg_sz<=FD_BLAKE3_CHUNK_SZ );
+
+  uint cv[ 8 ] = {
+    FD_BLAKE3_IV[0], FD_BLAKE3_IV[1], FD_BLAKE3_IV[2], FD_BLAKE3_IV[3],
+    FD_BLAKE3_IV[4], FD_BLAKE3_IV[5], FD_BLAKE3_IV[6], FD_BLAKE3_IV[7]
+  };
+  if( FD_UNLIKELY( in_chain ) ) fd_memcpy( cv, in_chain, FD_BLAKE3_OUTCHAIN_SZ );
+
+  uint flag_mask = ~fd_uint_if( flags&FD_BLAKE3_FLAG_PARENT,
+                                FD_BLAKE3_FLAG_CHUNK_START|FD_BLAKE3_FLAG_CHUNK_END,
+                                0U );
+
+  uint block_flags = flags | (flag_mask & FD_BLAKE3_FLAG_CHUNK_START);
+  if( FD_UNLIKELY( in_chain && !(flags&FD_BLAKE3_FLAG_CHUNK_START) ) ) block_flags &= ~FD_BLAKE3_FLAG_CHUNK_START;
+
+  do {
+    uint block_sz = fd_uint_min( msg_sz, FD_BLAKE3_BLOCK_SZ );
+    block_flags |= FD_BLAKE3_FLAG_CHUNK_END;
+    block_flags &= (flag_mask & ~fd_uint_if( msg_sz<=FD_BLAKE3_BLOCK_SZ, 0U, (FD_BLAKE3_FLAG_CHUNK_END|FD_BLAKE3_FLAG_ROOT) ) );
+
+    uchar tail[ FD_BLAKE3_BLOCK_SZ ] __attribute__((aligned(16)));
+    uchar const * block;
+    if( FD_LIKELY( msg_sz>=FD_BLAKE3_BLOCK_SZ ) ) {
+      block = msg;
+    } else {
+      fd_memset( tail, 0, sizeof(tail) );
+      fd_memcpy( tail, msg, msg_sz );
+      block = tail;
+    }
+
+    if( FD_UNLIKELY( out_chain && (block_flags & FD_BLAKE3_FLAG_CHUNK_END) ) ) {
+      fd_memcpy( out,       block, FD_BLAKE3_BLOCK_SZ    );
+      fd_memcpy( out_chain, cv,    FD_BLAKE3_OUTCHAIN_SZ );
+      FD_BLAKE3_TRACE(( "fd_blake3_neon_compress1: done (XOF mode)" ));
+      return;
+    }
+
+    uint32x4_t rows[ 4 ];
+    fd_blake3_compress_pre( rows, cv, block, block_sz, counter, block_flags );
+    if( FD_UNLIKELY( in_chain ) ) {
+      vst1q_u32( (uint *)(out+32), veorq_u32( vld1q_u32( cv   ), rows[2] ) );
+      vst1q_u32( (uint *)(out+48), veorq_u32( vld1q_u32( cv+4 ), rows[3] ) );
+    }
+    vst1q_u32( cv,   veorq_u32( rows[0], rows[2] ) );
+    vst1q_u32( cv+4, veorq_u32( rows[1], rows[3] ) );
+    msg    += FD_BLAKE3_BLOCK_SZ;
+    msg_sz -= block_sz;
+    block_flags = flags;
+  } while( (int)msg_sz>0 );
+
+  fd_memcpy( out, cv, FD_BLAKE3_OUTCHAIN_SZ );
+  FD_BLAKE3_TRACE(( "fd_blake3_neon_compress1: done" ));
+}
+
+#endif /* FD_HAS_NEON */

--- a/src/ballet/blake3/fd_blake3_private.h
+++ b/src/ballet/blake3/fd_blake3_private.h
@@ -99,6 +99,19 @@ fd_blake3_sse_compress1( uchar * restrict       out, /* align==1 len==32 */
 
 #endif /* FD_HAS_SSE */
 
+#if FD_HAS_NEON
+
+void
+fd_blake3_neon_compress1( uchar * restrict       out,
+                          uchar const * restrict msg,
+                          uint                   msg_sz,
+                          ulong                  counter,
+                          uint                   flags,
+                          uchar * restrict       out_chain,
+                          uchar const * restrict in_chain );
+
+#endif /* FD_HAS_NEON */
+
 #if FD_HAS_AVX
 
 /* BLAKE3 AVX cores

--- a/src/ballet/blake3/test_blake3.c
+++ b/src/ballet/blake3/test_blake3.c
@@ -447,6 +447,77 @@ test_reduced_xof2048( void ) {
   fd_rng_delete( fd_rng_leave( rng ) );
 }
 
+#if FD_HAS_NEON
+
+static void
+test_neon_compress1( void ) {
+  static uint const sz_case[] = {
+    0U, 1U, 63U, 64U, 65U, 127U, 128U, 255U, 512U, 1023U, 1024U
+  };
+  static uint const flag_case[] = {
+    0U,
+    FD_BLAKE3_FLAG_CHUNK_START,
+    FD_BLAKE3_FLAG_CHUNK_END,
+    FD_BLAKE3_FLAG_CHUNK_START | FD_BLAKE3_FLAG_CHUNK_END,
+    FD_BLAKE3_FLAG_CHUNK_START | FD_BLAKE3_FLAG_CHUNK_END | FD_BLAKE3_FLAG_ROOT,
+    FD_BLAKE3_FLAG_PARENT,
+    FD_BLAKE3_FLAG_PARENT | FD_BLAKE3_FLAG_ROOT
+  };
+
+  ulong iter = 0UL;
+  for( ulong sz_idx=0UL; sz_idx<sizeof(sz_case)/sizeof(sz_case[0]); sz_idx++ ) {
+    uint msg_sz = sz_case[ sz_idx ];
+    ulong msg_off = (iter*131UL) & ((sizeof(rand_buf)-FD_BLAKE3_CHUNK_SZ)-1UL);
+    uchar const * msg = rand_buf + msg_off;
+
+    uchar in_chain[ 32 ] __attribute__((aligned(32)));
+    fd_memcpy( in_chain, rand_buf + ((msg_off+977UL) & (sizeof(rand_buf)-32UL)), 32UL );
+
+    for( ulong flag_idx=0UL; flag_idx<sizeof(flag_case)/sizeof(flag_case[0]); flag_idx++ ) {
+      uint flags = flag_case[ flag_idx ];
+
+      for( int use_in_chain=0; use_in_chain<2; use_in_chain++ ) {
+        for( int use_xof=0; use_xof<2; use_xof++ ) {
+          uchar ref_out   [ 64 ] __attribute__((aligned(64))) = {0};
+          uchar neon_out  [ 64 ] __attribute__((aligned(64))) = {0};
+          uchar ref_chain [ 32 ] __attribute__((aligned(32))) = {0};
+          uchar neon_chain[ 32 ] __attribute__((aligned(32))) = {0};
+          ulong counter = iter*17UL + flag_idx;
+
+          fd_blake3_ref_compress1( ref_out,
+                                   msg,
+                                   msg_sz,
+                                   counter,
+                                   flags,
+                                   use_xof      ? ref_chain  : NULL,
+                                   use_in_chain ? in_chain   : NULL );
+          fd_blake3_neon_compress1( neon_out,
+                                    msg,
+                                    msg_sz,
+                                    counter,
+                                    flags,
+                                    use_xof      ? neon_chain : NULL,
+                                    use_in_chain ? in_chain   : NULL );
+
+          ulong out_sz = (ulong)( (use_xof | use_in_chain) ? 64U : 32U );
+          if( FD_UNLIKELY( memcmp( ref_out, neon_out, out_sz ) ) ) {
+            FD_LOG_ERR(( "fd_blake3_neon_compress1 output mismatch (sz=%u flags=%x use_in_chain=%d use_xof=%d ctr=%lu)",
+                         msg_sz, flags, use_in_chain, use_xof, counter ));
+          }
+          if( FD_UNLIKELY( use_xof && memcmp( ref_chain, neon_chain, 32UL ) ) ) {
+            FD_LOG_ERR(( "fd_blake3_neon_compress1 out_chain mismatch (sz=%u flags=%x use_in_chain=%d ctr=%lu)",
+                         msg_sz, flags, use_in_chain, counter ));
+          }
+
+          iter++;
+        }
+      }
+    }
+  }
+}
+
+#endif /* FD_HAS_NEON */
+
 static void
 test_lthash( void ) {
   fd_blake3_t blake_[1];
@@ -790,6 +861,9 @@ static struct test_fn const tests[] = {
   { "test avx_compress8",              test_avx_compress8 },
   { "test avx_compress8_xof2048_para", test_avx_compress8_xof2048_para },
   { "test avx_compress8_xof2048_seq",  test_avx_compress8_xof2048_seq },
+#endif
+#if FD_HAS_NEON
+  { "test neon_compress1",             test_neon_compress1 },
 #endif
 
   { "bench incremental",            bench_incremental },

--- a/src/ballet/chacha/Local.mk
+++ b/src/ballet/chacha/Local.mk
@@ -17,6 +17,9 @@ endif
 ifdef FD_HAS_AVX
 $(call add-objs,fd_chacha_rng_avx,fd_ballet)
 endif
+ifdef FD_HAS_NEON
+$(call add-objs,fd_chacha_rng_neon,fd_ballet)
+endif
 $(call make-unit-test,test_chacha_rng,test_chacha_rng,fd_ballet fd_util)
 $(call make-unit-test,test_chacha_rng_roll,test_chacha_rng_roll,fd_ballet fd_util)
 $(call run-unit-test,test_chacha_rng)

--- a/src/ballet/chacha/fd_chacha_rng.h
+++ b/src/ballet/chacha/fd_chacha_rng.h
@@ -33,6 +33,8 @@
 #define FD_CHACHA_RNG_BUFSZ (16*FD_CHACHA_BLOCK_SZ)
 #elif FD_HAS_AVX
 #define FD_CHACHA_RNG_BUFSZ (8*FD_CHACHA_BLOCK_SZ)
+#elif FD_HAS_NEON
+#define FD_CHACHA_RNG_BUFSZ (4*FD_CHACHA_BLOCK_SZ)
 #else
 #define FD_CHACHA_RNG_BUFSZ (256UL)
 #endif
@@ -139,6 +141,11 @@ void fd_chacha8_rng_refill_avx ( fd_chacha_rng_t * rng );
 void fd_chacha20_rng_refill_avx( fd_chacha_rng_t * rng );
 #endif
 
+#if FD_HAS_NEON
+void fd_chacha8_rng_refill_neon ( fd_chacha_rng_t * rng );
+void fd_chacha20_rng_refill_neon( fd_chacha_rng_t * rng );
+#endif
+
 void fd_chacha8_rng_refill_seq ( fd_chacha_rng_t * rng );
 void fd_chacha20_rng_refill_seq( fd_chacha_rng_t * rng );
 
@@ -148,6 +155,9 @@ void fd_chacha20_rng_refill_seq( fd_chacha_rng_t * rng );
 #elif FD_HAS_AVX
 #define fd_chacha8_rng_private_refill  fd_chacha8_rng_refill_avx
 #define fd_chacha20_rng_private_refill fd_chacha20_rng_refill_avx
+#elif FD_HAS_NEON
+#define fd_chacha8_rng_private_refill  fd_chacha8_rng_refill_neon
+#define fd_chacha20_rng_private_refill fd_chacha20_rng_refill_neon
 #else
 #define fd_chacha8_rng_private_refill  fd_chacha8_rng_refill_seq
 #define fd_chacha20_rng_private_refill fd_chacha20_rng_refill_seq

--- a/src/ballet/chacha/fd_chacha_rng_neon.c
+++ b/src/ballet/chacha/fd_chacha_rng_neon.c
@@ -1,0 +1,149 @@
+#include "fd_chacha_rng.h"
+
+#if FD_HAS_NEON
+
+#include "../../util/simd/fd_neon.h"
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_chacha_rotl7( fd_neon_u32x4_t x ) {
+  return fd_neon_u32x4_rotl( x, 7 );
+}
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_chacha_rotl8( fd_neon_u32x4_t x ) {
+  return fd_neon_u32x4_rotl( x, 8 );
+}
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_chacha_rotl12( fd_neon_u32x4_t x ) {
+  return fd_neon_u32x4_rotl( x, 12 );
+}
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_chacha_rotl16( fd_neon_u32x4_t x ) {
+  return fd_neon_u32x4_rotl( x, 16 );
+}
+
+static inline void
+fd_chacha_qr( fd_neon_u32x4_t * a,
+              fd_neon_u32x4_t * b,
+              fd_neon_u32x4_t * c,
+              fd_neon_u32x4_t * d ) {
+  *a = vaddq_u32( *a, *b ); *d = veorq_u32( *d, *a ); *d = fd_chacha_rotl16( *d );
+  *c = vaddq_u32( *c, *d ); *b = veorq_u32( *b, *c ); *b = fd_chacha_rotl12( *b );
+  *a = vaddq_u32( *a, *b ); *d = veorq_u32( *d, *a ); *d = fd_chacha_rotl8 ( *d );
+  *c = vaddq_u32( *c, *d ); *b = veorq_u32( *b, *c ); *b = fd_chacha_rotl7 ( *b );
+}
+
+static void
+fd_chacha_rng_refill_neon( fd_chacha_rng_t * rng,
+                           ulong             rnd2_cnt ) {
+  uint const * key = (uint const *)rng->key;
+  ulong idx = rng->buf_fill >> 6;
+  uint  idx_lo[ 4 ] = { (uint)(idx+0UL), (uint)(idx+1UL), (uint)(idx+2UL), (uint)(idx+3UL) };
+  uint  idx_hi[ 4 ] = {
+    (uint)((idx+0UL)>>32), (uint)((idx+1UL)>>32), (uint)((idx+2UL)>>32), (uint)((idx+3UL)>>32)
+  };
+
+  fd_neon_u32x4_t x0  = fd_neon_u32x4_bcast( 0x61707865U );
+  fd_neon_u32x4_t x1  = fd_neon_u32x4_bcast( 0x3320646eU );
+  fd_neon_u32x4_t x2  = fd_neon_u32x4_bcast( 0x79622d32U );
+  fd_neon_u32x4_t x3  = fd_neon_u32x4_bcast( 0x6b206574U );
+  fd_neon_u32x4_t x4  = fd_neon_u32x4_bcast( key[0] );
+  fd_neon_u32x4_t x5  = fd_neon_u32x4_bcast( key[1] );
+  fd_neon_u32x4_t x6  = fd_neon_u32x4_bcast( key[2] );
+  fd_neon_u32x4_t x7  = fd_neon_u32x4_bcast( key[3] );
+  fd_neon_u32x4_t x8  = fd_neon_u32x4_bcast( key[4] );
+  fd_neon_u32x4_t x9  = fd_neon_u32x4_bcast( key[5] );
+  fd_neon_u32x4_t x10 = fd_neon_u32x4_bcast( key[6] );
+  fd_neon_u32x4_t x11 = fd_neon_u32x4_bcast( key[7] );
+  fd_neon_u32x4_t x12 = vld1q_u32( idx_lo );
+  fd_neon_u32x4_t x13 = vld1q_u32( idx_hi );
+  fd_neon_u32x4_t x14 = fd_neon_u32x4_bcast( 0U );
+  fd_neon_u32x4_t x15 = fd_neon_u32x4_bcast( 0U );
+
+  fd_neon_u32x4_t i0  = x0;
+  fd_neon_u32x4_t i1  = x1;
+  fd_neon_u32x4_t i2  = x2;
+  fd_neon_u32x4_t i3  = x3;
+  fd_neon_u32x4_t i4  = x4;
+  fd_neon_u32x4_t i5  = x5;
+  fd_neon_u32x4_t i6  = x6;
+  fd_neon_u32x4_t i7  = x7;
+  fd_neon_u32x4_t i8  = x8;
+  fd_neon_u32x4_t i9  = x9;
+  fd_neon_u32x4_t i10 = x10;
+  fd_neon_u32x4_t i11 = x11;
+  fd_neon_u32x4_t i12 = x12;
+  fd_neon_u32x4_t i13 = x13;
+  fd_neon_u32x4_t i14 = x14;
+  fd_neon_u32x4_t i15 = x15;
+
+  for( ulong i=0UL; i<rnd2_cnt; i++ ) {
+    fd_chacha_qr( &x0, &x4, &x8,  &x12 );
+    fd_chacha_qr( &x1, &x5, &x9,  &x13 );
+    fd_chacha_qr( &x2, &x6, &x10, &x14 );
+    fd_chacha_qr( &x3, &x7, &x11, &x15 );
+    fd_chacha_qr( &x0, &x5, &x10, &x15 );
+    fd_chacha_qr( &x1, &x6, &x11, &x12 );
+    fd_chacha_qr( &x2, &x7, &x8,  &x13 );
+    fd_chacha_qr( &x3, &x4, &x9,  &x14 );
+  }
+
+  x0  = vaddq_u32( x0,  i0  );
+  x1  = vaddq_u32( x1,  i1  );
+  x2  = vaddq_u32( x2,  i2  );
+  x3  = vaddq_u32( x3,  i3  );
+  x4  = vaddq_u32( x4,  i4  );
+  x5  = vaddq_u32( x5,  i5  );
+  x6  = vaddq_u32( x6,  i6  );
+  x7  = vaddq_u32( x7,  i7  );
+  x8  = vaddq_u32( x8,  i8  );
+  x9  = vaddq_u32( x9,  i9  );
+  x10 = vaddq_u32( x10, i10 );
+  x11 = vaddq_u32( x11, i11 );
+  x12 = vaddq_u32( x12, i12 );
+  x13 = vaddq_u32( x13, i13 );
+  x14 = vaddq_u32( x14, i14 );
+  x15 = vaddq_u32( x15, i15 );
+
+  uint lane_words[ 16 ][ 4 ] __attribute__((aligned(64)));
+  vst1q_u32( lane_words[ 0], x0  );
+  vst1q_u32( lane_words[ 1], x1  );
+  vst1q_u32( lane_words[ 2], x2  );
+  vst1q_u32( lane_words[ 3], x3  );
+  vst1q_u32( lane_words[ 4], x4  );
+  vst1q_u32( lane_words[ 5], x5  );
+  vst1q_u32( lane_words[ 6], x6  );
+  vst1q_u32( lane_words[ 7], x7  );
+  vst1q_u32( lane_words[ 8], x8  );
+  vst1q_u32( lane_words[ 9], x9  );
+  vst1q_u32( lane_words[10], x10 );
+  vst1q_u32( lane_words[11], x11 );
+  vst1q_u32( lane_words[12], x12 );
+  vst1q_u32( lane_words[13], x13 );
+  vst1q_u32( lane_words[14], x14 );
+  vst1q_u32( lane_words[15], x15 );
+
+  for( ulong lane=0UL; lane<4UL; lane++ ) {
+    uint block_words[ 16 ] __attribute__((aligned(64)));
+    for( ulong word=0UL; word<16UL; word++ ) {
+      block_words[ word ] = lane_words[ word ][ lane ];
+    }
+    ulong off = ( rng->buf_fill + lane*FD_CHACHA_BLOCK_SZ ) % FD_CHACHA_RNG_BUFSZ;
+    fd_memcpy( rng->buf + off, block_words, FD_CHACHA_BLOCK_SZ );
+  }
+  rng->buf_fill += 4UL*FD_CHACHA_BLOCK_SZ;
+}
+
+void
+fd_chacha8_rng_refill_neon( fd_chacha_rng_t * rng ) {
+  fd_chacha_rng_refill_neon( rng, 4UL );
+}
+
+void
+fd_chacha20_rng_refill_neon( fd_chacha_rng_t * rng ) {
+  fd_chacha_rng_refill_neon( rng, 10UL );
+}
+
+#endif /* FD_HAS_NEON */

--- a/src/ballet/chacha/test_chacha_rng.c
+++ b/src/ballet/chacha/test_chacha_rng.c
@@ -2,6 +2,44 @@
 #include "fd_chacha.h"
 #include "fd_chacha_rng.h"
 
+#if FD_HAS_NEON
+
+static void
+test_neon_refill_matches_block_fn( void * (* block_fn)( void *, void const *, void const * ),
+                                   void   (* refill_fn)( fd_chacha_rng_t * ),
+                                   int       algo ) {
+  fd_chacha_rng_t rng_[1];
+  fd_chacha_rng_t * rng = fd_chacha_rng_join( fd_chacha_rng_new( rng_, FD_CHACHA_RNG_MODE_MOD ) );
+
+  uchar key[ 32 ];
+  for( ulong i=0UL; i<32UL; i++ ) key[i] = (uchar)( i*13UL + 7UL );
+
+  static ulong const idx_case[] = { 0UL, 4UL, 28UL, (1UL<<32) + 48UL };
+  for( ulong case_idx=0UL; case_idx<sizeof(idx_case)/sizeof(idx_case[0]); case_idx++ ) {
+    ulong idx = idx_case[ case_idx ];
+    ulong pos = idx * FD_CHACHA_BLOCK_SZ;
+
+    FD_TEST( fd_chacha_rng_init( rng, key, algo ) );
+    rng->buf_off  = pos;
+    rng->buf_fill = pos;
+    refill_fn( rng );
+    FD_TEST( rng->buf_fill == pos + 4UL*FD_CHACHA_BLOCK_SZ );
+
+    for( ulong lane=0UL; lane<4UL; lane++ ) {
+      uchar expect[ 64 ] __attribute__((aligned(64)));
+      uint idx_nonce[ 4 ] __attribute__((aligned(16))) = {
+        (uint)(idx+lane), (uint)((idx+lane)>>32), 0U, 0U
+      };
+      block_fn( expect, key, idx_nonce );
+      FD_TEST( !memcmp( rng->buf + lane*FD_CHACHA_BLOCK_SZ, expect, FD_CHACHA_BLOCK_SZ ) );
+    }
+  }
+
+  FD_TEST( (ulong)fd_chacha_rng_delete( fd_chacha_rng_leave( rng ) )==(ulong)rng_ );
+}
+
+#endif /* FD_HAS_NEON */
+
 
 int
 main( int     argc,
@@ -97,6 +135,10 @@ main( int     argc,
   REFILL_TEST( fd_chacha8_rng_refill_avx,      8*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA8  );
   REFILL_TEST( fd_chacha20_rng_refill_avx,     8*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA20 );
 # endif
+# if FD_HAS_NEON
+  REFILL_TEST( fd_chacha8_rng_refill_neon,     4*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA8  );
+  REFILL_TEST( fd_chacha20_rng_refill_neon,    4*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA20 );
+# endif
   REFILL_TEST( fd_chacha8_rng_refill_seq,      1*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA8  );
   REFILL_TEST( fd_chacha20_rng_refill_seq,     1*FD_CHACHA_BLOCK_SZ, FD_CHACHA_RNG_ALGO_CHACHA20 );
 
@@ -158,8 +200,21 @@ main( int     argc,
     FD_TEST( !memcmp( rng->buf, ref_block, 64 ) );
 #   endif
 
+#   if FD_HAS_NEON
+    FD_TEST( fd_chacha_rng_init( rng, key_ref, FD_CHACHA_RNG_ALGO_CHACHA20 ) );
+    rng->buf_off  = pos;
+    rng->buf_fill = pos;
+    fd_chacha20_rng_refill_neon( rng );
+    FD_TEST( !memcmp( rng->buf, ref_block, 64 ) );
+#   endif
+
     FD_LOG_NOTICE(( "OK: 64-bit counter" ));
   }
+
+# if FD_HAS_NEON
+  test_neon_refill_matches_block_fn( fd_chacha8_block,  fd_chacha8_rng_refill_neon,  FD_CHACHA_RNG_ALGO_CHACHA8  );
+  test_neon_refill_matches_block_fn( fd_chacha20_block, fd_chacha20_rng_refill_neon, FD_CHACHA_RNG_ALGO_CHACHA20 );
+# endif
 
   /* Test leave/delete */
 

--- a/src/ballet/sha256/fd_sha256.c
+++ b/src/ballet/sha256/fd_sha256.c
@@ -1,6 +1,10 @@
 #include "fd_sha256.h"
 #include "fd_sha256_constants.h"
 
+#if FD_HAS_ARM_SHA256
+#include <arm_neon.h>
+#endif
+
 #if FD_HAS_SHANI
 /* For the optimized repeated hash */
 #include "../../util/simd/fd_sse.h"
@@ -103,7 +107,9 @@ fd_sha256_delete( void * shsha ) {
 }
 
 #ifndef FD_SHA256_CORE_IMPL
-#if FD_HAS_SHANI
+#if FD_HAS_ARM_SHA256
+#define FD_SHA256_CORE_IMPL 2
+#elif FD_HAS_SHANI
 #define FD_SHA256_CORE_IMPL 1
 #else
 #define FD_SHA256_CORE_IMPL 0
@@ -351,6 +357,93 @@ fd_sha256_core_shaext( uint *        state,       /* 64-byte aligned, 8 entries 
 }
 
 #define fd_sha256_core fd_sha256_core_shaext
+
+#elif FD_SHA256_CORE_IMPL==2
+
+/* SHA-256 using ARMv8 FEAT_SHA256 Crypto Extensions. */
+
+static void
+fd_sha256_core_arm( uint *        state,
+                    uchar const * block,
+                    ulong         block_cnt ) {
+
+#define SHA256_ROUNDS( MSG, KIDX ) do {                                          \
+    uint32x4_t wk = vaddq_u32( (MSG), vld1q_u32( fd_sha256_K + (KIDX) ) );       \
+    uint32x4_t abcd_prev = abcd;                                                 \
+    abcd = vsha256hq_u32(  abcd, efgh, wk );                                     \
+    efgh = vsha256h2q_u32( efgh, abcd_prev, wk );                                \
+  } while( 0 )
+
+  do {
+    uint32x4_t abcd = vld1q_u32( state    );
+    uint32x4_t efgh = vld1q_u32( state+4  );
+    uint32x4_t abcd_init = abcd;
+    uint32x4_t efgh_init = efgh;
+
+    uint32x4_t msg0 = vreinterpretq_u32_u8( vrev32q_u8( vld1q_u8( block     ) ) );
+    uint32x4_t msg1 = vreinterpretq_u32_u8( vrev32q_u8( vld1q_u8( block+16  ) ) );
+    uint32x4_t msg2 = vreinterpretq_u32_u8( vrev32q_u8( vld1q_u8( block+32  ) ) );
+    uint32x4_t msg3 = vreinterpretq_u32_u8( vrev32q_u8( vld1q_u8( block+48  ) ) );
+
+    SHA256_ROUNDS( msg0,  0 );
+    msg0 = vsha256su0q_u32( msg0, msg1 );
+    SHA256_ROUNDS( msg1,  4 );
+    msg1 = vsha256su0q_u32( msg1, msg2 );
+    msg0 = vsha256su1q_u32( msg0, msg2, msg3 );
+    SHA256_ROUNDS( msg2,  8 );
+    msg2 = vsha256su0q_u32( msg2, msg3 );
+    msg1 = vsha256su1q_u32( msg1, msg3, msg0 );
+    SHA256_ROUNDS( msg3, 12 );
+    msg3 = vsha256su0q_u32( msg3, msg0 );
+    msg2 = vsha256su1q_u32( msg2, msg0, msg1 );
+
+    SHA256_ROUNDS( msg0, 16 );
+    msg0 = vsha256su0q_u32( msg0, msg1 );
+    msg3 = vsha256su1q_u32( msg3, msg1, msg2 );
+    SHA256_ROUNDS( msg1, 20 );
+    msg1 = vsha256su0q_u32( msg1, msg2 );
+    msg0 = vsha256su1q_u32( msg0, msg2, msg3 );
+    SHA256_ROUNDS( msg2, 24 );
+    msg2 = vsha256su0q_u32( msg2, msg3 );
+    msg1 = vsha256su1q_u32( msg1, msg3, msg0 );
+    SHA256_ROUNDS( msg3, 28 );
+    msg3 = vsha256su0q_u32( msg3, msg0 );
+    msg2 = vsha256su1q_u32( msg2, msg0, msg1 );
+
+    SHA256_ROUNDS( msg0, 32 );
+    msg0 = vsha256su0q_u32( msg0, msg1 );
+    msg3 = vsha256su1q_u32( msg3, msg1, msg2 );
+    SHA256_ROUNDS( msg1, 36 );
+    msg1 = vsha256su0q_u32( msg1, msg2 );
+    msg0 = vsha256su1q_u32( msg0, msg2, msg3 );
+    SHA256_ROUNDS( msg2, 40 );
+    msg2 = vsha256su0q_u32( msg2, msg3 );
+    msg1 = vsha256su1q_u32( msg1, msg3, msg0 );
+    SHA256_ROUNDS( msg3, 44 );
+    msg3 = vsha256su0q_u32( msg3, msg0 );
+    msg2 = vsha256su1q_u32( msg2, msg0, msg1 );
+
+    SHA256_ROUNDS( msg0, 48 );
+    msg0 = vsha256su0q_u32( msg0, msg1 );
+    msg3 = vsha256su1q_u32( msg3, msg1, msg2 );
+    SHA256_ROUNDS( msg1, 52 );
+    msg1 = vsha256su0q_u32( msg1, msg2 );
+    msg0 = vsha256su1q_u32( msg0, msg2, msg3 );
+    SHA256_ROUNDS( msg2, 56 );
+    SHA256_ROUNDS( msg3, 60 );
+
+    abcd = vaddq_u32( abcd, abcd_init );
+    efgh = vaddq_u32( efgh, efgh_init );
+    vst1q_u32( state,   abcd );
+    vst1q_u32( state+4, efgh );
+
+    block += FD_SHA256_BLOCK_SZ;
+  } while( --block_cnt );
+
+#undef SHA256_ROUNDS
+}
+
+#define fd_sha256_core fd_sha256_core_arm
 
 #else
 #error "Unsupported FD_SHA256_CORE_IMPL"

--- a/src/ballet/sha512/fd_sha512.c
+++ b/src/ballet/sha512/fd_sha512.c
@@ -1,5 +1,32 @@
 #include "fd_sha512.h"
 
+#if FD_HAS_ARM_SHA512
+#include <arm_neon.h>
+#endif
+
+static ulong const fd_sha512_K[80] __attribute__((unused)) = {
+  0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
+  0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
+  0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
+  0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
+  0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
+  0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
+  0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
+  0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
+  0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
+  0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
+  0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
+  0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
+  0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
+  0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
+  0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
+  0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
+  0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
+  0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
+  0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
+  0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL
+};
+
 ulong
 fd_sha512_align( void ) {
   return FD_SHA512_ALIGN;
@@ -97,7 +124,9 @@ fd_sha512_delete( void * shsha ) {
 }
 
 #ifndef FD_SHA512_CORE_IMPL
-#if FD_HAS_AVX
+#if FD_HAS_ARM_SHA512
+#define FD_SHA512_CORE_IMPL 2
+#elif FD_HAS_AVX
 #define FD_SHA512_CORE_IMPL 1
 #else
 #define FD_SHA512_CORE_IMPL 0
@@ -129,30 +158,6 @@ static void
 fd_sha512_core_ref( ulong *       state,        /* 64-byte aligned, 8 entries */
                     uchar const * block,        /* ideally 128-byte aligned (but not required), 128*block_cnt in size */
                     ulong         block_cnt ) { /* positive */
-
-  static ulong const K[80] = {
-    0x428a2f98d728ae22UL, 0x7137449123ef65cdUL, 0xb5c0fbcfec4d3b2fUL, 0xe9b5dba58189dbbcUL,
-    0x3956c25bf348b538UL, 0x59f111f1b605d019UL, 0x923f82a4af194f9bUL, 0xab1c5ed5da6d8118UL,
-    0xd807aa98a3030242UL, 0x12835b0145706fbeUL, 0x243185be4ee4b28cUL, 0x550c7dc3d5ffb4e2UL,
-    0x72be5d74f27b896fUL, 0x80deb1fe3b1696b1UL, 0x9bdc06a725c71235UL, 0xc19bf174cf692694UL,
-    0xe49b69c19ef14ad2UL, 0xefbe4786384f25e3UL, 0x0fc19dc68b8cd5b5UL, 0x240ca1cc77ac9c65UL,
-    0x2de92c6f592b0275UL, 0x4a7484aa6ea6e483UL, 0x5cb0a9dcbd41fbd4UL, 0x76f988da831153b5UL,
-    0x983e5152ee66dfabUL, 0xa831c66d2db43210UL, 0xb00327c898fb213fUL, 0xbf597fc7beef0ee4UL,
-    0xc6e00bf33da88fc2UL, 0xd5a79147930aa725UL, 0x06ca6351e003826fUL, 0x142929670a0e6e70UL,
-    0x27b70a8546d22ffcUL, 0x2e1b21385c26c926UL, 0x4d2c6dfc5ac42aedUL, 0x53380d139d95b3dfUL,
-    0x650a73548baf63deUL, 0x766a0abb3c77b2a8UL, 0x81c2c92e47edaee6UL, 0x92722c851482353bUL,
-    0xa2bfe8a14cf10364UL, 0xa81a664bbc423001UL, 0xc24b8b70d0f89791UL, 0xc76c51a30654be30UL,
-    0xd192e819d6ef5218UL, 0xd69906245565a910UL, 0xf40e35855771202aUL, 0x106aa07032bbd1b8UL,
-    0x19a4c116b8d2d0c8UL, 0x1e376c085141ab53UL, 0x2748774cdf8eeb99UL, 0x34b0bcb5e19b48a8UL,
-    0x391c0cb3c5c95a63UL, 0x4ed8aa4ae3418acbUL, 0x5b9cca4f7763e373UL, 0x682e6ff3d6b2b8a3UL,
-    0x748f82ee5defb2fcUL, 0x78a5636f43172f60UL, 0x84c87814a1f0ab72UL, 0x8cc702081a6439ecUL,
-    0x90befffa23631e28UL, 0xa4506cebde82bde9UL, 0xbef9a3f7b2c67915UL, 0xc67178f2e372532bUL,
-    0xca273eceea26619cUL, 0xd186b8c721c0c207UL, 0xeada7dd6cde0eb1eUL, 0xf57d4f7fee6ed178UL,
-    0x06f067aa72176fbaUL, 0x0a637dc5a2c898a6UL, 0x113f9804bef90daeUL, 0x1b710b35131c471bUL,
-    0x28db77f523047d84UL, 0x32caab7b40c72493UL, 0x3c9ebe0a15c9bebcUL, 0x431d67c49c100d4cUL,
-    0x4cc5d4becb3e42b6UL, 0x597f299cfc657e2aUL, 0x5fcb6fab3ad6faecUL, 0x6c44198c4a475817UL
-  };
-
 # define ROTR       fd_ulong_rotate_right
 # define Sigma0(x)  (ROTR((x),28) ^ ROTR((x),34) ^ ROTR((x),39))
 # define Sigma1(x)  (ROTR((x),14) ^ ROTR((x),18) ^ ROTR((x),41))
@@ -177,7 +182,7 @@ fd_sha512_core_ref( ulong *       state,        /* 64-byte aligned, 8 entries */
     ulong i;
     for( i=0UL; i<16UL; i++ ) {
       X[i] = fd_ulong_bswap( W[i] );
-      ulong T1 = X[i] + h + Sigma1(e) + Ch(e, f, g) + K[i];
+      ulong T1 = X[i] + h + Sigma1(e) + Ch(e, f, g) + fd_sha512_K[i];
       ulong T2 = Sigma0(a) + Maj(a, b, c);
       h = g;
       g = f;
@@ -194,7 +199,7 @@ fd_sha512_core_ref( ulong *       state,        /* 64-byte aligned, 8 entries */
       s0 = sigma0(s0);
       s1 = sigma1(s1);
       X[i & 0xfUL] += s0 + s1 + X[(i + 9UL) & 0xfUL];
-      ulong T1 = X[i & 0xfUL ] + h + Sigma1(e) + Ch(e, f, g) + K[i];
+      ulong T1 = X[i & 0xfUL ] + h + Sigma1(e) + Ch(e, f, g) + fd_sha512_K[i];
       ulong T2 = Sigma0(a) + Maj(a, b, c);
       h = g;
       g = f;
@@ -239,6 +244,157 @@ fd_sha512_core_avx2( ulong *       state,       /* 64-byte aligned, 8 entries */
                      ulong         block_cnt ); /* positive */
 
 #define fd_sha512_core fd_sha512_core_avx2
+
+#elif FD_SHA512_CORE_IMPL==2
+
+/* SHA-512 using ARMv8.2 FEAT_SHA512 Crypto Extensions. */
+
+FD_FN_PURE static inline uint64x2_t
+fd_sha512_load_input( uchar const * p ) {
+  return vreinterpretq_u64_u8( vrev64q_u8( vld1q_u8( p ) ) );
+}
+
+FD_FN_PURE static inline uint64x2_t
+fd_sha512_schedule_update( uint64x2_t m8,
+                           uint64x2_t m7,
+                           uint64x2_t m4,
+                           uint64x2_t m3,
+                           uint64x2_t m1 ) {
+  return vsha512su1q_u64( vsha512su0q_u64( m8, m7 ), m1, vextq_u64( m4, m3, 1 ) );
+}
+
+static inline void
+fd_sha512_round2( ulong       round_idx,
+                  uint64x2_t  sched,
+                  uint64x2_t * ab,
+                  uint64x2_t * cd,
+                  uint64x2_t * ef,
+                  uint64x2_t * gh ) {
+  uint64x2_t rk   = vld1q_u64( fd_sha512_K + round_idx );
+  uint64x2_t sum  = vaddq_u64( sched, rk );
+  uint64x2_t de   = vextq_u64( *cd, *ef, 1 );
+  uint64x2_t fg   = vextq_u64( *ef, *gh, 1 );
+  uint64x2_t acc  = vaddq_u64( vextq_u64( sum, sum, 1 ), *gh );
+  uint64x2_t tmp  = vsha512hq_u64( acc, fg, de );
+  *gh             = vsha512h2q_u64( tmp, *cd, *ab );
+  *cd             = vaddq_u64( *cd, tmp );
+}
+
+static void
+fd_sha512_core_arm( ulong *       state,
+                    uchar const * block,
+                    ulong         block_cnt ) {
+  do {
+    uint64x2_t s0 = fd_sha512_load_input( block      );
+    uint64x2_t s1 = fd_sha512_load_input( block+ 16  );
+    uint64x2_t s2 = fd_sha512_load_input( block+ 32  );
+    uint64x2_t s3 = fd_sha512_load_input( block+ 48  );
+    uint64x2_t s4 = fd_sha512_load_input( block+ 64  );
+    uint64x2_t s5 = fd_sha512_load_input( block+ 80  );
+    uint64x2_t s6 = fd_sha512_load_input( block+ 96  );
+    uint64x2_t s7 = fd_sha512_load_input( block+112  );
+
+    uint64x2_t ab = vld1q_u64( state    );
+    uint64x2_t cd = vld1q_u64( state+2  );
+    uint64x2_t ef = vld1q_u64( state+4  );
+    uint64x2_t gh = vld1q_u64( state+6  );
+
+    uint64x2_t ab_init = ab;
+    uint64x2_t cd_init = cd;
+    uint64x2_t ef_init = ef;
+    uint64x2_t gh_init = gh;
+
+    fd_sha512_round2(  0UL, s0, &ab, &cd, &ef, &gh );
+    fd_sha512_round2(  2UL, s1, &gh, &ab, &cd, &ef );
+    fd_sha512_round2(  4UL, s2, &ef, &gh, &ab, &cd );
+    fd_sha512_round2(  6UL, s3, &cd, &ef, &gh, &ab );
+    fd_sha512_round2(  8UL, s4, &ab, &cd, &ef, &gh );
+    fd_sha512_round2( 10UL, s5, &gh, &ab, &cd, &ef );
+    fd_sha512_round2( 12UL, s6, &ef, &gh, &ab, &cd );
+    fd_sha512_round2( 14UL, s7, &cd, &ef, &gh, &ab );
+
+    s0 = fd_sha512_schedule_update( s0, s1, s4, s5, s7 );
+    fd_sha512_round2( 16UL, s0, &ab, &cd, &ef, &gh );
+    s1 = fd_sha512_schedule_update( s1, s2, s5, s6, s0 );
+    fd_sha512_round2( 18UL, s1, &gh, &ab, &cd, &ef );
+    s2 = fd_sha512_schedule_update( s2, s3, s6, s7, s1 );
+    fd_sha512_round2( 20UL, s2, &ef, &gh, &ab, &cd );
+    s3 = fd_sha512_schedule_update( s3, s4, s7, s0, s2 );
+    fd_sha512_round2( 22UL, s3, &cd, &ef, &gh, &ab );
+    s4 = fd_sha512_schedule_update( s4, s5, s0, s1, s3 );
+    fd_sha512_round2( 24UL, s4, &ab, &cd, &ef, &gh );
+    s5 = fd_sha512_schedule_update( s5, s6, s1, s2, s4 );
+    fd_sha512_round2( 26UL, s5, &gh, &ab, &cd, &ef );
+    s6 = fd_sha512_schedule_update( s6, s7, s2, s3, s5 );
+    fd_sha512_round2( 28UL, s6, &ef, &gh, &ab, &cd );
+    s7 = fd_sha512_schedule_update( s7, s0, s3, s4, s6 );
+    fd_sha512_round2( 30UL, s7, &cd, &ef, &gh, &ab );
+
+    s0 = fd_sha512_schedule_update( s0, s1, s4, s5, s7 );
+    fd_sha512_round2( 32UL, s0, &ab, &cd, &ef, &gh );
+    s1 = fd_sha512_schedule_update( s1, s2, s5, s6, s0 );
+    fd_sha512_round2( 34UL, s1, &gh, &ab, &cd, &ef );
+    s2 = fd_sha512_schedule_update( s2, s3, s6, s7, s1 );
+    fd_sha512_round2( 36UL, s2, &ef, &gh, &ab, &cd );
+    s3 = fd_sha512_schedule_update( s3, s4, s7, s0, s2 );
+    fd_sha512_round2( 38UL, s3, &cd, &ef, &gh, &ab );
+    s4 = fd_sha512_schedule_update( s4, s5, s0, s1, s3 );
+    fd_sha512_round2( 40UL, s4, &ab, &cd, &ef, &gh );
+    s5 = fd_sha512_schedule_update( s5, s6, s1, s2, s4 );
+    fd_sha512_round2( 42UL, s5, &gh, &ab, &cd, &ef );
+    s6 = fd_sha512_schedule_update( s6, s7, s2, s3, s5 );
+    fd_sha512_round2( 44UL, s6, &ef, &gh, &ab, &cd );
+    s7 = fd_sha512_schedule_update( s7, s0, s3, s4, s6 );
+    fd_sha512_round2( 46UL, s7, &cd, &ef, &gh, &ab );
+
+    s0 = fd_sha512_schedule_update( s0, s1, s4, s5, s7 );
+    fd_sha512_round2( 48UL, s0, &ab, &cd, &ef, &gh );
+    s1 = fd_sha512_schedule_update( s1, s2, s5, s6, s0 );
+    fd_sha512_round2( 50UL, s1, &gh, &ab, &cd, &ef );
+    s2 = fd_sha512_schedule_update( s2, s3, s6, s7, s1 );
+    fd_sha512_round2( 52UL, s2, &ef, &gh, &ab, &cd );
+    s3 = fd_sha512_schedule_update( s3, s4, s7, s0, s2 );
+    fd_sha512_round2( 54UL, s3, &cd, &ef, &gh, &ab );
+    s4 = fd_sha512_schedule_update( s4, s5, s0, s1, s3 );
+    fd_sha512_round2( 56UL, s4, &ab, &cd, &ef, &gh );
+    s5 = fd_sha512_schedule_update( s5, s6, s1, s2, s4 );
+    fd_sha512_round2( 58UL, s5, &gh, &ab, &cd, &ef );
+    s6 = fd_sha512_schedule_update( s6, s7, s2, s3, s5 );
+    fd_sha512_round2( 60UL, s6, &ef, &gh, &ab, &cd );
+    s7 = fd_sha512_schedule_update( s7, s0, s3, s4, s6 );
+    fd_sha512_round2( 62UL, s7, &cd, &ef, &gh, &ab );
+
+    s0 = fd_sha512_schedule_update( s0, s1, s4, s5, s7 );
+    fd_sha512_round2( 64UL, s0, &ab, &cd, &ef, &gh );
+    s1 = fd_sha512_schedule_update( s1, s2, s5, s6, s0 );
+    fd_sha512_round2( 66UL, s1, &gh, &ab, &cd, &ef );
+    s2 = fd_sha512_schedule_update( s2, s3, s6, s7, s1 );
+    fd_sha512_round2( 68UL, s2, &ef, &gh, &ab, &cd );
+    s3 = fd_sha512_schedule_update( s3, s4, s7, s0, s2 );
+    fd_sha512_round2( 70UL, s3, &cd, &ef, &gh, &ab );
+    s4 = fd_sha512_schedule_update( s4, s5, s0, s1, s3 );
+    fd_sha512_round2( 72UL, s4, &ab, &cd, &ef, &gh );
+    s5 = fd_sha512_schedule_update( s5, s6, s1, s2, s4 );
+    fd_sha512_round2( 74UL, s5, &gh, &ab, &cd, &ef );
+    s6 = fd_sha512_schedule_update( s6, s7, s2, s3, s5 );
+    fd_sha512_round2( 76UL, s6, &ef, &gh, &ab, &cd );
+    s7 = fd_sha512_schedule_update( s7, s0, s3, s4, s6 );
+    fd_sha512_round2( 78UL, s7, &cd, &ef, &gh, &ab );
+
+    ab = vaddq_u64( ab, ab_init );
+    cd = vaddq_u64( cd, cd_init );
+    ef = vaddq_u64( ef, ef_init );
+    gh = vaddq_u64( gh, gh_init );
+    vst1q_u64( state,   ab );
+    vst1q_u64( state+2, cd );
+    vst1q_u64( state+4, ef );
+    vst1q_u64( state+6, gh );
+
+    block += FD_SHA512_BLOCK_SZ;
+  } while( --block_cnt );
+}
+
+#define fd_sha512_core fd_sha512_core_arm
 
 #else
 #error "Unsupported FD_SHA512_CORE_IMPL"

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -189,6 +189,43 @@
 #define FD_HAS_ARM 0
 #endif
 
+/* FD_HAS_NEON indicates the target supports Arm Advanced SIMD / NEON
+   instructions. This is the 128-bit SIMD baseline for Firedancer Arm
+   backends. Implies FD_HAS_ARM. */
+
+#ifndef FD_HAS_NEON
+#define FD_HAS_NEON 0
+#endif
+
+/* FD_HAS_ARM_CRYPTO indicates the target supports Arm cryptographic
+   instructions broadly, including AES and SHA-family acceleration.
+   Implies FD_HAS_NEON. */
+
+#ifndef FD_HAS_ARM_CRYPTO
+#define FD_HAS_ARM_CRYPTO 0
+#endif
+
+/* FD_HAS_ARM_SHA256 indicates that the target supports the Arm
+   Advanced SIMD SHA-256 instructions. Implies FD_HAS_NEON. */
+
+#ifndef FD_HAS_ARM_SHA256
+#define FD_HAS_ARM_SHA256 0
+#endif
+
+/* FD_HAS_ARM_SHA512 indicates that the target supports the Arm
+   Advanced SIMD SHA-512 instructions. Implies FD_HAS_NEON. */
+
+#ifndef FD_HAS_ARM_SHA512
+#define FD_HAS_ARM_SHA512 0
+#endif
+
+/* FD_HAS_ARM_AES indicates that the target supports the Arm Advanced
+   SIMD AES instructions. Implies FD_HAS_ARM_CRYPTO. */
+
+#ifndef FD_HAS_ARM_AES
+#define FD_HAS_ARM_AES 0
+#endif
+
 /* FD_HAS_LZ4 indicates that the target supports LZ4 compression.
    Roughly, does "#include <lz4.h>" and the APIs therein work? */
 
@@ -226,6 +263,29 @@
 
 #ifndef FD_HAS_DEEPASAN
 #define FD_HAS_DEEPASAN 0
+#endif
+
+/* ARM capability implications. Fail fast at compile time if a machine
+   config or manual CPPFLAGS override becomes inconsistent. */
+
+#if FD_HAS_NEON && !FD_HAS_ARM
+#error "FD_HAS_NEON requires FD_HAS_ARM"
+#endif
+
+#if FD_HAS_ARM_CRYPTO && !FD_HAS_NEON
+#error "FD_HAS_ARM_CRYPTO requires FD_HAS_NEON"
+#endif
+
+#if FD_HAS_ARM_SHA256 && !FD_HAS_NEON
+#error "FD_HAS_ARM_SHA256 requires FD_HAS_NEON"
+#endif
+
+#if FD_HAS_ARM_SHA512 && !FD_HAS_NEON
+#error "FD_HAS_ARM_SHA512 requires FD_HAS_NEON"
+#endif
+
+#if FD_HAS_ARM_AES && !FD_HAS_ARM_CRYPTO
+#error "FD_HAS_ARM_AES requires FD_HAS_ARM_CRYPTO"
 #endif
 
 /* Base development environment ***************************************/

--- a/src/util/simd/Local.mk
+++ b/src/util/simd/Local.mk
@@ -1,4 +1,5 @@
 $(call add-hdrs,fd_sse.h fd_sse_vc.h fd_sse_vi.h fd_sse_vu.h fd_sse_vf.h fd_sse_vl.h fd_sse_vv.h fd_sse_vd.h fd_sse_vl.h fd_sse_vb.h)
+$(call add-hdrs,fd_neon.h)
 ifdef FD_HAS_SSE
 $(call make-unit-test,test_sse_4x32,test_sse_4x32 test_sse_common,fd_util)
 $(call make-unit-test,test_sse_2x64,test_sse_2x64 test_sse_common,fd_util)

--- a/src/util/simd/fd_neon.h
+++ b/src/util/simd/fd_neon.h
@@ -1,0 +1,62 @@
+#ifndef HEADER_fd_src_util_simd_fd_neon_h
+#define HEADER_fd_src_util_simd_fd_neon_h
+
+#include "../bits/fd_bits.h"
+
+#if FD_HAS_NEON
+
+#include <arm_neon.h>
+
+typedef uint32x4_t fd_neon_u32x4_t;
+typedef uint8x16_t fd_neon_u8x16_t;
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_neon_u32x4_bcast( uint x ) {
+  return vdupq_n_u32( x );
+}
+
+static inline fd_neon_u32x4_t
+fd_neon_u32x4( uint x0, uint x1, uint x2, uint x3 ) {
+  uint const lane[ 4 ] = { x0, x1, x2, x3 };
+  return vld1q_u32( lane );
+}
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_neon_u32x4_rotl( fd_neon_u32x4_t x, int n ) {
+  switch( n ) {
+  case  7: return vorrq_u32( vshlq_n_u32( x,  7 ), vshrq_n_u32( x, 25 ) );
+  case  8: return vorrq_u32( vshlq_n_u32( x,  8 ), vshrq_n_u32( x, 24 ) );
+  case 12: return vorrq_u32( vshlq_n_u32( x, 12 ), vshrq_n_u32( x, 20 ) );
+  case 16: return vorrq_u32( vshlq_n_u32( x, 16 ), vshrq_n_u32( x, 16 ) );
+  default: return vorrq_u32( vshlq_u32( x, vdupq_n_s32( n ) ), vshlq_u32( x, vdupq_n_s32( n-32 ) ) );
+  }
+}
+
+FD_FN_CONST static inline fd_neon_u32x4_t
+fd_neon_u32x4_rev32( fd_neon_u32x4_t x ) {
+  return vreinterpretq_u32_u8( vrev32q_u8( vreinterpretq_u8_u32( x ) ) );
+}
+
+static inline fd_neon_u32x4_t
+fd_neon_u32x4_load( void const * p ) {
+  return vld1q_u32( (uint const *)p );
+}
+
+static inline void
+fd_neon_u32x4_store( void * p, fd_neon_u32x4_t x ) {
+  vst1q_u32( (uint *)p, x );
+}
+
+static inline fd_neon_u8x16_t
+fd_neon_u8x16_load( void const * p ) {
+  return vld1q_u8( (uchar const *)p );
+}
+
+static inline void
+fd_neon_u8x16_store( void * p, fd_neon_u8x16_t x ) {
+  vst1q_u8( (uchar *)p, x );
+}
+
+#endif /* FD_HAS_NEON */
+
+#endif /* HEADER_fd_src_util_simd_fd_neon_h */

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -14,6 +14,11 @@ FD_STATIC_ASSERT( !(FD_HAS_AVX    && !FD_HAS_SSE), devenv );
 FD_STATIC_ASSERT( !(FD_HAS_AVX512 && !FD_HAS_AVX), devenv );
 FD_STATIC_ASSERT( !(FD_HAS_SHANI  && !FD_HAS_AVX), devenv );
 FD_STATIC_ASSERT( !(FD_HAS_GFNI   && !FD_HAS_AVX), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_NEON         && !FD_HAS_ARM       ), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_ARM_CRYPTO   && !FD_HAS_NEON      ), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_ARM_SHA256   && !FD_HAS_NEON      ), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_ARM_SHA512   && !FD_HAS_NEON      ), devenv );
+FD_STATIC_ASSERT( !(FD_HAS_ARM_AES      && !FD_HAS_ARM_CRYPTO), devenv );
 
 /* Test size_t <> ulong, uintptr_t <> ulong, intptr_t <> long (which
    then further imply sizeof and alignof return a ulong and that


### PR DESCRIPTION
Adds ARM NEON backends for blake3, chacha, sha256, and sha512 using ARMv8 crypto extensions where available. No x86 code paths are affected.

Follow-ups:
- blake3: add compress4 NEON batching for lthash
- chacha: shuffle/permute transpose instead of using scalar lanes

This is alpha, we shouldn't call ARM first-class support yet until further tested. Plenty of cycle-count shaving to go.