### PR TITLE
util: fix FD_ATOMIC_XCHG

### DIFF
--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -868,42 +868,9 @@ fd_type_pun_const( void const * p ) {
      o = *p
      *p = v
      return o
-   as a single atomic operation.
+   as a single atomic operation. */
 
-   Intel's __sync compiler extensions from the days of yore mysteriously
-   implemented atomic exchange via the very misleadingly named
-   __sync_lock_test_and_set.  And some implementations (and C++)
-   debatably then implemented this API according to what the misleading
-   name implied as opposed to what it actually did.  But those
-   implementations didn't bother to provide a replacement for atomic
-   exchange functionality (forcing us to emulate atomic exchange more
-   slowly via CAS there).  Sigh ... we do what we can to fix this up. */
-
-#ifndef FD_ATOMIC_XCHG_STYLE
-#if FD_HAS_X86 && !__cplusplus
-#define FD_ATOMIC_XCHG_STYLE 1
-#else
-#define FD_ATOMIC_XCHG_STYLE 0
-#endif
-#endif
-
-#if FD_ATOMIC_XCHG_STYLE==0
-#define FD_ATOMIC_XCHG(p,v) (__extension__({                                                                            \
-    __typeof__(*(p)) * _fd_atomic_xchg_p = (p);                                                                         \
-    __typeof__(*(p))   _fd_atomic_xchg_v = (v);                                                                         \
-    __typeof__(*(p))   _fd_atomic_xchg_t;                                                                               \
-    for(;;) {                                                                                                           \
-      _fd_atomic_xchg_t = FD_VOLATILE_CONST( *_fd_atomic_xchg_p );                                                      \
-      if( FD_LIKELY( __sync_bool_compare_and_swap( _fd_atomic_xchg_p, _fd_atomic_xchg_t, _fd_atomic_xchg_v ) ) ) break; \
-      FD_SPIN_PAUSE();                                                                                                  \
-    }                                                                                                                   \
-    _fd_atomic_xchg_t;                                                                                                  \
-  }))
-#elif FD_ATOMIC_XCHG_STYLE==1
-#define FD_ATOMIC_XCHG(p,v) __sync_lock_test_and_set( (p), (v) )
-#else
-#error "Unknown FD_ATOMIC_XCHG_STYLE"
-#endif
+#define FD_ATOMIC_XCHG(p,v) __atomic_exchange_n( (p), (v), __ATOMIC_SEQ_CST )
 
 #endif /* FD_HAS_ATOMIC */
 


### PR DESCRIPTION
Removes silly atomic xchg emulation via CAS.

Switch from legacy __sync_lock_test_and_set API to seq-cst
__atomic_exchange_n which is supported since GCC 4.7.

Generated code (GCC 11)

```
    FD_TEST( FD_ATOMIC_XCHG( ctr, 4 )==3 && FD_VOLATILE_CONST( ctr[0] )==4 );
    12f9:       b8 04 00 00 00          mov    $0x4,%eax
    12fe:       87 85 a0 ef ff ff       xchg   %eax,-0x1060(%rbp)
    1304:       83 f8 03                cmp    $0x3,%eax
    1307:       0f 85 73 0e 00 00       jne    2180 <main+0x2180>
    130d:       8b 85 a0 ef ff ff       mov    -0x1060(%rbp),%eax
    1313:       83 f8 04                cmp    $0x4,%eax
    1316:       0f 85 64 0e 00 00       jne    2180 <main+0x2180>
```

Generated code (Clang)

```
    FD_TEST( FD_ATOMIC_XCHG( ctr, 4 )==3 && FD_VOLATILE_CONST( ctr[0] )==4 );
     f7d:       b8 04 00 00 00          mov    $0x4,%eax
     f82:       87 85 d0 f7 ff ff       xchg   %eax,-0x830(%rbp)
     f88:       83 f8 03                cmp    $0x3,%eax
     f8b:       0f 85 c7 1d 00 00       jne    2d58 <main+0x2d58>
     f91:       8b 85 d0 f7 ff ff       mov    -0x830(%rbp),%eax
     f97:       83 f8 04                cmp    $0x4,%eax
     f9a:       0f 85 b8 1d 00 00       jne    2d58 <main+0x2d58>
```