### PR TITLE
progcache: use txncache-like fork_id

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -268,16 +268,14 @@ replay_block_start( fd_replay_tile_t *  ctx,
     FD_LOG_CRIT(( "invariant violation: bank is NULL for bank index %lu", bank_idx ));
   }
   bank->f.slot = slot;
-  bank->txncache_fork_id = fd_txncache_attach_child( ctx->txncache, parent_bank->txncache_fork_id );
+  bank->txncache_fork_id  = fd_txncache_attach_child ( ctx->txncache,  parent_bank->txncache_fork_id  );
+  bank->progcache_fork_id = fd_progcache_attach_child( ctx->progcache, parent_bank->progcache_fork_id );
 
   /* Create a new funk txn for the block. */
 
   fd_funk_txn_xid_t xid        = fd_bank_xid( bank        );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
-  fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
-  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
-  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( ctx->progcache,   &pc_parent_xid, &pc_xid );
+  fd_accdb_attach_child( ctx->accdb_admin, &parent_xid, &xid );
 
   /* Update required runtime state and handle potential boundary. */
 
@@ -569,14 +567,12 @@ prepare_leader_bank( fd_replay_tile_t *  ctx,
   ctx->leader_bank->preparation_begin_nanos = before;
 
   ctx->leader_bank->f.slot = slot;
-  ctx->leader_bank->txncache_fork_id = fd_txncache_attach_child( ctx->txncache, parent_bank->txncache_fork_id );
+  ctx->leader_bank->txncache_fork_id  = fd_txncache_attach_child ( ctx->txncache,  parent_bank->txncache_fork_id  );
+  ctx->leader_bank->progcache_fork_id = fd_progcache_attach_child( ctx->progcache, parent_bank->progcache_fork_id );
   /* prepare the funk transaction for the leader bank */
   fd_funk_txn_xid_t xid        = fd_bank_xid( ctx->leader_bank );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank      );
-  fd_accdb_attach_child    ( ctx->accdb_admin, &parent_xid, &xid );
-  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
-  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( ctx->progcache,   &pc_parent_xid, &pc_xid );
+  fd_accdb_attach_child( ctx->accdb_admin, &parent_xid, &xid );
 
   int is_epoch_boundary = 0;
   fd_runtime_block_execute_prepare( ctx->banks, ctx->leader_bank, ctx->accdb, ctx->runtime_stack, ctx->capture_ctx, &is_epoch_boundary );
@@ -725,15 +721,6 @@ init_funk( fd_replay_tile_t * ctx,
                   "but there are incomplete database transactions leftover.\n"
                   "This is a bug in startup components."  ));
   }
-
-  /* The program cache tracks the account database's fork graph at all
-     times.  Perform initial synchronization: pivot from funk 'root' (a
-     sentinel XID) to 'last publish' (the bootstrap root slot). */
-  if( FD_UNLIKELY( !ctx->progcache->shmem ) ) {
-    FD_LOG_CRIT(( "failed to initialize account database: replay tile is not joined to program cache" ));
-  }
-  fd_funk_txn_xid_t root = fd_accdb_root_get( ctx->accdb_admin );
-  fd_progcache_clear( ctx->progcache, &(fd_progcache_xid_t){ .slot=root.ul[0], .bank_seq=root.ul[1] } );
 }
 
 static void
@@ -763,6 +750,9 @@ init_after_snapshot( fd_replay_tile_t *  ctx,
 
   fd_funk_txn_xid_t xid = fd_bank_xid( bank );
   init_funk( ctx, bank->f.slot );
+
+  fd_progcache_reset( ctx->progcache );
+  bank->progcache_fork_id = fd_progcache_fork_id_initial();
 
   bank->f.warmup_cooldown_rate_epoch = fd_slot_to_epoch( &bank->f.epoch_schedule, bank->f.features.reduce_stake_warmup_cooldown, NULL );
   fd_stake_delegations_t * root_delegations = fd_banks_stake_delegations_root_query( ctx->banks );
@@ -1065,8 +1055,8 @@ boot_genesis( fd_replay_tile_t *        ctx,
   fd_runtime_read_genesis( ctx->banks, bank, ctx->accdb, &xid, NULL, &meta->genesis_hash, &meta->lthash, ctx->genesis, genesis_blob, ctx->runtime_stack );
   fd_accdb_advance_root( ctx->accdb_admin, &target_xid );
 
-  static const fd_txncache_fork_id_t txncache_root = { .val = USHORT_MAX };
-  bank->txncache_fork_id = fd_txncache_attach_child( ctx->txncache, txncache_root );
+  bank->txncache_fork_id  = fd_txncache_attach_child ( ctx->txncache, (fd_txncache_fork_id_t){USHORT_MAX} );
+  bank->progcache_fork_id = fd_progcache_attach_child( ctx->progcache, fd_progcache_fork_id_initial()     );
 
   fd_hash_t const * block_hash = fd_blockhashes_peek_last_hash( &bank->f.block_hash_queue );
   fd_txncache_finalize_fork( ctx->txncache, bank->txncache_fork_id, 0UL, block_hash->uc );
@@ -1745,8 +1735,6 @@ accdb_advance_root( fd_replay_tile_t * ctx,
   fd_histf_sample( ctx->metrics.root_slot_dur,    (ulong)root_accounts_dt );
   fd_histf_sample( ctx->metrics.root_account_dur, (ulong)root_accounts_dt / (ulong)fd_long_max( rooted_accounts, 1L ) );
 
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( xid );
-  fd_progcache_advance_root( ctx->progcache, &pc_xid );
   long t2 = fd_tickcount();
   FD_MCNT_INC( REPLAY, PROGCACHE_TIME_SECONDS, (ulong)( t2-t1 ) );
 }
@@ -1787,7 +1775,8 @@ advance_published_root( fd_replay_tile_t * ctx ) {
   fd_xid_t const xid = fd_bank_xid( bank );
   accdb_advance_root( ctx, &xid );
 
-  fd_txncache_advance_root( ctx->txncache, bank->txncache_fork_id );
+  fd_txncache_advance_root ( ctx->txncache,  bank->txncache_fork_id  );
+  fd_progcache_advance_root( ctx->progcache, bank->progcache_fork_id );
   fd_sched_advance_root( ctx->sched, advanceable_root_idx );
   fd_banks_advance_root( ctx->banks, advanceable_root_idx );
 
@@ -1848,11 +1837,10 @@ after_credit( fd_replay_tile_t *  ctx,
   fd_banks_prune_cancel_info_t cancel_info[ 1 ];
   int pruned = fd_banks_prune_one_dead_bank( ctx->banks, cancel_info );
   if( FD_UNLIKELY( pruned==2 ) ) {
-    fd_txncache_cancel_fork( ctx->txncache, cancel_info->txncache_fork_id );
+    fd_txncache_cancel_fork ( ctx->txncache,  cancel_info->txncache_fork_id  );
+    fd_progcache_cancel_fork( ctx->progcache, cancel_info->progcache_fork_id );
     fd_funk_txn_xid_t xid = { .ul = { cancel_info->slot, cancel_info->bank_seq } };
     fd_accdb_cancel    ( ctx->accdb_admin, &xid );
-    fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
-    fd_progcache_cancel( ctx->progcache,   &pc_xid );
     *charge_busy = 1;
     *opt_poll_in = 0;
     return;

--- a/src/flamenco/progcache/fd_progcache.c
+++ b/src/flamenco/progcache/fd_progcache.c
@@ -10,10 +10,10 @@
 
 #define MAP_NAME              fd_prog_recm
 #define MAP_ELE_T             fd_progcache_rec_t
-#define MAP_KEY_T             fd_progcache_xid_key_pair_t
+#define MAP_KEY_T             fd_progcache_rec_key_t
 #define MAP_KEY               pair
-#define MAP_KEY_EQ(k0,k1)     fd_progcache_xid_key_pair_eq((k0),(k1))
-#define MAP_KEY_HASH(k0,seed) fd_progcache_rec_key_hash( (k0->key), (seed) )
+#define MAP_KEY_EQ(k0,k1)     fd_progcache_rec_key_eq((k0),(k1))
+#define MAP_KEY_HASH(k0,seed) fd_progcache_rec_key_hash( &(k0)->prog, (seed) )
 #define MAP_IDX_T             uint
 #define MAP_NEXT              map_next
 #define MAP_MAGIC             (0xf173da2ce77ecdb8UL)
@@ -29,10 +29,7 @@
 
 #define  MAP_NAME              fd_prog_txnm
 #define  MAP_ELE_T             fd_progcache_txn_t
-#define  MAP_KEY_T             fd_progcache_xid_t
 #define  MAP_KEY               xid
-#define  MAP_KEY_EQ(k0,k1)     fd_progcache_txn_xid_eq((k0),(k1))
-#define  MAP_KEY_HASH(k0,seed) fd_ulong_hash( (k0)->bank_seq ^ (seed) )
 #define  MAP_IDX_T             uint
 #define  MAP_NEXT              map_next
 #define  MAP_MAGIC             (0xf173da2ce77ecdb9UL)
@@ -149,7 +146,8 @@ fd_progcache_shmem_new( void * shmem,
   pc->txn.max = txn_max;
   pc->txn.child_head_idx = UINT_MAX;
   pc->txn.child_tail_idx = UINT_MAX;
-  *pc->txn.last_publish = (fd_progcache_xid_t){0};
+  pc->txn.root = fd_progcache_fork_id_initial();
+  pc->txn.seq  = fd_progcache_fork_id_initial();
   for( ulong i=0UL; i<txn_max; i++ ) {
     fd_rwlock_new( &txn_ele[ i ].lock );
   }

--- a/src/flamenco/progcache/fd_progcache.h
+++ b/src/flamenco/progcache/fd_progcache.h
@@ -8,7 +8,6 @@
 
 #include "fd_progcache_rec.h" /* includes fd_progcache_base.h */
 #include "fd_progcache_xid.h"
-#include "fd_progcache_clock.h"
 #include "../fd_rwlock.h"
 #include "../runtime/fd_runtime_const.h"
 
@@ -42,7 +41,8 @@ struct fd_progcache_shmem {
     ulong       ele_gaddr;
     uint        child_head_idx;
     uint        child_tail_idx;
-    fd_progcache_xid_t last_publish[1];  /* root XID (initially zero) */
+    fd_progcache_fork_id_t root;
+    fd_progcache_fork_id_t seq;
   } txn;
 
   struct {
@@ -75,10 +75,10 @@ FD_STATIC_ASSERT( FD_PROGCACHE_SPAD_MAX<=UINT_MAX, "layout" );
 
 #define MAP_NAME              fd_prog_recm
 #define MAP_ELE_T             fd_progcache_rec_t
-#define MAP_KEY_T             fd_progcache_xid_key_pair_t
+#define MAP_KEY_T             fd_progcache_rec_key_t
 #define MAP_KEY               pair
-#define MAP_KEY_EQ(k0,k1)     fd_progcache_xid_key_pair_eq((k0),(k1))
-#define MAP_KEY_HASH(k0,seed) fd_progcache_rec_key_hash( (k0->key), (seed) )
+#define MAP_KEY_EQ(k0,k1)     fd_progcache_rec_key_eq((k0),(k1))
+#define MAP_KEY_HASH(k0,seed) fd_progcache_rec_key_hash( &(k0)->prog, (seed) )
 #define MAP_IDX_T             uint
 #define MAP_NEXT              map_next
 #define MAP_MAGIC             (0xf173da2ce77ecdb8UL)
@@ -89,10 +89,10 @@ FD_STATIC_ASSERT( FD_PROGCACHE_SPAD_MAX<=UINT_MAX, "layout" );
    synchronized) */
 
 struct __attribute__((aligned(64))) fd_progcache_txn {
-  fd_progcache_xid_t xid;
-  uint        map_next;
-  fd_rwlock_t lock;
-  ushort      tag : 2;
+  fd_progcache_fork_id_t xid;
+  uint                   map_next;
+  fd_rwlock_t            lock;
+  ushort                 tag : 2;
 
   uint   parent_idx;
   uint   child_head_idx;
@@ -113,10 +113,7 @@ struct __attribute__((aligned(64))) fd_progcache_txn {
 
 #define  MAP_NAME              fd_prog_txnm
 #define  MAP_ELE_T             fd_progcache_txn_t
-#define  MAP_KEY_T             fd_progcache_xid_t
 #define  MAP_KEY               xid
-#define  MAP_KEY_EQ(k0,k1)     fd_progcache_txn_xid_eq((k0),(k1))
-#define  MAP_KEY_HASH(k0,seed) fd_ulong_hash( (k0)->bank_seq ^ (seed) )
 #define  MAP_IDX_T             uint
 #define  MAP_NEXT              map_next
 #define  MAP_MAGIC             (0xf173da2ce77ecdb9UL)
@@ -199,6 +196,11 @@ fd_progcache_rec_unlink( fd_progcache_rec_t * rec0,
 
   *fd_ptr_if( rec->prev_idx!=UINT_MAX, &rec0[ rec->prev_idx ].next_idx, &txn->rec_head_idx ) =
     rec->next_idx;
+}
+
+FD_FN_CONST static inline fd_progcache_fork_id_t
+fd_progcache_fork_id_initial( void ) {
+  return 0UL;
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -4,6 +4,7 @@
 #include "fd_progcache_clock.h"
 #include "fd_progcache_rec.h"
 #include "fd_progcache_reclaim.h"
+#include "fd_progcache_xid.h"
 #include "../../util/racesan/fd_racesan_target.h"
 
 /* FIXME get rid of this thread-local */
@@ -32,19 +33,12 @@ fd_progcache_est_rec_max( ulong wksp_footprint,
    structures are not concurrently modified.  This includes txn_pool and
    txn_map. */
 
-void
-fd_progcache_attach_child( fd_progcache_join_t *      cache,
-                           fd_progcache_xid_t const * xid_parent,
-                           fd_progcache_xid_t const * xid_new ) {
-  if( FD_UNLIKELY( !cache || !xid_parent || !xid_new ) ) {
-    FD_LOG_CRIT(( "invalid arguments" ));
-  }
+fd_progcache_fork_id_t
+fd_progcache_attach_child( fd_progcache_join_t *  cache,
+                           fd_progcache_fork_id_t parent_fork_id ) {
+  if( FD_UNLIKELY( !cache ) ) FD_LOG_CRIT(( "invalid arguments" ));
 
   fd_rwlock_write( &cache->shmem->txn.rwlock );
-
-  if( FD_UNLIKELY( fd_prog_txnm_idx_query_const( cache->txn.map, xid_new, ULONG_MAX, cache->txn.pool )!=ULONG_MAX ) ) {
-    FD_LOG_ERR(( "fd_progcache_attach_child failed: xid %lu:%lu already in use", xid_new->slot, xid_new->bank_seq ));
-  }
   if( FD_UNLIKELY( fd_prog_txnp_free( cache->txn.pool )==0UL ) ) {
     FD_LOG_ERR(( "fd_progcache_attach_child failed: transaction object pool out of memory" ));
   }
@@ -54,7 +48,8 @@ fd_progcache_attach_child( fd_progcache_join_t *      cache,
   uint * _child_head_idx;
   uint * _child_tail_idx;
 
-  if( FD_UNLIKELY( fd_progcache_txn_xid_eq( xid_parent, cache->shmem->txn.last_publish ) ) ) {
+  fd_progcache_fork_id_t root = __atomic_load_n( &cache->shmem->txn.root, memory_order_relaxed );
+  if( FD_UNLIKELY( parent_fork_id == root ) ) {
 
     parent_idx = FD_PROGCACHE_TXN_IDX_NULL;
 
@@ -63,10 +58,9 @@ fd_progcache_attach_child( fd_progcache_join_t *      cache,
 
   } else {
 
-    parent_idx = fd_prog_txnm_idx_query( cache->txn.map, xid_parent, ULONG_MAX, cache->txn.pool );
+    parent_idx = fd_prog_txnm_idx_query( cache->txn.map, &parent_fork_id, ULONG_MAX, cache->txn.pool );
     if( FD_UNLIKELY( parent_idx==ULONG_MAX ) ) {
-      FD_LOG_CRIT(( "fd_progcache_attach_child failed: user provided invalid parent XID %lu:%lu",
-                    xid_parent->slot, xid_parent->bank_seq ));
+      FD_LOG_CRIT(( "fd_progcache_attach_child failed: user provided invalid parent fork_id %lu", parent_fork_id ));
     }
     if( FD_UNLIKELY( parent_idx >= txn_max ) )
       FD_LOG_CRIT(( "progcache: corruption detected (attach_child parent_idx=%lu txn_max=%lu)", parent_idx, txn_max ));
@@ -79,7 +73,7 @@ fd_progcache_attach_child( fd_progcache_join_t *      cache,
   uint txn_idx = (uint)fd_prog_txnp_idx_acquire( cache->txn.pool );
   if( FD_UNLIKELY( txn_idx==UINT_MAX ) ) FD_LOG_ERR(( "fd_progcache_attach_child failed: transaction object pool out of memory" ));
   fd_progcache_txn_t * txn = &cache->txn.pool[ txn_idx ];
-  txn->xid = *xid_new;
+  txn->xid = __atomic_add_fetch( &cache->shmem->txn.seq, 1UL, memory_order_relaxed );
 
   uint sibling_prev_idx = *_child_tail_idx;
 
@@ -105,6 +99,7 @@ fd_progcache_attach_child( fd_progcache_join_t *      cache,
   fd_prog_txnm_idx_insert( cache->txn.map, txn_idx, cache->txn.pool );
 
   fd_rwlock_unwrite( &cache->shmem->txn.rwlock );
+  return txn->xid;
 }
 
 static void
@@ -117,8 +112,8 @@ fd_progcache_cancel_one( fd_progcache_join_t * cache,
 
   if( FD_UNLIKELY( txn->child_head_idx!=UINT_MAX ||
                    txn->child_tail_idx!=UINT_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_cancel failed: txn at %p with xid %lu:%lu has children (data corruption?)",
-                  (void *)txn, txn->xid.slot, txn->xid.bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_cancel failed: txn at %p with fork_id %lu has children (data corruption?)",
+                  (void *)txn, txn->xid ));
   }
 
   /* Remove records */
@@ -163,8 +158,7 @@ fd_progcache_cancel_one( fd_progcache_join_t * cache,
   /* Remove transaction from index */
 
   if( FD_UNLIKELY( !fd_prog_txnm_ele_remove( cache->txn.map, &txn->xid, NULL, cache->txn.pool ) ) ) {
-    FD_LOG_CRIT(( "fd_progcache_cancel failed: fd_prog_txnm_ele_remove(%lu:%lu) failed",
-                  txn->xid.slot, txn->xid.bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_cancel failed: fd_prog_txnm_ele_remove(%lu) failed", txn->xid ));
   }
 
   /* Free transaction object */
@@ -231,12 +225,12 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
 
   /* Phase 1: Mark transaction as "last published" */
 
-  fd_progcache_xid_t const xid = txn->xid;
+  fd_progcache_fork_id_t const fork_id = txn->xid;
   if( FD_UNLIKELY( txn->parent_idx!=UINT_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_publish failed: txn with xid %lu:%lu is not a child of the last published txn", xid.slot, xid.bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_publish failed: txn with fork_id %lu is not a child of the last published txn", fork_id ));
   }
   fd_racesan_hook( "prog_publish_one:pre_xid_store" );
-  fd_progcache_xid_st_atomic( cache->shmem->txn.last_publish, &xid );
+  __atomic_store_n( &cache->shmem->txn.root, fork_id, memory_order_release );
 
   /* Phase 2: Drain inserters from transaction */
 
@@ -271,7 +265,7 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
   /* Phase 5: Remove transaction from index */
 
   if( FD_UNLIKELY( fd_prog_txnm_idx_remove( cache->txn.map, &txn->xid, ULONG_MAX, cache->txn.pool )==ULONG_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_publish failed: fd_prog_txnm_idx_remove(%lu:%lu) failed", xid.slot, xid.bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_publish failed: fd_prog_txnm_idx_remove(%lu) failed", txn->xid ));
   }
 
   /* Phase 6: Free transaction object */
@@ -286,26 +280,24 @@ fd_progcache_txn_publish_one( fd_progcache_join_t * cache,
 }
 
 void
-fd_progcache_advance_root( fd_progcache_join_t *      cache,
-                           fd_progcache_xid_t const * xid ) {
-  if( FD_UNLIKELY( !cache || !xid ) ) {
-    FD_LOG_CRIT(( "invalid arguments" ));
-  }
+fd_progcache_advance_root( fd_progcache_join_t *  cache,
+                           fd_progcache_fork_id_t fork_id ) {
+  if( FD_UNLIKELY( !cache ) ) FD_LOG_CRIT(( "invalid arguments" ));
 
   /* Detach records from txns without acquiring record locks */
 
   fd_rwlock_write( &cache->shmem->txn.rwlock );
 
   ulong txn_max = fd_prog_txnp_max( cache->txn.pool );
-  uint txn_idx = (uint)fd_prog_txnm_idx_query( cache->txn.map, xid, UINT_MAX, cache->txn.pool );
+  uint txn_idx = (uint)fd_prog_txnm_idx_query( cache->txn.map, &fork_id, UINT_MAX, cache->txn.pool );
   if( FD_UNLIKELY( txn_idx==UINT_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_advance_root failed: invalid XID %lu:%lu", xid->slot, xid->bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_advance_root failed: invalid fork_id %lu", fork_id ));
   }
   if( FD_UNLIKELY( (ulong)txn_idx >= txn_max ) )
     FD_LOG_CRIT(( "progcache: corruption detected (advance_root txn_idx=%u txn_max=%lu)", txn_idx, txn_max ));
   fd_progcache_txn_t * txn = &cache->txn.pool[ txn_idx ];
   if( FD_UNLIKELY( txn->parent_idx!=UINT_MAX ) ) {
-    FD_LOG_CRIT(( "fd_progcache_advance_root: parent of txn %lu:%lu is not root", xid->slot, xid->bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_advance_root: parent of txn %lu is not root", fork_id ));
   }
 
   fd_progcache_cancel_prev_list( cache, txn );
@@ -324,16 +316,16 @@ fd_progcache_advance_root( fd_progcache_join_t *      cache,
 }
 
 void
-fd_progcache_cancel( fd_progcache_join_t *      cache,
-                     fd_progcache_xid_t const * xid ) {
-  if( FD_UNLIKELY( !cache || !xid ) ) {
+fd_progcache_cancel_fork( fd_progcache_join_t *  cache,
+                          fd_progcache_fork_id_t fork_id ) {
+  if( FD_UNLIKELY( !cache ) ) {
     FD_LOG_CRIT(( "invalid arguments" ));
   }
 
   fd_rwlock_write( &cache->shmem->txn.rwlock );
-  fd_progcache_txn_t * txn = fd_prog_txnm_ele_query( cache->txn.map, xid, NULL, cache->txn.pool );
+  fd_progcache_txn_t * txn = fd_prog_txnm_ele_query( cache->txn.map, &fork_id, NULL, cache->txn.pool );
   if( FD_UNLIKELY( !txn ) ) {
-    FD_LOG_CRIT(( "fd_progcache_cancel failed: invalid XID %lu:%lu", xid->slot, xid->bank_seq ));
+    FD_LOG_CRIT(( "fd_progcache_cancel failed: invalid fork_id %lu", fork_id ));
   }
   fd_progcache_cancel_tree( cache, txn );
   fd_rwlock_unwrite( &cache->shmem->txn.rwlock );
@@ -397,13 +389,13 @@ clear_txn_list( fd_progcache_join_t * join,
 }
 
 void
-fd_progcache_clear( fd_progcache_join_t *      cache,
-                    fd_progcache_xid_t const * root_xid ) {
+fd_progcache_reset( fd_progcache_join_t * cache ) {
   clear_txn_list( cache, cache->shmem->txn.child_head_idx );
   cache->shmem->txn.child_head_idx = UINT_MAX;
   cache->shmem->txn.child_tail_idx = UINT_MAX;
   reset_rec_map( cache );
-  *cache->shmem->txn.last_publish = *root_xid;
+  cache->shmem->txn.root = fd_progcache_fork_id_initial();
+  cache->shmem->txn.seq  = fd_progcache_fork_id_initial();
 }
 
 static int

--- a/src/flamenco/progcache/fd_progcache_admin.h
+++ b/src/flamenco/progcache/fd_progcache_admin.h
@@ -34,10 +34,9 @@ fd_progcache_est_rec_max( ulong wksp_footprint,
    It is assumed that less than txn_max non-root transactions exist when
    this is called. */
 
-void
-fd_progcache_attach_child( fd_progcache_join_t *      cache,
-                           fd_progcache_xid_t const * xid_parent,
-                           fd_progcache_xid_t const * xid_new );
+fd_progcache_fork_id_t
+fd_progcache_attach_child( fd_progcache_join_t *  cache,
+                           fd_progcache_fork_id_t parent_fork_id );
 
 /* fd_progcache_advance_root advances the fork graph root to the
    given xid.  (In funk terminology, this is the "last publish")
@@ -45,22 +44,20 @@ fd_progcache_attach_child( fd_progcache_join_t *      cache,
    Assumes that the xid's parent is the fork graph root. */
 
 void
-fd_progcache_advance_root( fd_progcache_join_t *      cache,
-                           fd_progcache_xid_t const * xid );
+fd_progcache_advance_root( fd_progcache_join_t *  cache,
+                           fd_progcache_fork_id_t fork_id );
 
-/* fd_progcache_cancel removes a fork graph node by XID and its
-   children (recursively). */
+/* fd_progcache_cancel_fork removes a fork graph node. */
 
 void
-fd_progcache_cancel( fd_progcache_join_t *      cache,
-                     fd_progcache_xid_t const * xid );
+fd_progcache_cancel_fork( fd_progcache_join_t *  cache,
+                          fd_progcache_fork_id_t fork_id );
 
-/* fd_progcache_clear removes all cache entries and destroys the txn
+/* fd_progcache_reset removes all cache entries and destroys the txn
    graph.  Does not support concurrent usage. */
 
 void
-fd_progcache_clear( fd_progcache_join_t *      cache,
-                    fd_progcache_xid_t const * root_xid );
+fd_progcache_reset( fd_progcache_join_t * cache );
 
 /* fd_progcache_verify checks the structural integrity of the program
    cache.  Returns 0 on success, -1 on failure.  Logs warnings

--- a/src/flamenco/progcache/fd_progcache_base.h
+++ b/src/flamenco/progcache/fd_progcache_base.h
@@ -1,6 +1,10 @@
 #ifndef HEADER_fd_src_flamenco_progcache_fd_progcache_base_h
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_base_h
 
+#include "../../util/fd_util_base.h"
+
+typedef ulong fd_progcache_fork_id_t;
+
 typedef struct fd_progcache fd_progcache_t;
 
 typedef struct fd_progcache_shmem fd_progcache_shmem_t;

--- a/src/flamenco/progcache/fd_progcache_lineage.h
+++ b/src/flamenco/progcache/fd_progcache_lineage.h
@@ -5,14 +5,13 @@
    records by fork graph lineage. */
 
 #include "fd_progcache_base.h"
-#include "fd_progcache_xid.h"
 
 struct fd_progcache_lineage {
 
   /* Current fork cache */
-  fd_progcache_xid_t fork[ FD_PROGCACHE_DEPTH_MAX ];
-  ulong              fork_depth;
-  ulong              root_slot;
+  fd_progcache_fork_id_t fork[ FD_PROGCACHE_DEPTH_MAX ];
+  ulong                  fork_depth;
+  fd_progcache_fork_id_t root;
 
   uint txn_idx[ FD_PROGCACHE_DEPTH_MAX ];
 
@@ -33,11 +32,11 @@ FD_PROTOTYPES_BEGIN
 
 FD_FN_UNUSED static int
 fd_progcache_lineage_has_xid( fd_progcache_lineage_t const * lineage,
-                              fd_progcache_xid_t const *     rec_xid ) {
+                              fd_progcache_fork_id_t         rec_xid ) {
   ulong const fork_depth = lineage->fork_depth;
-  if( rec_xid->slot <= lineage->root_slot ) return 1;
+  if( rec_xid <= lineage->root ) return 1;
   for( ulong i=0UL; i<fork_depth; i++ ) {
-    if( fd_progcache_txn_xid_eq( &lineage->fork[i], rec_xid ) ) return 1;
+    if( lineage->fork[i]==rec_xid ) return 1;
   }
   return 0;
 }

--- a/src/flamenco/progcache/fd_progcache_rec.h
+++ b/src/flamenco/progcache/fd_progcache_rec.h
@@ -2,12 +2,24 @@
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_rec_h
 
 #include "fd_progcache_base.h"
-#include "fd_progcache_xid.h"
 #include "../../ballet/sbpf/fd_sbpf_loader.h"
 #include "../fd_flamenco_base.h"
 #include "../fd_rwlock.h"
 
 #include <stdatomic.h>
+
+struct fd_progcache_rec_key {
+  fd_progcache_fork_id_t xid;
+  fd_pubkey_t            prog;
+};
+
+typedef struct fd_progcache_rec_key fd_progcache_rec_key_t;
+
+static inline int
+fd_progcache_rec_key_eq( fd_progcache_rec_key_t const * k0,
+                         fd_progcache_rec_key_t const * k1 ) {
+  return ( (k0->xid == k1->xid) & fd_pubkey_eq( &k0->prog, &k1->prog ) );
+}
 
 /* fd_progcache_rec_t is the fixed size header of a program cache entry
    object.  Entries are either non-executable (e.g. programs that failed
@@ -17,7 +29,7 @@
    segment, control flow metadata, ...). */
 
 struct __attribute__((aligned(64))) fd_progcache_rec {
-  fd_progcache_xid_key_pair_t pair;  /* Transaction id and record key pair */
+  fd_progcache_rec_key_t pair;  /* Transaction id and record key pair */
 
   ulong feature_slot;
   ulong deploy_slot;

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -62,22 +62,22 @@ fd_progcache_leave( fd_progcache_t *        cache,
    present in that list. */
 
 static void
-fd_progcache_load_fork_slow( fd_progcache_t *           cache,
-                             fd_progcache_xid_t const * xid ) {
+fd_progcache_load_fork_slow( fd_progcache_t *       cache,
+                             fd_progcache_fork_id_t fork_id ) {
   fd_progcache_lineage_t *    lineage = cache->lineage;
   fd_progcache_join_t const * ljoin   = cache->join;
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
   lineage->fork_depth  = 0UL;
   lineage->tip_txn_idx = ULONG_MAX;
+  lineage->root = __atomic_load_n( &ljoin->shmem->txn.root, memory_order_acquire );
 
   ulong txn_max = fd_prog_txnp_max( ljoin->txn.pool );
-  fd_progcache_xid_t next_xid = *xid;
   ulong i;
   for( i=0UL;; i++ ) {
     if( FD_UNLIKELY( i>=FD_PROGCACHE_DEPTH_MAX ) ) {
       FD_LOG_CRIT(( "fd_progcache_load_fork: fork depth exceeded max of %lu", (ulong)FD_PROGCACHE_DEPTH_MAX ));
     }
-    uint next_idx = (uint)fd_prog_txnm_idx_query_const( ljoin->txn.map, &next_xid, UINT_MAX, ljoin->txn.pool );
+    uint next_idx = (uint)fd_prog_txnm_idx_query_const( ljoin->txn.map, &fork_id, UINT_MAX, ljoin->txn.pool );
     if( FD_UNLIKELY( next_idx==UINT_MAX ) ) break;
     if( FD_UNLIKELY( (ulong)next_idx >= txn_max ) )
       FD_LOG_CRIT(( "progcache: corruption detected (load_fork txn_idx=%u txn_max=%lu)", next_idx, txn_max ));
@@ -85,7 +85,7 @@ fd_progcache_load_fork_slow( fd_progcache_t *           cache,
 
     uint parent_idx = candidate->parent_idx;
     FD_TEST( parent_idx!=next_idx );
-    lineage->fork   [ i ] = next_xid;
+    lineage->fork   [ i ] = fork_id;
     lineage->txn_idx[ i ] = next_idx;
     if( FD_LIKELY( !i ) ) lineage->tip_txn_idx = next_idx;
     if( parent_idx==UINT_MAX ) {
@@ -94,25 +94,23 @@ fd_progcache_load_fork_slow( fd_progcache_t *           cache,
     }
     if( FD_UNLIKELY( (ulong)parent_idx >= txn_max ) )
       FD_LOG_CRIT(( "progcache: corruption detected (load_fork parent_idx=%u txn_max=%lu)", parent_idx, txn_max ));
-    next_xid = ljoin->txn.pool[ parent_idx ].xid;
+    fork_id = ljoin->txn.pool[ parent_idx ].xid;
   }
 
   lineage->fork_depth = i;
 
   fd_rwlock_unread( &ljoin->shmem->txn.rwlock );
 
-  fd_progcache_xid_t root_xid[1];
-  fd_progcache_xid_ld_atomic( root_xid, ljoin->shmem->txn.last_publish );
-  lineage->root_slot = root_xid->slot;
+  lineage->root = __atomic_load_n( &ljoin->shmem->txn.root, memory_order_acquire );
 }
 
 static inline void
-fd_progcache_load_fork( fd_progcache_t *           cache,
-                        fd_progcache_xid_t const * xid ) {
+fd_progcache_load_fork( fd_progcache_t *       cache,
+                        fd_progcache_fork_id_t fork_id ) {
   /* Skip if already on the correct fork */
   fd_progcache_lineage_t * lineage = cache->lineage;
-  if( FD_LIKELY( (!!lineage->fork_depth) & (!!fd_progcache_txn_xid_eq( &lineage->fork[ 0 ], xid ) ) ) ) return;
-  fd_progcache_load_fork_slow( cache, xid ); /* switch fork */
+  if( FD_LIKELY( (!!lineage->fork_depth) & (lineage->fork[ 0 ]==fork_id ) ) ) return;
+  fd_progcache_load_fork_slow( cache, fork_id ); /* switch fork */
 }
 
 /* fd_progcache_query searches for a program cache entry on the current
@@ -152,15 +150,14 @@ fd_progcache_search_chain( fd_progcache_t const * cache,
     if( FD_UNLIKELY( (ulong)ele_idx >= rec_max ) ) return FD_MAP_ERR_AGAIN;
     fd_progcache_rec_t * rec = &rec_tbl[ ele_idx ];
 
-    if( FD_UNLIKELY( ( !fd_pubkey_eq( rec->pair.key, key ) ) |
+    if( FD_UNLIKELY( ( !fd_pubkey_eq( &rec->pair.prog, key ) ) |
                      ( rec->feature_slot != feature_slot   ) |
                      ( rec->deploy_slot  != deploy_slot    ) ) ) {
       continue;
     }
 
-    fd_progcache_xid_t rec_xid[1];
-    fd_progcache_xid_ld_atomic( rec_xid, rec->pair.xid );
-    if( FD_UNLIKELY( !fd_progcache_lineage_has_xid( lineage, rec_xid ) ) ) continue;
+    fd_progcache_fork_id_t rec_fork_id = __atomic_load_n( &rec->pair.xid, memory_order_relaxed );
+    if( FD_UNLIKELY( !fd_progcache_lineage_has_xid( lineage, rec_fork_id ) ) ) continue;
 
     if( FD_UNLIKELY( rec->map_next==ele_idx ) ) return FD_MAP_ERR_AGAIN;
     if( FD_UNLIKELY( rec->map_next!=UINT_MAX && rec->map_next>=rec_max ) ) return FD_MAP_ERR_AGAIN;
@@ -207,13 +204,13 @@ fd_progcache_query( fd_progcache_t *    cache,
 }
 
 fd_progcache_rec_t * /* read locked */
-fd_progcache_peek( fd_progcache_t *           cache,
-                   fd_progcache_xid_t const * xid,
-                   fd_pubkey_t const *        prog_addr,
-                   ulong                      feature_slot,
-                   ulong                      deploy_slot ) {
+fd_progcache_peek( fd_progcache_t *       cache,
+                   fd_progcache_fork_id_t fork_id,
+                   fd_pubkey_t const *    prog_addr,
+                   ulong                  feature_slot,
+                   ulong                  deploy_slot ) {
   if( FD_UNLIKELY( !cache || !cache->join->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
-  fd_progcache_load_fork( cache, xid );
+  fd_progcache_load_fork( cache, fork_id );
   fd_progcache_rec_t * rec = fd_progcache_query( cache, prog_addr, feature_slot, deploy_slot );
   if( FD_UNLIKELY( !rec ) ) return NULL;
   return rec;
@@ -255,9 +252,9 @@ fd_progcache_push( fd_progcache_join_t * cache,
 
   rec->prev_idx = UINT_MAX;
   rec->next_idx = UINT_MAX;
-  memcpy( rec->pair.key, prog_addr, 32UL );
+  memcpy( &rec->pair.prog, prog_addr, 32UL );
   if( FD_UNLIKELY( !txn ) ) FD_LOG_CRIT(( "NULL txn" ));
-  *rec->pair.xid = txn->xid;
+  __atomic_store_n( &rec->pair.xid, txn->xid, memory_order_relaxed );
 
   /* Lock rec_map chain, entering critical section */
 
@@ -342,7 +339,6 @@ typedef struct insert_params insert_params_t;
 
 static insert_params_t *
 insert_params( insert_params_t *          p,
-               fd_progcache_xid_t const * load_xid,
                fd_pubkey_t const *        prog_addr,
                fd_prog_load_env_t const * env,
                fd_accdb_ro_t *            prog_ro,
@@ -355,9 +351,8 @@ insert_params( insert_params_t *          p,
 
   /* Pre-flight checks, determine required buffer size */
 
-  fd_features_t const * features  = env->features;
-  ulong         const   load_slot = load_xid->slot;
-  fd_prog_versions_t versions = fd_prog_versions( features, load_slot );
+  fd_features_t const * features = env->features;
+  fd_prog_versions_t versions = fd_prog_versions( features, env->feature_slot );
   fd_sbpf_elf_info_t elf_info;
   fd_sbpf_loader_config_t config = {
     .sbpf_min_version = versions.min_sbpf_version,
@@ -545,13 +540,13 @@ fd_progcache_insert( fd_progcache_t *        cache,
 
 fd_progcache_rec_t * /* read locked */
 fd_progcache_pull( fd_progcache_t *           cache,
-                   fd_progcache_xid_t const * xid,
+                   fd_progcache_fork_id_t     fork_id,
                    fd_pubkey_t const *        prog_addr,
                    fd_prog_load_env_t const * env,
                    fd_accdb_ro_t *            prog_ro ) {
   if( FD_UNLIKELY( !cache || !cache->join->shmem ) ) FD_LOG_CRIT(( "NULL progcache" ));
   long dt = -fd_tickcount();
-  fd_progcache_load_fork( cache, xid );
+  fd_progcache_load_fork( cache, fork_id );
   cache->metrics->lookup_cnt++;
 
   fd_prog_info_t info[1];
@@ -560,12 +555,12 @@ fd_progcache_pull( fd_progcache_t *           cache,
   insert_params_t insert[1];
   fd_progcache_rec_t * found_rec = NULL;
   for( int attempt=0;; attempt++ ) {
-    found_rec = fd_progcache_peek( cache, xid, prog_addr, env->feature_slot, info->deploy_slot );
+    found_rec = fd_progcache_peek( cache, fork_id, prog_addr, env->feature_slot, info->deploy_slot );
     if( FD_LIKELY( found_rec ) ) {
       cache->metrics->hit_cnt++;
       break;
     }
-    if( attempt==0 ) insert_params( insert, xid, prog_addr, env, prog_ro, info );
+    if( attempt==0 ) insert_params( insert, prog_addr, env, prog_ro, info );
     found_rec = fd_progcache_insert( cache, insert );
     if( FD_LIKELY( found_rec ) ) {
       cache->metrics->miss_cnt++;

--- a/src/flamenco/progcache/fd_progcache_user.h
+++ b/src/flamenco/progcache/fd_progcache_user.h
@@ -122,11 +122,11 @@ fd_progcache_leave( fd_progcache_t *        cache,
    fd_progcache_rec_close. */
 
 fd_progcache_rec_t * /* read locked */
-fd_progcache_peek( fd_progcache_t *           cache,
-                   fd_progcache_xid_t const * xid,
-                   fd_pubkey_t const *        prog_addr,
-                   ulong                      feature_slot,
-                   ulong                      deploy_slot );
+fd_progcache_peek( fd_progcache_t *       cache,
+                   fd_progcache_fork_id_t fork_id,
+                   fd_pubkey_t const *    prog_addr,
+                   ulong                  feature_slot,
+                   ulong                  deploy_slot );
 
 /* fd_progcache_pull loads a program from cache, filling the cache if
    necessary.  The load operation can have a number of outcomes:
@@ -145,7 +145,7 @@ fd_progcache_peek( fd_progcache_t *           cache,
 
 fd_progcache_rec_t * /* read locked */
 fd_progcache_pull( fd_progcache_t *           cache,
-                   fd_progcache_xid_t const * xid,
+                   fd_progcache_fork_id_t     fork_id,
                    fd_pubkey_t const *        prog_addr,
                    fd_prog_load_env_t const * env,
                    fd_accdb_ro_t *            progdata_ro );

--- a/src/flamenco/progcache/fd_progcache_xid.h
+++ b/src/flamenco/progcache/fd_progcache_xid.h
@@ -2,38 +2,8 @@
 #define HEADER_fd_src_flamenco_progcache_fd_progcache_xid_h
 
 #include "../fd_flamenco_base.h"
-#include "../../funk/fd_funk_base.h"
-
-#if FD_HAS_X86
-#include <immintrin.h>
-#endif
 
 #define FD_PROGCACHE_TXN_IDX_NULL ((ulong)UINT_MAX)
-
-union __attribute__((aligned(16))) fd_progcache_xid {
-  struct {
-    ulong slot;
-    ulong bank_seq;
-  };
-  __extension__ unsigned __int128 uf[1];
-#if FD_HAS_X86
-  __m128i xmm[1];
-#endif
-};
-
-typedef union fd_progcache_xid fd_progcache_xid_t;
-
-FD_STATIC_ASSERT( sizeof(fd_progcache_xid_t)==16, layout );
-
-/* A fd_progcache_xid_key_pair_t identifies a progcache record.  It is just
-   xid and key packed into the same structure. */
-
-struct fd_progcache_xid_key_pair {
-  fd_progcache_xid_t xid[1];
-  fd_pubkey_t        key[1];
-};
-
-typedef struct fd_progcache_xid_key_pair fd_progcache_xid_key_pair_t;
 
 /* fd_progcache_rec_key_hash provides a family of hashes that hash the key
    pointed to by k to a uniform quasi-random 64-bit integer.  seed
@@ -106,84 +76,5 @@ fd_progcache_rec_key_hash( fd_pubkey_t const * k,
 }
 
 #endif /* FD_HAS_INT128 */
-
-#if FD_HAS_THREADS
-
-static inline fd_progcache_xid_t *
-fd_progcache_xid_ld_atomic( fd_progcache_xid_t *       xd,
-                            fd_progcache_xid_t const * xs ) {
-# if FD_HAS_X86
-  xd->xmm[0] = FD_VOLATILE_CONST( xs->xmm[0] );
-# elif FD_HAS_ARM
-  fd_arm_ldp16( &xs->slot, xd->slot, xd->bank_seq );
-# elif FD_HAS_ATOMIC
-  xd->uf[0] = __atomic_load_n( &xs->uf[0], __ATOMIC_RELAXED );
-# else
-# error "Unsupported architecture"
-# endif
-  return xd;
-}
-
-static inline fd_progcache_xid_t *
-fd_progcache_xid_st_atomic( fd_progcache_xid_t *       xd,
-                            fd_progcache_xid_t const * xs ) {
-# if FD_HAS_X86
-  FD_VOLATILE( xd->xmm[0] ) = xs->xmm[0];
-# elif FD_HAS_ARM
-  fd_arm_stp16( &xd->slot, xs->slot, xs->bank_seq );
-# elif FD_HAS_ATOMIC
-  __atomic_store_n( &xd->uf[0], xs->uf[0], __ATOMIC_RELEASE );
-# else
-# error "Unsupported architecture"
-# endif
-  return xd;
-}
-
-#else
-
-static inline fd_progcache_xid_t *
-fd_progcache_xid_ld_atomic( fd_progcache_xid_t *       xd,
-                            fd_progcache_xid_t const * xs ) {
-  *xd = *xs;
-  return xd;
-}
-
-static inline fd_progcache_xid_t *
-fd_progcache_xid_st_atomic( fd_progcache_xid_t *       xd,
-                            fd_progcache_xid_t const * xs ) {
-  *xd = *xs;
-  return xd;
-}
-
-#endif
-
-FD_FN_PURE static inline int
-fd_progcache_txn_xid_eq( fd_progcache_xid_t const * xa,
-                         fd_progcache_xid_t const * xb ) {
-  return (xa->slot == xb->slot) & (xa->bank_seq == xb->bank_seq);
-}
-
-/* fd_progcache_xid_key_pair_eq returns 1 if (xid,key) pair pointed to by pa
-   and pb are equal and 0 otherwise.  Assumes pa and pb are in the
-   caller's address space and valid. */
-
-FD_FN_UNUSED FD_FN_PURE static int /* Work around -Winline */
-fd_progcache_xid_key_pair_eq( fd_progcache_xid_key_pair_t const * pa,
-                              fd_progcache_xid_key_pair_t const * pb ) {
-  return fd_progcache_txn_xid_eq( pa->xid, pb->xid ) & fd_pubkey_eq( pa->key, pb->key );
-}
-
-/* fd_progcache_xid_from_funk converts a funk transaction id into a
-   progcache transaction id.  fd_progcache_xid_t and fd_funk_txn_xid_t
-   are byte-compatible 16-byte identifiers; this helper exists to make
-   the type boundary explicit at progcache API call sites. */
-
-FD_FN_PURE static inline fd_progcache_xid_t
-fd_progcache_xid_from_funk( fd_funk_txn_xid_t const * src ) {
-  fd_progcache_xid_t out;
-  out.slot     = src->ul[0];
-  out.bank_seq = src->ul[1];
-  return out;
-}
 
 #endif /* HEADER_fd_src_flamenco_progcache_fd_progcache_xid_h */

--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -2,6 +2,7 @@
    progcache. */
 
 #include "test_progcache_common.c"
+#include "fd_progcache_clock.h"
 #include "fd_progcache_reclaim.h"
 #include "../runtime/fd_system_ids.h"
 #include "../runtime/program/fd_bpf_loader_program.h"
@@ -59,10 +60,10 @@ FD_IMPORT_BINARY( invalid_program_data,      "src/ballet/sbpf/fixtures/malformed
 /* query_rec_exact fetches a funk record at a precise xid:key pair. */
 
 static fd_progcache_rec_t const *
-query_rec_exact( test_env_t *               env,
-                 fd_progcache_xid_t const * xid,
-                 fd_pubkey_t const *        key ) {
-  fd_progcache_xid_key_pair_t pair = { .xid = {*xid}, .key = {*key} };
+query_rec_exact( test_env_t *           env,
+                 fd_progcache_fork_id_t fork_id,
+                 fd_pubkey_t const *    key ) {
+  fd_progcache_rec_key_t pair = { .xid = fork_id, .prog = *key };
   fd_prog_recm_query_t query[1];
   int query_err = fd_prog_recm_query_try( env->progcache->join->rec.map, &pair, NULL, query, 0 );
   if( query_err==FD_MAP_ERR_KEY ) return NULL;
@@ -76,12 +77,12 @@ query_rec_exact( test_env_t *               env,
    by cancel/publish/destroy. */
 
 static fd_progcache_rec_t *
-test_peek( fd_progcache_t *           cache,
-           fd_progcache_xid_t const * xid,
-           fd_pubkey_t const *        prog_addr,
-           ulong                      feature_slot,
-           ulong                      deploy_slot ) {
-  fd_progcache_rec_t * rec = fd_progcache_peek( cache, xid, prog_addr, feature_slot, deploy_slot );
+test_peek( fd_progcache_t *       cache,
+           fd_progcache_fork_id_t fork_id,
+           fd_pubkey_t const *    prog_addr,
+           ulong                  feature_slot,
+           ulong                  deploy_slot ) {
+  fd_progcache_rec_t * rec = fd_progcache_peek( cache, fork_id, prog_addr, feature_slot, deploy_slot );
   if( rec ) fd_progcache_rec_close( cache, rec );
   return rec;
 }
@@ -89,10 +90,10 @@ test_peek( fd_progcache_t *           cache,
 static fd_progcache_rec_t *
 test_pull( fd_progcache_t *           cache,
            fd_accdb_ro_t *            prog_ro,
-           fd_progcache_xid_t const * xid,
+           fd_progcache_fork_id_t     fork_id,
            fd_pubkey_t const *        prog_addr,
            fd_prog_load_env_t const * env ) {
-  fd_progcache_rec_t * rec = fd_progcache_pull( cache, xid, prog_addr, env, prog_ro );
+  fd_progcache_rec_t * rec = fd_progcache_pull( cache, fork_id, prog_addr, env, prog_ro );
   if( rec ) fd_progcache_rec_close( cache, rec );
   return rec;
 }
@@ -102,8 +103,7 @@ test_pull( fd_progcache_t *           cache,
 static void
 test_invalid_owner( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
@@ -114,9 +114,9 @@ test_invalid_owner( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  FD_TEST( !test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env ) );
+  FD_TEST( !test_pull( env->progcache, acc.ro, fork_a, &key, &load_env ) );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
@@ -125,28 +125,27 @@ test_invalid_owner( fd_wksp_t * wksp ) {
 static void
 test_invalid_program( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
   test_account_init( &acc, &key, &fd_solana_bpf_loader_program_id,
                      1, invalid_program_data, invalid_program_data_sz );
 
-  FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, fork_a, &key, 0UL, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a ) );
+  FD_TEST( env->progcache->lineage->fork[ 0 ]==fork_a );
 
   fd_prog_load_env_t load_env = {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( !rec->data_gaddr );
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL, 0UL )==rec );
+  FD_TEST( test_peek( env->progcache, fork_a, &key, 0UL, 0UL )==rec );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
@@ -155,39 +154,37 @@ test_invalid_program( fd_wksp_t * wksp ) {
 static void
 test_valid_program( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
   test_account_init( &acc, &key, &fd_solana_bpf_loader_program_id,
                      1, valid_program_data, valid_program_data_sz );
 
-  FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, fork_a, &key, 0UL, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
+  FD_TEST( env->progcache->lineage->fork[ 0 ]==fork_a );
 
   fd_prog_load_env_t load_env = {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( rec->data_gaddr );
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL, 0UL )==rec );
+  FD_TEST( test_peek( env->progcache, fork_a, &key, 0UL, 0UL )==rec );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
 
-  fd_progcache_xid_t fork_b = { .slot = 64UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_a, &fork_b );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 0UL, 0UL )==rec );
+  fd_progcache_fork_id_t fork_b = fd_progcache_attach_child( env->progcache->join, fork_a );
+  FD_TEST( test_peek( env->progcache, fork_b, &key, 0UL, 0UL )==rec );
   FD_TEST( env->progcache->lineage->fork_depth==2UL );
 
   load_env.feature_slot = 0UL;
-  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, &fork_b, &key, &load_env );
+  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, fork_b, &key, &load_env );
   FD_TEST( rec==rec2 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 0UL, 0UL )==rec );
+  FD_TEST( test_peek( env->progcache, fork_b, &key, 0UL, 0UL )==rec );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a ); /* should also cancel fork_b */
+  fd_progcache_cancel_fork( env->progcache->join, fork_a ); /* should also cancel fork_b */
   test_env_destroy( env );
 }
 
@@ -197,46 +194,43 @@ test_valid_program( fd_wksp_t * wksp ) {
 static void
 test_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
   test_account_init( &acc, &key, &fd_solana_bpf_loader_program_id,
                      1, valid_program_data, valid_program_data_sz );
 
-  FD_TEST( !test_peek( env->progcache, &fork_a, &key, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, fork_a, &key, 0UL, 0UL ) );
   FD_TEST( env->progcache->lineage->fork_depth==1UL );
-  FD_TEST( fd_progcache_txn_xid_eq( &env->progcache->lineage->fork[ 0 ], &fork_a   ) );
+  FD_TEST( env->progcache->lineage->fork[ 0 ]==fork_a );
 
   fd_prog_load_env_t load_env = {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( rec->data_gaddr );
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL, 0UL )==rec );
+  FD_TEST( test_peek( env->progcache, fork_a, &key, 0UL, 0UL )==rec );
 
-  fd_progcache_xid_t fork_b = { .slot = 64UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_a, &fork_b );
+  fd_progcache_fork_id_t fork_b = fd_progcache_attach_child( env->progcache->join, fork_a );
   load_env.feature_slot = 64UL;
-  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, &fork_b, &key, &load_env );
+  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, fork_b, &key, &load_env );
   FD_TEST( rec2 );
   FD_TEST( rec!=rec2 );
   FD_TEST( rec2->data_gaddr );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 64UL, 0UL )==rec2 );
+  FD_TEST( test_peek( env->progcache, fork_b, &key, 64UL, 0UL )==rec2 );
 
-  fd_progcache_cancel( env->progcache->join, &fork_b );
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_b );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
 static void
 test_epoch_boundary2( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t prog_key       = test_key( 1UL );
   fd_pubkey_t prog0_data_key = test_key( 2UL );
@@ -260,20 +254,19 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, prog0_data.ro, &fork_a, &prog_key, &load_env );
+  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, prog0_data.ro, fork_a, &prog_key, &load_env );
   FD_TEST( rec1 );
-  FD_TEST( test_peek( env->progcache, &fork_a, &prog_key, 0UL, 1UL )==rec1 );
+  FD_TEST( test_peek( env->progcache, fork_a, &prog_key, 0UL, 1UL )==rec1 );
 
   /* Invoke old program at epoch 1 */
   fd_prog_load_env_t load_env2 = {
     .features     = env->features,
     .feature_slot = 64UL
   };
-  fd_progcache_xid_t fork_b = { .slot = 64UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_a, &fork_b );
-  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, prog0_data.ro, &fork_b, &prog_key, &load_env2 );
+  fd_progcache_fork_id_t fork_b = fd_progcache_attach_child( env->progcache->join, fork_a );
+  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, prog0_data.ro, fork_b, &prog_key, &load_env2 );
   FD_TEST( rec1!=rec2 );
-  FD_TEST( query_rec_exact( env, &fork_b, &prog_key )==rec2 );
+  FD_TEST( query_rec_exact( env, fork_b, &prog_key )==rec2 );
 
   /* Invoke new (redeployed) program at epoch1 */
   test_account_init_v3( &prog1, prog1_buf, sizeof(prog1_buf), &prog_key, &prog1_data_key );
@@ -284,15 +277,14 @@ test_epoch_boundary2( fd_wksp_t * wksp ) {
       bigger_valid_program_data, bigger_valid_program_data_sz,
       64UL
   );
-  fd_progcache_xid_t fork_c = { .slot = 65UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_b, &fork_c );
-  fd_progcache_rec_t const * rec3 = test_pull( env->progcache, prog1_data.ro, &fork_c, &prog_key, &load_env2 );
+  fd_progcache_fork_id_t fork_c = fd_progcache_attach_child( env->progcache->join, fork_b );
+  fd_progcache_rec_t const * rec3 = test_pull( env->progcache, prog1_data.ro, fork_c, &prog_key, &load_env2 );
   FD_TEST( rec3!=rec1 && rec3!=rec2 );
-  FD_TEST( query_rec_exact( env, &fork_c, &prog_key )==rec3 );
+  FD_TEST( query_rec_exact( env, fork_c, &prog_key )==rec3 );
 
-  fd_progcache_cancel( env->progcache->join, &fork_c );
-  fd_progcache_cancel( env->progcache->join, &fork_b );
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_c );
+  fd_progcache_cancel_fork( env->progcache->join, fork_b );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
@@ -303,10 +295,8 @@ test_publish_trivial( fd_wksp_t * wksp ) {
 
   test_env_t * env = test_env_create( wksp );
 
-  fd_progcache_xid_t root = {0};
-  fd_progcache_xid_t fork_368528500 = { .slot = 368528500UL, .bank_seq = 368528500UL };
-  fd_progcache_attach_child( env->progcache->join, &root, &fork_368528500 );
-  fd_progcache_advance_root( env->progcache->join,        &fork_368528500 );
+  fd_progcache_fork_id_t fork_368528500 = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
+  fd_progcache_advance_root( env->progcache->join, fork_368528500 );
 
   /* FIXME more operations here ... */
 }
@@ -317,39 +307,35 @@ test_publish_trivial( fd_wksp_t * wksp ) {
 static void
 test_root_nonroot_prio( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_1 = { .slot = 1UL, .bank_seq = 1UL }; /* account deployed here */
-  fd_progcache_xid_t fork_2 = { .slot = 2UL, .bank_seq = 1UL }; /* root */
-  fd_progcache_xid_t fork_3 = { .slot = 3UL, .bank_seq = 2UL }; /* account redeployed here */
-  fd_progcache_xid_t fork_4 = { .slot = 4UL, .bank_seq = 2UL }; /* tip */
 
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_1 );
+  fd_progcache_fork_id_t fork_1 = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() ); /* account deployed here */
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
   test_account_init( &acc, &key, &fd_solana_bpf_loader_program_id,
                      1, valid_program_data, valid_program_data_sz );
-  fd_progcache_advance_root( env->progcache->join, &fork_1 );
+  fd_progcache_advance_root( env->progcache->join, fork_1 );
 
-  fd_progcache_attach_child( env->progcache->join, &fork_1, &fork_2 );
-  fd_progcache_attach_child( env->progcache->join, &fork_2, &fork_3 );
-  fd_progcache_attach_child( env->progcache->join, &fork_3, &fork_4 );
+  fd_progcache_fork_id_t fork_2 = fd_progcache_attach_child( env->progcache->join, fork_1 ); /* root */
+  fd_progcache_fork_id_t fork_3 = fd_progcache_attach_child( env->progcache->join, fork_2 ); /* account redeployed here */
+  fd_progcache_fork_id_t fork_4 = fd_progcache_attach_child( env->progcache->join, fork_3 ); /* tip */
 
   fd_prog_load_env_t load_env1 = {
     .features     = env->features,
     .feature_slot = 1UL
   };
-  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_2, &key, &load_env1 );
+  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, fork_2, &key, &load_env1 );
   FD_TEST( rec1 );
-  fd_progcache_advance_root( env->progcache->join, &fork_2 );
+  fd_progcache_advance_root( env->progcache->join, fork_2 );
 
   fd_prog_load_env_t load_env4 = {
     .features     = env->features,
     .feature_slot = 4UL
   };
-  fd_progcache_rec_t const * rec4 = test_pull( env->progcache, acc.ro, &fork_4, &key, &load_env4 );
+  fd_progcache_rec_t const * rec4 = test_pull( env->progcache, acc.ro, fork_4, &key, &load_env4 );
   FD_TEST( rec4 );
 
-  fd_progcache_cancel( env->progcache->join, &fork_4 );
-  fd_progcache_cancel( env->progcache->join, &fork_3 );
+  fd_progcache_cancel_fork( env->progcache->join, fork_4 );
+  fd_progcache_cancel_fork( env->progcache->join, fork_3 );
   test_env_destroy( env );
 }
 
@@ -361,14 +347,10 @@ static void
 test_reattach_after_cancel_all( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
 
-  fd_progcache_xid_t parent  = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_xid_t child_a = { .slot = 2UL, .bank_seq = 2UL };
-  fd_progcache_xid_t child_b = { .slot = 3UL, .bank_seq = 2UL };
-  fd_progcache_xid_t child_c = { .slot = 4UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0},    &parent  );
-  fd_progcache_attach_child( env->progcache->join, &parent, &child_a );
-  fd_progcache_attach_child( env->progcache->join, &parent, &child_b );
-  fd_progcache_attach_child( env->progcache->join, &parent, &child_c );
+  fd_progcache_fork_id_t parent  = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
+  fd_progcache_fork_id_t child_a = fd_progcache_attach_child( env->progcache->join, parent );
+  fd_progcache_fork_id_t child_b = fd_progcache_attach_child( env->progcache->join, parent );
+  fd_progcache_fork_id_t child_c = fd_progcache_attach_child( env->progcache->join, parent );
 
   uint parent_idx = (uint)fd_prog_txnm_idx_query_const( env->progcache->join->txn.map, &parent, UINT_MAX, env->progcache->join->txn.pool );
   FD_TEST( parent_idx!=UINT_MAX );
@@ -376,30 +358,29 @@ test_reattach_after_cancel_all( fd_wksp_t * wksp ) {
   FD_TEST( parent_txn->child_head_idx!=UINT_MAX );
   FD_TEST( parent_txn->child_tail_idx!=UINT_MAX );
 
-  fd_progcache_cancel( env->progcache->join, &child_c );
-  fd_progcache_cancel( env->progcache->join, &child_b );
-  fd_progcache_cancel( env->progcache->join, &child_a );
+  fd_progcache_cancel_fork( env->progcache->join, child_c );
+  fd_progcache_cancel_fork( env->progcache->join, child_b );
+  fd_progcache_cancel_fork( env->progcache->join, child_a );
 
   FD_TEST( parent_txn->child_head_idx==UINT_MAX );
   FD_TEST( parent_txn->child_tail_idx==UINT_MAX );
 
-  fd_progcache_xid_t child_d = { .slot = 5UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &parent, &child_d );
+  fd_progcache_fork_id_t child_d = fd_progcache_attach_child( env->progcache->join, parent );
 
   FD_TEST( parent_txn->child_head_idx!=UINT_MAX );
   FD_TEST( parent_txn->child_tail_idx!=UINT_MAX );
   FD_TEST( parent_txn->child_head_idx==parent_txn->child_tail_idx );
 
   fd_progcache_txn_t * child_d_txn = &env->progcache->join->txn.pool[ parent_txn->child_head_idx ];
-  FD_TEST( fd_progcache_txn_xid_eq( &child_d_txn->xid, &child_d ) );
+  FD_TEST( child_d_txn->xid==child_d );
   FD_TEST( child_d_txn->parent_idx==parent_idx );
   FD_TEST( child_d_txn->sibling_prev_idx==UINT_MAX );
   FD_TEST( child_d_txn->sibling_next_idx==UINT_MAX );
 
   FD_TEST( !fd_progcache_verify( env->progcache->join ) );
 
-  fd_progcache_cancel( env->progcache->join, &child_d );
-  fd_progcache_cancel( env->progcache->join, &parent );
+  fd_progcache_cancel_fork( env->progcache->join, child_d );
+  fd_progcache_cancel_fork( env->progcache->join, parent );
   test_env_destroy( env );
 }
 
@@ -421,8 +402,7 @@ test_reclaim_empty( fd_wksp_t * wksp ) {
 static void
 test_reclaim_no_readers( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
@@ -433,7 +413,7 @@ test_reclaim_no_readers( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t * rec = test_pull( env->progcache, acc.ro, &xid, &key, &load_env );
+  fd_progcache_rec_t * rec = test_pull( env->progcache, acc.ro, xid, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( rec->exists );
 
@@ -444,7 +424,7 @@ test_reclaim_no_readers( fd_wksp_t * wksp ) {
   FD_TEST( fd_prog_reclaim_work( env->progcache->join )==1UL );
   FD_TEST( env->progcache->join->rec.reclaim_head==UINT_MAX );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -454,8 +434,7 @@ test_reclaim_no_readers( fd_wksp_t * wksp ) {
 static void
 test_reclaim_active_reader( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
@@ -466,9 +445,9 @@ test_reclaim_active_reader( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  FD_TEST( test_pull( env->progcache, acc.ro, &xid, &key, &load_env ) );
+  FD_TEST( test_pull( env->progcache, acc.ro, xid, &key, &load_env ) );
 
-  fd_progcache_rec_t * rec = fd_progcache_peek( env->progcache, &xid, &key, 0UL, 0UL );
+  fd_progcache_rec_t * rec = fd_progcache_peek( env->progcache, xid, &key, 0UL, 0UL );
   FD_TEST( rec );
 
   fd_prog_delete_rec( env->progcache->join, rec );
@@ -479,7 +458,7 @@ test_reclaim_active_reader( fd_wksp_t * wksp ) {
   FD_TEST( fd_prog_reclaim_work( env->progcache->join )==1UL );
   FD_TEST( env->progcache->join->rec.reclaim_head==UINT_MAX );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -489,8 +468,7 @@ test_reclaim_active_reader( fd_wksp_t * wksp ) {
 static void
 test_reclaim_txn_unlink( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
@@ -501,7 +479,7 @@ test_reclaim_txn_unlink( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 1UL
   };
-  fd_progcache_rec_t * rec = test_pull( env->progcache, acc.ro, &xid, &key, &load_env );
+  fd_progcache_rec_t * rec = test_pull( env->progcache, acc.ro, xid, &key, &load_env );
   FD_TEST( rec );
 
   uint txn_idx = atomic_load_explicit( &rec->txn_idx, memory_order_relaxed );
@@ -514,7 +492,7 @@ test_reclaim_txn_unlink( fd_wksp_t * wksp ) {
   FD_TEST( txn->rec_head_idx==UINT_MAX );
   FD_TEST( txn->rec_tail_idx==UINT_MAX );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -578,9 +556,7 @@ test_shmem_delete_fast( fd_wksp_t * wksp ) {
   fd_progcache_t cache[1];
   FD_TEST( fd_progcache_join( cache, progcache_mem, scratch, sizeof(scratch) ) );
 
-  fd_progcache_xid_t root = {0};
-  fd_progcache_xid_t fork = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( cache->join, &root, &fork );
+  fd_progcache_fork_id_t fork = fd_progcache_attach_child( cache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key = test_key( 1UL );
   test_account_t acc;
@@ -591,7 +567,7 @@ test_shmem_delete_fast( fd_wksp_t * wksp ) {
     .features     = features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t * rec = test_pull( cache, acc.ro, &fork, &key, &load_env );
+  fd_progcache_rec_t * rec = test_pull( cache, acc.ro, fork, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( rec->data_gaddr );
 
@@ -608,8 +584,7 @@ test_shmem_delete_fast( fd_wksp_t * wksp ) {
 static void
 test_reclaim_mixed( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key1 = test_key( 1UL );
   fd_pubkey_t key2 = test_key( 2UL );
@@ -623,12 +598,12 @@ test_reclaim_mixed( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  FD_TEST( test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env ) );
-  FD_TEST( test_pull( env->progcache, acc2.ro, &xid, &key2, &load_env ) );
+  FD_TEST( test_pull( env->progcache, acc1.ro, xid, &key1, &load_env ) );
+  FD_TEST( test_pull( env->progcache, acc2.ro, xid, &key2, &load_env ) );
 
-  fd_progcache_rec_t * rec1 = fd_progcache_peek( env->progcache, &xid, &key1, 0UL, 0UL );
+  fd_progcache_rec_t * rec1 = fd_progcache_peek( env->progcache, xid, &key1, 0UL, 0UL );
   FD_TEST( rec1 );
-  fd_progcache_rec_t * rec2 = fd_progcache_peek( env->progcache, &xid, &key2, 0UL, 0UL );
+  fd_progcache_rec_t * rec2 = fd_progcache_peek( env->progcache, xid, &key2, 0UL, 0UL );
   FD_TEST( rec2 );
   fd_progcache_rec_close( env->progcache, rec2 );
 
@@ -643,15 +618,14 @@ test_reclaim_mixed( fd_wksp_t * wksp ) {
   FD_TEST( fd_prog_reclaim_work( env->progcache->join )==1UL );
   FD_TEST( env->progcache->join->rec.reclaim_head==UINT_MAX );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
 static void
 test_loader_v3_ok( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 42UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   uchar buf[ 655536 ];
   fd_pubkey_t key = test_key( 1UL );
@@ -668,22 +642,21 @@ test_loader_v3_ok( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( rec );
   FD_TEST( rec->data_gaddr );
 
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL, 42UL )==rec  );
-  FD_TEST( test_peek( env->progcache, &fork_a, &key, 0UL,  0UL )==NULL );
+  FD_TEST( test_peek( env->progcache, fork_a, &key, 0UL, 42UL )==rec  );
+  FD_TEST( test_peek( env->progcache, fork_a, &key, 0UL,  0UL )==NULL );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
 static void
 test_loader_v3_wrong_account_type( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   ulong data_sz = PROGRAMDATA_METADATA_SIZE + valid_program_data_sz;
   uchar data[ PROGRAMDATA_METADATA_SIZE + 1048576 ];
@@ -706,18 +679,17 @@ test_loader_v3_wrong_account_type( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( !rec );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
 static void
 test_loader_v3_undersize( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   uchar data[ PROGRAMDATA_METADATA_SIZE-1 ];
   memset( data, 0, sizeof(data) );
@@ -731,18 +703,17 @@ test_loader_v3_undersize( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( !rec );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
 static void
 test_loader_v3_corrupt( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   uchar data[ PROGRAMDATA_METADATA_SIZE+1 ];
   memset( data, 0x41, sizeof(data) );
@@ -756,18 +727,17 @@ test_loader_v3_corrupt( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( !rec );
 
-  fd_progcache_cancel( env->progcache->join, &fork_a );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a );
   test_env_destroy( env );
 }
 
 static void
 test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t fork_a = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a );
+  fd_progcache_fork_id_t fork_a = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   uchar buf[ 655536 ];
   fd_pubkey_t key = test_key( 1UL );
@@ -784,27 +754,26 @@ test_loader_v3_epoch_boundary( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, &fork_a, &key, &load_env );
+  fd_progcache_rec_t const * rec1 = test_pull( env->progcache, acc.ro, fork_a, &key, &load_env );
   FD_TEST( rec1 );
   FD_TEST( rec1->data_gaddr );
 
-  fd_progcache_xid_t fork_b = { .slot = 100UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_a, &fork_b );
+  fd_progcache_fork_id_t fork_b = fd_progcache_attach_child( env->progcache->join, fork_a );
 
   load_env.feature_slot = 100UL;
-  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, &fork_b, &key, &load_env );
+  fd_progcache_rec_t const * rec2 = test_pull( env->progcache, acc.ro, fork_b, &key, &load_env );
   FD_TEST( rec2 );
   FD_TEST( rec2->data_gaddr );
   FD_TEST( rec1!=rec2 );
 
-  FD_TEST( test_peek( env->progcache, &fork_a, &key,   0UL, 42UL )==rec1 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 100UL, 42UL )==rec2 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key,   0UL, 42UL )==rec1 );
+  FD_TEST( test_peek( env->progcache, fork_a, &key,   0UL, 42UL )==rec1 );
+  FD_TEST( test_peek( env->progcache, fork_b, &key, 100UL, 42UL )==rec2 );
+  FD_TEST( test_peek( env->progcache, fork_b, &key,   0UL, 42UL )==rec1 );
 
-  fd_progcache_advance_root( env->progcache->join, &fork_a );
-  FD_TEST( test_peek( env->progcache, &fork_a, &key,   0UL, 42UL )==rec1 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key, 100UL, 42UL )==rec2 );
-  FD_TEST( test_peek( env->progcache, &fork_b, &key,   0UL, 42UL )==rec1 );
+  fd_progcache_advance_root( env->progcache->join, fork_a );
+  FD_TEST( test_peek( env->progcache, fork_a, &key,   0UL, 42UL )==rec1 );
+  FD_TEST( test_peek( env->progcache, fork_b, &key, 100UL, 42UL )==rec2 );
+  FD_TEST( test_peek( env->progcache, fork_b, &key,   0UL, 42UL )==rec1 );
 
   test_env_destroy( env );
 }
@@ -844,37 +813,33 @@ test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
     .feature_slot = e0
   };
 
-  fd_progcache_xid_t root = {0};
+  fd_progcache_fork_id_t root = fd_progcache_fork_id_initial();
 
   /* Fork A upgraded the program at e0-1 and invokes after skipped slot e0. */
-  fd_progcache_xid_t fork_a_deploy = { .slot = e0-1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_a_deploy );
+  fd_progcache_fork_id_t fork_a_deploy = fd_progcache_attach_child( env->progcache->join, root );
+  fd_progcache_fork_id_t fork_a_invoke = fd_progcache_attach_child( env->progcache->join, fork_a_deploy );
 
-  fd_progcache_xid_t fork_a_invoke = { .slot = e0+1UL, .bank_seq = 2UL };
-  fd_progcache_attach_child( env->progcache->join, &fork_a_deploy, &fork_a_invoke );
-
-  fd_progcache_rec_t const * rec_a = test_pull( env->progcache, fork_a_acc.ro, &fork_a_invoke, &key, &load_env );
+  fd_progcache_rec_t const * rec_a = test_pull( env->progcache, fork_a_acc.ro, fork_a_invoke, &key, &load_env );
   FD_TEST( rec_a );
   FD_TEST( rec_a->data_gaddr );
-  FD_TEST( query_rec_exact( env, &fork_a_deploy, &key )==NULL  );
-  FD_TEST( query_rec_exact( env, &fork_a_invoke, &key )==rec_a );
-  FD_TEST( query_rec_exact( env, &root, &key )==NULL );
+  FD_TEST( query_rec_exact( env, fork_a_deploy, &key )==NULL  );
+  FD_TEST( query_rec_exact( env, fork_a_invoke, &key )==rec_a );
+  FD_TEST( query_rec_exact( env, root, &key )==NULL );
 
   /* Fork B crosses the same skipped epoch boundary without fork A's
      upgrade.  It supplies different loader-v3 ProgramData bytes, so it
      must not receive fork A's loaded program record. */
-  fd_progcache_xid_t fork_b_invoke = { .slot = e0+1UL, .bank_seq = 3UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &fork_b_invoke );
+  fd_progcache_fork_id_t fork_b_invoke = fd_progcache_attach_child( env->progcache->join, root );
 
-  fd_progcache_rec_t const * rec_b = test_pull( env->progcache, fork_b_acc.ro, &fork_b_invoke, &key, &load_env );
+  fd_progcache_rec_t const * rec_b = test_pull( env->progcache, fork_b_acc.ro, fork_b_invoke, &key, &load_env );
   FD_TEST( rec_b );
   FD_TEST( rec_b!=rec_a );
-  FD_TEST( query_rec_exact( env, &fork_a_invoke, &key )==rec_a );
-  FD_TEST( query_rec_exact( env, &fork_b_invoke, &key )==rec_b );
-  FD_TEST( query_rec_exact( env, &root,          &key )==NULL  );
+  FD_TEST( query_rec_exact( env, fork_a_invoke, &key )==rec_a );
+  FD_TEST( query_rec_exact( env, fork_b_invoke, &key )==rec_b );
+  FD_TEST( query_rec_exact( env, root,          &key )==NULL  );
 
-  fd_progcache_cancel( env->progcache->join, &fork_b_invoke );
-  fd_progcache_cancel( env->progcache->join, &fork_a_deploy );
+  fd_progcache_cancel_fork( env->progcache->join, fork_b_invoke );
+  fd_progcache_cancel_fork( env->progcache->join, fork_a_deploy );
 
   test_env_destroy( env );
 }
@@ -885,8 +850,7 @@ test_loader_v3_epoch_boundary_skipped_slots( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_all_visited( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key1 = test_key( 1UL );
   fd_pubkey_t key2 = test_key( 2UL );
@@ -904,9 +868,9 @@ test_clock_evict_all_visited( fd_wksp_t * wksp ) {
     .feature_slot = 0UL
   };
 
-  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env );
-  fd_progcache_rec_t * rec2 = test_pull( env->progcache, acc2.ro, &xid, &key2, &load_env );
-  fd_progcache_rec_t * rec3 = test_pull( env->progcache, acc3.ro, &xid, &key3, &load_env );
+  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, xid, &key1, &load_env );
+  fd_progcache_rec_t * rec2 = test_pull( env->progcache, acc2.ro, xid, &key2, &load_env );
+  fd_progcache_rec_t * rec3 = test_pull( env->progcache, acc3.ro, xid, &key3, &load_env );
   FD_TEST( rec1 && rec2 && rec3 );
 
   /* Ensure visited bits are set */
@@ -923,11 +887,11 @@ test_clock_evict_all_visited( fd_wksp_t * wksp ) {
   fd_prog_clock_evict( env->progcache, 3UL, 0UL );
 
   FD_TEST( env->progcache->metrics->evict_cnt - evict_cnt_before == 3UL );
-  FD_TEST( !test_peek( env->progcache, &xid, &key1, 0UL, 0UL ) );
-  FD_TEST( !test_peek( env->progcache, &xid, &key2, 0UL, 0UL ) );
-  FD_TEST( !test_peek( env->progcache, &xid, &key3, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key1, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key2, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key3, 0UL, 0UL ) );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -936,8 +900,7 @@ test_clock_evict_all_visited( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_wraps_around( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key1 = test_key( 1UL );
   test_account_t acc1;
@@ -948,7 +911,7 @@ test_clock_evict_wraps_around( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env );
+  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, xid, &key1, &load_env );
   FD_TEST( rec1 );
 
   ulong rec_max = env->progcache->join->rec.pool->ele_max;
@@ -967,9 +930,9 @@ test_clock_evict_wraps_around( fd_wksp_t * wksp ) {
 
   FD_TEST( env->progcache->join->shmem->clock.head <= rec_max );
   FD_TEST( env->progcache->metrics->evict_cnt - evict_cnt_before == 1UL );
-  FD_TEST( !test_peek( env->progcache, &xid, &key1, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key1, 0UL, 0UL ) );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -994,8 +957,7 @@ test_clock_evict_empty_cache( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key1 = test_key( 1UL );
   fd_pubkey_t key2 = test_key( 2UL );
@@ -1009,8 +971,8 @@ test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env );
-  fd_progcache_rec_t * rec2 = test_pull( env->progcache, acc2.ro, &xid, &key2, &load_env );
+  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, xid, &key1, &load_env );
+  fd_progcache_rec_t * rec2 = test_pull( env->progcache, acc2.ro, xid, &key2, &load_env );
   FD_TEST( rec1 && rec2 );
 
   ulong rec1_idx = (ulong)( rec1 - env->progcache->join->rec.pool->ele );
@@ -1040,9 +1002,9 @@ test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
   fd_prog_clock_evict( env->progcache, 1UL, 0UL );
 
   FD_TEST( env->progcache->metrics->evict_cnt - evict_cnt_before >= 1UL );
-  FD_TEST( !test_peek( env->progcache, &xid, &key2, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key2, 0UL, 0UL ) );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 
@@ -1051,8 +1013,7 @@ test_clock_evict_delete_fails( fd_wksp_t * wksp ) {
 static void
 test_clock_evict_heap_only( fd_wksp_t * wksp ) {
   test_env_t * env = test_env_create( wksp );
-  fd_progcache_xid_t xid = { .slot = 1UL, .bank_seq = 1UL };
-  fd_progcache_attach_child( env->progcache->join, &(fd_progcache_xid_t){0}, &xid );
+  fd_progcache_fork_id_t xid = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_pubkey_t key1 = test_key( 1UL );
   test_account_t acc1;
@@ -1063,7 +1024,7 @@ test_clock_evict_heap_only( fd_wksp_t * wksp ) {
     .features     = env->features,
     .feature_slot = 0UL
   };
-  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, &xid, &key1, &load_env );
+  fd_progcache_rec_t * rec1 = test_pull( env->progcache, acc1.ro, xid, &key1, &load_env );
   FD_TEST( rec1 );
   FD_TEST( rec1->data_gaddr );
 
@@ -1083,9 +1044,9 @@ test_clock_evict_heap_only( fd_wksp_t * wksp ) {
 
   FD_TEST( env->progcache->metrics->evict_cnt - evict_cnt_before == 1UL );
   FD_TEST( env->progcache->metrics->evict_tot_sz - evict_sz_before > 0UL );
-  FD_TEST( !test_peek( env->progcache, &xid, &key1, 0UL, 0UL ) );
+  FD_TEST( !test_peek( env->progcache, xid, &key1, 0UL, 0UL ) );
 
-  fd_progcache_cancel( env->progcache->join, &xid );
+  fd_progcache_cancel_fork( env->progcache->join, xid );
   test_env_destroy( env );
 }
 

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -19,8 +19,6 @@ static fd_features_t g_features[1];
 #define ITER_DEFAULT    (4096UL)
 #define STEP_MAX        (100000UL)
 
-#define ROOT_XID ((fd_progcache_xid_t){{1UL,0UL}})
-
 /* Declare fibers */
 
 struct fiber {
@@ -36,19 +34,19 @@ struct fiber {
   union {
 
     struct {
-      fd_progcache_t *   cache;
-      fd_progcache_xid_t           xid;
-      fd_pubkey_t        prog_addr;
-      fd_prog_load_env_t load_env;
-      fd_accdb_ro_t *    prog_ro;
+      fd_progcache_t *       cache;
+      fd_progcache_fork_id_t fork_id;
+      fd_pubkey_t            prog_addr;
+      fd_prog_load_env_t     load_env;
+      fd_accdb_ro_t *        prog_ro;
     } pull;
 
     struct {
-      fd_progcache_t *   cache;
-      fd_progcache_xid_t xid;
-      fd_pubkey_t        prog_addr;
-      ulong              feature_slot;
-      ulong              deploy_slot;
+      fd_progcache_t *       cache;
+      fd_progcache_fork_id_t fork_id;
+      fd_pubkey_t            prog_addr;
+      ulong                  feature_slot;
+      ulong                  deploy_slot;
     } peek;
 
     struct {
@@ -58,13 +56,13 @@ struct fiber {
     } evict;
 
     struct {
-      fd_progcache_join_t * cache;
-      fd_progcache_xid_t              xid;
+      fd_progcache_join_t *  cache;
+      fd_progcache_fork_id_t fork_id;
     } advance_root;
 
     struct {
-      fd_progcache_join_t * cache;
-      fd_progcache_xid_t              xid;
+      fd_progcache_join_t *  cache;
+      fd_progcache_fork_id_t fork_id;
     } cancel;
 
   };
@@ -84,20 +82,20 @@ static void
 fiber_pull_exec( void * _ctx ) {
   fiber_t * f = _ctx;
   fd_progcache_rec_t * res = fd_progcache_pull(
-      f->pull.cache, &f->pull.xid, &f->pull.prog_addr, &f->pull.load_env, f->pull.prog_ro );
+      f->pull.cache, f->pull.fork_id, &f->pull.prog_addr, &f->pull.load_env, f->pull.prog_ro );
   if( res ) fd_progcache_rec_close( f->pull.cache, res );
 }
 
 static fd_racesan_async_t *
 fiber_pull( fiber_t *                  fiber,
             void *                     shmem,
-            fd_progcache_xid_t const * xid,
+            fd_progcache_fork_id_t     fork_id,
             void const *               prog_addr,
             fd_prog_load_env_t const * load_env,
             fd_accdb_ro_t *            prog_ro ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->pull.cache     = fiber->cache;
-  fiber->pull.xid       = *xid;
+  fiber->pull.fork_id   = fork_id;
   fiber->pull.prog_addr = FD_LOAD( fd_pubkey_t, prog_addr );
   fiber->pull.load_env  = *load_env;
   fiber->pull.prog_ro   = prog_ro;
@@ -109,19 +107,19 @@ static void
 fiber_peek_exec( void * _ctx ) {
   fiber_t * f = _ctx;
   fd_progcache_rec_t * res = fd_progcache_peek(
-      f->peek.cache, &f->peek.xid, &f->peek.prog_addr,
+      f->peek.cache, f->peek.fork_id, &f->peek.prog_addr,
       f->peek.feature_slot, f->peek.deploy_slot );
   if( res ) fd_progcache_rec_close( f->peek.cache, res );
 }
 
 static fd_racesan_async_t *
-fiber_peek( fiber_t *                  fiber,
-            void *                     shmem,
-            fd_progcache_xid_t const * xid,
-            void const *               prog_addr ) {
+fiber_peek( fiber_t *              fiber,
+            void *                 shmem,
+            fd_progcache_fork_id_t fork_id,
+            void const *           prog_addr ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
   fiber->peek.cache        = fiber->cache;
-  fiber->peek.xid          = *xid;
+  fiber->peek.fork_id      = fork_id;
   fiber->peek.prog_addr    = FD_LOAD( fd_pubkey_t, prog_addr );
   fiber->peek.feature_slot = 0UL;
   fiber->peek.deploy_slot  = 1UL;
@@ -151,16 +149,16 @@ fiber_evict( fiber_t * fiber,
 static void
 fiber_advance_root_exec( void * _ctx ) {
   fiber_t * f = _ctx;
-  fd_progcache_advance_root( f->advance_root.cache, &f->advance_root.xid );
+  fd_progcache_advance_root( f->advance_root.cache, f->advance_root.fork_id );
 }
 
 static fd_racesan_async_t *
-fiber_advance_root( fiber_t *                  fiber,
-                    void *                     shmem,
-                    fd_progcache_xid_t const * xid ) {
+fiber_advance_root( fiber_t *              fiber,
+                    void *                 shmem,
+                    fd_progcache_fork_id_t fork_id ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
-  fiber->advance_root.cache = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
-  fiber->advance_root.xid   = *xid;
+  fiber->advance_root.cache   = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
+  fiber->advance_root.fork_id = fork_id;
   fd_racesan_async_new( fiber->async, fiber->stack+FIBER_STACK_MAX, FIBER_STACK_MAX, fiber_advance_root_exec, fiber );
   return fiber->async;
 }
@@ -168,16 +166,16 @@ fiber_advance_root( fiber_t *                  fiber,
 static void
 fiber_cancel_exec( void * _ctx ) {
   fiber_t * f = _ctx;
-  fd_progcache_cancel( f->cancel.cache, &f->cancel.xid );
+  fd_progcache_cancel_fork( f->cancel.cache, f->cancel.fork_id );
 }
 
 static fd_racesan_async_t *
-fiber_cancel( fiber_t *                  fiber,
-              void *                     shmem,
-              fd_progcache_xid_t const * xid ) {
+fiber_cancel( fiber_t *              fiber,
+              void *                 shmem,
+              fd_progcache_fork_id_t fork_id ) {
   FD_TEST( fd_progcache_join( fiber->cache, shmem, fiber->scratch, sizeof(fiber->scratch) ) );
-  fiber->cancel.cache = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
-  fiber->cancel.xid   = *xid;
+  fiber->cancel.cache   = (fd_progcache_join_t *)fd_type_pun( fiber->cache );
+  fiber->cancel.fork_id = fork_id;
   fd_racesan_async_new( fiber->async, fiber->stack+FIBER_STACK_MAX, FIBER_STACK_MAX, fiber_cancel_exec, fiber );
   return fiber->async;
 }
@@ -204,7 +202,6 @@ test_progcache_shmem_new( fd_wksp_t * wksp ) {
 
   fd_progcache_shmem_t * shmem = fd_wksp_alloc_laddr( wksp, fd_progcache_shmem_align(), fd_progcache_shmem_footprint( txn_max, progcache_rec_max ), wksp_tag );
   FD_TEST( fd_progcache_shmem_new( shmem, wksp_tag, 1UL, txn_max, progcache_rec_max ) );
-  *shmem->txn.last_publish = ROOT_XID;
   return shmem;
 }
 
@@ -214,8 +211,8 @@ test_progcache_shmem_delete( fd_progcache_shmem_t * shmem ) {
 }
 
 static void
-test_progcache_clear( fd_progcache_join_t * join ) {
-  fd_progcache_clear( join, &ROOT_XID );
+test_progcache_reset( fd_progcache_join_t * join ) {
+  fd_progcache_reset( join );
 }
 
 /* TESTS **************************************************************/
@@ -226,7 +223,6 @@ static void
 test_pull_pull( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t xid = { .slot=1UL, .bank_seq=1UL };
   fd_pubkey_t        key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot=0UL };
 
@@ -236,12 +232,12 @@ test_pull_pull( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &ROOT_XID, &xid );
+    fd_progcache_fork_id_t xid = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, &xid, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 1 ], shmem, &xid, &key, &load_env, acc.ro ) );
+    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, xid, &key, &load_env, acc.ro ) );
+    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 1 ], shmem, xid, &key, &load_env, acc.ro ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -256,7 +252,7 @@ test_pull_pull( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -269,7 +265,6 @@ static void
 test_pull_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid = {{ 1UL, 1UL }};
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -279,12 +274,12 @@ test_pull_peek( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &ROOT_XID, &xid );
+    fd_progcache_fork_id_t xid = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, &xid, &key, &load_env, acc.ro ) );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key ) );
+    fd_racesan_weave_add( w, fiber_pull( &g_fiber[ 0 ], shmem, xid, &key, &load_env, acc.ro ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, xid, &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -298,7 +293,7 @@ test_pull_peek( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -312,9 +307,6 @@ static void
 test_cancel_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid_pre = {{ 1UL, 1UL }};
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -325,23 +317,24 @@ test_cancel_peek( fd_wksp_t * wksp ) {
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
     /* Pre-populate the cache at root through a real txn */
+    fd_progcache_fork_id_t xid_pre;
     {
-      fd_progcache_attach_child( admin, &xid0, &xid_pre );
+      xid_pre = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid_pre, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
-      fd_progcache_advance_root( admin, &xid_pre );
+      fd_progcache_advance_root( admin, xid_pre );
     }
 
-    fd_progcache_attach_child( admin, &xid_pre, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, xid_pre );
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 0 ], shmem, &xid1 ) );
-    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 1 ], shmem, &xid0, &key ) );
+    fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 0 ], shmem, xid1 ) );
+    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 1 ], shmem, fd_progcache_fork_id_initial(), &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -352,7 +345,7 @@ test_cancel_peek( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -365,8 +358,6 @@ static void
 test_publish_evict( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -376,13 +367,13 @@ test_publish_evict( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     /* Pre-populate the cache */
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
@@ -390,7 +381,7 @@ test_publish_evict( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, xid1 ) );
     fd_racesan_weave_add( w, fiber_evict(        &g_fiber[ 1 ], shmem, 1UL, 0UL ) );
 
     metrics_reset();
@@ -401,7 +392,7 @@ test_publish_evict( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -414,8 +405,6 @@ static void
 test_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -425,13 +414,13 @@ test_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     /* Pre-populate the cache */
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
@@ -439,8 +428,8 @@ test_peek_root( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, xid1, &key ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, xid1 ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -451,7 +440,7 @@ test_peek_root( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -464,8 +453,6 @@ static void
 test_peek_cancel( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -475,13 +462,13 @@ test_peek_cancel( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     /* Pre-populate the cache */
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
@@ -489,8 +476,8 @@ test_peek_cancel( fd_wksp_t * wksp ) {
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 0 ], shmem, &xid1, &key ) );
-    fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 1 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_peek(   &g_fiber[ 0 ], shmem, xid1, &key ) );
+    fd_racesan_weave_add( w, fiber_cancel( &g_fiber[ 1 ], shmem, xid1 ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -501,7 +488,7 @@ test_peek_cancel( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -514,8 +501,6 @@ static void
 test_peek_peek( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid = ROOT_XID;
-  fd_progcache_xid_t    xid_pre = {{ 1UL, 1UL }};
   fd_pubkey_t key = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -526,21 +511,22 @@ test_peek_peek( fd_wksp_t * wksp ) {
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
     /* Pre-populate the cache at root through a real txn */
+    fd_progcache_fork_id_t xid_pre;
     {
-      fd_progcache_attach_child( admin, &xid, &xid_pre );
+      xid_pre = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid_pre, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
-      fd_progcache_advance_root( admin, &xid_pre );
+      fd_progcache_advance_root( admin, xid_pre );
     }
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 0 ], shmem, &xid, &key ) );
-    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, &xid, &key ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 0 ], shmem, fd_progcache_fork_id_initial(), &key ) );
+    fd_racesan_weave_add( w, fiber_peek( &g_fiber[ 1 ], shmem, fd_progcache_fork_id_initial(), &key ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -551,7 +537,7 @@ test_peek_peek( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -565,9 +551,6 @@ static void
 test_peek_root_sibling( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
-  fd_progcache_xid_t    xid2 = {{ 3UL, 2UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -577,24 +560,24 @@ test_peek_root_sibling( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
-    fd_progcache_attach_child( admin, &xid0, &xid2 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
+    fd_progcache_fork_id_t xid2 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
       fd_progcache_rec_t * rec;
-      rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
-      rec = fd_progcache_pull( tmp, &xid2, &key, &load_env, acc.ro );
+      rec = fd_progcache_pull( tmp, xid2, &key, &load_env, acc.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
     }
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid2, &key ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, xid2, &key ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, xid1 ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -605,7 +588,7 @@ test_peek_root_sibling( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -618,9 +601,6 @@ static void
 test_peek_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
-  fd_progcache_xid_t    xid2 = {{ 3UL, 2UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -630,25 +610,25 @@ test_peek_peek_root( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
-    fd_progcache_attach_child( admin, &xid0, &xid2 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
+    fd_progcache_fork_id_t xid2 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
       fd_progcache_rec_t * rec;
-      rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
-      rec = fd_progcache_pull( tmp, &xid2, &key, &load_env, acc.ro );
+      rec = fd_progcache_pull( tmp, xid2, &key, &load_env, acc.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
     }
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, &xid1, &key ) );
-    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 1 ], shmem, &xid2, &key ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 2 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 0 ], shmem, xid1, &key ) );
+    fd_racesan_weave_add( w, fiber_peek(         &g_fiber[ 1 ], shmem, xid2, &key ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 2 ], shmem, xid1 ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -660,7 +640,7 @@ test_peek_peek_root( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 1 ] );
     fiber_delete( &g_fiber[ 2 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -674,8 +654,6 @@ static void
 test_inject_at_hook( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -684,18 +662,18 @@ test_inject_at_hook( fd_wksp_t * wksp ) {
 
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
-  fd_progcache_attach_child( admin, &xid0, &xid1 );
+  fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
   {
     fd_progcache_t tmp[1];
     FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-    fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+    fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
     FD_TEST( rec );
     fd_progcache_rec_close( tmp, rec );
     fd_progcache_leave( tmp, NULL );
   }
 
-  fd_racesan_async_t * a = fiber_advance_root( &g_fiber[ 0 ], shmem, &xid1 );
+  fd_racesan_async_t * a = fiber_advance_root( &g_fiber[ 0 ], shmem, xid1 );
 
   for(;;) {
     int ret = fd_racesan_async_step( a );
@@ -715,8 +693,6 @@ static void
 test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
 
@@ -726,12 +702,12 @@ test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
@@ -740,7 +716,7 @@ test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
     fd_racesan_weave_add( w, fiber_evict(        &g_fiber[ 0 ], shmem, 1UL, 0UL ) );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 1 ], shmem, xid1 ) );
 
     metrics_reset();
     fd_racesan_weave_exec_rand( w, i, STEP_MAX );
@@ -750,7 +726,7 @@ test_publish_reclaim_evicted( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -764,9 +740,6 @@ static void
 test_root_evict_two( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
-  fd_progcache_xid_t    xid2 = {{ 3UL, 2UL }};
   fd_pubkey_t ka   = test_key( 1UL );
   fd_pubkey_t kb   = test_key( 2UL );
   fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
@@ -779,23 +752,23 @@ test_root_evict_two( fd_wksp_t * wksp ) {
   fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
 
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
-    fd_progcache_attach_child( admin, &xid0, &xid1 );
-    fd_progcache_attach_child( admin, &xid0, &xid2 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
+    fd_progcache_fork_id_t xid2 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
 
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
       fd_progcache_rec_t * rec;
-      rec = fd_progcache_pull( tmp, &xid1, &ka, &load_env, acc_a.ro );
+      rec = fd_progcache_pull( tmp, xid1, &ka, &load_env, acc_a.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
-      rec = fd_progcache_pull( tmp, &xid2, &kb, &load_env, acc_b.ro );
+      rec = fd_progcache_pull( tmp, xid2, &kb, &load_env, acc_b.ro );
       FD_TEST( rec ); fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
     }
 
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, xid1 ) );
     fd_racesan_weave_add( w, fiber_evict(        &g_fiber[ 1 ], shmem, 1UL, 0UL ) );
 
     metrics_reset();
@@ -807,7 +780,7 @@ test_root_evict_two( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
@@ -822,9 +795,6 @@ static void
 test_publish_evict_stale( fd_wksp_t * wksp ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new( wksp );
 
-  fd_progcache_xid_t    xid0 = ROOT_XID;
-  fd_progcache_xid_t    xid_pre = {{ 1UL, 1UL }};
-  fd_progcache_xid_t    xid1 = {{ 2UL, 1UL }};
   fd_pubkey_t key  = test_key( 42UL );
 
   fd_prog_load_env_t load_env_root  = { .features = g_features, .feature_slot = 0UL };
@@ -838,24 +808,25 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
   for( ulong i=0UL; i<ITER_DEFAULT; i++ ) {
 
     /* Pre-populate the same program at root through a real txn */
+    fd_progcache_fork_id_t xid_pre;
     {
-      fd_progcache_attach_child( admin, &xid0, &xid_pre );
+      xid_pre = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid_pre, &key, &load_env_root, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid_pre, &key, &load_env_root, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
-      fd_progcache_advance_root( admin, &xid_pre );
+      fd_progcache_advance_root( admin, xid_pre );
     }
 
     /* Create child fork and populate the same key under xid1's txn
        Peek won't hit the root record because slot 2 != slot 0. */
-    fd_progcache_attach_child( admin, &xid_pre, &xid1 );
+    fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, xid_pre );
     {
       fd_progcache_t tmp[1];
       FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 0 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
-      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, &xid1, &key, &load_env_child, acc.ro );
+      fd_progcache_rec_t * rec = fd_progcache_pull( tmp, xid1, &key, &load_env_child, acc.ro );
       FD_TEST( rec );
       fd_progcache_rec_close( tmp, rec );
       fd_progcache_leave( tmp, NULL );
@@ -868,7 +839,7 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
        revisit entries whose visited bits were cleared on pass 1. */
     fd_racesan_weave_t w[1];
     fd_racesan_weave_new( w );
-    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, &xid1 ) );
+    fd_racesan_weave_add( w, fiber_advance_root( &g_fiber[ 0 ], shmem, xid1 ) );
     fd_racesan_weave_add( w, fiber_evict(        &g_fiber[ 1 ], shmem, 2UL, 0UL ) );
 
     metrics_reset();
@@ -879,7 +850,7 @@ test_publish_evict_stale( fd_wksp_t * wksp ) {
     fiber_delete( &g_fiber[ 0 ] );
     fiber_delete( &g_fiber[ 1 ] );
     FD_TEST( !fd_progcache_verify( admin ) );
-    test_progcache_clear( admin );
+    test_progcache_reset( admin );
   }
 
   FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -1094,10 +1094,11 @@ fd_banks_prune_one_dead_bank( fd_banks_t *                   banks,
     bank->stake_rewards_fork_id = UCHAR_MAX;
 
     if( FD_LIKELY( started_replaying ) ) {
-      cancel->txncache_fork_id = bank->txncache_fork_id;
-      cancel->slot             = bank->f.slot;
-      cancel->bank_seq         = bank->bank_seq;
-      cancel->bank_idx         = bank->idx;
+      cancel->txncache_fork_id  = bank->txncache_fork_id;
+      cancel->progcache_fork_id = bank->progcache_fork_id;
+      cancel->slot              = bank->f.slot;
+      cancel->bank_seq          = bank->bank_seq;
+      cancel->bank_idx          = bank->idx;
     }
 
     bank->state = FD_BANK_STATE_INACTIVE;

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -12,6 +12,7 @@
 #include "sysvar/fd_sysvar_cache.h"
 #include "../../ballet/lthash/fd_lthash.h"
 #include "fd_txncache_shmem.h"
+#include "../progcache/fd_progcache_base.h"
 
 FD_PROTOTYPES_BEGIN
 
@@ -261,12 +262,13 @@ struct fd_bank {
 
   ulong refcnt; /* reference count on the bank, see replay for more details */
 
-  fd_txncache_fork_id_t txncache_fork_id; /* fork id used by the txn cache */
-  ushort                vote_stakes_fork_id; /* fork id used by the vote stakes */
-  uchar                 stake_rewards_fork_id; /* fork id used by stake rewards */
-  ushort                stake_delegations_fork_id; /* fork id used by stake delegations deltas */
-  ushort                new_votes_fork_id; /* fork id used by new vote account deltas */
-  ulong                 cost_tracker_pool_idx;
+  fd_txncache_fork_id_t  txncache_fork_id;
+  fd_progcache_fork_id_t progcache_fork_id;
+  ushort                 vote_stakes_fork_id;
+  uchar                  stake_rewards_fork_id;
+  ushort                 stake_delegations_fork_id;
+  ushort                 new_votes_fork_id;
+  ulong                  cost_tracker_pool_idx;
 
   ulong banks_data_offset; /* offset from this fd_bank_t back to fd_banks_t */
 
@@ -339,10 +341,11 @@ struct fd_bank {
 typedef struct fd_bank fd_bank_t;
 
 struct fd_banks_prune_cancel_info {
-  fd_txncache_fork_id_t txncache_fork_id;
-  ulong                 slot;
-  ulong                 bank_seq;
-  ulong                 bank_idx;
+  fd_txncache_fork_id_t  txncache_fork_id;
+  fd_progcache_fork_id_t progcache_fork_id;
+  ulong                  slot;
+  ulong                  bank_seq;
+  ulong                  bank_idx;
 };
 typedef struct fd_banks_prune_cancel_info fd_banks_prune_cancel_info_t;
 

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -2233,11 +2233,9 @@ fd_bpf_loader_program_execute( fd_exec_instr_ctx_t * ctx ) {
   }
 
   fd_prog_load_env_t load_env[1]; fd_prog_load_env_from_bank( load_env, ctx->bank );
-  fd_funk_txn_xid_t xid = fd_bank_xid( ctx->bank );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
   fd_progcache_t * progcache = ctx->runtime->progcache;
   fd_progcache_rec_t * cache_entry =
-      fd_progcache_pull( progcache, &pc_xid, program_id, load_env, progdata_ro );
+      fd_progcache_pull( progcache, ctx->bank->progcache_fork_id, program_id, load_env, progdata_ro );
   if( FD_UNLIKELY( !cache_entry ) ) {
     fd_log_collector_msg_literal( ctx, "Program is not deployed" );
     return FD_EXECUTOR_INSTR_ERR_UNSUPPORTED_PROGRAM_ID;

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -166,10 +166,8 @@ test_env_init( test_env_t * env, fd_wksp_t * wksp, int enable_loader_v4 ) {
   fd_funk_txn_xid_set_root( root );
   env->xid = fd_bank_xid( env->bank );
   fd_accdb_attach_child( env->accdb_admin, root, &env->xid );
-  fd_progcache_xid_t pc_root = fd_progcache_xid_from_funk( root );
-  fd_progcache_xid_t pc_xid  = fd_progcache_xid_from_funk( &env->xid );
-  fd_progcache_clear( env->progcache->join, &pc_root );
-  fd_progcache_attach_child( env->progcache->join, &pc_root, &pc_xid );
+  fd_progcache_reset( env->progcache->join );
+  env->bank->progcache_fork_id = fd_progcache_attach_child( env->progcache->join, fd_progcache_fork_id_initial() );
 
   init_rent_sysvar( env );
   init_epoch_schedule_sysvar( env );
@@ -213,9 +211,8 @@ test_env_cleanup( test_env_t * env ) {
     fd_runtime_cancel_txn( env->runtime, &env->txn_out[0] );
   }
 
-  fd_accdb_cancel    ( env->accdb_admin,     &env->xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &env->xid );
-  fd_progcache_cancel( env->progcache->join, &pc_xid );
+  fd_accdb_cancel         ( env->accdb_admin,     &env->xid );
+  fd_progcache_cancel_fork( env->progcache->join, env->bank->progcache_fork_id );
 
   if( env->runtime ) {
     if( env->runtime->acc_pool ) {
@@ -263,10 +260,8 @@ process_slot( test_env_t * env, ulong slot ) {
 
   fd_funk_txn_xid_t xid        = fd_bank_xid( new_bank    );
   fd_funk_txn_xid_t parent_xid = fd_bank_xid( parent_bank );
-  fd_accdb_attach_child    ( env->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
-  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( env->progcache->join, &pc_parent_xid, &pc_xid );
+  fd_accdb_attach_child( env->accdb_admin, &parent_xid, &xid );
+  new_bank->progcache_fork_id = fd_progcache_attach_child( env->progcache->join, parent_bank->progcache_fork_id );
 
   env->xid  = xid;
   env->bank = new_bank;

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -101,7 +101,7 @@ fd_solfuzz_pb_block_ctx_destroy( fd_solfuzz_runner_t * runner ) {
   runner->bank->stake_rewards_fork_id = UCHAR_MAX;
 
   fd_accdb_v1_clear( runner->accdb_admin );
-  fd_progcache_clear( runner->progcache->join, &(fd_progcache_xid_t){0} );
+  fd_progcache_reset( runner->progcache->join );
 
   /* In order to check for leaks in the workspace, we need to compact the
      allocators. Without doing this, empty superblocks may be retained
@@ -133,9 +133,8 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
 
   /* Create temporary funk transaction and slot / epoch contexts */
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
-  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( xid );
-  fd_progcache_attach_child( runner->progcache->join, &(fd_progcache_xid_t){0}, &pc_xid );
+  fd_accdb_attach_child( runner->accdb_admin, &parent_xid, xid );
+  runner->bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, fd_progcache_fork_id_initial() );
 
   /* Initialize bank from input block bank */
   FD_TEST( test_ctx->has_bank );
@@ -301,10 +300,8 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
 
   /* Make a new funk transaction since we're done loading in accounts for context */
   fd_funk_txn_xid_t fork_xid = fd_bank_xid( bank );
-  fd_accdb_attach_child    ( runner->accdb_admin,     xid, &fork_xid );
-  fd_progcache_xid_t pc_xid2     = fd_progcache_xid_from_funk( xid );
-  fd_progcache_xid_t pc_fork_xid = fd_progcache_xid_from_funk( &fork_xid );
-  fd_progcache_attach_child( runner->progcache->join, &pc_xid2, &pc_fork_xid );
+  fd_accdb_attach_child( runner->accdb_admin, xid, &fork_xid );
+  bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, bank->progcache_fork_id );
   xid[0] = fork_xid;
 
   /* Set the initial lthash from the input since we're in a new Funk txn */

--- a/src/flamenco/runtime/tests/fd_bundle_harness.c
+++ b/src/flamenco/runtime/tests/fd_bundle_harness.c
@@ -21,7 +21,7 @@ fd_solfuzz_bundle_ctx_destroy( fd_solfuzz_runner_t * runner ) {
   fd_banks_stake_delegations_evict_bank_fork( runner->banks, runner->bank );
 
   fd_accdb_v1_clear( runner->accdb_admin );
-  fd_progcache_clear( runner->progcache->join, &(fd_progcache_xid_t){0} );
+  fd_progcache_reset( runner->progcache->join );
 
   /* Keep the runner reusable across many bundle inputs. */
   fd_alloc_compact( fd_accdb_user_v1_funk( runner->accdb )->alloc );
@@ -43,9 +43,8 @@ fd_solfuzz_pb_bundle_ctx_create( fd_solfuzz_runner_t *                 runner,
 
   fd_funk_txn_xid_t xid = fd_bank_xid( runner->bank );
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
-  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( runner->progcache->join, &(fd_progcache_xid_t){0}, &pc_xid );
+  fd_accdb_attach_child( runner->accdb_admin, &parent_xid, &xid );
+  runner->bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, fd_progcache_fork_id_initial() );
 
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -27,9 +27,8 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   /* Create temporary funk transaction and txn / slot / epoch contexts */
 
   fd_funk_txn_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
-  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( xid );
-  fd_progcache_attach_child( runner->progcache->join, &(fd_progcache_xid_t){0}, &pc_xid );
+  fd_accdb_attach_child( runner->accdb_admin, &parent_xid, xid );
+  runner->bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, fd_progcache_fork_id_initial() );
 
   fd_txn_in_t *  txn_in  = fd_spad_alloc( runner->spad, alignof(fd_txn_in_t), sizeof(fd_txn_in_t) );
   fd_txn_out_t * txn_out = fd_spad_alloc( runner->spad, alignof(fd_txn_out_t), sizeof(fd_txn_out_t) );
@@ -233,10 +232,8 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   runner->bank->f.slot = clock->slot;
 
   fd_funk_txn_xid_t exec_xid[1] = { fd_bank_xid( runner->bank ) };
-  fd_accdb_attach_child    ( runner->accdb_admin,     xid, exec_xid );
-  fd_progcache_xid_t pc_xid2      = fd_progcache_xid_from_funk( xid );
-  fd_progcache_xid_t pc_exec_xid = fd_progcache_xid_from_funk( exec_xid );
-  fd_progcache_attach_child( runner->progcache->join, &pc_xid2, &pc_exec_xid );
+  fd_accdb_attach_child( runner->accdb_admin, xid, exec_xid );
+  runner->bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, runner->bank->progcache_fork_id );
 
   fd_epoch_schedule_t epoch_schedule_[1];
   fd_epoch_schedule_t * epoch_schedule = fd_sysvar_cache_epoch_schedule_read( ctx->sysvar_cache, epoch_schedule_ );
@@ -297,7 +294,7 @@ fd_solfuzz_pb_instr_ctx_destroy( fd_solfuzz_runner_t * runner,
                                  fd_exec_instr_ctx_t * ctx ) {
   if( !ctx ) return;
   fd_accdb_v1_clear( runner->accdb_admin );
-  fd_progcache_clear( runner->progcache->join, &(fd_progcache_xid_t){0} );
+  fd_progcache_reset( runner->progcache->join );
 
   /* In order to check for leaks in the workspace, we need to compact the
      allocators. Without doing this, empty superblocks may be retained

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -384,7 +384,7 @@ fd_svm_mini_reset( fd_svm_mini_t *        mini,
                    fd_svm_mini_params_t * params ) {
 
   fd_accdb_v1_clear( mini->accdb_admin );
-  fd_progcache_clear( mini->progcache->join, &(fd_progcache_xid_t){0} );
+  fd_progcache_reset( mini->progcache->join );
   fd_banks_clear( mini->banks           );
 
   fd_bank_t * bank = fd_banks_init_bank( mini->banks );
@@ -396,7 +396,7 @@ fd_svm_mini_reset( fd_svm_mini_t *        mini,
   fd_xid_t root_xid = fd_bank_xid( bank );
   fd_funk_t * funk = fd_accdb_user_v1_funk( mini->accdb );
   fd_funk_txn_xid_copy( funk->shmem->last_publish, &root_xid );
-  *mini->progcache->join->shmem->txn.last_publish = fd_progcache_xid_from_funk( &root_xid );
+  bank->progcache_fork_id = fd_progcache_fork_id_initial();
 
   if( params->clock ) {
     bank->f.slot  = params->clock->slot;
@@ -569,10 +569,8 @@ fd_svm_mini_attach_child( fd_svm_mini_t * mini,
   bank->f.slot = child_slot;
   fd_xid_t xid = fd_bank_xid( bank );
 
-  fd_accdb_attach_child    ( mini->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_xid_t pc_parent_xid = fd_progcache_xid_from_funk( &parent_xid );
-  fd_progcache_xid_t pc_xid        = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( mini->progcache->join, &pc_parent_xid, &pc_xid );
+  fd_accdb_attach_child( mini->accdb_admin, &parent_xid, &xid );
+  bank->progcache_fork_id = fd_progcache_attach_child( mini->progcache->join, parent_bank->progcache_fork_id );
 
   int is_epoch_boundary = 0;
   fd_runtime_block_execute_prepare( mini->banks, bank, mini->accdb, mini->runtime_stack, NULL, &is_epoch_boundary );
@@ -599,9 +597,8 @@ fd_svm_mini_cancel_fork( fd_svm_mini_t * mini,
   if( FD_UNLIKELY( !bank ) ) FD_LOG_ERR(( "invalid bank_idx" ));
   fd_xid_t xid = fd_bank_xid( bank );
 
-  fd_accdb_cancel    ( mini->accdb_admin,     &xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_cancel( mini->progcache->join, &pc_xid );
+  fd_accdb_cancel         ( mini->accdb_admin,     &xid );
+  fd_progcache_cancel_fork( mini->progcache->join, bank->progcache_fork_id );
 }
 
 void
@@ -613,8 +610,7 @@ fd_svm_mini_advance_root( fd_svm_mini_t * mini,
   fd_xid_t xid = fd_bank_xid( bank );
 
   fd_accdb_advance_root    ( mini->accdb_admin,     &xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_advance_root( mini->progcache->join, &pc_xid );
+  fd_progcache_advance_root( mini->progcache->join, bank->progcache_fork_id );
   fd_banks_advance_root    ( mini->banks, bank_idx );
 }
 

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -29,7 +29,7 @@
 static void
 fd_solfuzz_txn_ctx_destroy( fd_solfuzz_runner_t * runner ) {
   fd_accdb_v1_clear( runner->accdb_admin );
-  fd_progcache_clear( runner->progcache->join, &(fd_progcache_xid_t){0} );
+  fd_progcache_reset( runner->progcache->join );
 
   /* In order to check for leaks in the workspace, we need to compact the
      allocators. Without doing this, empty superblocks may be retained
@@ -54,9 +54,8 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
   /* Set up the funk transaction */
   fd_xid_t xid = fd_bank_xid( runner->bank );
   fd_xid_t parent_xid; fd_funk_txn_xid_set_root( &parent_xid );
-  fd_accdb_attach_child    ( runner->accdb_admin,     &parent_xid, &xid );
-  fd_progcache_xid_t pc_xid = fd_progcache_xid_from_funk( &xid );
-  fd_progcache_attach_child( runner->progcache->join, &(fd_progcache_xid_t){0}, &pc_xid );
+  fd_accdb_attach_child( runner->accdb_admin, &parent_xid, &xid );
+  runner->bank->progcache_fork_id = fd_progcache_attach_child( runner->progcache->join, fd_progcache_fork_id_initial() );
 
   FD_TEST( test_ctx->has_bank );
   fd_exec_test_txn_bank_t const * txn_bank = &test_ctx->bank;


### PR DESCRIPTION
Fully decouple progcache from account database by using opaque
fork graph identifiers.  These identifiers are chosen by the
progcache itself instead of externally-chosen like funk XIDs.
