### PR TITLE
Fix repair dedup key packing

### DIFF
--- a/src/discof/repair/fd_policy.h
+++ b/src/discof/repair/fd_policy.h
@@ -50,8 +50,9 @@ typedef struct fd_policy_dedup_ele fd_policy_dedup_ele_t;
 
 FD_FN_CONST static inline ulong
 fd_policy_dedup_key( uint kind, ulong slot, uint shred_idx ) {
-  slot = fd_ulong_extract_lsb( (ulong)slot, 32 );
-  return (ulong)kind << 62 | slot << 30 | shred_idx << 15;
+  return (((ulong)kind      & 0x3UL       ) << 62) |
+         (( slot            & 0xffffffffUL) << 30) |
+         (((ulong)shred_idx & 0x7fffUL    ) << 15);
 }
 
 FD_FN_CONST static inline uint  fd_policy_dedup_key_kind     ( ulong key ) { return (uint)fd_ulong_extract( key, 62, 63 ); }

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -1,6 +1,17 @@
 #include "fd_policy.h"
 
 void
+test_dedup_key_distinguishes_slots( void ) {
+  ulong orphan_a = fd_policy_dedup_key( FD_REPAIR_KIND_ORPHAN,        42UL, UINT_MAX );
+  ulong orphan_b = fd_policy_dedup_key( FD_REPAIR_KIND_ORPHAN,        43UL, UINT_MAX );
+  ulong highest_a = fd_policy_dedup_key( FD_REPAIR_KIND_HIGHEST_SHRED, 42UL, UINT_MAX );
+  ulong highest_b = fd_policy_dedup_key( FD_REPAIR_KIND_HIGHEST_SHRED, 43UL, UINT_MAX );
+
+  FD_TEST( orphan_a  != orphan_b  );
+  FD_TEST( highest_a != highest_b );
+}
+
+void
 test_peer_removal( fd_wksp_t * wksp ) {
   ulong peer_max  = 1024;
   ulong dedup_max = 1024;
@@ -128,6 +139,7 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   test_peer_removal( wksp );
+  test_dedup_key_distinguishes_slots();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
Mask the packed kind, slot, and shred index fields so sentinel shred indexes cannot spill into the slot bits.
Add a regression for orphan and highest-shred requests on adjacent slots.