### PR TITLE
Fix hardcoded Python interpreter versions

### DIFF
--- a/src/flamenco/features/Makefile
+++ b/src/flamenco/features/Makefile
@@ -1,7 +1,7 @@
-# python3.8 -m pip install fd58 --user
-# PYTHON=python3.8 make
+# python3 -m pip install fd58 --user
+# PYTHON=python3 make
 
-PYTHON?=python3.8
+PYTHON?=python3
 BLACK?=$(PYTHON) -m black
 
 .PHONY: generate

--- a/src/flamenco/runtime/tests/fetch_and_generate.sh
+++ b/src/flamenco/runtime/tests/fetch_and_generate.sh
@@ -6,11 +6,12 @@ PROJECT_ROOT=../../../..
 # Set protosol version
 PROTO_VERSION="v7.3.0"
 
+PYTHON=${PYTHON:-python3}
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 FD_NANOPB_TAG=$(cat ${PROJECT_ROOT}/src/ballet/nanopb/nanopb_tag.txt)
 
 # Create venv and install packages
-python3.11 -m venv nanopb_venv
+if [ ! -e nanopb_venv ]; then "$PYTHON" -m venv nanopb_venv; fi
 source nanopb_venv/bin/activate
 pip install protobuf grpcio-tools
 


### PR DESCRIPTION
Fixes hardcoded Python 3.8 and 3.11 versions in various scripts.
Just default to `python3`, and allow the user to override.
