### PR TITLE
neigh: fix double shift

### DIFF
--- a/src/waltz/mib/fd_netdev_netlink.c
+++ b/src/waltz/mib/fd_netdev_netlink.c
@@ -5,7 +5,7 @@
 #include <linux/if_link.h>
 
 #if !defined(__linux__)
-#error "fd_fib4_netlink.c requires a Linux system with kernel headers"
+#error "fd_netdev_netlink.c requires a Linux system with kernel headers"
 #endif
 
 #include <errno.h>

--- a/src/waltz/neigh/fd_neigh4_map.h
+++ b/src/waltz/neigh/fd_neigh4_map.h
@@ -22,7 +22,6 @@ union __attribute__((aligned(16))) fd_neigh4_entry {
 
     #define FD_NEIGH4_PROBE_SUPPRESS_UNTIL_SET(entry, deadline) \
       ulong udead = ((ulong)(deadline))>>FD_NEIGH4_PROBE_SUPPRESS_SHIFT; \
-      udead >>= FD_NEIGH4_PROBE_SUPPRESS_SHIFT; \
       (entry)->probe_suppress_until = udead & FD_NEIGH4_PROBE_SUPPRESS_MASK;
     #define FD_NEIGH4_PROBE_SUPPRESS_UNTIL_GET(entry) \
       (long)(((entry)->probe_suppress_until)<<FD_NEIGH4_PROBE_SUPPRESS_SHIFT)


### PR DESCRIPTION
The struct comment says `probe_suppress_until` "Holds deadline>>24", but the setter shifts twice by 24 => `deadline >> 48`. This makes the FD_NEIGH4_PROBE_SUPPRESS_UNTIL_GET check dead code.