### PR TITLE
runtime: handle null prune cancel info

### DIFF
--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -1093,7 +1093,7 @@ fd_banks_prune_one_dead_bank( fd_banks_t *                   banks,
 
     bank->stake_rewards_fork_id = UCHAR_MAX;
 
-    if( FD_LIKELY( started_replaying ) ) {
+    if( FD_LIKELY( started_replaying && cancel ) ) {
       cancel->txncache_fork_id  = bank->txncache_fork_id;
       cancel->progcache_fork_id = bank->progcache_fork_id;
       cancel->slot              = bank->f.slot;

--- a/src/flamenco/runtime/test_bank.c
+++ b/src/flamenco/runtime/test_bank.c
@@ -348,6 +348,17 @@ test_bank_dead_eviction( void * mem ) {
   FD_TEST( cancel->bank_idx==bank_D_idx  );
   FD_TEST( fd_banks_pool_used( bank_data_pool )==1UL );
 
+  /* Case: started-replaying dead bank can be pruned without requesting cancellation info. */
+  fd_bank_t * bank_N = fd_banks_new_bank( banks, bank_P->idx, 0L );
+  FD_TEST( fd_banks_pool_used( bank_data_pool )==2UL );
+  bank_N = fd_banks_clone_from_parent( banks, bank_N->idx );
+  FD_TEST( bank_N );
+  FD_TEST( fd_banks_pool_used( bank_data_pool )==2UL );
+  fd_banks_mark_bank_frozen( bank_N );
+  fd_banks_mark_bank_dead( banks, bank_N->idx, NULL, NULL );
+  FD_TEST( fd_banks_prune_one_dead_bank( banks, NULL )==2 );
+  FD_TEST( fd_banks_pool_used( bank_data_pool )==1UL );
+
   /* Case: multiple isolated dead banks get pruned at once. */
   fd_bank_t * bank_C = fd_banks_new_bank( banks, bank_P->idx, 0L );
   FD_TEST( fd_banks_pool_used( bank_data_pool )==2UL );


### PR DESCRIPTION
  fd_banks_prune_one_dead_bank documents the cancel info pointer as optional. Only populate it if provided.