### PR TITLE
tower: serdes hardening

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -247,7 +247,7 @@ fd_tower_delete( void * shtower ) {
 
 static fd_vote_acc_vote_t const *
 v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
+  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + !!voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
 }
 
 /* expiration calculates the expiration slot of vote given a slot and
@@ -1150,35 +1150,37 @@ fd_tower_reconcile( fd_tower_t      * tower,
 void
 fd_tower_from_vote_acc( fd_tower_vote_t * votes,
                         ulong           * root,
-                        uchar  const    * vote_acc ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
-  uint                  kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
+                        uchar const data[ static FD_VOTE_STATE_DATA_MAX ] ) {
+  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( data );
+  uint                  kind  = fd_uint_load_4_fast( data );
+  ulong                 cnt   = fd_vote_acc_vote_cnt( data );
+  for( ulong i=0; i<cnt; i++ ) {
     switch( kind ) {
     case FD_VOTE_ACC_V4: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf } ); break;
     case FD_VOTE_ACC_V3: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf } ); break;
     case FD_VOTE_ACC_V2: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = voter->v2.votes[i].slot, .conf = voter->v2.votes[i].conf } ); break;
-    default:          FD_LOG_ERR(( "unsupported voter account version: %u", kind ));
+    default: *root = ULONG_MAX; return;
     }
   }
-  *root = fd_vote_acc_root_slot( vote_acc );
+  *root = fd_vote_acc_root_slot( data );
 }
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
-  uint               kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
+                                 uchar const        data [ static FD_VOTE_STATE_DATA_MAX ] ) {
+  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( data );
+  uint               kind  = fd_uint_load_4_fast( data );
+  ulong              cnt   = fd_vote_acc_vote_cnt( data );
+  for( ulong i=0; i<cnt; i++ ) {
     switch( kind ) {
     case FD_VOTE_ACC_V4: tower[ i ] = (fd_vote_acc_vote_t){ .latency = v4_off( voter )[i].latency, .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf }; break;
     case FD_VOTE_ACC_V3: tower[ i ] = (fd_vote_acc_vote_t){ .latency = voter->v3.votes[i].latency, .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf }; break;
     case FD_VOTE_ACC_V2: tower[ i ] = (fd_vote_acc_vote_t){ .latency = UCHAR_MAX,                  .slot = voter->v2.votes[i].slot, .conf = voter->v2.votes[i].conf }; break;
-    default:          FD_LOG_ERR(( "unsupported voter account version: %u", kind ));
+    default: return 0UL;
     }
   }
 
-  return fd_vote_acc_vote_cnt( vote_acc );
+  return cnt;
 }
 
 void
@@ -1394,7 +1396,7 @@ void
 fd_tower_count_vote( fd_tower_t *        tower,
                      fd_pubkey_t const * vote_acc,
                      ulong               stake,
-                     uchar const         data[static FD_VOTE_STATE_DATA_MAX] ) {
+                     uchar const         data[ static FD_VOTE_STATE_DATA_MAX ] ) {
   fd_tower_vtr_t * vtr = fd_tower_vtr_push_tail_nocopy( tower->vtrs );
   vtr->vote_acc        = *vote_acc;
   vtr->stake           = stake;

--- a/src/choreo/tower/fd_tower.h
+++ b/src/choreo/tower/fd_tower.h
@@ -644,8 +644,8 @@ fd_tower_blocks_canonical_block_id( fd_tower_t * tower,
 
 void
 fd_tower_from_vote_acc( fd_tower_vote_t * votes,
-                        ulong           * root,
-                        uchar const     * vote_acc );
+                        ulong *           root,
+                        uchar const       data[ static FD_VOTE_STATE_DATA_MAX ] );
 
 /* fd_tower_with_lat_from_vote_acc deserializes the vote account into
    tower, including slot latency (when available) for tower votes.
@@ -655,7 +655,7 @@ fd_tower_from_vote_acc( fd_tower_vote_t * votes,
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc );
+                                 uchar const        data [ static FD_VOTE_STATE_DATA_MAX ] );
 
 /* fd_tower_to_vote_txn writes tower into a fd_tower_sync_t vote
    instruction and serializes it into a Solana transaction.  Assumes

--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -1,8 +1,6 @@
 #include "fd_tower_serdes.h"
 #include "fd_tower.h"
 
-#define SHORTVEC 0
-
 #define DE( T, name ) do {                                \
     if( FD_UNLIKELY( buf_sz<sizeof(T) ) ) return -1;      \
     serde->name = *(T const *)fd_type_pun_const( buf );   \
@@ -141,49 +139,41 @@ fd_compact_tower_sync_ser( fd_compact_tower_sync_serde_t const * serde,
 
 static fd_vote_acc_vote_t const *
 v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
+  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + !!voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
 }
 
 ulong
-fd_vote_acc_vote_cnt( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
+fd_vote_acc_vote_cnt( uchar const data[ static FD_VOTE_STATE_DATA_MAX ] ) {
+  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( data );
+  uchar * cnt_ptr;
   switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: return fd_ulong_load_8( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) );
-  case FD_VOTE_ACC_V3: return voter->v3.votes_cnt;
-  case FD_VOTE_ACC_V2: return voter->v2.votes_cnt;
-  default: FD_LOG_HEXDUMP_CRIT(( "bad voter", vote_account_data, 3762 ));
+  case FD_VOTE_ACC_V4: cnt_ptr = (uchar *)&voter->v4.bls_pubkey_compressed + !!voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed); break;
+  case FD_VOTE_ACC_V3: cnt_ptr = (uchar *)&voter->v3.votes_cnt; break;
+  case FD_VOTE_ACC_V2: cnt_ptr = (uchar *)&voter->v2.votes_cnt; break;
+  default: return 0UL;
   }
-}
-
-/* fd_vote_acc_vote_slot takes a voter's vote account data and returns the
-   voter's most recent vote slot in the tower.  Returns ULONG_MAX if
-   they have an empty tower. */
-
-ulong
-fd_vote_acc_vote_slot( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
-  ulong              cnt   = fd_vote_acc_vote_cnt( vote_account_data );
-  switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: return cnt ? v4_off( voter )[cnt-1].slot : ULONG_MAX;
-  case FD_VOTE_ACC_V3: return cnt ? voter->v3.votes[cnt-1].slot : ULONG_MAX;
-  case FD_VOTE_ACC_V2: return cnt ? voter->v2.votes[cnt-1].slot : ULONG_MAX;
-  default: FD_LOG_HEXDUMP_CRIT(( "bad voter", vote_account_data, 3762 ));
-  }
+  if( FD_UNLIKELY( (ulong)cnt_ptr+sizeof(ulong) > (ulong)data+FD_VOTE_STATE_DATA_MAX ) ) return 0UL;
+  ulong cnt = FD_LOAD( ulong, cnt_ptr );
+  return fd_ulong_min( cnt, MAX_LOCKOUT_HISTORY );
 }
 
 /* fd_vote_acc_root_slot takes a voter's vote account data and returns the
    voter's root slot.  Returns ULONG_MAX if they don't have a root. */
 
-ulong
-fd_vote_acc_root_slot( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
-  ulong              cnt   = fd_vote_acc_vote_cnt( vote_account_data );
+FD_FN_PURE ulong
+fd_vote_acc_root_slot( uchar const data[ static FD_VOTE_STATE_DATA_MAX ] ) {
+  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( data );
+  ulong cnt = fd_vote_acc_vote_cnt( data );
+  uchar * opt_root_ptr;
   switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&v4_off( voter )[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&v4_off( voter )[cnt] + 1UL ) : ULONG_MAX; }
-  case FD_VOTE_ACC_V3: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&voter->v3.votes[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&voter->v3.votes[cnt] + 1UL ) : ULONG_MAX; }
-  case FD_VOTE_ACC_V2: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&voter->v2.votes[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&voter->v2.votes[cnt] + 1UL ) : ULONG_MAX; }
-  default:          FD_LOG_CRIT(( "unhandled kind %u", voter->kind ));
+  case FD_VOTE_ACC_V4: opt_root_ptr = (uchar *)&v4_off( voter )[ cnt ]; break;
+  case FD_VOTE_ACC_V3: opt_root_ptr = (uchar *)&voter->v3.votes[ cnt ]; break;
+  case FD_VOTE_ACC_V2: opt_root_ptr = (uchar *)&voter->v2.votes[ cnt ]; break;
+  default: return ULONG_MAX;
   }
+  if( FD_UNLIKELY( (ulong)opt_root_ptr+9UL > (ulong)data+FD_VOTE_STATE_DATA_MAX ) ) return ULONG_MAX;
+  if( *opt_root_ptr != 1 ) return ULONG_MAX;
+  return FD_LOAD( ulong, opt_root_ptr+1 );
 }
 
 int
@@ -222,3 +212,6 @@ fd_txn_parse_simple_vote( fd_txn_t const * txn,
   }
   return 0;
 }
+
+#undef DE
+#undef SER

--- a/src/choreo/tower/fd_tower_serdes.h
+++ b/src/choreo/tower/fd_tower_serdes.h
@@ -1,9 +1,16 @@
 #ifndef HEADER_fd_src_choreo_tower_fd_tower_serdes_h
 #define HEADER_fd_src_choreo_tower_fd_tower_serdes_h
 
+/* fd_tower_serdes.h provides APIs for serializing and deserializing
+   vote accounts and instructions. */
+
 #include "../fd_choreo_base.h"
 #include "../../ballet/txn/fd_txn.h"
 #include "../../flamenco/runtime/program/vote/fd_vote_codec.h"
+
+/* FD_VOTE_IX_KIND_* give vote program instruction discriminants (first
+   four bytes of instruction data).  Older instruction types are ignored
+   by tower. */
 
 #define FD_VOTE_IX_KIND_TOWER_SYNC        (14)
 #define FD_VOTE_IX_KIND_TOWER_SYNC_SWITCH (15)
@@ -57,7 +64,12 @@ fd_compact_tower_sync_de( fd_compact_tower_sync_serde_t * serde,
                           uchar const *                   buf,
                           ulong                           buf_sz );
 
-#define FD_VOTE_STATE_DATA_MAX 3762UL
+/* A buffer with capacity FD_VOTE_STATE_DATA_MAX can fit any valid vote
+   account supported by tower (v2, v3, and v4). */
+
+#define FD_VOTE_STATE_DATA_MAX (3762UL)
+
+/* FD_VOTE_ACC_V* give vote account/state versions. */
 
 #define FD_VOTE_ACC_V2 (1)
 #define FD_VOTE_ACC_V3 (2)
@@ -137,21 +149,22 @@ struct __attribute__((packed)) fd_vote_acc {
 };
 typedef struct fd_vote_acc fd_vote_acc_t;
 
+FD_PROTOTYPES_BEGIN
+
+/* fd_vote_acc_vote_cnt peeks the number of votes from a vote account's
+   data region.  Returns 0UL if data is obviously invalid.  Might return
+   an impossible count (exceeding FD_VOTE_STATE_DATA_MAX) if data
+   contains a corrupt vote state. */
+
 ulong
-fd_vote_acc_vote_cnt( uchar const * buf );
+fd_vote_acc_vote_cnt( uchar const data[ static FD_VOTE_STATE_DATA_MAX ] );
 
-/* fd_vote_acc_vote_slot takes a voter's vote account data and returns
-   the voter's most recent vote slot in the tower.  Returns ULONG_MAX if
-   they have an empty tower. */
-
-FD_FN_PURE ulong
-fd_vote_acc_vote_slot( uchar const * buf );
-
-/* fd_vote_acc_root_slot takes a voter's vote account data and returns
-   the voter's root slot.  Returns ULONG_MAX if they don't have one. */
+/* fd_vote_acc_root_slot peeks a voter's root slot from a vote account's
+   data region.  Returns ULONG_MAX if there is no root slot, or data is
+   invalid. */
 
 FD_FN_PURE ulong
-fd_vote_acc_root_slot( uchar const * buf );
+fd_vote_acc_root_slot( uchar const data[ static FD_VOTE_STATE_DATA_MAX ] );
 
 /* fd_txn_parse_simple_vote optionally extracts the vote account pubkey,
    identity pubkey, and largest voted-for slot from a vote transaction. */
@@ -162,5 +175,7 @@ fd_txn_parse_simple_vote( fd_txn_t const * txn,
                           fd_pubkey_t *    opt_identity,
                           fd_pubkey_t *    opt_vote_acct,
                           ulong *          opt_vote_slot );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_choreo_tower_fd_tower_serdes_h */

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -207,19 +207,15 @@ test_tower_from_vote_acc_data_current( void ) {
 
 void
 mock_vote_acc( fd_hash_t const * pubkey, ulong stake, ulong vote, uint conf, fd_tower_vtr_t * out, fd_tower_vote_t * votes_mem ) {
-  fd_vote_acc_t voter = {
-    .kind = FD_VOTE_ACC_V3,
-    .v3 = {
-      .node_pubkey = *pubkey,
-      .votes_cnt = 1,
-      .votes = {
-        { .slot = vote, .conf = conf },
-      },
-    }
-  };
+  uchar data[ FD_VOTE_STATE_DATA_MAX ] = {0};
+  fd_vote_acc_t * voter = (fd_vote_acc_t *)fd_type_pun( data );
+  voter->kind           = FD_VOTE_ACC_V3;
+  voter->v3.node_pubkey = *pubkey;
+  voter->v3.votes_cnt   = 1;
+  voter->v3.votes[0]    = (fd_vote_acc_vote_t){ .slot = vote, .conf = conf };
 
   fd_tower_vote_remove_all( votes_mem );
-  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter );
+  fd_tower_from_vote_acc( votes_mem, &out->root, data );
   out->votes    = votes_mem;
   out->stake    = stake;
   out->vote_acc = *pubkey;

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -2,19 +2,15 @@
 
 void
 mock_vote_acc( fd_hash_t const * pubkey, ulong stake, ulong vote, uint conf, fd_tower_vtr_t * out, fd_tower_vote_t * votes_mem ) {
-  fd_vote_acc_t voter = {
-    .kind = FD_VOTE_ACC_V3,
-    .v3 = {
-      .node_pubkey = *pubkey,
-      .votes_cnt = 1,
-      .votes = {
-        { .slot = vote, .conf = conf },
-      },
-    }
-  };
+  uchar data[ FD_VOTE_STATE_DATA_MAX ] = {0};
+  fd_vote_acc_t * voter = (fd_vote_acc_t *)fd_type_pun( data );
+  voter->kind           = FD_VOTE_ACC_V3;
+  voter->v3.node_pubkey = *pubkey;
+  voter->v3.votes_cnt   = 1;
+  voter->v3.votes[0]    = (fd_vote_acc_vote_t){ .slot = vote, .conf = conf };
 
   fd_tower_vote_remove_all( votes_mem );
-  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter );
+  fd_tower_from_vote_acc( votes_mem, &out->root, data );
   out->votes    = votes_mem;
   out->stake    = stake;
   out->vote_acc = *pubkey;

--- a/src/choreo/tower/test_tower_serdes.c
+++ b/src/choreo/tower/test_tower_serdes.c
@@ -12,7 +12,6 @@ test_voter_v1_14_11( void ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v2 );
   FD_TEST( voter->kind == FD_VOTE_ACC_V2 );
   FD_TEST( fd_vote_acc_vote_cnt( vote_acc_v2 ) == 31 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v2 ) != ULONG_MAX );
   FD_TEST( fd_vote_acc_root_slot( vote_acc_v2 ) != ULONG_MAX );
 }
 
@@ -21,7 +20,6 @@ test_voter_current( void ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v3 );
   FD_TEST( voter->kind == FD_VOTE_ACC_V3 );
   FD_TEST( fd_vote_acc_vote_cnt( vote_acc_v3 ) == 31 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v3 ) != ULONG_MAX );
   FD_TEST( fd_vote_acc_root_slot( vote_acc_v3 ) != ULONG_MAX );
 }
 
@@ -288,7 +286,6 @@ main( int argc, char ** argv ) {
   fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v4 );
   FD_TEST( voter );
   FD_TEST( voter->kind==FD_VOTE_ACC_V4 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v4 )==699 );
   FD_TEST( fd_vote_acc_root_slot( vote_acc_v4 )==668 );
 
   test_voter_v1_14_11();


### PR DESCRIPTION
Make tower memory-safe even when vote accounts are corrupted.
This acts as defense-in-depth against malicious snapshots.
