### PR TITLE
tower: cleanup vote account peek API

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -243,11 +244,6 @@ fd_tower_delete( void * shtower ) {
   }
 
   return shtower;
-}
-
-static fd_vote_acc_vote_t const *
-v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
 }
 
 /* expiration calculates the expiration slot of vote given a slot and
@@ -1149,36 +1145,61 @@ fd_tower_reconcile( fd_tower_t      * tower,
 
 void
 fd_tower_from_vote_acc( fd_tower_vote_t * votes,
-                        ulong           * root,
-                        uchar  const    * vote_acc ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
-  uint                  kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
-    switch( kind ) {
-    case FD_VOTE_ACC_V4: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf } ); break;
-    case FD_VOTE_ACC_V3: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf } ); break;
-    case FD_VOTE_ACC_V2: fd_tower_vote_push_tail( votes, (fd_tower_vote_t){ .slot = voter->v2.votes[i].slot, .conf = voter->v2.votes[i].conf } ); break;
-    default:          FD_LOG_ERR(( "unsupported voter account version: %u", kind ));
-    }
+                        ulong *           root,
+                        uchar const *     data,
+                        ulong             data_sz ) {
+  fd_vote_acc_desc_t desc[1];
+  if( FD_UNLIKELY( !fd_vote_acc_desc( desc, data, data_sz ) ) ) {
+    *root = ULONG_MAX;
+    return;
   }
-  *root = fd_vote_acc_root_slot( vote_acc );
+  *root = desc->root_slot;
+  for( ulong i=0UL; i<desc->vote_cnt; i++ ) {
+    fd_tower_vote_t vote = {0};
+    switch( desc->kind ) {
+    case FD_VOTE_ACC_V2: {
+      fd_vote_acc_vote_v2_t const * v = fd_vote_acc_desc_vote( desc, data, i );
+      vote.slot = v->slot;
+      vote.conf = v->conf;
+      break;
+    }
+    case FD_VOTE_ACC_V3:
+    case FD_VOTE_ACC_V4: {
+      fd_vote_acc_vote_t const * v = fd_vote_acc_desc_vote( desc, data, i );
+      vote.slot = v->slot;
+      vote.conf = v->conf;
+      break;
+    }
+    }
+    fd_tower_vote_push_tail( votes, vote );
+  }
 }
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc );
-  uint               kind  = fd_uint_load_4_fast( vote_acc ); /* skip node_pubkey */
-  for( ulong i=0; i<fd_vote_acc_vote_cnt( vote_acc ); i++ ) {
-    switch( kind ) {
-    case FD_VOTE_ACC_V4: tower[ i ] = (fd_vote_acc_vote_t){ .latency = v4_off( voter )[i].latency, .slot = v4_off( voter )[i].slot, .conf = v4_off( voter )[i].conf }; break;
-    case FD_VOTE_ACC_V3: tower[ i ] = (fd_vote_acc_vote_t){ .latency = voter->v3.votes[i].latency, .slot = voter->v3.votes[i].slot, .conf = voter->v3.votes[i].conf }; break;
-    case FD_VOTE_ACC_V2: tower[ i ] = (fd_vote_acc_vote_t){ .latency = UCHAR_MAX,                  .slot = voter->v2.votes[i].slot, .conf = voter->v2.votes[i].conf }; break;
-    default:          FD_LOG_ERR(( "unsupported voter account version: %u", kind ));
+                                 uchar const *      data,
+                                 ulong              data_sz ) {
+  fd_vote_acc_desc_t desc[1];
+  if( FD_UNLIKELY( !fd_vote_acc_desc( desc, data, data_sz ) ) ) return 0UL;
+  assert( desc->vote_cnt <= FD_TOWER_VOTE_MAX );
+  switch( desc->kind ) {
+  case FD_VOTE_ACC_V2: {
+    for( ulong i=0UL; i<desc->vote_cnt; i++ ) {
+      fd_vote_acc_vote_v2_t const * v = fd_vote_acc_desc_vote( desc, data, i );
+      tower[ i ] = (fd_vote_acc_vote_t){
+        .slot    = v->slot,
+        .conf    = v->conf,
+        .latency = UCHAR_MAX
+      };
     }
+    break;
   }
-
-  return fd_vote_acc_vote_cnt( vote_acc );
+  case FD_VOTE_ACC_V3:
+  case FD_VOTE_ACC_V4:
+    fd_memcpy( tower, fd_vote_acc_desc_vote( desc, data, 0UL ), desc->vote_cnt * sizeof(fd_vote_acc_vote_t) );
+    break;
+  }
+  return desc->vote_cnt;
 }
 
 void
@@ -1394,12 +1415,13 @@ void
 fd_tower_count_vote( fd_tower_t *        tower,
                      fd_pubkey_t const * vote_acc,
                      ulong               stake,
-                     uchar const         data[static FD_VOTE_STATE_DATA_MAX] ) {
+                     uchar const *       data,
+                     ulong               data_sz ) {
   fd_tower_vtr_t * vtr = fd_tower_vtr_push_tail_nocopy( tower->vtrs );
   vtr->vote_acc        = *vote_acc;
   vtr->stake           = stake;
   fd_tower_vote_remove_all( vtr->votes );
-  fd_tower_from_vote_acc( vtr->votes, &vtr->root, data );
+  fd_tower_from_vote_acc( vtr->votes, &vtr->root, data, data_sz );
 }
 
 /* Block functions ********************************************************/

--- a/src/choreo/tower/fd_tower.h
+++ b/src/choreo/tower/fd_tower.h
@@ -565,7 +565,8 @@ void
 fd_tower_count_vote( fd_tower_t *        tower,
                      fd_pubkey_t const * vote_acc,
                      ulong               stake,
-                     uchar const         data[static FD_VOTE_STATE_DATA_MAX] );
+                     uchar const *       data,
+                     ulong               data_sz );
 
 /* fd_tower_vote_and_reset selects both a block to vote for and block to
    reset to.  Returns flags (FD_TOWER_FLAG_{...}) and writes results to
@@ -644,8 +645,9 @@ fd_tower_blocks_canonical_block_id( fd_tower_t * tower,
 
 void
 fd_tower_from_vote_acc( fd_tower_vote_t * votes,
-                        ulong           * root,
-                        uchar const     * vote_acc );
+                        ulong *           root,
+                        uchar const *     data,
+                        ulong             data_sz );
 
 /* fd_tower_with_lat_from_vote_acc deserializes the vote account into
    tower, including slot latency (when available) for tower votes.
@@ -655,7 +657,8 @@ fd_tower_from_vote_acc( fd_tower_vote_t * votes,
 
 ulong
 fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_MAX ],
-                                 uchar const *      vote_acc );
+                                 uchar const *      data,
+                                 ulong              data_sz );
 
 /* fd_tower_to_vote_txn writes tower into a fd_tower_sync_t vote
    instruction and serializes it into a Solana transaction.  Assumes

--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -1,8 +1,6 @@
 #include "fd_tower_serdes.h"
 #include "fd_tower.h"
 
-#define SHORTVEC 0
-
 #define DE( T, name ) do {                                \
     if( FD_UNLIKELY( buf_sz<sizeof(T) ) ) return -1;      \
     serde->name = *(T const *)fd_type_pun_const( buf );   \
@@ -139,51 +137,56 @@ fd_compact_tower_sync_ser( fd_compact_tower_sync_serde_t const * serde,
   return 0;
 }
 
-static fd_vote_acc_vote_t const *
-v4_off( fd_vote_acc_t const * voter ) {
-  return (fd_vote_acc_vote_t const *)( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) + sizeof(ulong) );
-}
-
-ulong
-fd_vote_acc_vote_cnt( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
-  switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: return fd_ulong_load_8( voter->v4.bls_pubkey_compressed + voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed) );
-  case FD_VOTE_ACC_V3: return voter->v3.votes_cnt;
-  case FD_VOTE_ACC_V2: return voter->v2.votes_cnt;
-  default: FD_LOG_HEXDUMP_CRIT(( "bad voter", vote_account_data, 3762 ));
+fd_vote_acc_desc_t *
+fd_vote_acc_desc( fd_vote_acc_desc_t * desc,
+                  uchar const *        data,
+                  ulong                data_sz ) {
+  if( FD_UNLIKELY( data_sz < sizeof(uint) ) ) return NULL;
+  uint kind = FD_LOAD( uint, data );
+  fd_vote_acc_t const * voter = fd_type_pun_const( data );
+  void const *  vote_cnt_p;
+  ulong         vote_stride;
+  switch( kind ) {
+  case FD_VOTE_ACC_V2:
+    vote_cnt_p  = &voter->v2.votes_cnt;
+    vote_stride = sizeof(fd_vote_acc_vote_v2_t);
+    break;
+  case FD_VOTE_ACC_V3:
+    vote_cnt_p  = &voter->v3.votes_cnt;
+    vote_stride = sizeof(fd_vote_acc_vote_t);
+    break;
+  case FD_VOTE_ACC_V4:
+    if( FD_UNLIKELY( (ulong)&voter->v4.has_bls_pubkey_compressed >= (ulong)data+data_sz ) ) return NULL;
+    vote_cnt_p  = voter->v4.bls_pubkey_compressed + (!!voter->v4.has_bls_pubkey_compressed * sizeof(voter->v4.bls_pubkey_compressed));
+    vote_stride = sizeof(fd_vote_acc_vote_t);
+    break;
+  default:
+    return NULL;
   }
-}
-
-/* fd_vote_acc_vote_slot takes a voter's vote account data and returns the
-   voter's most recent vote slot in the tower.  Returns ULONG_MAX if
-   they have an empty tower. */
-
-ulong
-fd_vote_acc_vote_slot( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
-  ulong              cnt   = fd_vote_acc_vote_cnt( vote_account_data );
-  switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: return cnt ? v4_off( voter )[cnt-1].slot : ULONG_MAX;
-  case FD_VOTE_ACC_V3: return cnt ? voter->v3.votes[cnt-1].slot : ULONG_MAX;
-  case FD_VOTE_ACC_V2: return cnt ? voter->v2.votes[cnt-1].slot : ULONG_MAX;
-  default: FD_LOG_HEXDUMP_CRIT(( "bad voter", vote_account_data, 3762 ));
+  if( FD_UNLIKELY( (ulong)vote_cnt_p+sizeof(ulong) > (ulong)data+data_sz ) ) return NULL;
+  ulong vote_cnt = FD_LOAD( ulong, vote_cnt_p );
+  /* FIXME silent truncation is questionable behavior */
+  vote_cnt = fd_ulong_min( vote_cnt, FD_TOWER_VOTE_MAX );
+  ulong vote_hi_p = (ulong)vote_cnt_p + sizeof(ulong) + vote_cnt*vote_stride;
+  if( FD_UNLIKELY( vote_hi_p > (ulong)data+data_sz ) ) return NULL;
+  /* Option<ulong> "root_slot" follows vote array */
+  ulong root_slot = ULONG_MAX;
+  if( FD_UNLIKELY( vote_hi_p+1UL > (ulong)data+data_sz ) ) return NULL;
+  int root_opt = FD_LOAD( uchar, (void const *)vote_hi_p );
+  if( root_opt==1 ) {
+    if( FD_UNLIKELY( vote_hi_p+9UL > (ulong)data+data_sz ) ) return NULL;
+    root_slot = FD_LOAD( ulong, (void const *)(vote_hi_p+1UL) );
+  } else if( FD_UNLIKELY( root_opt!=0 ) ) {
+    return NULL;
   }
-}
-
-/* fd_vote_acc_root_slot takes a voter's vote account data and returns the
-   voter's root slot.  Returns ULONG_MAX if they don't have a root. */
-
-ulong
-fd_vote_acc_root_slot( uchar const * vote_account_data ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_account_data );
-  ulong              cnt   = fd_vote_acc_vote_cnt( vote_account_data );
-  switch( voter->kind ) {
-  case FD_VOTE_ACC_V4: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&v4_off( voter )[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&v4_off( voter )[cnt] + 1UL ) : ULONG_MAX; }
-  case FD_VOTE_ACC_V3: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&voter->v3.votes[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&voter->v3.votes[cnt] + 1UL ) : ULONG_MAX; }
-  case FD_VOTE_ACC_V2: { uchar root_option = fd_uchar_load_1_fast( (uchar *)&voter->v2.votes[cnt] ); return root_option ? fd_ulong_load_8_fast( (uchar *)&voter->v2.votes[cnt] + 1UL ) : ULONG_MAX; }
-  default:          FD_LOG_CRIT(( "unhandled kind %u", voter->kind ));
-  }
+  *desc = (fd_vote_acc_desc_t){
+    .kind        = (int)kind,
+    .votes_off   = (ushort)( (ulong)vote_cnt_p + sizeof(ulong) - (ulong)data ),
+    .vote_cnt    = (uchar)vote_cnt,
+    .vote_stride = (uchar)vote_stride,
+    .root_slot   = root_slot
+  };
+  return desc;
 }
 
 int
@@ -222,3 +225,6 @@ fd_txn_parse_simple_vote( fd_txn_t const * txn,
   }
   return 0;
 }
+
+#undef DE
+#undef SER

--- a/src/choreo/tower/fd_tower_serdes.h
+++ b/src/choreo/tower/fd_tower_serdes.h
@@ -1,9 +1,16 @@
 #ifndef HEADER_fd_src_choreo_tower_fd_tower_serdes_h
 #define HEADER_fd_src_choreo_tower_fd_tower_serdes_h
 
+/* fd_tower_serdes.h provides APIs for serializing and deserializing
+   vote accounts and instructions. */
+
 #include "../fd_choreo_base.h"
 #include "../../ballet/txn/fd_txn.h"
 #include "../../flamenco/runtime/program/vote/fd_vote_codec.h"
+
+/* FD_VOTE_IX_KIND_* give vote program instruction discriminants (first
+   four bytes of instruction data).  Older instruction types are ignored
+   by tower. */
 
 #define FD_VOTE_IX_KIND_TOWER_SYNC        (14)
 #define FD_VOTE_IX_KIND_TOWER_SYNC_SWITCH (15)
@@ -57,7 +64,12 @@ fd_compact_tower_sync_de( fd_compact_tower_sync_serde_t * serde,
                           uchar const *                   buf,
                           ulong                           buf_sz );
 
-#define FD_VOTE_STATE_DATA_MAX 3762UL
+/* A buffer with capacity FD_VOTE_STATE_DATA_MAX can fit any valid vote
+   account supported by tower (v2, v3, and v4). */
+
+#define FD_VOTE_STATE_DATA_MAX (3762UL)
+
+/* FD_VOTE_ACC_V* give vote account/state versions. */
 
 #define FD_VOTE_ACC_V2 (1)
 #define FD_VOTE_ACC_V3 (2)
@@ -92,6 +104,12 @@ struct __attribute__((packed)) fd_vote_acc_vote {
 };
 typedef struct fd_vote_acc_vote fd_vote_acc_vote_t;
 
+struct __attribute__((packed)) fd_vote_acc_vote_v2 {
+  ulong slot;
+  uint  conf;
+};
+typedef struct fd_vote_acc_vote_v2 fd_vote_acc_vote_v2_t;
+
 struct __attribute__((packed)) fd_vote_acc {
   uint kind;
   union __attribute__((packed)) {
@@ -100,10 +118,7 @@ struct __attribute__((packed)) fd_vote_acc {
       fd_pubkey_t authorized_withdrawer;
       uchar       commission;
       ulong       votes_cnt;
-      struct __attribute__((packed)) {
-        ulong slot;
-        uint  conf;
-      } votes[31]; /* variable-length */
+      fd_vote_acc_vote_v2_t votes[31]; /* variable-length */
       /* uchar root_option */
       /* ulong root */
     } v2;
@@ -113,7 +128,7 @@ struct __attribute__((packed)) fd_vote_acc {
       fd_pubkey_t        authorized_withdrawer;
       uchar              commission;
       ulong              votes_cnt;
-      fd_vote_acc_vote_t    votes[31]; /* variable-length */
+      fd_vote_acc_vote_t votes[31]; /* variable-length */
       /* uchar root_option */
       /* ulong root */
     } v3;
@@ -137,21 +152,42 @@ struct __attribute__((packed)) fd_vote_acc {
 };
 typedef struct fd_vote_acc fd_vote_acc_t;
 
-ulong
-fd_vote_acc_vote_cnt( uchar const * buf );
+/* fd_vote_acc_desc is a lightweight vote account descriptor for zero-
+   copy inspection of a vote account. */
 
-/* fd_vote_acc_vote_slot takes a voter's vote account data and returns
-   the voter's most recent vote slot in the tower.  Returns ULONG_MAX if
-   they have an empty tower. */
+struct fd_vote_acc_desc {
+  int    kind;        /* FD_VOTE_ACC_* */
+  ushort votes_off;   /* offset to vote array */
+  uchar  vote_cnt;    /* number of votes (max FD_TOWER_VOTE_MAX) */
+  uchar  vote_stride; /* byte stride between votes */
+  ulong  root_slot;   /* ULONG_MAX if not set */
+};
+typedef struct fd_vote_acc_desc fd_vote_acc_desc_t;
 
-FD_FN_PURE ulong
-fd_vote_acc_vote_slot( uchar const * buf );
+FD_PROTOTYPES_BEGIN
 
-/* fd_vote_acc_root_slot takes a voter's vote account data and returns
-   the voter's root slot.  Returns ULONG_MAX if they don't have one. */
+/* fd_vote_acc_desc recovers offsets to vote account bits given
+   serialized data.  Does minimal input validation.  Initializes *desc
+   and returns desc on success, or NULL on failure (invalid or
+   unsupported vote account data). */
 
-FD_FN_PURE ulong
-fd_vote_acc_root_slot( uchar const * buf );
+fd_vote_acc_desc_t *
+fd_vote_acc_desc( fd_vote_acc_desc_t * desc,
+                  uchar const *        data,
+                  ulong                data_sz );
+
+/* fd_vote_acc_desc_vote returns a pointer to a vote in a serialized
+   vote account.  The return type depends on desc->kind:
+   - FD_VOTE_ACC_V2 -> fd_vote_acc_vote_v2_t
+   - FD_VOTE_ACC_V3 -> fd_vote_acc_vote_t
+   - FD_VOTE_ACC_V4 -> fd_vote_acc_vote_t */
+
+FD_FN_PURE static inline void const *
+fd_vote_acc_desc_vote( fd_vote_acc_desc_t const * desc,
+                       uchar const *              data,
+                       ulong                      idx ) {
+  return data + desc->votes_off + idx*desc->vote_stride;
+}
 
 /* fd_txn_parse_simple_vote optionally extracts the vote account pubkey,
    identity pubkey, and largest voted-for slot from a vote transaction. */
@@ -162,5 +198,7 @@ fd_txn_parse_simple_vote( fd_txn_t const * txn,
                           fd_pubkey_t *    opt_identity,
                           fd_pubkey_t *    opt_vote_acct,
                           ulong *          opt_vote_slot );
+
+FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_choreo_tower_fd_tower_serdes_h */

--- a/src/choreo/tower/fuzz_tower_serdes.c
+++ b/src/choreo/tower/fuzz_tower_serdes.c
@@ -8,6 +8,7 @@
 
 #include "../../util/fd_util.h"
 #include "../../util/sanitize/fd_fuzz.h"
+#include "fd_tower.h"
 #include "fd_tower_serdes.h"
 
 int
@@ -25,6 +26,8 @@ LLVMFuzzerInitialize( int  *   argc,
 int
 LLVMFuzzerTestOneInput( uchar const * data,
                         ulong         data_sz ) {
+
+  /* Decode/encode round-trip for vote instruction data */
 
   fd_compact_tower_sync_serde_t serde[1];
   memset( serde, 0, sizeof(fd_compact_tower_sync_serde_t) );
@@ -65,5 +68,18 @@ LLVMFuzzerTestOneInput( uchar const * data,
   assert( !memcmp( &serde->block_id, &serde2->block_id, sizeof(fd_hash_t) ) );
 
   FD_FUZZ_MUST_BE_COVERED;
+
+  /* Also interpret input as vote account */
+
+  fd_vote_acc_desc_t desc[1];
+  if( fd_vote_acc_desc( desc, data, data_sz ) ) {
+    assert( desc->kind>=FD_VOTE_ACC_V2 && desc->kind<=FD_VOTE_ACC_V4 );
+    assert( desc->vote_cnt <= FD_TOWER_VOTE_MAX );
+    assert( desc->vote_stride );
+    ulong vote0 = (ulong)fd_vote_acc_desc_vote( desc, data, 0UL );
+    ulong vote1 = vote0 + ( (ulong)desc->vote_cnt * (ulong)desc->vote_stride );
+    assert( vote0>=(ulong)data && vote1<=(ulong)data+data_sz );
+  }
+
   return 0;
 }

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -104,7 +104,7 @@ test_tower_from_vote_acc_data_v1_14_11( void ) {
   fd_tower_t * tower = fd_tower_join( fd_tower_new( scratch, 2, 2, 0 ) );
   FD_TEST( tower );
 
-  fd_tower_from_vote_acc( tower->votes, &tower->root,vote_acc_v2 );
+  fd_tower_from_vote_acc( tower->votes, &tower->root, vote_acc_v2, vote_acc_v2_sz );
 
   fd_tower_vote_t expected_votes[31] = {
     { 159175525, 31 },
@@ -157,7 +157,7 @@ test_tower_from_vote_acc_data_current( void ) {
   fd_tower_t * tower = fd_tower_join( fd_tower_new( scratch, 2, 2, 0 ) );
   FD_TEST( tower );
 
-  fd_tower_from_vote_acc( tower->votes, &tower->root,vote_acc_v3 );
+  fd_tower_from_vote_acc( tower->votes, &tower->root, vote_acc_v3, vote_acc_v3_sz );
 
   fd_tower_vote_t expected_votes[31] = {
     { 285373759, 31 },
@@ -219,7 +219,7 @@ mock_vote_acc( fd_hash_t const * pubkey, ulong stake, ulong vote, uint conf, fd_
   };
 
   fd_tower_vote_remove_all( votes_mem );
-  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter );
+  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter, sizeof(fd_vote_acc_t) );
   out->votes    = votes_mem;
   out->stake    = stake;
   out->vote_acc = *pubkey;
@@ -897,7 +897,7 @@ test_vtr_valid_join( fd_wksp_t * wksp ) {
     voter->v3.node_pubkey = pks[i];
     voter->v3.votes_cnt   = 1;
     voter->v3.votes[0]    = (fd_vote_acc_vote_t){ .slot = i + 1, .conf = 1 };
-    fd_tower_count_vote( tower, &pks[i], 100, data );
+    fd_tower_count_vote( tower, &pks[i], 100, data, sizeof(data) );
   }
 
   /* Every vtr in the deque must have a valid (non-NULL) votes join. */

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -14,7 +14,7 @@ mock_vote_acc( fd_hash_t const * pubkey, ulong stake, ulong vote, uint conf, fd_
   };
 
   fd_tower_vote_remove_all( votes_mem );
-  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter );
+  fd_tower_from_vote_acc( votes_mem, &out->root, (uchar const *)&voter, sizeof(fd_vote_acc_t) );
   out->votes    = votes_mem;
   out->stake    = stake;
   out->vote_acc = *pubkey;

--- a/src/choreo/tower/test_tower_serdes.c
+++ b/src/choreo/tower/test_tower_serdes.c
@@ -8,21 +8,30 @@ FD_IMPORT_BINARY( vote_acc_v3, "src/choreo/tower/fixtures/vote_acc_v3.bin" );
 FD_IMPORT_BINARY( vote_acc_v4, "src/choreo/tower/fixtures/vote_acc_v4.bin" );
 
 void
-test_voter_v1_14_11( void ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v2 );
-  FD_TEST( voter->kind == FD_VOTE_ACC_V2 );
-  FD_TEST( fd_vote_acc_vote_cnt( vote_acc_v2 ) == 31 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v2 ) != ULONG_MAX );
-  FD_TEST( fd_vote_acc_root_slot( vote_acc_v2 ) != ULONG_MAX );
+test_voter_v2( void ) {
+  fd_vote_acc_desc_t desc[1];
+  FD_TEST( fd_vote_acc_desc( desc, vote_acc_v2, vote_acc_v2_sz ) );
+  FD_TEST( desc->kind == FD_VOTE_ACC_V2 );
+  FD_TEST( desc->vote_cnt == 31 );
+  FD_TEST( desc->root_slot != ULONG_MAX );
 }
 
 void
-test_voter_current( void ) {
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v3 );
-  FD_TEST( voter->kind == FD_VOTE_ACC_V3 );
-  FD_TEST( fd_vote_acc_vote_cnt( vote_acc_v3 ) == 31 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v3 ) != ULONG_MAX );
-  FD_TEST( fd_vote_acc_root_slot( vote_acc_v3 ) != ULONG_MAX );
+test_voter_v3( void ) {
+  fd_vote_acc_desc_t desc[1];
+  FD_TEST( fd_vote_acc_desc( desc, vote_acc_v3, vote_acc_v3_sz ) );
+  FD_TEST( desc->kind == FD_VOTE_ACC_V3 );
+  FD_TEST( desc->vote_cnt == 31 );
+  FD_TEST( desc->root_slot != ULONG_MAX );
+}
+
+void
+test_voter_v4( void ) {
+  fd_vote_acc_desc_t desc[1];
+  FD_TEST( fd_vote_acc_desc( desc, vote_acc_v4, vote_acc_v4_sz ) );
+  FD_TEST( desc->kind == FD_VOTE_ACC_V4 );
+  FD_TEST( desc->vote_cnt == 31 );
+  FD_TEST( desc->root_slot == 668 );
 }
 
 /* Helper: serialize a valid CompactTowerSync into buf.  Returns the
@@ -282,17 +291,15 @@ test_de_attacker( void ) {
 }
 
 int
-main( int argc, char ** argv ) {
+main( int     argc,
+      char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_vote_acc_t const * voter = (fd_vote_acc_t const *)fd_type_pun_const( vote_acc_v4 );
-  FD_TEST( voter );
-  FD_TEST( voter->kind==FD_VOTE_ACC_V4 );
-  FD_TEST( fd_vote_acc_vote_slot( vote_acc_v4 )==699 );
-  FD_TEST( fd_vote_acc_root_slot( vote_acc_v4 )==668 );
-
-  test_voter_v1_14_11();
-  test_voter_current();
+  test_voter_v2();
+  test_voter_v3();
+  test_voter_v4();
   test_de_attacker();
+
+  FD_LOG_NOTICE(( "pass" ));
   fd_halt();
 }

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -635,7 +635,7 @@ publish_slot_done( fd_tower_tile_t *            ctx,
   }
 
   msg->tower_cnt = 0UL; /* FIXME */
-  if( FD_LIKELY( found ) ) msg->tower_cnt = fd_tower_with_lat_from_vote_acc( msg->tower, ctx->our_vote_acct );
+  if( FD_LIKELY( found ) ) msg->tower_cnt = fd_tower_with_lat_from_vote_acc( msg->tower, ctx->our_vote_acct, ctx->our_vote_acct_sz );
 }
 
 static void
@@ -695,7 +695,7 @@ count_vote_acc( fd_tower_tile_t *            ctx,
                 uchar const *                data,
                 ulong                        data_sz ) {
 
-  fd_tower_count_vote( ctx->tower, vote_acc, stake, data );
+  fd_tower_count_vote( ctx->tower, vote_acc, stake, data, data_sz );
 
   fd_tower_vtr_t const * vtr = fd_tower_vtr_peek_tail_const( ctx->tower->vtrs );
 
@@ -1000,7 +1000,9 @@ query_vote_accs( fd_tower_tile_t *            ctx,
     fd_accdb_close_ro( ctx->accdb, reconcile_ro );
     int skip_reconcile = !ctx->init && ctx->wfs;
     if( FD_LIKELY( !skip_reconcile ) ) {
-      ulong root; fd_tower_vote_remove_all( ctx->scratch_tower ); fd_tower_from_vote_acc( ctx->scratch_tower, &root, ctx->our_vote_acct );
+      ulong root;
+      fd_tower_vote_remove_all( ctx->scratch_tower );
+      fd_tower_from_vote_acc( ctx->scratch_tower, &root, ctx->our_vote_acct, ctx->our_vote_acct_sz );
       fd_tower_reconcile( ctx->tower, ctx->scratch_tower, root );
     } else {
       FD_LOG_NOTICE(( "wait_for_supermajority: skipping tower reconcile on init slot %lu", slot_completed->slot ));


### PR DESCRIPTION
Clean up and harden the method used to 'peek' into serialized vote account data.  Now memory-safe even for invalid vote account data.