### PR TITLE
[ballet] Fix BLAKE3 AVX512 sign-conversion warnings

### DIFF
--- a/src/ballet/blake3/fd_blake3_avx512.c
+++ b/src/ballet/blake3/fd_blake3_avx512.c
@@ -222,7 +222,7 @@ fd_blake3_avx512_compress16( ulong                   batch_cnt,
       ulong tail_data_off = fd_ulong_align_dn( sz, FD_BLAKE3_BLOCK_SZ );
 
       batch_tail_data[ batch_idx ] = tail_data;
-      batch_tail_rem [ batch_idx ] = (!!tail_data_sz) ^ (!sz);  /* (hash 1 tail block if 0 sz) */
+      batch_tail_rem [ batch_idx ] = (ulong)( (!!tail_data_sz) ^ (!sz) );  /* (hash 1 tail block if 0 sz) */
 
       scratch_free += FD_BLAKE3_BLOCK_SZ;
 
@@ -662,10 +662,10 @@ fd_blake3_avx512_compress16_fast( uchar const * restrict msg,
   ulong off = 0UL;
   do {
     ulong const off_next = off+FD_BLAKE3_BLOCK_SZ;
-    int chunk_flags =
-        ( off     ==0UL ? FD_BLAKE3_FLAG_CHUNK_START : 0 ) |
-        ( off_next==sz  ? FD_BLAKE3_FLAG_CHUNK_END   : 0 );
-    int flags_ = flags | fd_int_if( parent, 0, chunk_flags );
+    uint chunk_flags =
+        ( off     ==0UL ? FD_BLAKE3_FLAG_CHUNK_START : 0u ) |
+        ( off_next==sz  ? FD_BLAKE3_FLAG_CHUNK_END   : 0u );
+    uint flags_ = (uint)flags | fd_uint_if( parent, 0u, chunk_flags );
     wwu_t flags_vec = wwu_bcast( flags_ );
 
     wwu_t m[16];


### PR DESCRIPTION
## Summary

Fix two sign-conversion warnings in the BLAKE3 AVX512 backend, copying the AVX2 solution:

- cast the tail-block boolean expression before storing it in `ulong`
- keep `chunk_flags` / `flags_` unsigned in `fd_blake3_avx512_compress16_fast`

## Reproduction

The warnings were hit when running:

```sh
podman build -t firedancer-gcc10:rocky8 -f contrib/containers/gcc-10.dockerfile .
podman run --rm -v "$PWD:/data/firedancer" firedancer-gcc10:rocky8 bash -lc '
set -e
cd /data/firedancer
FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh +dev fetch check install
MACHINE=linux_gcc_x86_64 CC=gcc CXX=g++ make -j 16 fddev fdctl
'
```

GCC error:

```text
src/ballet/blake3/fd_blake3_avx512.c: In function 'fd_blake3_avx512_compress16':
src/ballet/blake3/fd_blake3_avx512.c:225:38: error: conversion to 'ulong' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Werror=sign-conversion]
  225 |       batch_tail_rem [ batch_idx ] = (!!tail_data_sz) ^ (!sz);  /* (hash 1 tail block if 0 sz) */
      |                                      ^
src/ballet/blake3/fd_blake3_avx512.c: In function 'fd_blake3_avx512_compress16_fast':
src/ballet/blake3/fd_blake3_avx512.c:666:9: error: conversion to 'int' from 'unsigned int' may change the sign of the result [-Werror=sign-conversion]
  666 |         ( off     ==0UL ? FD_BLAKE3_FLAG_CHUNK_START : 0 ) |
      |         ^
```
