### PR TITLE
tower: diff fuzz vote state zero-copy decoder

### DIFF
--- a/src/choreo/tower/fuzz_tower_serdes.c
+++ b/src/choreo/tower/fuzz_tower_serdes.c
@@ -8,6 +8,7 @@
 
 #include "../../util/fd_util.h"
 #include "../../util/sanitize/fd_fuzz.h"
+#include "../../flamenco/runtime/program/vote/fd_vote_codec.h"
 #include "fd_tower.h"
 #include "fd_tower_serdes.h"
 
@@ -23,9 +24,9 @@ LLVMFuzzerInitialize( int  *   argc,
   return 0;
 }
 
-int
-LLVMFuzzerTestOneInput( uchar const * data,
-                        ulong         data_sz ) {
+static void
+fuzz_vote_instruction( uchar const * data,
+                       ulong         data_sz ) {
 
   /* Decode/encode round-trip for vote instruction data */
 
@@ -35,7 +36,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
   int de_err = fd_compact_tower_sync_de( serde, data, data_sz );
   if( de_err ) {
     FD_FUZZ_MUST_BE_COVERED;
-    return 0;
+    return;
   }
 
   FD_FUZZ_MUST_BE_COVERED;
@@ -68,11 +69,21 @@ LLVMFuzzerTestOneInput( uchar const * data,
   assert( !memcmp( &serde->block_id, &serde2->block_id, sizeof(fd_hash_t) ) );
 
   FD_FUZZ_MUST_BE_COVERED;
+}
 
-  /* Also interpret input as vote account */
+static void
+fuzz_vote_state( uchar const * data,
+                 ulong         data_sz ) {
+  /* Test zero-copy vote state deserialization;
+     differentially fuzz against the vote program's full decoder. */
 
-  fd_vote_acc_desc_t desc[1];
-  if( fd_vote_acc_desc( desc, data, data_sz ) ) {
+  fd_vote_state_versioned_t vsv_[1];
+  fd_vote_state_versioned_t * vsv = fd_vote_state_versioned_deserialize( vsv_, data, data_sz );
+  fd_vote_acc_desc_t desc_[1];
+  fd_vote_acc_desc_t * desc = fd_vote_acc_desc( desc_, data, data_sz );
+
+  if( desc ) {
+    /* Decoded invariants */
     assert( desc->kind>=FD_VOTE_ACC_V2 && desc->kind<=FD_VOTE_ACC_V4 );
     assert( desc->vote_cnt <= FD_TOWER_VOTE_MAX );
     assert( desc->vote_stride );
@@ -81,5 +92,66 @@ LLVMFuzzerTestOneInput( uchar const * data,
     assert( vote0>=(ulong)data && vote1<=(ulong)data+data_sz );
   }
 
+  if( vsv ) {
+    /* If the vote state is valid, peek must also support it
+       (The opposite is not true, as peek does not do full validation) */
+    if( vsv->kind!=fd_vote_state_versioned_enum_uninitialized ) {
+      assert( desc );
+    }
+
+    /* Ensure content is the same */
+    switch( vsv->kind ) {
+    case fd_vote_state_versioned_enum_uninitialized:
+      assert( desc==NULL );
+      break;
+    case fd_vote_state_versioned_enum_v1_14_11: {
+      assert( desc->root_slot ==
+              ( vsv->v1_14_11.has_root_slot ? vsv->v1_14_11.root_slot : ULONG_MAX ) );
+      assert( desc->vote_cnt == deq_fd_landed_vote_t_cnt( vsv->v1_14_11.votes ) );
+      fd_vote_acc_vote_v2_t const * vote0 = fd_vote_acc_desc_vote( desc, data, 0UL );
+      for( ulong i=0UL; i<(desc->vote_cnt); i++ ) {
+        fd_landed_vote_t const * lv = deq_fd_landed_vote_t_peek_index_const( vsv->v1_14_11.votes, i );
+        assert( vote0[ i ].slot == lv->lockout.slot );
+        assert( vote0[ i ].conf == lv->lockout.confirmation_count );
+      }
+      break;
+    }
+    case fd_vote_state_versioned_enum_v3: {
+      assert( desc->root_slot ==
+              ( vsv->v3.has_root_slot ? vsv->v3.root_slot : ULONG_MAX ) );
+      assert( desc->vote_cnt == deq_fd_landed_vote_t_cnt( vsv->v3.votes ) );
+      fd_vote_acc_vote_t const * vote0 = fd_vote_acc_desc_vote( desc, data, 0UL );
+      for( ulong i=0UL; i<(desc->vote_cnt); i++ ) {
+        fd_landed_vote_t const * lv = deq_fd_landed_vote_t_peek_index_const( vsv->v3.votes, i );
+        assert( vote0[ i ].latency == lv->latency );
+        assert( vote0[ i ].slot == lv->lockout.slot );
+        assert( vote0[ i ].conf == lv->lockout.confirmation_count );
+      }
+      break;
+    }
+    case fd_vote_state_versioned_enum_v4: {
+      assert( desc->root_slot ==
+              ( vsv->v4.has_root_slot ? vsv->v4.root_slot : ULONG_MAX ) );
+      assert( desc->vote_cnt == deq_fd_landed_vote_t_cnt( vsv->v4.votes ) );
+      fd_vote_acc_vote_t const * vote0 = fd_vote_acc_desc_vote( desc, data, 0UL );
+      for( ulong i=0UL; i<(desc->vote_cnt); i++ ) {
+        fd_landed_vote_t const * lv = deq_fd_landed_vote_t_peek_index_const( vsv->v4.votes, i );
+        assert( vote0[ i ].latency == lv->latency );
+        assert( vote0[ i ].slot == lv->lockout.slot );
+        assert( vote0[ i ].conf == lv->lockout.confirmation_count );
+      }
+      break;
+    }
+    default:
+      abort();
+    }
+  }
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         data_sz ) {
+  fuzz_vote_instruction( data, data_sz );
+  fuzz_vote_state      ( data, data_sz );
   return 0;
 }


### PR DESCRIPTION
Ensure the new zero-copy peek API matches the full compliant
fd_types-based vote state decoder
