### PR TITLE
flamenco: seek_epoch_credits enforce MAX_EPOCH_CREDITS_HISTORY bound

### DIFF
--- a/src/flamenco/runtime/program/vote/fd_vote_codec.c
+++ b/src/flamenco/runtime/program/vote/fd_vote_codec.c
@@ -566,6 +566,7 @@ seek_epoch_credits( uchar const *                    data,
   /* Now at epoch_credits deque */
   ulong epoch_credits_len;
   READ_U64( epoch_credits_len, &ptr, &remaining );
+  CHECK( epoch_credits_len<=MAX_EPOCH_CREDITS_HISTORY );
   CHECK_U64_MUL_OVERFLOW( epoch_credits_len, sizeof(fd_vote_epoch_credits_t) );
   CHECK( epoch_credits_len*sizeof(fd_vote_epoch_credits_t)<=remaining );
 

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -344,6 +344,7 @@ get_vote_credits( uchar const *        account_data,
 
   fd_vote_epoch_credits_t const * vote_epoch_credits = fd_vote_account_epoch_credits( account_data, account_data_len, &epoch_credits->cnt );
   FD_TEST( vote_epoch_credits );
+  FD_TEST( epoch_credits->cnt<=FD_EPOCH_CREDITS_MAX );
 
   ulong base = epoch_credits->cnt ? vote_epoch_credits[0].prev_credits : 0UL;
   for( ulong i=0UL; i<epoch_credits->cnt; i++ ) {


### PR DESCRIPTION
Add missing `epoch_credits_len <= MAX_EPOCH_CREDITS_HISTORY` check in `seek_epoch_credits` to match the existing check in `deser_epoch_credits`.
Also assert `cnt <= MAX_EPOCH_CREDITS_HISTORY` before writing into fixed-size arrays.

Closes https://github.com/firedancer-io/firedancer/issues/9706.