### PR TITLE
gossip: bump active stake-threshold

### DIFF
--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -562,9 +562,10 @@ static inline int
 is_ping_active( fd_gossvf_tile_ctx_t *  ctx,
                 fd_ip4_port_t           addr,
                 fd_pubkey_t const *     pubkey ) {
-  /* 1. If the node has more than 1 sol staked, it is active */
+  /* 1. If the node has more than FD_GOSSIP_STAKED_THRESHOLD lamports
+        staked, it is active */
   stake_t const * stake = stake_map_ele_query_const( ctx->stake.map, pubkey, NULL, ctx->stake.pool );
-  if( FD_LIKELY( stake && stake->stake>=1000000000UL ) ) return 1;
+  if( FD_LIKELY( stake && stake->stake>=FD_GOSSIP_STAKED_THRESHOLD ) ) return 1;
 
   /* 2. If the node has actively ponged a ping, it is active */
   ping_t * ping = ping_map_ele_query( ctx->ping_map, pubkey, NULL, ctx->pings );

--- a/src/flamenco/gossip/fd_gossip_message.h
+++ b/src/flamenco/gossip/fd_gossip_message.h
@@ -55,6 +55,12 @@
 #define FD_GOSSIP_FAILED_NO_CONTACT_INFO (1)
 #define FD_GOSSIP_FAILED_WALLCLOCK       (2)
 
+/* FD_GOSSIP_STAKED_THRESHOLD is the minimum stake (in lamports) at
+   which a node is considered an active participant (e.g. it does not
+   need to maintain a connection by responding to pings), whereas nodes
+   below this threshold are treated as unstaked.  This is 100 SOL. */
+#define FD_GOSSIP_STAKED_THRESHOLD (100UL*1000000000UL)
+
 #define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO        (offsetof(fd_gossip_update_message_t, contact_info)        + sizeof((fd_gossip_update_message_t *)0)->contact_info)
 #define FD_GOSSIP_UPDATE_SZ_CONTACT_INFO_REMOVE (offsetof(fd_gossip_update_message_t, contact_info_remove) + sizeof((fd_gossip_update_message_t *)0)->contact_info_remove)
 #define FD_GOSSIP_UPDATE_SZ_VOTE                (offsetof(fd_gossip_update_message_t, vote)                + sizeof((fd_gossip_update_message_t *)0)->vote)

--- a/src/flamenco/gossip/fd_gossip_wsample.c
+++ b/src/flamenco/gossip/fd_gossip_wsample.c
@@ -11,6 +11,7 @@
 
 #include "fd_gossip_wsample.h"
 #include "fd_active_set.h"
+#include "fd_gossip_message.h"
 #include "../../util/log/fd_log.h"
 
 #define R           (9UL)  /* Radix of the sampling trees. */
@@ -291,8 +292,9 @@ fd_gossip_wsample_join( void * shwsample ) {
 static inline int
 is_active( ulong stake,
            int   ping_tracked ) {
-  /* 1. If the node has more than 1 sol staked, it is active */
-  if( FD_UNLIKELY( stake>=1000000000UL ) ) return 1;
+  /* 1. If the node has more than FD_GOSSIP_STAKED_THRESHOLD lamports
+        staked, it is active */
+  if( FD_UNLIKELY( stake>=FD_GOSSIP_STAKED_THRESHOLD ) ) return 1;
 
   /* 2. If the node has actively ponged a ping, it is active */
   if( FD_UNLIKELY( ping_tracked ) ) return 1;

--- a/src/flamenco/gossip/fd_ping_tracker.c
+++ b/src/flamenco/gossip/fd_ping_tracker.c
@@ -282,7 +282,7 @@ fd_ping_tracker_track( fd_ping_tracker_t * ping_tracker,
   fd_ping_peer_t * peer = peer_map_ele_query( ping_tracker->peers, fd_type_pun_const( peer_pubkey ), NULL, ping_tracker->pool );
 
   if( FD_UNLIKELY( !peer ) ) {
-    if( FD_LIKELY( peer_stake>=1000000000UL ) ) return;
+    if( FD_LIKELY( peer_stake>=FD_GOSSIP_STAKED_THRESHOLD ) ) return;
 
     if( FD_UNLIKELY( !pool_free( ping_tracker->pool ) ) ) {
       peer = lru_list_ele_peek_head( ping_tracker->lru, ping_tracker->pool );
@@ -306,9 +306,10 @@ fd_ping_tracker_track( fd_ping_tracker_t * ping_tracker,
     peer_map_ele_insert( ping_tracker->peers, peer, ping_tracker->pool );
     lru_list_ele_push_tail( ping_tracker->lru, peer, ping_tracker->pool );
   } else {
-    if( FD_LIKELY( peer_stake>=1000000000UL ) ) {
-      /* Node went from unstaked (or low staked) to >=1 SOL.  No longer
-         need to ping it. */
+    if( FD_LIKELY( peer_stake>=FD_GOSSIP_STAKED_THRESHOLD ) ) {
+      /* Node went from unstaked (or low staked) to
+         >=FD_GOSSIP_STAKED_THRESHOLD lamports.  No longer need to ping
+         it. */
       ping_tracker->metrics->stake_changed_cnt++;
       remove_peer( ping_tracker, peer, now, FD_PING_TRACKER_CHANGE_TYPE_INACTIVE_STAKED );
       return;
@@ -353,7 +354,7 @@ fd_ping_tracker_register( fd_ping_tracker_t * ping_tracker,
                           fd_ip4_port_t       peer_address,
                           uchar const *       pong_token,
                           long                now ) {
-  if( FD_UNLIKELY( peer_stake>=1000000000UL ) ) {
+  if( FD_UNLIKELY( peer_stake>=FD_GOSSIP_STAKED_THRESHOLD ) ) {
     ping_tracker->metrics->pong_result[ 0UL ]++;
     return;
   }

--- a/src/flamenco/gossip/fd_ping_tracker.h
+++ b/src/flamenco/gossip/fd_ping_tracker.h
@@ -16,7 +16,8 @@
 
    Any peer which has tried to send us a gossip message within the last
    sixty seconds is eligible to be pinged, except nodes with at least
-   one SOL of stake which are exempt from ping requirements.
+   FD_GOSSIP_STAKED_THRESHOLD lamports of stake which are exempt from
+   ping requirements.
 
    Once a peer has been pinged, we wait up to twenty seconds for a
    response before trying again.  We repeatedly retry pinging the peer
@@ -28,6 +29,7 @@
    begin pinging the peer again, every twenty seconds, to refresh the
    peer. */
 
+#include "fd_gossip_message.h"
 #include "../../util/rng/fd_rng.h"
 #include "../../util/net/fd_net_headers.h"
 

--- a/src/flamenco/gossip/test_ping_tracker.c
+++ b/src/flamenco/gossip/test_ping_tracker.c
@@ -78,7 +78,7 @@ test_basic( void ) {
 
 
   /* High stake nodes do not get tracked ... */
-  fd_ping_tracker_track( ping_tracker, random_pubkey, 1000000000UL, entrypoints[0], now );
+  fd_ping_tracker_track( ping_tracker, random_pubkey, FD_GOSSIP_STAKED_THRESHOLD, entrypoints[0], now );
   FD_TEST( !fd_ping_tracker_pop_request( ping_tracker, now+seconds(10), NULL, NULL, NULL ) );
 
   /* Low stake nodes do get tracked ... */


### PR DESCRIPTION
Mitigates attacker who trivially bypasses the ping tracker for ~32K SOL by using peers with 1 SOL