### PR TITLE
stem: fix during_frag contract violations

### DIFF
--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -112,11 +112,6 @@ during_frag( fd_dedup_ctx_t * ctx,
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP ) ) {
     if( FD_UNLIKELY( sz>FD_TPU_RAW_MTU ) ) FD_LOG_ERR(( "received a gossip transaction that was too large" ));
     fd_memcpy( dst, src, sz );
-
-    fd_txn_m_t const * txnm = (fd_txn_m_t const *)dst;
-    if( FD_UNLIKELY( txnm->payload_sz>FD_TPU_MTU ) ) {
-      FD_LOG_ERR(( "vote txn payload size %hu exceeds max %lu", txnm->payload_sz, FD_TPU_MTU ));
-    }
   } else if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPLAY ) ) {
     if( FD_LIKELY( sig==REPLAY_SIG_TXN_EXECUTED ) ) {
       fd_replay_txn_executed_t * txn_executed = fd_type_pun( src );
@@ -164,7 +159,9 @@ after_frag( fd_dedup_ctx_t *    ctx,
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_REPLAY       ) ) return;
 
   fd_txn_m_t * txnm = (fd_txn_m_t *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
-  FD_TEST( txnm->payload_sz<=FD_TPU_MTU );
+  if( FD_UNLIKELY( txnm->payload_sz>FD_TPU_MTU ) ) {
+    FD_LOG_ERR(( "dedup: txn payload size %hu exceeds max %lu", txnm->payload_sz, FD_TPU_MTU ));
+  }
   fd_txn_t * txn = fd_txn_m_txn_t( txnm );
 
   if( FD_UNLIKELY( txnm->block_engine.bundle_id && (txnm->block_engine.bundle_id!=ctx->bundle_id) ) ) {

--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -556,10 +556,15 @@ during_frag( fd_sock_tile_t * ctx,
     FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->link_tx[ in_idx ].chunk0, ctx->link_tx[ in_idx ].wmark ));
   }
 
+  ctx->parsed.invalid = 0;
+
   ulong const hdr_min = sizeof(fd_eth_hdr_t)+sizeof(fd_ip4_hdr_t)+sizeof(fd_udp_hdr_t);
   if( FD_UNLIKELY( sz<hdr_min ) ) {
-    /* FIXME support ICMP messages in the future? */
-    FD_LOG_ERR(( "packet too small %lu (in_idx=%lu)", sz, in_idx ));
+    /* FIXME support ICMP messages in the future?
+       Defer the error to after_frag, where we know we weren't
+       overrun. */
+    ctx->parsed.invalid = 1;
+    return;
   }
 
   uchar const * frame   = fd_chunk_to_laddr_const( ctx->link_tx[ in_idx ].base, chunk );
@@ -573,9 +578,14 @@ during_frag( fd_sock_tile_t * ctx,
 
   fd_ip4_hdr_t const * ip_hdr  = (fd_ip4_hdr_t const *)( frame  +sizeof(fd_eth_hdr_t) );
   fd_udp_hdr_t const * udp_hdr = (fd_udp_hdr_t const *)( payload-sizeof(fd_udp_hdr_t) );
-  if( FD_UNLIKELY( ( FD_IP4_GET_VERSION( *ip_hdr )!=4 ) |
-                   ( ip_hdr->protocol != FD_IP4_HDR_PROTOCOL_UDP ) ) ) {
-    FD_LOG_ERR(( "packet from in_idx=%lu: sock tile only supports IPv4 UDP for now", in_idx ));
+  ctx->parsed.ip_version  = FD_IP4_GET_VERSION( *ip_hdr );
+  ctx->parsed.ip_protocol = ip_hdr->protocol;
+  if( FD_UNLIKELY( ( ctx->parsed.ip_version !=4                       ) |
+                   ( ctx->parsed.ip_protocol!=FD_IP4_HDR_PROTOCOL_UDP ) ) ) {
+    /* sock tile only supports IPv4 UDP for now.  Defer the error to
+       after_frag, where we know we weren't overrun. */
+    ctx->parsed.invalid = 1;
+    return;
   }
 
   ulong msg_sz = sizeof(fd_udp_hdr_t) + payload_sz;
@@ -624,14 +634,28 @@ during_frag( fd_sock_tile_t * ctx,
 
 static void
 after_frag( fd_sock_tile_t *    ctx,
-            ulong               in_idx FD_PARAM_UNUSED,
+            ulong               in_idx,
             ulong               seq    FD_PARAM_UNUSED,
             ulong               sig    FD_PARAM_UNUSED,
             ulong               sz,
             ulong               tsorig FD_PARAM_UNUSED,
             ulong               tspub  FD_PARAM_UNUSED,
             fd_stem_context_t * stem   FD_PARAM_UNUSED ) {
-  /* Commit the packet added in during_frag */
+  /* Commit the packet added in during_frag.  during_frag defers fatal
+     errors to here (where we know we weren't overrun) by setting the
+     invalid flag. */
+
+  if( FD_UNLIKELY( ctx->parsed.invalid ) ) {
+    ulong const hdr_min = sizeof(fd_eth_hdr_t)+sizeof(fd_ip4_hdr_t)+sizeof(fd_udp_hdr_t);
+    if( FD_UNLIKELY( sz<hdr_min ) ) {
+      /* FIXME support ICMP messages in the future? */
+      FD_LOG_ERR(( "packet too small %lu (in_idx=%lu)", sz, in_idx ));
+    }
+    if( FD_UNLIKELY( ( ctx->parsed.ip_version !=4                       ) |
+                     ( ctx->parsed.ip_protocol!=FD_IP4_HDR_PROTOCOL_UDP ) ) ) {
+      FD_LOG_ERR(( "packet from in_idx=%lu: sock tile only supports IPv4 UDP for now", in_idx ));
+    }
+  }
 
   ctx->tx_idle_cnt = 0;
   ctx->batch_cnt++;

--- a/src/disco/net/sock/fd_sock_tile_private.h
+++ b/src/disco/net/sock/fd_sock_tile_private.h
@@ -88,6 +88,14 @@ struct fd_sock_tile {
   uchar * tx_scratch1;
   uchar * tx_ptr; /* in [tx_scratch0,tx_scratch1) */
 
+  /* Values parsed from the current frag in during_frag, validated in
+     after_frag */
+  struct {
+    int  invalid; /* set if the frag failed validation in during_frag */
+    uint ip_version;
+    uint ip_protocol;
+  } parsed;
+
   fd_sock_tile_metrics_t metrics;
 };
 

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -459,7 +459,7 @@ during_frag( fd_shred_ctx_t * ctx,
 
   /* Firedancer only */
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_ROOTED ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
+    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz<sizeof(fd_tower_slot_rooted_t) ) )
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
                    ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
     fd_tower_slot_rooted_t const * rooted_msg = fd_chunk_to_laddr_const( ctx->in[ in_idx ].mem, chunk );
@@ -469,7 +469,7 @@ during_frag( fd_shred_ctx_t * ctx,
 
   /* Frankendancer only */
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_ROOTEDH ) ) {
-    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark ) )
+    if( FD_UNLIKELY( chunk<ctx->in[ in_idx ].chunk0 || chunk>ctx->in[ in_idx ].wmark || sz<sizeof(fd_rooted_bank_t) ) )
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz,
                    ctx->in[ in_idx ].chunk0, ctx->in[ in_idx ].wmark ));
     /* The message format is a pointer to the bank (which is in the

--- a/src/disco/verify/fd_verify_tile.c
+++ b/src/disco/verify/fd_verify_tile.c
@@ -75,11 +75,6 @@ during_frag( fd_verify_ctx_t * ctx,
     uchar * src = fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk );
     uchar * dst = fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
     fd_memcpy( dst, src, sz );
-
-    fd_txn_m_t const * txnm = (fd_txn_m_t const *)dst;
-    if( FD_UNLIKELY( txnm->payload_sz>FD_TPU_MTU ) ) {
-      FD_LOG_ERR(( "fd_verify: txn payload size %hu exceeds max %lu", txnm->payload_sz, FD_TPU_MTU ));
-    }
   } else if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP ) ) {
     if( FD_UNLIKELY( chunk<ctx->in[in_idx].chunk0 || chunk>ctx->in[in_idx].wmark || sz>2048UL ) )
       FD_LOG_ERR(( "chunk %lu %lu corrupt, not in range [%lu,%lu]", chunk, sz, ctx->in[in_idx].chunk0, ctx->in[in_idx].wmark ));
@@ -113,6 +108,9 @@ after_frag( fd_verify_ctx_t *   ctx,
   if( FD_UNLIKELY( ctx->in_kind[ in_idx ]==IN_KIND_GOSSIP || ctx->in_kind[ in_idx ]==IN_KIND_TXSEND ) ) ctx->metrics.gossiped_votes_cnt++;
 
   fd_txn_m_t * txnm = (fd_txn_m_t *)fd_chunk_to_laddr( ctx->out_mem, ctx->out_chunk );
+  if( FD_UNLIKELY( txnm->payload_sz>FD_TPU_MTU ) ) {
+    FD_LOG_ERR(( "verify: txn payload size %hu exceeds max %lu", txnm->payload_sz, FD_TPU_MTU ));
+  }
   fd_txn_t *  txnt = fd_txn_m_txn_t( txnm );
   txnm->txn_t_sz = (ushort)fd_txn_parse( fd_txn_m_payload( txnm ), txnm->payload_sz, txnt, NULL );
 


### PR DESCRIPTION
Fixes a couple of instanced of the following class of bug:

In `during_frag`, frag data from an **unreliable** (or potentially-overrun) link may be torn/corrupt. So `during_frag` must NOT:
1. Crash (`FD_LOG_ERR`/`FD_TEST`/assert) based on frag **contents** (i.e. dcache read)
2. Mutate persistent state that affects other callbacks (housekeeping, before/after_credit). I didn't find any violations of this rule.