### PR TITLE
bn254: speed up syscalls

### DIFF
--- a/src/ballet/bn254/fd_bn254_field.c
+++ b/src/ballet/bn254/fd_bn254_field.c
@@ -1,5 +1,8 @@
 #include "./fd_bn254.h"
 #include "../fiat-crypto/bn254_64.c"
+#if FD_HAS_S2NBIGNUM
+#include <s2n-bignum.h>
+#endif
 
 /* Fp = base field */
 
@@ -155,12 +158,41 @@ fd_bn254_fp_set( fd_bn254_fp_t * r,
   return r;
 }
 
+/* fd_bn254_fp_add: r = a + b mod p, output in [0, p).  Used everywhere. */
 INLINE fd_bn254_fp_t *
 fd_bn254_fp_add( fd_bn254_fp_t * r,
                  fd_bn254_fp_t const * a,
                  fd_bn254_fp_t const * b ) {
   fiat_bn254_add( r->limbs, a->limbs, b->limbs );
   return r;
+}
+
+/* fd_bn254_fp_add_lazy: r = a + b, output in [0, 2p) (NO conditional sub).
+   Safe ONLY if the result feeds a Mont mul (the CIOS reduction tolerates
+   inputs up to 2p for BN254 since p_limbs[3] < (2^64-1)/2-1).  Do NOT
+   feed lazy outputs to fp_sub, fp_neg, fp_eq, frombytes, halve, etc.
+   On non-x86 builds we fall back to the (eager) fp_add: still correct,
+   just no perf win. */
+INLINE fd_bn254_fp_t *
+fd_bn254_fp_add_lazy( fd_bn254_fp_t * r,
+                      fd_bn254_fp_t const * a,
+                      fd_bn254_fp_t const * b ) {
+#if FD_HAS_X86
+  unsigned long long t0, t1, t2, t3;
+  uchar c = 0;
+  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[0], (unsigned long long)b->limbs[0], &t0 );
+  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[1], (unsigned long long)b->limbs[1], &t1 );
+  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[2], (unsigned long long)b->limbs[2], &t2 );
+  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[3], (unsigned long long)b->limbs[3], &t3 );
+  (void)c; /* p < 2^254 so c is always 0 for a, b < 2p */
+  r->limbs[0] = (ulong)t0;
+  r->limbs[1] = (ulong)t1;
+  r->limbs[2] = (ulong)t2;
+  r->limbs[3] = (ulong)t3;
+  return r;
+#else
+  return fd_bn254_fp_add( r, a, b );
+#endif
 }
 
 INLINE fd_bn254_fp_t *
@@ -218,16 +250,30 @@ fd_bn254_fp_pow( fd_bn254_fp_t * restrict r,
   return r;
 }
 
-/* fd_bn254_fp_inv computes r = 1 / a.
-   a MUST not be 0.
-   Computes via a^{-1} <=> a^{p-2}. */
+/* fd_bn254_fp_inv computes r = 1 / a.  a MUST not be 0.
+   With s2n-bignum: bignum_modinv (Bernstein-Yang divsteps), ~10x faster
+   than Fermat's little theorem.  Without: a^{p-2} via square-and-multiply. */
 static inline fd_bn254_fp_t *
 fd_bn254_fp_inv( fd_bn254_fp_t * r,
                   fd_bn254_fp_t const * a ) {
+#if FD_HAS_S2NBIGNUM
+  /* a is in Mont form: a_limbs = a*R mod p.
+     bignum_modinv treats inputs as canonical residues, so it computes
+       z = (a*R)^{-1} = a^{-1} * R^{-1}    (non-Mont form).
+     Two fiat_bn254_to_montgomery calls multiply by R each, giving
+       r = a^{-1} * R^{-1} * R * R = a^{-1} * R = (a^{-1})_mont. */
+  ulong tmp[12]; /* bignum_modinv needs 3*k temporary */
+  ulong z[4];
+  bignum_modinv( 4, z, a->limbs, fd_bn254_const_p->limbs, tmp );
+  fiat_bn254_to_montgomery( r->limbs, z );
+  fiat_bn254_to_montgomery( r->limbs, r->limbs );
+  return r;
+#else
   fd_uint256_t p_minus_2[1];
   fd_bn254_fp_set( p_minus_2, fd_bn254_const_p );
   p_minus_2->limbs[0] -= 2UL;
   return fd_bn254_fp_pow( r, a, p_minus_2 );
+#endif
 }
 
 static inline fd_bn254_fp_t *

--- a/src/ballet/bn254/fd_bn254_field.c
+++ b/src/ballet/bn254/fd_bn254_field.c
@@ -3,6 +3,10 @@
 #if FD_HAS_S2NBIGNUM
 #include <s2n-bignum.h>
 #endif
+#if FD_HAS_X86
+#include <immintrin.h>
+#endif
+
 
 /* Fp = base field */
 
@@ -158,7 +162,7 @@ fd_bn254_fp_set( fd_bn254_fp_t * r,
   return r;
 }
 
-/* fd_bn254_fp_add: r = a + b mod p, output in [0, p).  Used everywhere. */
+/* r = a + b mod p, output in [0, p). */
 INLINE fd_bn254_fp_t *
 fd_bn254_fp_add( fd_bn254_fp_t * r,
                  fd_bn254_fp_t const * a,
@@ -167,12 +171,9 @@ fd_bn254_fp_add( fd_bn254_fp_t * r,
   return r;
 }
 
-/* fd_bn254_fp_add_lazy: r = a + b, output in [0, 2p) (NO conditional sub).
-   Safe ONLY if the result feeds a Mont mul (the CIOS reduction tolerates
-   inputs up to 2p for BN254 since p_limbs[3] < (2^64-1)/2-1).  Do NOT
-   feed lazy outputs to fp_sub, fp_neg, fp_eq, frombytes, halve, etc.
-   On non-x86 builds we fall back to the (eager) fp_add: still correct,
-   just no perf win. */
+/* r = a + b, output in [0, 2p).
+   Safe only if the result feeds into a multiplication, but should not
+   be fed into fp_sub, fp_neg, fp_eq, frombytes, halve, etc. */
 INLINE fd_bn254_fp_t *
 fd_bn254_fp_add_lazy( fd_bn254_fp_t * r,
                       fd_bn254_fp_t const * a,
@@ -191,6 +192,8 @@ fd_bn254_fp_add_lazy( fd_bn254_fp_t * r,
   r->limbs[3] = (ulong)t3;
   return r;
 #else
+  /* We find no performance improvement on non-x86 targets, so we
+     fallback to the original fp_add. */
   return fd_bn254_fp_add( r, a, b );
 #endif
 }
@@ -250,19 +253,17 @@ fd_bn254_fp_pow( fd_bn254_fp_t * restrict r,
   return r;
 }
 
-/* fd_bn254_fp_inv computes r = 1 / a.  a MUST not be 0.
-   With s2n-bignum: bignum_modinv (Bernstein-Yang divsteps), ~10x faster
-   than Fermat's little theorem.  Without: a^{p-2} via square-and-multiply. */
+/* r = 1 / a mod p. a MUST not be 0. */
 static inline fd_bn254_fp_t *
 fd_bn254_fp_inv( fd_bn254_fp_t * r,
                   fd_bn254_fp_t const * a ) {
 #if FD_HAS_S2NBIGNUM
-  /* a is in Mont form: a_limbs = a*R mod p.
-     bignum_modinv treats inputs as canonical residues, so it computes
-       z = (a*R)^{-1} = a^{-1} * R^{-1}    (non-Mont form).
-     Two fiat_bn254_to_montgomery calls multiply by R each, giving
-       r = a^{-1} * R^{-1} * R * R = a^{-1} * R = (a^{-1})_mont. */
-  ulong tmp[12]; /* bignum_modinv needs 3*k temporary */
+  /* a is in montgomery form, giving a' = a*R mod p.
+     bignum_modinv treats its inputs as canonical residues, so it computes:
+      z = (a*R)^{-1} = a^{-1} * R^{-1}
+     We can apply to_montgomery twice, each time multiplying by R, giving:
+      r = a^{-1} * R^{-1} * R * R = a^{-1} * R = (a^{-1})' */
+  ulong tmp[12];
   ulong z[4];
   bignum_modinv( 4, z, a->limbs, fd_bn254_const_p->limbs, tmp );
   fiat_bn254_to_montgomery( r->limbs, z );

--- a/src/ballet/bn254/fd_bn254_field_ext.c
+++ b/src/ballet/bn254/fd_bn254_field_ext.c
@@ -187,6 +187,17 @@ fd_bn254_fp2_add( fd_bn254_fp2_t * r,
   return r;
 }
 
+/* Same as above but skips reduction: r in [0, 2p)^2.  Only safe if r is
+   consumed by an fp2_mul/fp2_sqr next.  See fd_bn254_fp_add_lazy. */
+static inline fd_bn254_fp2_t *
+fd_bn254_fp2_add_lazy( fd_bn254_fp2_t * r,
+                       fd_bn254_fp2_t const * a,
+                       fd_bn254_fp2_t const * b ) {
+  fd_bn254_fp_add_lazy( &r->el[0], &a->el[0], &b->el[0] );
+  fd_bn254_fp_add_lazy( &r->el[1], &a->el[1], &b->el[1] );
+  return r;
+}
+
 /* fd_bn254_fp2_sub computes r = a - b in Fp2. */
 static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sub( fd_bn254_fp2_t * r,
@@ -223,8 +234,9 @@ fd_bn254_fp2_mul( fd_bn254_fp2_t * r,
   fd_bn254_fp_t * r1 = &r->el[1];
   fd_bn254_fp_t a0b0[1], a1b1[1], sa[1], sb[1];
 
-  fd_bn254_fp_add( sa, a0, a1 );
-  fd_bn254_fp_add( sb, b0, b1 );
+  /* sa, sb consumed only by fp_mul -> safe lazy. */
+  fd_bn254_fp_add_lazy( sa, a0, a1 );
+  fd_bn254_fp_add_lazy( sb, b0, b1 );
 
   fd_bn254_fp_mul( a0b0, a0, b0 );
   fd_bn254_fp_mul( a1b1, a1, b1 );
@@ -243,8 +255,9 @@ static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sqr( fd_bn254_fp2_t * r,
                   fd_bn254_fp2_t const * a ) {
   fd_bn254_fp_t p[1], m[1];
-  fd_bn254_fp_add( p, &a->el[0], &a->el[1] );
-  fd_bn254_fp_sub( m, &a->el[0], &a->el[1] );
+  /* p is consumed only by fp_mul -> lazy ok. */
+  fd_bn254_fp_add_lazy( p, &a->el[0], &a->el[1] );
+  fd_bn254_fp_sub     ( m, &a->el[0], &a->el[1] );
   /* r1 = 2 a0*a1 */
   fd_bn254_fp_mul( &r->el[1], &a->el[0], &a->el[1] );
   fd_bn254_fp_add( &r->el[1], &r->el[1], &r->el[1] );
@@ -303,39 +316,57 @@ fd_bn254_fp2_pow( fd_bn254_fp2_t * restrict r,
 }
 
 /* fd_bn254_fp2_sqrt computes r = sqrt(a) in Fp2.
-   https://eprint.iacr.org/2012/685, Alg. 9.
-   Note: r is one of the two sqrt, the other is -r. This function
-   can return either the positive or negative one, no assumptions/promises.
-   Returns r if a is a square (sqrt exists), or NULL otherwise. */
+   "Complex method" / Adj-Lindqvist Alg. 8 of https://eprint.iacr.org/2012/685.
+   For BN254 the non-residue is i with i^2 = -1, so norm(c) = c0^2 + c1^2.
+   Cost is 2 (avg ~2.25) fp_sqrt + 1 fp_inv + a handful of fp_mul/sqr,
+   vs the 2 fp2_pow of Alg. 9 (each ~3x the cost of an fp_pow). */
 static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sqrt( fd_bn254_fp2_t * r,
                    fd_bn254_fp2_t const * a ) {
-  fd_bn254_fp2_t a0[1], a1[1], alpha[1], x0[1];
+  fd_bn254_fp_t const * c0 = &a->el[0];
+  fd_bn254_fp_t const * c1 = &a->el[1];
+  fd_bn254_fp_t norm[1], alpha[1], delta[1], tmp[1];
+  fd_bn254_fp_t x[1], y[1], xinv[1];
 
-  fd_bn254_fp2_pow( a1, a, fd_bn254_const_sqrt_exp );
-
-  fd_bn254_fp2_sqr( alpha, a1 );
-  fd_bn254_fp2_mul( alpha, alpha, a );
-
-  fd_bn254_fp2_conj( a0, alpha );
-  fd_bn254_fp2_mul( a0, a0, alpha );
-
-  if( FD_UNLIKELY( fd_bn254_fp2_is_minus_one( a0 ) ) ) {
-    return NULL;
+  /* c1 == 0: sqrt reduces to Fp sqrt on c0 (or sqrt(-c0) shifted to imag). */
+  if( FD_UNLIKELY( fd_bn254_fp_is_zero( c1 ) ) ) {
+    if( fd_bn254_fp_sqrt( x, c0 ) ) {
+      fd_bn254_fp_set( &r->el[0], x );
+      fd_bn254_fp_set_zero( &r->el[1] );
+      return r;
+    }
+    fd_bn254_fp_neg( y, c0 );
+    if( !fd_bn254_fp_sqrt( y, y ) ) return NULL;
+    fd_bn254_fp_set_zero( &r->el[0] );
+    fd_bn254_fp_set( &r->el[1], y );
+    return r;
   }
 
-  fd_bn254_fp2_mul( x0, a1, a );
-  if( fd_bn254_fp2_is_minus_one( alpha ) ) {
-    /* COV: I don't know if there's a point that hits this condition.
-       sqrt(-1) hits this, but doesn't correspond to a valid point.
-       Tried with some other possible values, nothing corresponds to a point. */
-    fd_bn254_fp2_mul_by_i( r, x0 );
-  } else {
-    fd_bn254_fp2_set_one( a1 );
-    fd_bn254_fp2_add( a0, alpha, a1 );                           /* 1 + alpha */
-    fd_bn254_fp2_pow( a1, a0, fd_bn254_const_p_minus_one_half ); /* b */
-    fd_bn254_fp2_mul( r, a1, x0 );
+  /* norm = c0^2 + c1^2 */
+  fd_bn254_fp_sqr( norm, c0 );
+  fd_bn254_fp_sqr( tmp,  c1 );
+  fd_bn254_fp_add( norm, norm, tmp );
+
+  /* alpha = sqrt(norm); NULL means a is a non-square in Fp2. */
+  if( !fd_bn254_fp_sqrt( alpha, norm ) ) return NULL;
+
+  /* delta = (alpha + c0)/2; if not a QR, use (c0 - alpha)/2 instead.
+     We probe by trying sqrt(delta) directly. */
+  fd_bn254_fp_add( delta, alpha, c0 );
+  fd_bn254_fp_halve( delta, delta );
+
+  if( !fd_bn254_fp_sqrt( x, delta ) ) {
+    fd_bn254_fp_sub( delta, delta, alpha );
+    if( !fd_bn254_fp_sqrt( x, delta ) ) return NULL;
   }
+
+  /* y = c1 / (2x) = c1 * (1/x) / 2 */
+  fd_bn254_fp_inv  ( xinv, x );
+  fd_bn254_fp_mul  ( y, c1, xinv );
+  fd_bn254_fp_halve( y, y );
+
+  fd_bn254_fp_set( &r->el[0], x );
+  fd_bn254_fp_set( &r->el[1], y );
   return r;
 }
 
@@ -396,6 +427,16 @@ fd_bn254_fp6_add( fd_bn254_fp6_t * r,
 }
 
 static inline fd_bn254_fp6_t *
+fd_bn254_fp6_add_lazy( fd_bn254_fp6_t * r,
+                       fd_bn254_fp6_t const * a,
+                       fd_bn254_fp6_t const * b ) {
+  fd_bn254_fp2_add_lazy( &r->el[0], &a->el[0], &b->el[0] );
+  fd_bn254_fp2_add_lazy( &r->el[1], &a->el[1], &b->el[1] );
+  fd_bn254_fp2_add_lazy( &r->el[2], &a->el[2], &b->el[2] );
+  return r;
+}
+
+static inline fd_bn254_fp6_t *
 fd_bn254_fp6_sub( fd_bn254_fp6_t * r,
                   fd_bn254_fp6_t const * a,
                   fd_bn254_fp6_t const * b ) {
@@ -436,6 +477,8 @@ fd_bn254_fp6_mul( fd_bn254_fp6_t * r,
   fd_bn254_fp2_mul( a1b1, a1, b1 );
   fd_bn254_fp2_mul( a2b2, a2, b2 );
 
+  /* NOT lazy: fp2_mul has its own internal lazy adds; compounding would
+     push intermediate values past Mont mul's <2p precondition. */
   fd_bn254_fp2_add( sa, a1, a2 );
   fd_bn254_fp2_add( sb, b1, b2 );
   fd_bn254_fp2_mul( r0, sa, sb );
@@ -485,6 +528,7 @@ fd_bn254_fp6_sqr( fd_bn254_fp6_t * r,
 
   fd_bn254_fp2_sqr( c3, a0 );
   fd_bn254_fp2_sub( c4, a0, a1 );
+  /* NOT lazy: fp2_sqr internally lazy-adds, compounding would overflow. */
   fd_bn254_fp2_add( c4, c4, a2 );
 
   fd_bn254_fp2_mul( c5, a1, a2 );
@@ -648,7 +692,8 @@ fd_bn254_fp12_mul_sparse( fd_bn254_fp12_t *       r,
   /* a1*b1 = a.el[1] * (c3, c4, 0) : 5 Fp2_mul */
   fd_bn254_fp6_mul_by_01( a1b1, &a->el[1], c3, c4 );
 
-  /* r1 = (a0+a1) * (c0+c3, c4, 0) - a0b0 - a1b1 : 5 Fp2_mul */
+  /* r1 = (a0+a1) * (c0+c3, c4, 0) - a0b0 - a1b1 : 5 Fp2_mul.
+     NOT lazy: same compounding issue as fp12_mul. */
   fd_bn254_fp6_add( sa, &a->el[0], &a->el[1] );
   fd_bn254_fp2_add( sc0, c0, c3 );
   fd_bn254_fp6_mul_by_01( &r->el[1], sa, sc0, c4 );
@@ -674,6 +719,8 @@ fd_bn254_fp12_mul( fd_bn254_fp12_t * r,
   fd_bn254_fp6_t * r1 = &r->el[1];
   fd_bn254_fp6_t a0b0[1], a1b1[1], sa[1], sb[1];
 
+  /* NOT lazy: fp6_mul internally uses fp2_mul which lazy-adds its inputs;
+     a lazy_add here would compound and overflow Mont mul's <2p precondition. */
   fd_bn254_fp6_add( sa, a0, a1 );
   fd_bn254_fp6_add( sb, b0, b1 );
 

--- a/src/ballet/bn254/fd_bn254_field_ext.c
+++ b/src/ballet/bn254/fd_bn254_field_ext.c
@@ -187,17 +187,6 @@ fd_bn254_fp2_add( fd_bn254_fp2_t * r,
   return r;
 }
 
-/* Same as above but skips reduction: r in [0, 2p)^2.  Only safe if r is
-   consumed by an fp2_mul/fp2_sqr next.  See fd_bn254_fp_add_lazy. */
-static inline fd_bn254_fp2_t *
-fd_bn254_fp2_add_lazy( fd_bn254_fp2_t * r,
-                       fd_bn254_fp2_t const * a,
-                       fd_bn254_fp2_t const * b ) {
-  fd_bn254_fp_add_lazy( &r->el[0], &a->el[0], &b->el[0] );
-  fd_bn254_fp_add_lazy( &r->el[1], &a->el[1], &b->el[1] );
-  return r;
-}
-
 /* fd_bn254_fp2_sub computes r = a - b in Fp2. */
 static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sub( fd_bn254_fp2_t * r,
@@ -234,7 +223,7 @@ fd_bn254_fp2_mul( fd_bn254_fp2_t * r,
   fd_bn254_fp_t * r1 = &r->el[1];
   fd_bn254_fp_t a0b0[1], a1b1[1], sa[1], sb[1];
 
-  /* sa, sb consumed only by fp_mul -> safe lazy. */
+  /* sa, sb are lazy additions as they're only consumed by fp_mul */
   fd_bn254_fp_add_lazy( sa, a0, a1 );
   fd_bn254_fp_add_lazy( sb, b0, b1 );
 
@@ -255,7 +244,7 @@ static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sqr( fd_bn254_fp2_t * r,
                   fd_bn254_fp2_t const * a ) {
   fd_bn254_fp_t p[1], m[1];
-  /* p is consumed only by fp_mul -> lazy ok. */
+  /* p is a lazy addition as it's only consumed by fp_mul */
   fd_bn254_fp_add_lazy( p, &a->el[0], &a->el[1] );
   fd_bn254_fp_sub     ( m, &a->el[0], &a->el[1] );
   /* r1 = 2 a0*a1 */
@@ -316,10 +305,11 @@ fd_bn254_fp2_pow( fd_bn254_fp2_t * restrict r,
 }
 
 /* fd_bn254_fp2_sqrt computes r = sqrt(a) in Fp2.
-   "Complex method" / Adj-Lindqvist Alg. 8 of https://eprint.iacr.org/2012/685.
-   For BN254 the non-residue is i with i^2 = -1, so norm(c) = c0^2 + c1^2.
-   Cost is 2 (avg ~2.25) fp_sqrt + 1 fp_inv + a handful of fp_mul/sqr,
-   vs the 2 fp2_pow of Alg. 9 (each ~3x the cost of an fp_pow). */
+   https://eprint.iacr.org/2012/685, Alg. 8.
+
+   For bn254 the non-residue is i with i^2 = -1, so norm(c) = c0^2 + c1^2.
+   This method costs us 2 fp_sqrt + 1 fp_inv + a few fp_mul/sqr.
+   The method described in Alg. 9 is 2 fp2_pow, which is more expensive. */
 static inline fd_bn254_fp2_t *
 fd_bn254_fp2_sqrt( fd_bn254_fp2_t * r,
                    fd_bn254_fp2_t const * a ) {
@@ -328,7 +318,7 @@ fd_bn254_fp2_sqrt( fd_bn254_fp2_t * r,
   fd_bn254_fp_t norm[1], alpha[1], delta[1], tmp[1];
   fd_bn254_fp_t x[1], y[1], xinv[1];
 
-  /* c1 == 0: sqrt reduces to Fp sqrt on c0 (or sqrt(-c0) shifted to imag). */
+  /* c1 == 0, sqrt reduces to Fp sqrt on c0 (or sqrt(-c0) shifted to imaginary). */
   if( FD_UNLIKELY( fd_bn254_fp_is_zero( c1 ) ) ) {
     if( fd_bn254_fp_sqrt( x, c0 ) ) {
       fd_bn254_fp_set( &r->el[0], x );
@@ -350,8 +340,9 @@ fd_bn254_fp2_sqrt( fd_bn254_fp2_t * r,
   /* alpha = sqrt(norm); NULL means a is a non-square in Fp2. */
   if( !fd_bn254_fp_sqrt( alpha, norm ) ) return NULL;
 
-  /* delta = (alpha + c0)/2; if not a QR, use (c0 - alpha)/2 instead.
-     We probe by trying sqrt(delta) directly. */
+  /* delta = (alpha + c0) / 2
+     If delta is not a quadratic residue, use (c0 - alpha) / 2 instead.
+     We test this by trying sqrt(delta) first. */
   fd_bn254_fp_add( delta, alpha, c0 );
   fd_bn254_fp_halve( delta, delta );
 
@@ -427,16 +418,6 @@ fd_bn254_fp6_add( fd_bn254_fp6_t * r,
 }
 
 static inline fd_bn254_fp6_t *
-fd_bn254_fp6_add_lazy( fd_bn254_fp6_t * r,
-                       fd_bn254_fp6_t const * a,
-                       fd_bn254_fp6_t const * b ) {
-  fd_bn254_fp2_add_lazy( &r->el[0], &a->el[0], &b->el[0] );
-  fd_bn254_fp2_add_lazy( &r->el[1], &a->el[1], &b->el[1] );
-  fd_bn254_fp2_add_lazy( &r->el[2], &a->el[2], &b->el[2] );
-  return r;
-}
-
-static inline fd_bn254_fp6_t *
 fd_bn254_fp6_sub( fd_bn254_fp6_t * r,
                   fd_bn254_fp6_t const * a,
                   fd_bn254_fp6_t const * b ) {
@@ -477,8 +458,8 @@ fd_bn254_fp6_mul( fd_bn254_fp6_t * r,
   fd_bn254_fp2_mul( a1b1, a1, b1 );
   fd_bn254_fp2_mul( a2b2, a2, b2 );
 
-  /* NOT lazy: fp2_mul has its own internal lazy adds; compounding would
-     push intermediate values past Mont mul's <2p precondition. */
+  /* fp2_mul has its own internal lazy additions, so we cannot compound
+     here as it would push intermediate values past our [0, 2p) bound. */
   fd_bn254_fp2_add( sa, a1, a2 );
   fd_bn254_fp2_add( sb, b1, b2 );
   fd_bn254_fp2_mul( r0, sa, sb );
@@ -528,7 +509,7 @@ fd_bn254_fp6_sqr( fd_bn254_fp6_t * r,
 
   fd_bn254_fp2_sqr( c3, a0 );
   fd_bn254_fp2_sub( c4, a0, a1 );
-  /* NOT lazy: fp2_sqr internally lazy-adds, compounding would overflow. */
+  /* not lazy for the same reasons as fd_bn254_fp6_mul. */
   fd_bn254_fp2_add( c4, c4, a2 );
 
   fd_bn254_fp2_mul( c5, a1, a2 );
@@ -693,7 +674,7 @@ fd_bn254_fp12_mul_sparse( fd_bn254_fp12_t *       r,
   fd_bn254_fp6_mul_by_01( a1b1, &a->el[1], c3, c4 );
 
   /* r1 = (a0+a1) * (c0+c3, c4, 0) - a0b0 - a1b1 : 5 Fp2_mul.
-     NOT lazy: same compounding issue as fp12_mul. */
+     not lazy for the same reasons as fd_bn254_fp6_mul */
   fd_bn254_fp6_add( sa, &a->el[0], &a->el[1] );
   fd_bn254_fp2_add( sc0, c0, c3 );
   fd_bn254_fp6_mul_by_01( &r->el[1], sa, sc0, c4 );
@@ -719,8 +700,7 @@ fd_bn254_fp12_mul( fd_bn254_fp12_t * r,
   fd_bn254_fp6_t * r1 = &r->el[1];
   fd_bn254_fp6_t a0b0[1], a1b1[1], sa[1], sb[1];
 
-  /* NOT lazy: fp6_mul internally uses fp2_mul which lazy-adds its inputs;
-     a lazy_add here would compound and overflow Mont mul's <2p precondition. */
+  /* not lazy for the same reasons as fd_bn254_fp6_mul */
   fd_bn254_fp6_add( sa, a0, a1 );
   fd_bn254_fp6_add( sb, b0, b1 );
 


### PR DESCRIPTION
Everything in microseconds:
| Operation | Main (Clang) | Main (GCC) | Branch (Clang) | Branch (GCC) | Agave (LLVM) |
  | - | - | - | - | - | - |
  | G1 Add | 9.122 | 8.723 | 2.367 | 2.464 | 6.543 |
  | G2 Add | 9.794 | 9.664 | 3.005 | 3.322 | 10.157 |
  | G1 Scalar Mul | 75.206 | 79.282 | 61.152 | 66.936 | 139.460 |
  | G2 Scalar Mul | 259.246 | 301.111 | 220.890 | 251.701 | 576.780 |
  | Final Exp | 382.420 | 486.449 | 360.623 | 447.054 | |
  | G1 Compress | 0.013 | 0.017 | 0.013 | 0.017 | |
  | G1 Decompress | 8.752 | 8.334 | 8.674 | 8.355 | |
  | G2 Compress | 0.016 | 0.027 | 0.016 | 0.028 | |
  | G2 Decompress | 47.016 | 68.825 | 19.305 | 18.793 | |
  | Pairing | 828.175 | 1087.748 | 754.626 | 989.428 | 891.030 |