### PR TITLE
musl libc fixes

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -243,10 +243,12 @@ check_alpine_pkgs () {
     build-base       # C/C++ compiler
     curl             # download rustup
     linux-headers    # base dependency
-    libucontext-dev  # base dependency
     patch            # build system
     zstd             # build system
     gzip             # build system
+    grep             # build system
+    make             # build system
+    perl             # OpenSSL
   )
   if [[ $DEVMODE == 1 ]]; then
     REQUIRED_APKS+=( autoconf automake bison flex gettext perl protobuf-dev )

--- a/src/app/shared/commands/configure/hugetlbfs.c
+++ b/src/app/shared/commands/configure/hugetlbfs.c
@@ -36,7 +36,7 @@ static char const * FREE_HUGE_PAGE_PATH[ 2 ] = {
   "/sys/devices/system/node/node%lu/hugepages/hugepages-1048576kB/free_hugepages",
 };
 
-static ulong PAGE_SIZE[ 2 ] = {
+static ulong FD_PAGE_SIZE[ 2 ] = {
   2097152,
   1073741824,
 };
@@ -153,8 +153,8 @@ init( config_t const * config ) {
 
   ulong min_size[ 2 ] = {0};
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
-    min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
-    min_size[ 1 ] += PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
+    min_size[ 0 ] += FD_PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
+    min_size[ 1 ] += FD_PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
   }
 
   for( ulong i=0UL; i<2UL; i++ ) {
@@ -164,7 +164,7 @@ init( config_t const * config ) {
     }
 
     char options[ 256 ];
-    FD_TEST( fd_cstr_printf_check( options, sizeof(options), NULL, "pagesize=%lu,min_size=%lu", PAGE_SIZE[ i ], min_size[ i ] ) );
+    FD_TEST( fd_cstr_printf_check( options, sizeof(options), NULL, "pagesize=%lu,min_size=%lu", FD_PAGE_SIZE[ i ], min_size[ i ] ) );
     FD_LOG_NOTICE(( "RUN: `mount -t hugetlbfs none %s -o %s`", mount_path[ i ], options ));
     if( FD_UNLIKELY( mount( "none", mount_path[ i ], "hugetlbfs", 0, options) ) )
       FD_LOG_ERR(( "mount of hugetlbfs at `%s` failed (%i-%s)", mount_path[ i ], errno, fd_io_strerror( errno ) ));
@@ -303,8 +303,8 @@ check( config_t const * config,
   ulong numa_node_cnt = fd_shmem_numa_cnt();
   ulong required_min_size[ 2 ] = {0};
   for( ulong i=0UL; i<numa_node_cnt; i++ ) {
-    required_min_size[ 0 ] += PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
-    required_min_size[ 1 ] += PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
+    required_min_size[ 0 ] += FD_PAGE_SIZE[ 0 ] * fd_topo_huge_page_cnt( &config->topo, i, 0 );
+    required_min_size[ 1 ] += FD_PAGE_SIZE[ 1 ] * fd_topo_gigantic_page_cnt( &config->topo, i );
   }
 
   struct stat st;

--- a/src/app/shared_dev/commands/bench/fd_benchs.c
+++ b/src/app/shared_dev/commands/bench/fd_benchs.c
@@ -450,8 +450,7 @@ unprivileged_init( fd_topo_t const *      topo,
 static void
 quic_tx_aio_send_flush( fd_benchs_ctx_t * ctx ) {
   if( FD_LIKELY( ctx->tx_idx ) ) {
-    int flags = 0;
-    int rtn = sendmmsg( ctx->conn_fd[0], ctx->tx_msgs, (uint)ctx->tx_idx, flags );
+    int rtn = sendmmsg( ctx->conn_fd[0], ctx->tx_msgs, (uint)ctx->tx_idx, 0 );
     if( FD_UNLIKELY( rtn < 0 ) ) {
       FD_LOG_NOTICE(( "Error occurred in sendmmsg. Error: %d %s",
           errno, strerror( errno ) ));

--- a/src/discof/backtest/fd_libc_zstd.c
+++ b/src/discof/backtest/fd_libc_zstd.c
@@ -53,9 +53,9 @@ rstream_read( void * cookie,
 }
 
 static int
-rstream_seek( void *    cookie,
-              off64_t * pos,
-              int       w ) {
+rstream_seek( void * cookie,
+              long * pos,
+              int    w ) {
   fd_zstd_rstream_t * zs = cookie;
   if( FD_UNLIKELY( *pos ) ) {
     FD_LOG_WARNING(( "Invalid seek(%ld,%i) on fd_libc_zstd_rstream handle", *pos, w ));
@@ -203,9 +203,9 @@ cleanup:
 }
 
 static int
-wstream_seek( void *    cookie,
-              off64_t * pos,
-              int       w ) {
+wstream_seek( void * cookie,
+              long * pos,
+              int    w ) {
   fd_zstd_wstream_t * zs = cookie;
   if( FD_UNLIKELY( !( w==SEEK_CUR && *pos==0 ) ) ) {
     FD_LOG_WARNING(( "Attempted to seek in fd_libc_zstd_wstream handle" ));

--- a/src/discof/genesis/fd_genesi_tile.c
+++ b/src/discof/genesis/fd_genesi_tile.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>

--- a/src/discof/genesis/fd_genesis_client_private.h
+++ b/src/discof/genesis/fd_genesis_client_private.h
@@ -3,7 +3,7 @@
 
 #include "fd_genesis_client.h"
 #include "../../disco/topo/fd_topo.h"
-#include <sys/poll.h>
+#include <poll.h>
 
 struct fd_genesis_client_peer {
   fd_ip4_port_t addr;

--- a/src/discof/genesis/fuzz_genesis_client.c
+++ b/src/discof/genesis/fuzz_genesis_client.c
@@ -7,7 +7,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <errno.h>
 #include <string.h>
 

--- a/src/discof/ipecho/fd_ipecho_client_private.h
+++ b/src/discof/ipecho/fd_ipecho_client_private.h
@@ -3,7 +3,7 @@
 
 #include "../../util/fd_util_base.h"
 
-#include <sys/poll.h>
+#include <poll.h>
 
 struct fd_ipecho_client_peer {
   int writing;

--- a/src/discof/ipecho/fd_ipecho_server.c
+++ b/src/discof/ipecho/fd_ipecho_server.c
@@ -6,7 +6,7 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 

--- a/src/discof/ipecho/fd_ipecho_tile.c
+++ b/src/discof/ipecho/fd_ipecho_tile.c
@@ -9,7 +9,7 @@
 
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "generated/fd_ipecho_tile_seccomp.h"
 

--- a/src/discof/restore/utils/fd_ssping.c
+++ b/src/discof/restore/utils/fd_ssping.c
@@ -326,7 +326,7 @@ remove_fdesc_idx( fd_ssping_t * ssping,
     .sin_addr   = { .s_addr = 0U },
     .sin_port   = 0
   }};
-  if( FD_UNLIKELY( connect( fdesc, addr, sizeof(addr) ) ) ) FD_LOG_ERR(( "connect(AF_UNSPEC) failed (%d-%s)", errno, fd_io_strerror( errno ) ));
+  if( FD_UNLIKELY( connect( fdesc, fd_type_pun_const( addr ), sizeof(addr) ) ) ) FD_LOG_ERR(( "connect(AF_UNSPEC) failed (%d-%s)", errno, fd_io_strerror( errno ) ));
 
   /* Mark that the pool element no longer has an associated index. */
   ssping->pool[ pool_idx ].used_fd_idx = ULONG_MAX;
@@ -477,7 +477,7 @@ send_pings( fd_ssping_t *     ssping,
       .sin_port   = peer->addr.port
     }};
 
-    if( FD_UNLIKELY( connect( fdesc, addr, sizeof(addr) ) && errno!=EINPROGRESS ) ) {
+    if( FD_UNLIKELY( connect( fdesc, fd_type_pun_const( addr ), sizeof(addr) ) && errno!=EINPROGRESS ) ) {
       FD_LOG_WARNING(( "connect(" FD_IP4_ADDR_FMT ":%hu) failed (%d-%s)", FD_IP4_ADDR_FMT_ARGS( peer->addr.addr ), fd_ushort_bswap( peer->addr.port ), errno, fd_io_strerror( errno ) ));
       /* Nothing to do.  It will get "reaped" later. */
     }

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -162,7 +162,7 @@ fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descri
        If we don't align it the compiler might prove somthing weird and
        trash this code, and also ASAN would flag it as an error.  So we
        just align it anyway. */
-    uchar buf[ 4096 ] __attribute__((aligned(alignof(struct dirent64))));
+    uchar buf[ 4096 ] __attribute__((aligned(alignof(struct dirent))));
 
     long dents_bytes = syscall( SYS_getdents64, dirfd, buf, sizeof( buf ) );
     if( !dents_bytes ) break;
@@ -170,7 +170,7 @@ fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descri
 
     ulong offset = 0UL;
     while( offset<(ulong)dents_bytes ) {
-      struct dirent64 const * dent = (struct dirent64 const *)(buf + offset);
+      struct dirent const * dent = (struct dirent const *)(buf + offset);
       if( !strcmp( dent->d_name, "." ) || !strcmp( dent->d_name, ".." ) ) {
         offset += dent->d_reclen;
         continue;
@@ -429,7 +429,7 @@ fd_sandbox_private_set_rlimits( ulong rlimit_file_cnt,
   for( ulong i=0UL; i<sizeof(rlimits)/sizeof(rlimits[ 0 ]); i++ ) {
     if( dumpable && rlimits[i].resource==RLIMIT_CORE ) continue;
     struct rlimit limit = { .rlim_cur=rlimits[ i ].limit, .rlim_max=rlimits[ i ].limit };
-    if( -1==setrlimit( rlimits[ i ].resource, &limit ) ) FD_LOG_ERR(( "setrlimit(%u) failed (%i-%s)", rlimits[ i ].resource, errno, fd_io_strerror( errno ) ));
+    if( -1==setrlimit( rlimits[ i ].resource, &limit ) ) FD_LOG_ERR(( "setrlimit(%u) failed (%i-%s)", (uint)rlimits[ i ].resource, errno, fd_io_strerror( errno ) ));
   }
 }
 

--- a/src/util/sandbox/test_sandbox.c
+++ b/src/util/sandbox/test_sandbox.c
@@ -256,7 +256,7 @@ test_pivot_root_inner( void ) {
 
     ulong offset = 0UL;
     while( offset<(ulong)dents_bytes ) {
-      struct dirent64 const * dent = (struct dirent64 const *)(buf + offset);
+      struct dirent const * dent = (struct dirent const *)(buf + offset);
       FD_TEST( !strcmp( dent->d_name, "." ) || !strcmp( dent->d_name, "..") );
       offset += dent->d_reclen;
     }

--- a/src/waltz/ebpf/fd_linux_bpf.h
+++ b/src/waltz/ebpf/fd_linux_bpf.h
@@ -5,7 +5,7 @@
 
 #include "../../util/fd_util_base.h"
 
-#if defined(__linux__) && defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)
+#if defined(__linux__)
 
 #include <sys/syscall.h>
 #include <unistd.h>

--- a/src/waltz/mib/fd_netdev_netlink.c
+++ b/src/waltz/mib/fd_netdev_netlink.c
@@ -12,6 +12,8 @@
 #include <linux/if.h> /* IFNAMSIZ */
 #include <linux/if_arp.h> /* ARPHRD_NETROM */
 #include <linux/rtnetlink.h> /* RTM_{...}, NLM_{...} */
+#include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/if_tunnel.h>
 
 static fd_netdev_t *


### PR DESCRIPTION
- deps.sh: update Alpine package deps
- Fix PAGE_SIZE identifier usage (conflicts with libc)
- Fix sendmmsg flags integer type (different on musl vs glibc)
- Fix usage of off64_t (better to use long)
- Fix <sys/poll.h> include (better to use <poll.h>)
- Fix sockaddr type punning with connect(2)
- Fix usage of dirent64 (better to use dirent, which is identical)
- Don't assume struct rlimit->resource is uint
- Enable bpf syscall wrappers for musl libc
- Fix missing <linux/ip.h> include when using <linux/if_tunnel.h>
