### PR TITLE
Remove usages of libc assert

### DIFF
--- a/src/ballet/aes/fd_aes_base_ref.c
+++ b/src/ballet/aes/fd_aes_base_ref.c
@@ -39,7 +39,6 @@
 /* Note: rewritten a little bit to provide error control and an OpenSSL-
    compatible API */
 
-#include <assert.h>
 #include <stdlib.h>
 #include "fd_aes_gcm_ref.h"
 
@@ -660,7 +659,7 @@ fd_aes_ref_encrypt_core( uchar const *            in,
                          uchar *                  out,
                          fd_aes_key_ref_t const * key ) {
 
-  assert(in && out && key);
+  FD_DCHECK_CRIT( in && out && key, "invalid params" );
   ulong const * rk = (ulong *)fd_type_pun_const( key->rd_key );
 
   Cipher(in, out, rk, key->rounds);
@@ -675,7 +674,7 @@ fd_aes_ref_decrypt_core( uchar const *            in,
                          uchar *                  out,
                          fd_aes_key_ref_t const * key ) {
 
-  assert(in && out && key);
+  FD_DCHECK_CRIT( in && out && key, "invalid params" );
   ulong const * rk = (ulong const *)fd_type_pun_const( key->rd_key );
 
   InvCipher(in, out, rk, key->rounds );

--- a/src/ballet/aes/fd_aes_gcm_ref.c
+++ b/src/ballet/aes/fd_aes_gcm_ref.c
@@ -3,8 +3,6 @@
 
 #include "fd_aes_gcm.h"
 
-#include <assert.h>
-
 #define fd_gcm_init  fd_gcm_init_4bit
 #define fd_gcm_gmult fd_gcm_gmult_4bit
 #define fd_gcm_ghash fd_gcm_ghash_4bit
@@ -259,7 +257,8 @@ fd_aes_gcm_encrypt_ref( fd_aes_gcm_ref_t * aes_gcm,
   fd_gcm128_aad( aes_gcm, aad, aad_sz );
 
   ulong bulk = 0UL;
-  assert( 0==fd_gcm128_encrypt( aes_gcm, p+bulk, c+bulk, sz-bulk ) );
+  int res = fd_gcm128_encrypt( aes_gcm, p+bulk, c+bulk, sz-bulk );
+  FD_DCHECK_CRIT( res==0, "internal error" );
 
   /* CRYPTO_gcm128_tag */
   fd_gcm128_finish( aes_gcm );
@@ -278,7 +277,8 @@ fd_aes_gcm_decrypt_ref( fd_aes_gcm_ref_t * aes_gcm,
   fd_gcm128_aad( aes_gcm, aad, aad_sz );
 
   ulong bulk = 0UL;
-  assert( 0==fd_gcm128_decrypt( aes_gcm, c+bulk, p+bulk, sz-bulk ) );
+  int res = fd_gcm128_decrypt( aes_gcm, c+bulk, p+bulk, sz-bulk );
+  FD_DCHECK_CRIT( res==0, "internal error" );
 
   /* CRYPTO_gcm128_finish */
   fd_gcm128_finish( aes_gcm );

--- a/src/ballet/blake3/fd_blake3.c
+++ b/src/ballet/blake3/fd_blake3.c
@@ -1,6 +1,5 @@
 #include "fd_blake3.h"
 #include "fd_blake3_private.h"
-#include <assert.h>
 
 /* Hash state machine *************************************************/
 
@@ -160,7 +159,7 @@ fd_blake3_prepare_branch( fd_blake3_pos_t * restrict s,
   if( !fd_blake3_seek_branch( s, buf, tick ) )
     return NULL;
 
-  assert( s->layer < FD_BLAKE3_ROW_CNT );
+  FD_DCHECK_CRIT( s->layer < FD_BLAKE3_ROW_CNT, "invariant violation" );
 
   uchar const * msg = buf->slots[ s->layer-1U ][ s->tail.uc[ s->layer-1U ] ];
   uchar       * out = buf->slots[ s->layer    ][ s->head.uc[ s->layer    ] ];
@@ -226,7 +225,7 @@ fd_blake3_prepare( fd_blake3_pos_t * restrict s,
                    fd_blake3_op_t *  restrict op,
                    ulong                      tick ) {
 
-  assert( s->layer < FD_BLAKE3_ROW_CNT );
+  FD_DCHECK_CRIT( s->layer < FD_BLAKE3_ROW_CNT, "invariant violation" );
 
   if( fd_blake3_is_finished( s, tick ) )
     return NULL;

--- a/src/ballet/blake3/fd_blake3_avx2.c
+++ b/src/ballet/blake3/fd_blake3_avx2.c
@@ -5,7 +5,6 @@
 #include "fd_blake3.h"
 #include "fd_blake3_private.h"
 #include "../../util/simd/fd_avx.h"
-#include <assert.h>
 
 #define wu_rot16 wb_exch_adj_pair
 

--- a/src/ballet/blake3/fd_blake3_sse41.c
+++ b/src/ballet/blake3/fd_blake3_sse41.c
@@ -5,7 +5,6 @@
 #include "fd_blake3.h"
 #include "fd_blake3_private.h"
 #include "../../util/simd/fd_sse.h"
-#include <assert.h>
 
 #define _mm_shuffle_ps2(a, b, c)                                       \
   (_mm_castps_si128(                                                   \
@@ -257,7 +256,7 @@ fd_blake3_sse_compress1( uchar * restrict       out,
                          uchar const * restrict in_chain ) {
   FD_BLAKE3_TRACE(( "fd_blake3_sse_compress1(out=%p,msg=%p,sz=%u,counter=%lu,flags=%02x)",
                     (void *)out, (void *)msg, msg_sz, counter, flags ));
-  assert( msg_sz<=FD_BLAKE3_CHUNK_SZ );
+  FD_DCHECK_CRIT( msg_sz<=FD_BLAKE3_CHUNK_SZ, "internal error" );
 
   uint cv[8] = { FD_BLAKE3_IV[0], FD_BLAKE3_IV[1], FD_BLAKE3_IV[2], FD_BLAKE3_IV[3],
                  FD_BLAKE3_IV[4], FD_BLAKE3_IV[5], FD_BLAKE3_IV[6], FD_BLAKE3_IV[7] };

--- a/src/ballet/chacha/fd_chacha_rng_avx.c
+++ b/src/ballet/chacha/fd_chacha_rng_avx.c
@@ -1,6 +1,5 @@
 #include "fd_chacha_rng.h"
 #include "../../util/simd/fd_avx.h"
-#include <assert.h>
 
 #define wu_rol16(a) wb_exch_adj_pair( (a) )
 #define wu_rol12(a) wu_rol( (a), 12 )

--- a/src/ballet/chacha/fd_chacha_rng_avx512.c
+++ b/src/ballet/chacha/fd_chacha_rng_avx512.c
@@ -1,6 +1,5 @@
 #include "fd_chacha_rng.h"
 #include "../../util/simd/fd_avx512.h"
-#include <assert.h>
 
 #define wwu_rol16(a) wwb_exch_adj_pair( (a) )
 #define wwu_rol12(a) wwu_rol( (a), 12 )

--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -4,7 +4,6 @@
 #include "../../util/bits/fd_sat.h"
 #include "../murmur3/fd_murmur3.h"
 
-#include <assert.h>
 #include <stdio.h>
 
 /* ELF loader, part 1 **************************************************

--- a/src/ballet/utf8/test_utf8.c
+++ b/src/ballet/utf8/test_utf8.c
@@ -1,5 +1,4 @@
 #include "fd_utf8.h"
-#include <assert.h>
 
 struct fd_utf8_test_vector {
   char const * input;
@@ -88,7 +87,7 @@ test_glyph_pairs( void ) {
       char  input[8];
       ulong input_sz = 0UL;
 
-      assert( vec0->sz + vec1->sz <= sizeof(input) );
+      FD_TEST( vec0->sz + vec1->sz <= sizeof(input) );
 
       fd_memcpy( input, vec0->input, vec0->sz );
       input_sz += vec0->sz;

--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -1181,7 +1180,7 @@ fd_tower_with_lat_from_vote_acc( fd_vote_acc_vote_t tower[ static FD_TOWER_VOTE_
                                  ulong              data_sz ) {
   fd_vote_acc_desc_t desc[1];
   if( FD_UNLIKELY( !fd_vote_acc_desc( desc, data, data_sz ) ) ) return 0UL;
-  assert( desc->vote_cnt <= FD_TOWER_VOTE_MAX );
+  FD_DCHECK_CRIT( desc->vote_cnt <= FD_TOWER_VOTE_MAX, "invalid vote account" );
   switch( desc->kind ) {
   case FD_VOTE_ACC_V2: {
     for( ulong i=0UL; i<desc->vote_cnt; i++ ) {

--- a/src/disco/net/sock/fd_sock_tile.c
+++ b/src/disco/net/sock/fd_sock_tile.c
@@ -6,7 +6,6 @@
 #include "../../../util/net/fd_ip4.h"
 #include "../../../util/net/fd_udp.h"
 
-#include <assert.h> /* assert */
 #include <stdalign.h> /* alignof */
 #include <errno.h>
 #include <fcntl.h> /* fcntl */
@@ -164,8 +163,7 @@ privileged_init( fd_topo_t const *      topo,
   struct sockaddr_in * batch_sa   = FD_SCRATCH_ALLOC_APPEND( l, alignof(struct sockaddr_in), STEM_BURST*sizeof(struct sockaddr_in) );
   struct mmsghdr *     batch_msg  = FD_SCRATCH_ALLOC_APPEND( l, alignof(struct mmsghdr),     STEM_BURST*sizeof(struct mmsghdr)     );
   uchar *              tx_scratch = FD_SCRATCH_ALLOC_APPEND( l, FD_CHUNK_ALIGN,              tx_scratch_footprint()                );
-
-  assert( scratch==ctx );
+  FD_DCHECK_CRIT( scratch==ctx, "invalid layout" );
 
   fd_memset( ctx,       0, sizeof(fd_sock_tile_t)                );
   fd_memset( batch_iov, 0, STEM_BURST*sizeof(struct iovec)       );
@@ -591,7 +589,7 @@ during_frag( fd_sock_tile_t * ctx,
   ulong msg_sz = sizeof(fd_udp_hdr_t) + payload_sz;
 
   ulong batch_idx = ctx->batch_cnt;
-  assert( batch_idx<STEM_BURST );
+  FD_DCHECK_CRIT( batch_idx<STEM_BURST, "flow control error" );
   struct mmsghdr *     msg  = ctx->batch_msg + batch_idx;
   struct sockaddr_in * sa   = ctx->batch_sa  + batch_idx;
   struct iovec   *     iov  = ctx->batch_iov + batch_idx;

--- a/src/disco/quic/fd_tpu_reasm_private.h
+++ b/src/disco/quic/fd_tpu_reasm_private.h
@@ -3,8 +3,6 @@
 
 #include "fd_tpu.h"
 
-#include <assert.h>
-
 /* fd_tpu_reasm_private.h contains reusable logic of fd_tpu_reasm such
    that it can be included in test cases. */
 
@@ -180,14 +178,8 @@ slotq_remove( fd_tpu_reasm_t *      reasm,
     return;
   }
 
-  assert( lru_prev < reasm->slot_cnt );
-  assert( lru_next < reasm->slot_cnt );
-  if( FD_UNLIKELY( lru_prev >= reasm->slot_cnt ) ) {
-    FD_LOG_ERR(( "OOB lru_prev (lru_prev=%u, slot_cnt=%u)", lru_prev, reasm->slot_cnt ));
-  }
-  if( FD_UNLIKELY( lru_next >= reasm->slot_cnt ) ) {
-    FD_LOG_ERR(( "OOB lru_next (lru_next=%u, slot_cnt=%u)", lru_next, reasm->slot_cnt ));
-  }
+  FD_DCHECK_CRIT( lru_prev < reasm->slot_cnt, "memory corruption detected" );
+  FD_DCHECK_CRIT( lru_next < reasm->slot_cnt, "memory corruption detected" );
   prev->lru_next = lru_next;
   next->lru_prev = lru_prev;
 }

--- a/src/flamenco/runtime/fd_core_bpf_migration.c
+++ b/src/flamenco/runtime/fd_core_bpf_migration.c
@@ -11,7 +11,6 @@
 #include "../../ballet/sbpf/fd_sbpf_loader.h"
 #include "../progcache/fd_prog_load.h"
 #include "../vm/fd_vm.h"
-#include <assert.h>
 
 static fd_pubkey_t
 get_program_data_address( fd_pubkey_t const * program_addr ) {
@@ -621,7 +620,7 @@ migrate_builtin_to_core_bpf1( fd_core_bpf_migration_config_t const * config,
   ulong new_data_sz;
   if( FD_UNLIKELY( fd_ulong_checked_add( new_target_program->data_sz, new_target_program_data->data_sz, &new_data_sz ) ) ) return;
 
-  assert( new_target_program_data->data_sz>=PROGRAMDATA_METADATA_SIZE );
+  FD_DCHECK_CRIT( new_target_program_data->data_sz >= PROGRAMDATA_METADATA_SIZE, "undersize account" );
   /* FIXME call fd_directly_invoke_loader_v3_deploy */
 
   /* https://github.com/anza-xyz/agave/blob/v3.1.8/runtime/src/bank/builtins/core_bpf_migration/mod.rs#L267-L281 */

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -26,7 +26,6 @@
 
 #include "../../disco/pack/fd_pack_tip_prog_blacklist.h"
 
-#include <assert.h>
 #include <math.h>
 #include <stdio.h>   /* snprintf(3) */
 #include <fcntl.h>   /* openat(2) */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.c
@@ -4,8 +4,6 @@
 #include "fd_sysvar_base.h"
 #include "../../accdb/fd_accdb_sync.h"
 
-#include <assert.h>
-
 void
 fd_sysvar_rent_write( fd_bank_t *               bank,
                       fd_accdb_user_t *         accdb,

--- a/src/flamenco/runtime/tests/fd_harness_common.c
+++ b/src/flamenco/runtime/tests/fd_harness_common.c
@@ -5,7 +5,6 @@
 #include "../fd_system_ids.h"
 #include "../../features/fd_features.h"
 #include "../../accdb/fd_accdb_sync.h"
-#include <assert.h>
 
 void
 fd_solfuzz_pb_restore_fee_rate_governor( fd_bank_t *                              bank,

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -11,7 +11,6 @@
 #include "../../accdb/fd_accdb_admin_v1.h"
 #include "../../progcache/fd_progcache_admin.h"
 #include "../../log_collector/fd_log_collector.h"
-#include <assert.h>
 
 void
 fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
@@ -371,7 +370,9 @@ fd_solfuzz_pb_instr_run( fd_solfuzz_runner_t * runner,
     }
 
     ulong modified_idx = effects->modified_accounts_count;
-    assert( modified_idx < modified_acct_cnt );
+    if( FD_UNLIKELY( modified_idx >= modified_acct_cnt ) ) {
+      FD_LOG_CRIT(( "invalid modified account index" ));
+    }
 
     fd_exec_test_acct_state_t * out_acct = &effects->modified_accounts[ modified_idx ];
     memset( out_acct, 0, sizeof(fd_exec_test_acct_state_t) );

--- a/src/flamenco/runtime/tests/fd_sol_compat.c
+++ b/src/flamenco/runtime/tests/fd_sol_compat.c
@@ -15,7 +15,6 @@
 #include "generated/vm_serialization.pb.h"
 #include "generated/shred.pb.h"
 
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/flamenco/runtime/tests/fd_solfuzz_exec.c
+++ b/src/flamenco/runtime/tests/fd_solfuzz_exec.c
@@ -10,7 +10,6 @@
 #include "generated/shred.pb.h"
 
 #include "../fd_executor_err.h"
-#include <assert.h>
 
 /*
  * fixtures
@@ -62,7 +61,9 @@ static int
 _diff_txn_acct( fd_exec_test_acct_state_t * expected,
                 fd_exec_test_acct_state_t * actual ) {
   /* AcctState -> address (This must hold true when calling this function!) */
-  assert( fd_memeq( expected->address, actual->address, sizeof(fd_pubkey_t) ) );
+  if( FD_UNLIKELY( !fd_memeq( expected->address, actual->address, sizeof(fd_pubkey_t) ) ) ) {
+    FD_LOG_CRIT(( "diff algorithm error" ));
+  }
 
   /* AcctState -> lamports */
   if( expected->lamports != actual->lamports ) {

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -3,7 +3,6 @@
 #include "../../ballet/sbpf/fd_sbpf_opcodes.h"
 #include "../../ballet/murmur3/fd_murmur3.h"
 #include <stddef.h>
-#include <assert.h>
 
 FD_STATIC_ASSERT( FD_VM_FOOTPRINT                       == sizeof( fd_vm_t ), vm_struct );
 FD_STATIC_ASSERT( FD_VM_ALIGN                           == alignof( fd_vm_t ), vm_struct );

--- a/src/flamenco/vm/test_vm_instr.c
+++ b/src/flamenco/vm/test_vm_instr.c
@@ -5,7 +5,6 @@
 #include "fd_vm_base.h"
 #include "fd_vm_private.h"
 #include "../../ballet/sbpf/fd_sbpf_opcodes.h"
-#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -86,7 +85,7 @@ typedef struct test_parser test_parser_t;
 static void
 parse_advance( test_parser_t * p,
                ulong           n ) {
-  assert( p->cur+n <= p->end );
+  FD_TEST( p->cur+n <= p->end );
   for( ulong i=0UL; i<n; i++ ) {
     if( p->cur[i]=='\n' ) {
       p->line++;
@@ -133,7 +132,7 @@ parse_hex_buf( test_parser_t * p,
   }
 
   uchar * buf = malloc( sz );
-  assert( buf );
+  FD_TEST( buf );
 
   /* Second pass: Deserialize */
 
@@ -276,7 +275,7 @@ parse_token( test_parser_t *  p,
 
     parse_assign_sep( p );
     ulong op = parse_hex_int( p );
-    assert( op <= UCHAR_MAX );
+    FD_TEST( op <= UCHAR_MAX );
     p->input.op = (uchar)op;
 
   } else if( 0==strncmp( word, "dst", word_len ) ) {
@@ -295,7 +294,7 @@ parse_token( test_parser_t *  p,
 
     parse_assign_sep( p );
     ulong off = parse_hex_int( p );
-    assert( off <= USHORT_MAX );
+    FD_TEST( off <= USHORT_MAX );
     p->input.off = (ushort)off;
 
   } else if( 0==strncmp( word, "imm", word_len ) ) {
@@ -324,7 +323,7 @@ parse_token( test_parser_t *  p,
   } else if( word_len >= 2 && word[0] == 'r' && fd_isdigit( word[1] ) ) {
 
     ulong reg = fd_cstr_to_uchar( word+1 );
-    assert( reg < REG_CNT );
+    FD_TEST( reg < REG_CNT );
     parse_assign_sep( p );
 
     ulong * out = p->state == PARSE_STATE_ASSERT ? p->effects.reg : p->input.reg;
@@ -403,7 +402,7 @@ run_input( test_input_t const * input,
   /* Set up VM */
 
   uchar * input_copy = malloc( input->input_sz );
-  assert( input_copy );
+  FD_TEST( input_copy );
   memcpy( input_copy, input->input, input->input_sz );
 
   /* Turn input into a single memory region */
@@ -473,7 +472,7 @@ run_input( test_input_t const * input,
       /* dump_syscall_to_pb                     */ 0,
       /* r2_initial_value                       */ 0UL
   );
-  assert( vm_ok );
+  FD_TEST( vm_ok );
 
   for( uint i=0; i<REG_CNT; i++ ) {
     vm->reg[i] = input->reg[i];
@@ -548,7 +547,7 @@ handle_file( char const * file_path,
   }
 
   char * buf = malloc( (ulong)st.st_size );
-  assert( buf );
+  FD_TEST( buf );
 
   if( FD_UNLIKELY( st.st_size!=read( fd, buf, (ulong)st.st_size ) ) ) {
     FD_LOG_ERR(( "read(%s) failed (%d-%s)", file_path, errno, fd_io_strerror( errno ) ));

--- a/src/util/rng/fd_rng_secure.c
+++ b/src/util/rng/fd_rng_secure.c
@@ -5,7 +5,6 @@
 
 #if defined(__linux__) || defined(__FreeBSD__)
 
-#include <assert.h>
 #include <errno.h>
 #include <sys/random.h>
 
@@ -20,7 +19,7 @@ fd_rng_secure( void * d,
       FD_LOG_WARNING(( "getrandom(sz=%lu) failed (%d-%s)", sz, errno, fd_io_strerror( errno ) ));
       return NULL;
     }
-    assert( (ulong)res <= sz );
+    if( FD_UNLIKELY( (ulong)res > sz ) ) FD_LOG_CRIT(( "invalid getrandom() return value" ));
     sz -= (ulong)res;
   }
   return d;

--- a/src/waltz/quic/fd_quic_retry.c
+++ b/src/waltz/quic/fd_quic_retry.c
@@ -5,7 +5,6 @@
 #include "fd_quic_enum.h"
 #include "fd_quic_private.h"
 #include "../../ballet/aes/fd_aes_gcm.h"
-#include <assert.h>
 
 FD_STATIC_ASSERT( FD_QUIC_RETRY_LOCAL_SZ==
                   FD_QUIC_MAX_FOOTPRINT(retry_hdr) +
@@ -84,7 +83,6 @@ fd_quic_retry_create(
   memcpy( retry_hdr->dst_conn_id, src_conn_id->conn_id, FD_QUIC_MAX_CONN_ID_SZ );
   FD_STORE( ulong, retry_hdr->src_conn_id, new_conn_id );
   ulong rc = fd_quic_encode_retry_hdr( retry, FD_QUIC_RETRY_LOCAL_SZ, retry_hdr );
-  assert( rc!=FD_QUIC_PARSE_FAIL );
   if( FD_UNLIKELY( rc==FD_QUIC_PARSE_FAIL ) ) FD_LOG_CRIT(( "fd_quic_encode_retry_hdr failed" ));
   out_ptr  += rc;
   out_free -= rc;
@@ -92,7 +90,7 @@ fd_quic_retry_create(
   /* Craft a new retry token */
 
   fd_quic_retry_token_t * retry_token = fd_type_pun( out_ptr );
-  assert( out_free >= sizeof(fd_quic_retry_token_t) );
+  FD_DCHECK_CRIT( out_free >= sizeof(fd_quic_retry_token_t), "insufficient space for retry token" );
 
   uint   src_ip4_addr = pkt->ip4->saddr;  /* net order */
   ushort src_udp_port = (ushort)fd_ushort_bswap( (ushort)pkt->udp->net_sport );
@@ -136,7 +134,7 @@ fd_quic_retry_create(
 
 # endif /* FD_QUIC_DISABLE_CRYPTO */
 
-  assert( (ulong)out_ptr - (ulong)retry <= FD_QUIC_RETRY_LOCAL_SZ );
+  FD_DCHECK_CRIT( (ulong)out_ptr - (ulong)retry <= FD_QUIC_RETRY_LOCAL_SZ, "retry packet overflow" );
   ulong retry_sz = (ulong)out_ptr - (ulong)retry;
   return retry_sz;
 }
@@ -254,7 +252,7 @@ fd_quic_retry_client_verify( uchar const * const       retry_ptr,
   /* Consume retry integrity tag */
 
   uchar const * retry_tag = cur_ptr;
-  assert( cur_sz==FD_QUIC_CRYPTO_TAG_SZ );
+  FD_DCHECK_CRIT( cur_sz==FD_QUIC_CRYPTO_TAG_SZ, "invalid retry tag size" );
   cur_ptr += FD_QUIC_CRYPTO_TAG_SZ;
   cur_sz  -= FD_QUIC_CRYPTO_TAG_SZ;
 

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -4,8 +4,6 @@
 #include "../../ballet/ed25519/fd_x25519.h"
 #include "../../ballet/hmac/fd_hmac.h"
 
-#include <assert.h>
-
 /* Pre-generated keys */
 
 char const fd_tls13_cli_sign_prefix[ 98 ] =


### PR DESCRIPTION
libc assert has a few problems
- whether it runs depends on compiler settings (e.g. 'zig cc'
  behaves differently than 'gcc' on a modern Ubuntu/RHEL box)
- if NDEBUG is defined, the expression inside assert is not
  evaluated, which breaks various Firedancer code

Replaced with FD_DCHECK / FD_LOG_CRIT / FD_TEST as appropriate
