### PR TITLE
Fix crash when ipecho traffic blocked by iptables

### DIFF
--- a/src/discof/ipecho/fd_ipecho_server.c
+++ b/src/discof/ipecho/fd_ipecho_server.c
@@ -213,7 +213,9 @@ is_expected_network_error( int err ) {
     err==ENETRESET ||
     err==ECONNABORTED ||
     err==ECONNRESET ||
-    err==EPIPE;
+    err==EPIPE ||
+    err==EPERM || /* iptables */
+    err==ENOMEM; /* net stack OOM */
 }
 
 static void

--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -394,7 +394,9 @@ is_expected_network_error( int err ) {
     err==ENETRESET ||
     err==ECONNABORTED ||
     err==ECONNRESET ||
-    err==EPIPE;
+    err==EPIPE ||
+    err==EPERM || /* iptables */
+    err==ENOMEM; /* net stack OOM */
 }
 
 static void


### PR DESCRIPTION
Linux netfilter can cause network operations to return EPERM.
