### PR TITLE
config: `zig cc` support

### DIFF
--- a/config/extra/with-zigcc-pre.mk
+++ b/config/extra/with-zigcc-pre.mk
@@ -1,0 +1,6 @@
+# Default Clang executables
+ifeq ($(CROSS),)
+CC=zig cc
+CXX=zig c++
+LD=zig c++
+endif

--- a/config/extra/with-zigcc.mk
+++ b/config/extra/with-zigcc.mk
@@ -1,0 +1,6 @@
+# Experimental cross-compiling via `zig cc`.
+#
+# Not recommended for production:
+# As of Zig 0.15, 'zig cc' includes undocumented breaking behavior
+# changes, like passing `-NDEBUG`, and system header precedence bugs.
+include config/extra/with-clang.mk

--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -42,7 +42,7 @@ else ifdef FD_USING_CLANG
 include config/extra/with-clang.mk
 endif
 
-BUILDDIR?=native/$(notdir $(CC))
+BUILDDIR?=native/$(notdir $(firstword $(CC)))
 CPPFLAGS+=-march=native -mtune=native
 RUSTFLAGS+=-C target-cpu=native
 


### PR DESCRIPTION
Basic zig cc support. Currently broken due to bugs in Zig.
