### PR TITLE
txsend: don't assert on leader missing

### DIFF
--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -271,6 +271,12 @@ replay_block_start( fd_replay_tile_t * ctx,
   bank->txncache_fork_id  = fd_txncache_attach_child ( ctx->txncache,  parent_bank->txncache_fork_id  );
   bank->progcache_fork_id = fd_progcache_attach_child( ctx->progcache, parent_bank->progcache_fork_id );
 
+  ulong new_epoch  = fd_slot_to_epoch( &parent_bank->f.epoch_schedule, slot, NULL );
+  ulong root_epoch = fd_slot_to_epoch( &parent_bank->f.epoch_schedule, ctx->published_root_slot, NULL );
+  if( FD_UNLIKELY( new_epoch>root_epoch+1UL ) ) {
+    FD_LOG_CRIT(( "firedancer replay does not support replaying more than one epoch ahead of the current root" ));
+  }
+
   /* Create a new funk txn for the block. */
 
   fd_funk_txn_xid_t xid        = fd_bank_xid( bank        );

--- a/src/discof/txsend/fd_txsend_tile.c
+++ b/src/discof/txsend/fd_txsend_tile.c
@@ -299,11 +299,9 @@ after_credit( fd_txsend_tile_t *  ctx,
 
   for( ulong i=0UL; i<7UL; i++ ) {
     ulong target_slot = ctx->voted_slot+1UL + i*FD_EPOCH_SLOTS_PER_ROTATION;
+    /* leaders[i] may be NULL if target_slot lands in an epoch whose
+       schedule isn't published yet; the loops below skip NULL entries. */
     leaders[ i ] = fd_multi_epoch_leaders_get_leader_for_slot( ctx->mleaders, target_slot );
-    if( FD_UNLIKELY( !leaders[ i ] ) ) {
-      FD_LOG_WARNING(( "no leader found for slot %lu", target_slot ));
-      continue;
-    }
   }
 
   /* Disconnect any QUIC connection to a leader that does not have a
@@ -312,7 +310,7 @@ after_credit( fd_txsend_tile_t *  ctx,
   for( ulong i=0UL; i<conn_cnt; ) {
     int keep_conn = 0;
     for( ulong j=0UL; j<7UL; j++ ) {
-      if( fd_pubkey_eq( &ctx->conns[ i ].pubkey, leaders[ j ] ) ) {
+      if( leaders[j] && fd_pubkey_eq( &ctx->conns[ i ].pubkey, leaders[ j ] ) ) {
         keep_conn = 1;
         break;
       }
@@ -326,6 +324,7 @@ after_credit( fd_txsend_tile_t *  ctx,
   /* Connect to any leader that does not have a connection yet. */
   for( ulong i=0UL; i<7UL; i++ ) {
     fd_pubkey_t const * leader = leaders[ i ];
+    if( FD_UNLIKELY( !leader ) ) continue;
     peer_entry_t * peer = peer_map_ele_query( ctx->peer_map, leader, NULL, ctx->peers );
     if( FD_UNLIKELY( !peer ) ) continue; /* no contact info */
 

--- a/src/discof/txsend/fd_txsend_tile.c
+++ b/src/discof/txsend/fd_txsend_tile.c
@@ -298,9 +298,10 @@ after_credit( fd_txsend_tile_t *  ctx,
   fd_pubkey_t const * leaders[ 7UL ];
 
   for( ulong i=0UL; i<7UL; i++ ) {
+    /* It's possible for leaders[i] to be NULL if target slot is two
+       epochs ahead of the replay root.  This is not possible on mainnet
+       but can occur on local clusters during warmup epochs. */
     ulong target_slot = ctx->voted_slot+1UL + i*FD_EPOCH_SLOTS_PER_ROTATION;
-    /* leaders[i] may be NULL if target_slot lands in an epoch whose
-       schedule isn't published yet; the loops below skip NULL entries. */
     leaders[ i ] = fd_multi_epoch_leaders_get_leader_for_slot( ctx->mleaders, target_slot );
   }
 

--- a/src/discof/txsend/fd_txsend_tile.c
+++ b/src/discof/txsend/fd_txsend_tile.c
@@ -300,7 +300,10 @@ after_credit( fd_txsend_tile_t *  ctx,
   for( ulong i=0UL; i<7UL; i++ ) {
     ulong target_slot = ctx->voted_slot+1UL + i*FD_EPOCH_SLOTS_PER_ROTATION;
     leaders[ i ] = fd_multi_epoch_leaders_get_leader_for_slot( ctx->mleaders, target_slot );
-    FD_TEST( leaders[ i ] );
+    if( FD_UNLIKELY( !leaders[ i ] ) ) {
+      FD_LOG_WARNING(( "no leader found for slot %lu", target_slot ));
+      continue;
+    }
   }
 
   /* Disconnect any QUIC connection to a leader that does not have a
@@ -534,7 +537,10 @@ handle_vote_msg( fd_txsend_tile_t *           ctx,
   for( ulong i=0UL; i<3UL; i++ ) {
     ulong target_slot = slot_done->vote_slot+1UL + i*FD_EPOCH_SLOTS_PER_ROTATION;
     fd_pubkey_t const * leader = fd_multi_epoch_leaders_get_leader_for_slot( ctx->mleaders, target_slot );
-    FD_TEST( leader );
+    if( FD_UNLIKELY( !leader ) ) {
+      FD_LOG_WARNING(( "no leader found for slot %lu", target_slot ));
+      continue;
+    }
     send_vote_to_leader( ctx, leader, payload, slot_done->vote_txn_sz );
   }
 


### PR DESCRIPTION
have to do this since we only publish leader schedule when root advances so this can cause problems when catching up on a local cluster while epochs are still warming up. This could lead to the client replaying slots 2 epochs ahead of where the root is. 

thanks @anwayde for flagging