### PR TITLE
Advertise binary support for shadow stack

### DIFF
--- a/config/extra/with-security.mk
+++ b/config/extra/with-security.mk
@@ -8,6 +8,13 @@ LDFLAGS+=-Wl,-z,relro,-z,now
 CPPFLAGS+=-fstack-protector-strong
 LDFLAGS+=-fstack-protector-strong
 
+ifdef FD_HAS_X86
+ifdef FD_HAS_LINUX
+CPPFLAGS+=-fcf-protection=return
+LDFLAGS_EXE+=-Wl,-z,shstk -Wl,-z,cet-report=error
+endif
+endif
+
 # _FORTIFY_SOURCE only works when optimization is enabled
 ifeq ($(FD_DISABLE_OPTIMIZATION),)
 CPPFLAGS+=-D_FORTIFY_SOURCE=$(FORTIFY_SOURCE)

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -21,4 +21,5 @@ include config/extra/with-openssl.mk
 include config/extra/with-rocksdb.mk
 endif
 
+FD_HAS_X86:=1
 FD_ARCH_SUPPORTS_SANDBOX:=1

--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -46,11 +46,6 @@ BUILDDIR?=native/$(notdir $(CC))
 CPPFLAGS+=-march=native -mtune=native
 RUSTFLAGS+=-C target-cpu=native
 
-include config/extra/with-brutality.mk
-include config/extra/with-optimization.mk
-include config/extra/with-debug.mk
-include config/extra/with-security.mk
-
 $(call map-define,FD_HAS_SHANI, __SHA__)
 $(call map-define,FD_HAS_INT128, __SIZEOF_INT128__)
 FD_HAS_DOUBLE:=1
@@ -63,6 +58,11 @@ $(call map-define,FD_HAS_AVX, __AVX2__)
 $(call map-define,FD_HAS_GFNI, __GFNI__)
 $(call map-define,FD_IS_X86_64, __x86_64__)
 $(call map-define,FD_HAS_AESNI, __AES__)
+
+include config/extra/with-brutality.mk
+include config/extra/with-optimization.mk
+include config/extra/with-debug.mk
+include config/extra/with-security.mk
 
 # Older version of GCC (<10) don't fully support AVX512, so we disable
 # it in those cases. Older versions of Clang (<8) don't support it

--- a/deps.sh
+++ b/deps.sh
@@ -37,8 +37,12 @@ DEVMODE=0
 MSAN=0
 _CC="${CC:=gcc}"
 _CXX="${CXX:=g++}"
-EXTRA_CFLAGS="-g3 -fno-omit-frame-pointer"
+EXTRA_CFLAGS="-g3"
 EXTRA_CXXFLAGS=""
+if [[ "$(uname -m)" == x86_64 ]]; then
+  EXTRA_CFLAGS+=" -fno-omit-frame-pointer -fcf-protection=return"
+  EXTRA_CXXFLAGS+=" -fno-omit-frame-pointer -fcf-protection=return"
+fi
 EXTRA_LDFLAGS=""
 
 help () {
@@ -403,6 +407,8 @@ install_libcxx () {
     -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
     -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-fcf-protection=return" \
+    -DCMAKE_CXX_FLAGS="-fcf-protection=return" \
     -DLLVM_DIR=".." \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     -DLLVM_USE_SANITIZER=Memory \
@@ -440,7 +446,11 @@ install_s2n () {
 
   echo "[+] Installing s2n-bignum to $PREFIX"
   if [[ "$(uname -m)" == x86_64 ]]; then
-    make -C x86
+    if [[ "$(uname -s)" == Linux ]]; then
+      make -C x86 PREPROCESS="$CC -E -fcf-protection=return -I../include -DWINDOWS_ABI=0 \$(SYMBOL_HIDING) -xassembler-with-cpp -"
+    else
+      make -C x86
+    fi
     cp x86/libs2nbignum.a "$PREFIX/lib"
   elif [[ "$(uname -m)" == aarch64 ]]; then
     make -C arm
@@ -455,7 +465,7 @@ install_blst () {
   cd "$PREFIX/git/blst"
 
   echo "[+] Building blst"
-  ./build.sh
+  CFLAGS="-O2 -fno-builtin -fPIC -Wall -Wextra -Werror $EXTRA_CFLAGS" ./build.sh
   echo "[+] Successfully built blst"
 
   echo "[+] Installing blst to $PREFIX"
@@ -536,7 +546,7 @@ install_openssl () {
     CONFIG_OPTS+=( enable-msan no-asm )
   fi
 
-  ./config "${CONFIG_OPTS[@]}"
+  CFLAGS="$EXTRA_CFLAGS" CXXFLAGS="$EXTRA_CXXFLAGS" ./config "${CONFIG_OPTS[@]}"
   echo "[+] Configured OpenSSL"
 
   echo "[+] Building OpenSSL"


### PR DESCRIPTION
Compile with `-fcf-protection=return`, automatically enabling shadow stack for Firedancer on Ubuntu 26.04.