### PR TITLE
Fix skipped slot eating our time window

### DIFF
--- a/src/discoh/pohh/fd_pohh_tile.c
+++ b/src/discoh/pohh/fd_pohh_tile.c
@@ -987,12 +987,14 @@ publish_became_leader( fd_pohh_tile_t * ctx,
   double tick_per_ns = fd_tempo_tick_per_ns( NULL );
   fd_histf_sample( ctx->begin_leader_delay, (ulong)((double)(fd_log_wallclock()-ctx->reset_slot_start_ns)/tick_per_ns) );
 
-  if( FD_UNLIKELY( ctx->lagged_consecutive_leader_start ) ) {
+  if( FD_UNLIKELY( ctx->lagged_consecutive_leader_start || ctx->reset_slot!=slot ) ) {
     /* If we are mirroring Agave behavior, the wall clock gets reset
        here so we don't count time spent waiting for a bank to freeze
        or replay stage to actually start the slot towards our 400ms.
 
-       See extended comments in the config file on this option. */
+       See extended comments in the config file on this option.
+
+       We must also reset the wall clock if we skipped a slot. */
     ctx->reset_slot_start_ns = fd_log_wallclock() - (long)((double)(slot-ctx->reset_slot)*ctx->slot_duration_ns);
   }
 


### PR DESCRIPTION
When we become leader, and without `lagged_consecutive_leader_start`,  `slot_start_ns` is set to `reset_slot_start_ns` + `slot_duration_ns * (slot-reset_slot)`.
But then, when we skip a slot because it took too much time to complete, all the extra time we waited eats our time window.
Example:
<img width="2037" height="343" alt="image" src="https://github.com/user-attachments/assets/918b7056-1045-427e-b275-13e4d157c70a" />
