### PR TITLE
Upstream hardcoded workspace params v2

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -170,26 +170,26 @@ variables.  This has the benefit of better support for some embedded
 targets such as on-chain virtual machines.
 
 **Memory allocation**: If a larger amount of memory is required, tests
-should allocate an anon workspace from shmem given the following flags:
+should allocate a workspace from shmem via `fd_wksp_from_env`, which
+strips the following flags from `argv`:
+- `--wksp`: Name of an existing workspace to attach to (optional)
 - `--page-sz`: Size of memory pages to request (normal/huge/gigantic)
-- `--page-cnt`: Number of pages to request for given type
+- `--page-cnt`: Number of pages to allocate; if omitted, the workspace
+  size defaults to `default_page_cnt * default_page_sz` bytes scaled
+  to the requested page type
 - `--numa-idx`: NUMA node on which memory should be allocated
 - Most tests default to 1 "gigantic" page, as per our recommendation to
   use x86 1 GiB pages.
-- This can be achieved with `fd_wksp_new_anon_from_env`, which reads
-  `--page-sz` and `--numa-idx` from `argv` (falling back to the supplied
-  defaults) and scales the page count so the workspace size stays fixed
-  regardless of page type.  `--page-cnt` is consumed from `argv` but
-  ignored, so the test runner's per-job budget does not inflate the
-  workspace beyond what the test needs.
   ```c
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   ...
   /* tests */
   ...
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   ```
 - Using `fd_scratch` over "raw" shmem pages or `static uchar[]` is also fine.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -178,6 +178,8 @@ strips the following flags from `argv`:
   size defaults to `default_page_cnt * default_page_sz` bytes scaled
   to the requested page type
 - `--numa-idx`: NUMA node on which memory should be allocated
+- `--near-cpu`: CPU index used to select the NUMA node (takes precedence
+  over `--numa-idx` when both are given)
 - Most tests default to 1 "gigantic" page, as per our recommendation to
   use x86 1 GiB pages.
   ```c

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -176,18 +176,14 @@ should allocate an anon workspace from shmem given the following flags:
 - `--numa-idx`: NUMA node on which memory should be allocated
 - Most tests default to 1 "gigantic" page, as per our recommendation to
   use x86 1 GiB pages.
-- This can be achieved with the following pattern:
+- This can be achieved with `fd_wksp_new_anon_from_env`, which reads
+  `--page-sz` and `--numa-idx` from `argv` (falling back to the supplied
+  defaults) and scales the page count so the workspace size stays fixed
+  regardless of page type.  `--page-cnt` is consumed from `argv` but
+  ignored, so the test runner's per-job budget does not inflate the
+  workspace beyond what the test needs.
   ```c
-  ...
-  /* setup */
-  ...
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx(cpu_idx) );
-
-  FD_LOG_NOTICE(( "Creating workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   ...

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -972,7 +972,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   // // test_print( wksp );

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -972,7 +972,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   // // test_print( wksp );

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -972,10 +972,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt  = 1;
-  char * _page_sz  = "gigantic";
-  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   // // test_print( wksp );

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -974,6 +974,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/choreo/ghost/test_ghost.c
+++ b/src/choreo/ghost/test_ghost.c
@@ -972,11 +972,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   // // test_print( wksp );

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1197,11 +1197,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_vote();

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1197,7 +1197,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_vote();

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1199,6 +1199,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1197,7 +1197,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_vote();

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1197,10 +1197,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_vote();

--- a/src/choreo/tower/test_tower.c
+++ b/src/choreo/tower/test_tower.c
@@ -1197,10 +1197,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt = 1;
-  char * page_sz = "gigantic";
-  ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_vote();

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -88,10 +88,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong       page_cnt = 1;
-  char *      page_sz  = "gigantic";
-  ulong       numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_lockos( wksp );

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -88,11 +88,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_lockos( wksp );

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -88,7 +88,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_lockos( wksp );

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -88,10 +88,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_lockos( wksp );

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -88,7 +88,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_lockos( wksp );

--- a/src/choreo/tower/test_tower_lockos.c
+++ b/src/choreo/tower/test_tower_lockos.c
@@ -90,6 +90,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/disco/bundle/fuzz_bundle_client.c
+++ b/src/disco/bundle/fuzz_bundle_client.c
@@ -23,12 +23,7 @@ LLVMFuzzerInitialize( int *    pargc,
 
   fd_boot( pargc, pargv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, "normal"                     );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 256UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 16UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( pargc, pargv, "normal", 256UL, "wksp", 16UL, NULL );
   FD_TEST( wksp );
   g_wksp = wksp;
 

--- a/src/disco/bundle/test_bundle_client.c
+++ b/src/disco/bundle/test_bundle_client.c
@@ -1497,7 +1497,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  wksp = fd_wksp_new_anon_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL );
+  int is_anon;
+  wksp = fd_wksp_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL, &is_anon );
   FD_TEST( wksp );
 
   fd_unit_tests( argc, argv );
@@ -1507,7 +1508,8 @@ main( int     argc,
   FD_TEST( fd_wksp_usage( wksp, NULL, 0UL, &wksp_usage ) );
   FD_TEST( wksp_usage.free_cnt==wksp_usage.total_cnt );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/disco/bundle/test_bundle_client.c
+++ b/src/disco/bundle/test_bundle_client.c
@@ -1497,14 +1497,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",     NULL, "normal"                     );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",    NULL, 256UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",    NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 16UL );
+  wksp = fd_wksp_new_anon_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL );
   FD_TEST( wksp );
 
   fd_unit_tests( argc, argv );

--- a/src/disco/bundle/test_bundle_client_wraparound.c
+++ b/src/disco/bundle/test_bundle_client_wraparound.c
@@ -124,18 +124,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "normal"                     );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 256UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
-                                            page_cnt,
-                                            fd_shmem_cpu_idx( numa_idx ),
-                                            "wksp",
-                                            16UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL );
   FD_TEST( wksp );
 
   test_bundle_msg_oversized_wraparound( wksp );

--- a/src/disco/bundle/test_bundle_client_wraparound.c
+++ b/src/disco/bundle/test_bundle_client_wraparound.c
@@ -124,7 +124,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 256UL, "wksp", 16UL, &is_anon );
   FD_TEST( wksp );
 
   test_bundle_msg_oversized_wraparound( wksp );
@@ -133,7 +134,8 @@ main( int     argc,
   FD_TEST( fd_wksp_usage( wksp, NULL, 0UL, &wksp_usage ) );
   FD_TEST( wksp_usage.free_cnt==wksp_usage.total_cnt );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/disco/dedup/test_dedup.c
+++ b/src/disco/dedup/test_dedup.c
@@ -461,12 +461,6 @@ main( int     argc,
     FD_TEST( fd_dedup_tile_scratch_footprint( in_cnt, out_cnt )==FD_DEDUP_TILE_SCRATCH_FOOTPRINT( in_cnt, out_cnt ) );
   }
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",        NULL, "gigantic"                 );
-  ulong        page_cnt       = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",       NULL, 1UL                        );
-  ulong        numa_idx       = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",       NULL, fd_shmem_numa_idx(cpu_idx) );
   ulong        tx_cnt         = fd_env_strip_cmdline_ulong( &argc, &argv, "--tx-cnt",         NULL, 2UL                        );
   ulong        tx_depth       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tx-depth",       NULL, 32768UL                    );
   ulong        tx_mtu         = fd_env_strip_cmdline_ulong( &argc, &argv, "--tx-mtu",         NULL, 1472UL                     );
@@ -489,8 +483,6 @@ main( int     argc,
   float dup_frac        = fd_env_strip_cmdline_float( &argc, &argv, "--dup-frac",        NULL,                      0.9f );
   float dup_avg_age     = fd_env_strip_cmdline_float( &argc, &argv, "--dup-avg-age",     NULL, 1e-3f*(float)tcache_depth );
 
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz                     ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
   if( FD_UNLIKELY( !tx_cnt                      ) ) FD_LOG_ERR(( "tx_cnt should be positive" ));
   if( FD_UNLIKELY( !rx_cnt                      ) ) FD_LOG_ERR(( "rx_cnt should be positive" ));
   if( FD_UNLIKELY( tx_cnt>FD_DEDUP_TILE_IN_MAX  ) ) FD_LOG_ERR(( "--tx-cnt too large for this unit test" ));
@@ -526,8 +518,8 @@ main( int     argc,
 
   uint dup_thresh = (uint)(0.5f + dup_frac*(float)(1UL<<32));
 
-  FD_LOG_NOTICE(( "Creating workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   FD_LOG_NOTICE(( "Creating cncs (--tx-cnt %lu, dedup-cnt 1, --rx-cnt %lu, app-sz 64)", tx_cnt, rx_cnt ));
@@ -721,7 +713,8 @@ main( int     argc,
   fd_wksp_free_laddr( fseq_mem          );
   fd_wksp_free_laddr( cnc_mem           );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,7 +344,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                     );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,10 +344,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong       page_cnt = 1;
-  char *      _page_sz = "gigantic";
-  ulong       numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                     );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_api         ( wksp );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -346,6 +346,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                     );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,7 +344,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                     );
   if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,7 +344,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_api         ( wksp );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,7 +344,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_api         ( wksp );

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -344,11 +344,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                     );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_api         ( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2094,7 +2094,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2094,11 +2094,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2094,10 +2094,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2094,10 +2094,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt = 1;
-  char * page_sz = "gigantic";
-  ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2094,7 +2094,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -2096,6 +2096,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/reasm/test_reasm.c
+++ b/src/discof/reasm/test_reasm.c
@@ -1264,13 +1264,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"        );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL               );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0 ) );
-  ulong        page_sz  = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
 
   test_insert( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -582,7 +582,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_peer_removal( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -582,7 +582,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_peer_removal( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -582,10 +582,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt = 1;
-  char * page_sz = "gigantic";
-  ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_peer_removal( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -582,11 +582,7 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_peer_removal( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -584,6 +584,7 @@ main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -582,10 +582,10 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_peer_removal( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -755,7 +755,7 @@ test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_after_net( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -755,7 +755,7 @@ test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_after_net( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -755,10 +755,10 @@ test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_after_net( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -757,6 +757,7 @@ int main( int argc, char ** argv ) {
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -755,11 +755,7 @@ test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_after_net( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -755,10 +755,10 @@ test_after_fec_dup_confirm_larger_slot( fd_wksp_t * wksp ) {
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt = 2;
-  char * page_sz = "gigantic";
-  ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_after_net( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -940,11 +940,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_banks_evict_backfill( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -940,10 +940,10 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_banks_evict_backfill( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -940,7 +940,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_banks_evict_backfill( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -942,6 +942,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -940,7 +940,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_banks_evict_backfill( wksp );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -940,10 +940,10 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong       page_cnt = 2;
-  char *      page_sz  = "gigantic";
-  ulong       numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_banks_evict_backfill( wksp );

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -518,7 +518,7 @@ int main( int     argc,
           char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   FD_TEST( wksp );
   void * _slot_delta_parser_mem = fd_wksp_alloc_laddr( wksp, fd_slot_delta_parser_align(), fd_slot_delta_parser_footprint(), 1UL );

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -518,7 +518,7 @@ int main( int     argc,
           char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
 
   FD_TEST( wksp );
   void * _slot_delta_parser_mem = fd_wksp_alloc_laddr( wksp, fd_slot_delta_parser_align(), fd_slot_delta_parser_footprint(), 1UL );

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -520,6 +520,7 @@ int main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
 

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -518,11 +518,7 @@ int main( int     argc,
           char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   FD_TEST( wksp );
   void * _slot_delta_parser_mem = fd_wksp_alloc_laddr( wksp, fd_slot_delta_parser_align(), fd_slot_delta_parser_footprint(), 1UL );

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -518,10 +518,10 @@ int main( int     argc,
           char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt  = 1;
-  char * _page_sz  = "gigantic";
-  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
 
   FD_TEST( wksp );
   void * _slot_delta_parser_mem = fd_wksp_alloc_laddr( wksp, fd_slot_delta_parser_align(), fd_slot_delta_parser_footprint(), 1UL );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -684,10 +684,10 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt = 1;
-  char * _page_sz = "gigantic";
-  ulong  numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -684,7 +684,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -686,6 +686,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -684,7 +684,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );
@@ -703,7 +704,8 @@ main( int     argc,
 
   fd_wksp_free_laddr( manifest );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach     ( wksp );
 
   FD_LOG_NOTICE(( "all ssload tests passed" ));
 

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -684,7 +684,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -684,11 +684,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   fd_snapshot_manifest_t * manifest = (fd_snapshot_manifest_t *)fd_wksp_alloc_laddr( wksp, alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t), 1UL );

--- a/src/discof/restore/utils/test_ssmanifest_parser.c
+++ b/src/discof/restore/utils/test_ssmanifest_parser.c
@@ -21,17 +21,7 @@ main( int     argc,
   if( FD_UNLIKELY( -1==stat( argv[1], &st ) ) ) FD_LOG_ERR(( "stat() failed (%d-%s)", errno, fd_io_strerror( errno ) ));
   ulong size = (ulong)st.st_size;
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"                   );
-  ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                          );
-  ulong        numa_idx   = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
 
   uchar * buffer = fd_wksp_alloc_laddr( wksp, 1UL, size, 1UL );

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -2403,10 +2403,10 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt  = 1;
-  char * _page_sz  = "gigantic";
-  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
 
   uint rng_seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 3714951721/* arbitrary seed, reproducible CI */ );
   if( FD_UNLIKELY( !rng_seed ) ) rng_seed = (uint)fd_log_wallclock(); /* random seed, used for development */

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -2405,6 +2405,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
 

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -2403,7 +2403,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   uint rng_seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 3714951721/* arbitrary seed, reproducible CI */ );
   if( FD_UNLIKELY( !rng_seed ) ) rng_seed = (uint)fd_log_wallclock(); /* random seed, used for development */

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -2403,7 +2403,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
 
   uint rng_seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 3714951721/* arbitrary seed, reproducible CI */ );
   if( FD_UNLIKELY( !rng_seed ) ) rng_seed = (uint)fd_log_wallclock(); /* random seed, used for development */

--- a/src/discof/restore/utils/test_sspeer_selector.c
+++ b/src/discof/restore/utils/test_sspeer_selector.c
@@ -2403,11 +2403,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   uint rng_seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 3714951721/* arbitrary seed, reproducible CI */ );
   if( FD_UNLIKELY( !rng_seed ) ) rng_seed = (uint)fd_log_wallclock(); /* random seed, used for development */

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -210,7 +210,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   /* Create a single ssping instance.  max_peers=8 is enough for all

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -210,11 +210,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   /* Create a single ssping instance.  max_peers=8 is enough for all

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -210,10 +210,10 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong  page_cnt  = 1;
-  char * _page_sz  = "gigantic";
-  ulong  numa_idx  = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   /* Create a single ssping instance.  max_peers=8 is enough for all

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -212,6 +212,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/discof/restore/utils/test_ssping.c
+++ b/src/discof/restore/utils/test_ssping.c
@@ -210,7 +210,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   /* Create a single ssping instance.  max_peers=8 is enough for all

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -681,7 +681,7 @@ main( int     argc,
 
   test_count_vote_txn();
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_fixture_replay( wksp );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -681,10 +681,10 @@ main( int     argc,
 
   test_count_vote_txn();
 
-  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 4UL                     );
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_fixture_replay( wksp );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -681,11 +681,7 @@ main( int     argc,
 
   test_count_vote_txn();
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 4UL                     );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
   FD_TEST( wksp );
 
   test_fixture_replay( wksp );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -681,7 +681,7 @@ main( int     argc,
 
   test_count_vote_txn();
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   test_fixture_replay( wksp );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -681,10 +681,10 @@ main( int     argc,
 
   test_count_vote_txn();
 
-  ulong       page_cnt = 4;
-  char *      page_sz  = "gigantic";
-  ulong       numa_idx = fd_shmem_numa_idx( 0 );
-  fd_wksp_t * wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  char const * page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 4UL                     );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );
 
   test_fixture_replay( wksp );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -683,6 +683,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 4UL                     );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp      = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
   FD_TEST( wksp );

--- a/src/flamenco/accdb/test_accdb_v1.c
+++ b/src/flamenco/accdb/test_accdb_v1.c
@@ -611,26 +611,23 @@ main( int     argc,
   fd_log_level_logfile_set( 0 );
 # endif
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
-  ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
-  ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,            32UL );
-  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,            512U );
-  ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL,       1048576UL );
+  ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,     5678UL );
+  ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,       32UL );
+  uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,       512U );
+  ulong        iter_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--iter-max",  NULL, 1048576UL );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)seed, 0UL ) );
 
-  FD_LOG_NOTICE(( "using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                  _page_sz, page_cnt, near_cpu ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
+  FD_TEST( wksp );
 
   test_simple( wksp );
   test_random_ops( wksp, rng, txn_max, rec_max, iter_max );
 
   /* FIXME leak check */
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/flamenco/accdb/test_accdb_v1_racesan.c
+++ b/src/flamenco/accdb/test_accdb_v1_racesan.c
@@ -471,18 +471,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"                   );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                          );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
 # define TEST( name ) { #name, name }
@@ -505,7 +495,8 @@ main( int     argc,
     }
   }
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/log_collector/test_log_collector.c
+++ b/src/flamenco/log_collector/test_log_collector.c
@@ -133,7 +133,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL, NULL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/log_collector/test_log_collector.c
+++ b/src/flamenco/log_collector/test_log_collector.c
@@ -132,21 +132,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 4UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/progcache/test_progcache.c
+++ b/src/flamenco/progcache/test_progcache.c
@@ -1027,23 +1027,14 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_unit_tests( argc, argv );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -852,23 +852,14 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_unit_tests( argc, argv );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/program/test_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/test_bpf_loader_program.c
@@ -235,17 +235,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "normal" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1100000UL );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  FD_TEST( page_sz );
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 1100000UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   test_deploy_v0_succeeds( wksp );
@@ -257,7 +248,8 @@ main( int     argc,
   test_finalize_v3_feature_off( );
   test_finalize_v3_feature_on ( );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/program/test_bpf_loader_serialization.c
+++ b/src/flamenco/runtime/program/test_bpf_loader_serialization.c
@@ -571,17 +571,8 @@ int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "normal" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1100000UL );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  FD_TEST( page_sz );
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 1100000UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   void * alloc_mem = fd_wksp_alloc_laddr( wksp, fd_alloc_align(), fd_alloc_footprint(), 1UL );
@@ -633,7 +624,8 @@ main( int argc, char ** argv ) {
   fd_alloc_free( alloc, data );
 
   fd_alloc_delete( fd_alloc_leave( alloc ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -615,21 +615,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL, NULL );
 
   test_account_initialize( wksp );
   test_account_initialize_simd_0387( wksp );

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -618,6 +618,7 @@ main( int     argc,
   char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
 
   fd_wksp_t * wksp;

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -1445,24 +1445,14 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx > fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 6UL );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 6UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   test_execute_bundles( wksp );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -1450,6 +1450,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 6UL );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
 
   ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -1448,7 +1448,7 @@ main( int     argc,
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx > fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 6UL );
   if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );

--- a/src/flamenco/runtime/test_cost_tracker.c
+++ b/src/flamenco/runtime/test_cost_tracker.c
@@ -4,7 +4,7 @@ int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
 
   void * cost_tracker_mem = fd_wksp_alloc_laddr( wksp, fd_cost_tracker_align(), fd_cost_tracker_footprint(), wksp_tag );
   FD_TEST( cost_tracker_mem );

--- a/src/flamenco/runtime/test_cost_tracker.c
+++ b/src/flamenco/runtime/test_cost_tracker.c
@@ -3,21 +3,8 @@
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   void * cost_tracker_mem = fd_wksp_alloc_laddr( wksp, fd_cost_tracker_align(), fd_cost_tracker_footprint(), wksp_tag );
   FD_TEST( cost_tracker_mem );

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -455,24 +455,14 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx > fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   test_deprecate_rent_exemption_threshold( wksp );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -460,6 +460,7 @@ main( int     argc,
 
   char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
 
   ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -458,7 +458,7 @@ main( int     argc,
   ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
   if( cpu_idx > fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv,  "--page-sz",  NULL, "gigantic" );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL );
   if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2240,16 +2240,7 @@ main( int argc, char ** argv ) {
   test_wire_rejects_truncated_padding();
   test_wire_encoded_field_offsets();
 
-  /* Create workspace */
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 16UL                    );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
-                                            page_cnt,
-                                            fd_shmem_cpu_idx( numa_idx ),
-                                            "test_runtime_alut_wksp",
-                                            0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL );
   FD_TEST( wksp );
 
   /* Run test cases */

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2240,7 +2240,7 @@ main( int argc, char ** argv ) {
   test_wire_rejects_truncated_padding();
   test_wire_encoded_field_offsets();
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL );
   FD_TEST( wksp );
 
   /* Run test cases */

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2240,7 +2240,7 @@ main( int argc, char ** argv ) {
   test_wire_rejects_truncated_padding();
   test_wire_encoded_field_offsets();
 
-  fd_wksp_t * wksp = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL , NULL);
   FD_TEST( wksp );
 
   /* Run test cases */

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2241,10 +2241,11 @@ main( int argc, char ** argv ) {
   test_wire_encoded_field_offsets();
 
   /* Create workspace */
-  char * _page_sz = "gigantic";
-  ulong numa_idx = fd_shmem_numa_idx( 0 );
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 16UL                    );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
-                                            16UL,
+                                            page_cnt,
                                             fd_shmem_cpu_idx( numa_idx ),
                                             "test_runtime_alut_wksp",
                                             0UL );

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2243,6 +2243,7 @@ main( int argc, char ** argv ) {
   /* Create workspace */
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 16UL                    );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ),
                                             page_cnt,

--- a/src/flamenco/runtime/test_runtime_alut.c
+++ b/src/flamenco/runtime/test_runtime_alut.c
@@ -2240,7 +2240,8 @@ main( int argc, char ** argv ) {
   test_wire_rejects_truncated_padding();
   test_wire_encoded_field_offsets();
 
-  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL , NULL);
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 16UL, "test_runtime_alut_wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   /* Run test cases */
@@ -2273,7 +2274,8 @@ main( int argc, char ** argv ) {
   test_alt_duplicate_indices( wksp );
   test_max_transaction_alts( wksp );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach     ( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
 

--- a/src/flamenco/stakes/test_new_votes.c
+++ b/src/flamenco/stakes/test_new_votes.c
@@ -3,21 +3,8 @@
 int main( int argc, char * argv[] ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   ulong max_accounts   = 64UL;
   ulong exp_accounts   = 64UL;

--- a/src/flamenco/stakes/test_new_votes.c
+++ b/src/flamenco/stakes/test_new_votes.c
@@ -4,7 +4,7 @@ int main( int argc, char * argv[] ) {
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
 
   ulong max_accounts   = 64UL;
   ulong exp_accounts   = 64UL;

--- a/src/flamenco/stakes/test_stake_delegations.c
+++ b/src/flamenco/stakes/test_stake_delegations.c
@@ -74,7 +74,7 @@ int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
 
   /* Test stake delegations where is_tombstone == 0 */
 

--- a/src/flamenco/stakes/test_stake_delegations.c
+++ b/src/flamenco/stakes/test_stake_delegations.c
@@ -73,21 +73,8 @@ assert_delegation( fd_stake_delegation_t const * d,
 int main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   /* Test stake delegations where is_tombstone == 0 */
 

--- a/src/flamenco/stakes/test_top_votes.c
+++ b/src/flamenco/stakes/test_top_votes.c
@@ -64,7 +64,7 @@ main( int argc, char * argv[] ) {
   fd_pubkey_t node_L = { .ul = { 212UL } };
   fd_pubkey_t node_M = { .ul = { 213UL } };
 
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
 
   ushort const vote_accounts_max = 4UL;
   ulong  const footprint         = fd_top_votes_footprint( vote_accounts_max );

--- a/src/flamenco/stakes/test_top_votes.c
+++ b/src/flamenco/stakes/test_top_votes.c
@@ -34,10 +34,6 @@ int
 main( int argc, char * argv[] ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
 
   fd_pubkey_t vote_A = { .ul = { 101UL } };
@@ -68,15 +64,7 @@ main( int argc, char * argv[] ) {
   fd_pubkey_t node_L = { .ul = { 212UL } };
   fd_pubkey_t node_M = { .ul = { 213UL } };
 
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   ushort const vote_accounts_max = 4UL;
   ulong  const footprint         = fd_top_votes_footprint( vote_accounts_max );

--- a/src/flamenco/stakes/test_vote_stakes.c
+++ b/src/flamenco/stakes/test_vote_stakes.c
@@ -21,7 +21,7 @@ int main( int argc, char * argv[] ) {
   fd_pubkey_t node_account_t_1_fork_2 = {.ul = {19}};
   fd_pubkey_t node_account_t_1_fork_3 = {.ul = {20}};
 
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
 
   ulong footprint = fd_vote_stakes_footprint( 64UL, 64UL, 16UL );
 

--- a/src/flamenco/stakes/test_vote_stakes.c
+++ b/src/flamenco/stakes/test_vote_stakes.c
@@ -4,10 +4,6 @@
 int main( int argc, char * argv[] ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
 
   fd_pubkey_t pubkey_A = {.ul = {10}}; (void)pubkey_A;
@@ -25,15 +21,7 @@ int main( int argc, char * argv[] ) {
   fd_pubkey_t node_account_t_1_fork_2 = {.ul = {19}};
   fd_pubkey_t node_account_t_1_fork_3 = {.ul = {20}};
 
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   ulong footprint = fd_vote_stakes_footprint( 64UL, 64UL, 16UL );
 

--- a/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
+++ b/src/flamenco/vm/syscall/test_vm_increase_cpi_account_info_limit.c
@@ -480,11 +480,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 4UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 4UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   test_both_enabled_exceeds_limit( wksp );
@@ -500,7 +497,8 @@ main( int     argc,
   test_increase_tx_account_lock_limit_enabled_below_limit( wksp );
   test_neither_enabled_below_limit( wksp );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/vm/syscall/test_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/test_vm_syscall_curve.c
@@ -94,21 +94,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/vm/syscall/test_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/test_vm_syscall_curve.c
@@ -95,7 +95,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL, NULL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/vm/syscall/test_vm_syscall_hash.c
+++ b/src/flamenco/vm/syscall/test_vm_syscall_hash.c
@@ -158,12 +158,9 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 5UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu", NULL, fd_log_cpu_id() );
-  ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag", NULL, 1234UL          );
+  ulong wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag", NULL, 1234UL );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );

--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -222,21 +222,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/vm/syscall/test_vm_syscalls.c
+++ b/src/flamenco/vm/syscall/test_vm_syscalls.c
@@ -223,7 +223,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL, NULL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/vm/test_vm_interp.c
+++ b/src/flamenco/vm/test_vm_interp.c
@@ -465,6 +465,7 @@ main( int     argc,
   char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
   ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
   ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
 

--- a/src/flamenco/vm/test_vm_interp.c
+++ b/src/flamenco/vm/test_vm_interp.c
@@ -462,22 +462,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL, NULL            );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"      );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 5UL             );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/flamenco/vm/test_vm_interp.c
+++ b/src/flamenco/vm/test_vm_interp.c
@@ -463,7 +463,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL, 1234UL          );
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL );
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 5UL, "wksp", 0UL, NULL );
 
   fd_runtime_t * runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   FD_TEST( runtime );

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -144,7 +144,7 @@ main( int     argc,
 
   fd_wksp_free_laddr( shlocks );
   fd_wksp_free_laddr( shmem );
-  if( is_anon ) fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
   else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -79,7 +79,8 @@ main( int     argc,
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,        262144UL );
   uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,          262144 );
 
-  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
+  int          is_anon;
+  fd_wksp_t *  wksp     = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
@@ -143,7 +144,8 @@ main( int     argc,
 
   fd_wksp_free_laddr( shlocks );
   fd_wksp_free_laddr( shmem );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anonymous( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/funk/test_funk.c
+++ b/src/funk/test_funk.c
@@ -74,24 +74,12 @@ main( int     argc,
 
   test_funk_val_shrink_compacts();
 
-  char const * name     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
-  ulong        near_cpu = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
   ulong        wksp_tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--wksp-tag",  NULL,          1234UL );
   ulong        seed     = fd_env_strip_cmdline_ulong( &argc, &argv, "--seed",      NULL,          5678UL );
   ulong        txn_max  = fd_env_strip_cmdline_ulong( &argc, &argv, "--txn-max",   NULL,        262144UL );
   uint         rec_max  = fd_env_strip_cmdline_uint(  &argc, &argv, "--rec-max",   NULL,          262144 );
 
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  fd_wksp_t *  wksp     = fd_wksp_new_anon_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL );
 
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
@@ -155,8 +143,7 @@ main( int     argc,
 
   fd_wksp_free_laddr( shlocks );
   fd_wksp_free_laddr( shmem );
-  if( name ) fd_wksp_detach( wksp );
-  else       fd_wksp_delete_anonymous( wksp );
+  fd_wksp_delete_anonymous( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/tango/tcache/test_tcache.c
+++ b/src/tango/tcache/test_tcache.c
@@ -40,20 +40,13 @@ main( int     argc,
     else FD_TEST( footprint==FD_TCACHE_FOOTPRINT( depth, map_cnt ) );
   }
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz    = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",     NULL, "gigantic"                   );
-  ulong        page_cnt    = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",    NULL, 1UL                          );
-  ulong        numa_idx    = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",    NULL, fd_shmem_numa_idx( cpu_idx ) );
   ulong        depth       = fd_env_strip_cmdline_ulong( &argc, &argv, "--depth",       NULL, (1UL<<22)-1UL );
   ulong        map_cnt     = fd_env_strip_cmdline_ulong( &argc, &argv, "--map-cnt",     NULL, 0UL           ); /* 0 <> use def */
   float        dup_frac    = fd_env_strip_cmdline_float( &argc, &argv, "--dup-frac",    NULL, 0.5f          );
   float        dup_avg_age = fd_env_strip_cmdline_float( &argc, &argv, "--dup-avg-age", NULL, 1.f           );
 
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp =
-    fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   ulong  align     = fd_tcache_align();
@@ -239,7 +232,8 @@ main( int     argc,
   FD_TEST( fd_tcache_leave ( tcache  )==_tcache );
   FD_TEST( fd_tcache_delete( _tcache )==mem     );
   fd_wksp_free_laddr( mem );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -300,29 +300,17 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  char const * name      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
-  ulong        near_cpu  = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
-  ulong        alloc_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--alloc-cnt", NULL,       1048576UL );
-  ulong        align_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--align-max", NULL,           256UL );
-  ulong        sz_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--sz-max",    NULL,         73728UL );
-  ulong        tag       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",       NULL,          1234UL );
-  ulong        tile_cnt  = fd_tile_cnt();
-  int          paired    = fd_env_strip_cmdline_int  ( &argc, &argv, "--paired",    NULL,               1 );
+  ulong alloc_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--alloc-cnt", NULL, 1048576UL );
+  ulong align_max = fd_env_strip_cmdline_ulong( &argc, &argv, "--align-max", NULL,    256UL );
+  ulong sz_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--sz-max",    NULL,  73728UL );
+  ulong tag       = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",       NULL,   1234UL );
+  ulong tile_cnt  = fd_tile_cnt();
+  int   paired    = fd_env_strip_cmdline_int  ( &argc, &argv, "--paired",    NULL,        1 );
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, (uint)tile_cnt, 0UL ) );
 
-  fd_wksp_t * wksp;
-  if( name ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", name ));
-    wksp = fd_wksp_attach( name );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace, --page-sz %s, --page-cnt %lu, --near-cpu %lu",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
-
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   if( FD_UNLIKELY( !wksp ) ) FD_LOG_ERR(( "Unable to attach to wksp" ));
 
   ulong  align     = fd_alloc_align();     FD_TEST( align    ==FD_ALLOC_ALIGN     );
@@ -441,8 +429,8 @@ main( int     argc,
   FD_TEST( fd_alloc_delete( shalloc )==shmem );
 
   fd_wksp_free_laddr( shmem );
-  if( name ) fd_wksp_detach( wksp );
-  else       fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -720,32 +720,6 @@ fd_wksp_new_anonymous( ulong         page_sz,
 
 static inline void fd_wksp_delete_anonymous( fd_wksp_t * wksp ) { fd_wksp_delete_anon( wksp ); }
 
-/* fd_wksp_new_anon_from_env parses --page-sz and --numa-idx from the
-   command line (falling back to defaults) and creates an anonymous workspace.
-   The workspace size is fixed at default_page_cnt*default_page_sz bytes;
-   --page-sz controls the page type used to back it (the page count is
-   scaled accordingly).  --page-cnt is consumed from argv but ignored so
-   that the test runner's budget does not inflate the workspace beyond what
-   the test actually needs. */
-
-static inline fd_wksp_t *
-fd_wksp_new_anon_from_env( int *        pargc,
-                           char ***     pargv,
-                           char const * default_page_sz,
-                           ulong        default_page_cnt,
-                           char const * name,
-                           ulong        opt_part_max ) {
-  char const * _page_sz    = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz          );
-  ulong        numa_idx    = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 0UL ); /* consume to keep argv clean */
-  ulong        page_sz     = fd_cstr_to_shmem_page_sz( _page_sz );
-  ulong        def_page_sz = fd_cstr_to_shmem_page_sz( default_page_sz );
-  ulong        page_cnt    = (default_page_cnt * def_page_sz + page_sz - 1UL) / page_sz;
-  ulong        cpu_idx     = fd_shmem_cpu_idx( numa_idx );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "invalid page size for requested workspace" ));
-  return fd_wksp_new_anon( name, page_sz, 1UL, &page_cnt, &cpu_idx, 0U, opt_part_max );
-}
-
 /* fd_wksp_attach attach to the workspace held by the shared memory
    region with the given name.  If there are regions with the same name
    backed by different page sizes, defaults to the region backed by the
@@ -764,6 +738,39 @@ fd_wksp_attach( char const * name );
 
 int
 fd_wksp_detach( fd_wksp_t * wksp );
+
+/* fd_wksp_from_env parses --wksp, --page-sz, --page-cnt, --numa-idx from
+   the command line.  If --wksp is given, attaches to the named workspace
+   and sets *opt_is_anon to 0.  Otherwise creates an anonymous workspace
+   and sets *opt_is_anon to 1.  opt_is_anon may be NULL.  The workspace
+   size is --page-cnt pages of --page-sz each; if --page-cnt is omitted it
+   defaults to default_page_cnt*default_page_sz bytes scaled to --page-sz. */
+
+static inline fd_wksp_t *
+fd_wksp_from_env( int *        pargc,
+                  char ***     pargv,
+                  char const * default_page_sz,
+                  ulong        default_page_cnt,
+                  char const * name,
+                  ulong        opt_part_max,
+                  int *        opt_is_anon ) {
+  char const * _wksp      = fd_env_strip_cmdline_cstr ( pargc, pargv, "--wksp",     NULL, NULL                    );
+  char const * _page_sz   = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz          );
+  ulong        numa_idx   = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  ulong        page_cnt_arg = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 0UL );
+  if( _wksp ) {
+    FD_LOG_NOTICE(( "Attaching to --wksp %s", _wksp ));
+    if( opt_is_anon ) *opt_is_anon = 0;
+    return fd_wksp_attach( _wksp );
+  }
+  ulong page_sz     = fd_cstr_to_shmem_page_sz( _page_sz );
+  ulong def_page_sz = fd_cstr_to_shmem_page_sz( default_page_sz );
+  ulong page_cnt    = page_cnt_arg ? page_cnt_arg : (default_page_cnt * def_page_sz + page_sz - 1UL) / page_sz;
+  ulong cpu_idx     = fd_shmem_cpu_idx( numa_idx );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "invalid page size for requested workspace" ));
+  if( opt_is_anon ) *opt_is_anon = 1;
+  return fd_wksp_new_anon( name, page_sz, 1UL, &page_cnt, &cpu_idx, 0U, opt_part_max );
+}
 
 /* fd_wksp_containing maps a fd_wksp local addr to the corresponding
    fd_wksp local join.  Returns NULL if laddr does not appear to be from

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -739,12 +739,14 @@ fd_wksp_attach( char const * name );
 int
 fd_wksp_detach( fd_wksp_t * wksp );
 
-/* fd_wksp_from_env parses --wksp, --page-sz, --page-cnt, --numa-idx from
-   the command line.  If --wksp is given, attaches to the named workspace
-   and sets *opt_is_anon to 0.  Otherwise creates an anonymous workspace
-   and sets *opt_is_anon to 1.  opt_is_anon may be NULL.  The workspace
-   size is --page-cnt pages of --page-sz each; if --page-cnt is omitted it
-   defaults to default_page_cnt*default_page_sz bytes scaled to --page-sz. */
+/* fd_wksp_from_env parses --wksp, --page-sz, --page-cnt, --numa-idx, and
+   --near-cpu from the command line.  If --wksp is given, attaches to the
+   named workspace and sets *opt_is_anon to 0.  Otherwise creates an
+   anonymous workspace and sets *opt_is_anon to 1.  opt_is_anon may be NULL.
+   The workspace size is --page-cnt pages of --page-sz each; if --page-cnt is
+   omitted it defaults to default_page_cnt*default_page_sz bytes scaled to
+   --page-sz.  --near-cpu specifies the NUMA node by CPU index; if both
+   --near-cpu and --numa-idx are absent, defaults to NUMA node 0. */
 
 static inline fd_wksp_t *
 fd_wksp_from_env( int *        pargc,
@@ -754,10 +756,12 @@ fd_wksp_from_env( int *        pargc,
                   char const * name,
                   ulong        opt_part_max,
                   int *        opt_is_anon ) {
-  char const * _wksp      = fd_env_strip_cmdline_cstr ( pargc, pargv, "--wksp",     NULL, NULL                    );
-  char const * _page_sz   = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz          );
-  ulong        numa_idx   = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  ulong        page_cnt_arg = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 0UL );
+  char const * _wksp        = fd_env_strip_cmdline_cstr ( pargc, pargv, "--wksp",     NULL, NULL           );
+  char const * _page_sz     = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz );
+  ulong        page_cnt_arg = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 0UL             );
+  ulong        near_cpu     = fd_env_strip_cmdline_ulong( pargc, pargv, "--near-cpu", NULL, ULONG_MAX       );
+  ulong        numa_idx     = (near_cpu!=ULONG_MAX) ? fd_shmem_numa_idx( near_cpu )
+                            : fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
   if( _wksp ) {
     FD_LOG_NOTICE(( "Attaching to --wksp %s", _wksp ));
     if( opt_is_anon ) *opt_is_anon = 0;

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -769,6 +769,8 @@ fd_wksp_from_env( int *        pargc,
   }
   ulong page_sz     = fd_cstr_to_shmem_page_sz( _page_sz );
   ulong def_page_sz = fd_cstr_to_shmem_page_sz( default_page_sz );
+  if( FD_UNLIKELY( !page_sz     ) ) FD_LOG_ERR(( "unsupported --page-sz \"%s\"",     _page_sz     ));
+  if( FD_UNLIKELY( !def_page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz \"%s\"",     default_page_sz ));
   ulong page_cnt    = page_cnt_arg ? page_cnt_arg : (default_page_cnt * def_page_sz + page_sz - 1UL) / page_sz;
   ulong cpu_idx     = fd_shmem_cpu_idx( numa_idx );
   if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "invalid page size for requested workspace" ));

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -720,6 +720,24 @@ fd_wksp_new_anonymous( ulong         page_sz,
 
 static inline void fd_wksp_delete_anonymous( fd_wksp_t * wksp ) { fd_wksp_delete_anon( wksp ); }
 
+/* fd_wksp_new_anonymous_from_env parses --page-sz, --page-cnt, --numa-idx
+   from the command line (falling back to defaults) and creates an anonymous
+   workspace. */
+
+static inline fd_wksp_t *
+fd_wksp_new_anonymous_from_env( int *        pargc,
+                                char ***     pargv,
+                                char const * default_page_sz,
+                                ulong        default_page_cnt,
+                                char const * name,
+                                ulong        opt_part_max ) {
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz  );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, default_page_cnt );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  return fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), name, opt_part_max );
+}
+
 /* fd_wksp_attach attach to the workspace held by the shared memory
    region with the given name.  If there are regions with the same name
    backed by different page sizes, defaults to the region backed by the

--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -720,22 +720,30 @@ fd_wksp_new_anonymous( ulong         page_sz,
 
 static inline void fd_wksp_delete_anonymous( fd_wksp_t * wksp ) { fd_wksp_delete_anon( wksp ); }
 
-/* fd_wksp_new_anonymous_from_env parses --page-sz, --page-cnt, --numa-idx
-   from the command line (falling back to defaults) and creates an anonymous
-   workspace. */
+/* fd_wksp_new_anon_from_env parses --page-sz and --numa-idx from the
+   command line (falling back to defaults) and creates an anonymous workspace.
+   The workspace size is fixed at default_page_cnt*default_page_sz bytes;
+   --page-sz controls the page type used to back it (the page count is
+   scaled accordingly).  --page-cnt is consumed from argv but ignored so
+   that the test runner's budget does not inflate the workspace beyond what
+   the test actually needs. */
 
 static inline fd_wksp_t *
-fd_wksp_new_anonymous_from_env( int *        pargc,
-                                char ***     pargv,
-                                char const * default_page_sz,
-                                ulong        default_page_cnt,
-                                char const * name,
-                                ulong        opt_part_max ) {
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz  );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, default_page_cnt );
-  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "--page-cnt must be at least 1" ));
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
-  return fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), name, opt_part_max );
+fd_wksp_new_anon_from_env( int *        pargc,
+                           char ***     pargv,
+                           char const * default_page_sz,
+                           ulong        default_page_cnt,
+                           char const * name,
+                           ulong        opt_part_max ) {
+  char const * _page_sz    = fd_env_strip_cmdline_cstr ( pargc, pargv, "--page-sz",  NULL, default_page_sz          );
+  ulong        numa_idx    = fd_env_strip_cmdline_ulong( pargc, pargv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_env_strip_cmdline_ulong( pargc, pargv, "--page-cnt", NULL, 0UL ); /* consume to keep argv clean */
+  ulong        page_sz     = fd_cstr_to_shmem_page_sz( _page_sz );
+  ulong        def_page_sz = fd_cstr_to_shmem_page_sz( default_page_sz );
+  ulong        page_cnt    = (default_page_cnt * def_page_sz + page_sz - 1UL) / page_sz;
+  ulong        cpu_idx     = fd_shmem_cpu_idx( numa_idx );
+  if( FD_UNLIKELY( page_cnt<1UL ) ) FD_LOG_ERR(( "invalid page size for requested workspace" ));
+  return fd_wksp_new_anon( name, page_sz, 1UL, &page_cnt, &cpu_idx, 0U, opt_part_max );
 }
 
 /* fd_wksp_attach attach to the workspace held by the shared memory

--- a/src/util/wksp/test_wksp.c
+++ b/src/util/wksp/test_wksp.c
@@ -186,8 +186,11 @@ main( int     argc,
 
   char const * name       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",      NULL,            NULL );
   char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL,      "gigantic" );
-  ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL,             1UL );
+  fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 0UL ); /* consume to keep argv clean */
   ulong        near_cpu   = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",  NULL, fd_log_cpu_id() );
+  ulong page_sz     = fd_cstr_to_shmem_page_sz( _page_sz );
+  ulong def_page_sz = fd_cstr_to_shmem_page_sz( "gigantic" );
+  ulong page_cnt    = (def_page_sz + page_sz - 1UL) / page_sz;
   uint         seed       = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",      NULL,              0U );
   ulong        part_max   = fd_env_strip_cmdline_ulong( &argc, &argv, "--part-max",  NULL,             0UL );
   /**/         _alloc_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--alloc-cnt", NULL,       1048576UL );
@@ -207,7 +210,7 @@ main( int     argc,
   } else {
     FD_LOG_NOTICE(( "--wksp not specified, using an anonymous --page-sz %s --page-cnt %lu --near-cpu %lu --seed %u --part-max %lu",
                     _page_sz, page_cnt, near_cpu, seed, part_max ));
-    _wksp = fd_wksp_new_anon( "wksp", fd_cstr_to_shmem_page_sz( _page_sz ), 1UL, &page_cnt, &near_cpu, seed, part_max );
+    _wksp = fd_wksp_new_anon( "wksp", page_sz, 1UL, &page_cnt, &near_cpu, seed, part_max );
   }
 
   FD_LOG_NOTICE(( "Testing with --alloc-cnt %lu, --align-max %lu, --sz-max %lu on %lu tile(s)",

--- a/src/vinyl/test_vinyl_req.c
+++ b/src/vinyl/test_vinyl_req.c
@@ -846,11 +846,7 @@ main( int     argc,
 
   if( FD_UNLIKELY( fd_tile_cnt() < 2UL ) ) FD_LOG_ERR(( "This test requires at least 2 tiles" ));
 
-  char const * _wksp       = fd_env_strip_cmdline_cstr ( &argc, &argv, "--wksp",        NULL,                   NULL );
-  char const * _page_sz    = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",     NULL,             "gigantic" );
-  ulong        page_cnt    = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",    NULL,                    8UL );
-  ulong        near_cpu    = fd_env_strip_cmdline_ulong( &argc, &argv, "--near-cpu",    NULL,        fd_log_cpu_id() );
-  ulong        tag         = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag",         NULL,                    1UL );
+  ulong tag = fd_env_strip_cmdline_ulong( &argc, &argv, "--tag", NULL, 1UL );
 
   ulong        spad_max    = fd_env_strip_cmdline_ulong( &argc, &argv, "--spad-max",    NULL, fd_vinyl_io_spad_est() );
   ulong        dev_sz      = fd_env_strip_cmdline_ulong( &argc, &argv, "--dev-sz",      NULL,              1UL << 30 );
@@ -884,15 +880,8 @@ main( int     argc,
 
   int style = fd_cstr_to_vinyl_bstream_ctl_style( _style );
 
-  fd_wksp_t * wksp;
-  if( _wksp ) {
-    FD_LOG_NOTICE(( "Attaching to --wksp %s", _wksp ));
-    wksp = fd_wksp_attach( _wksp );
-  } else {
-    FD_LOG_NOTICE(( "--wksp not specified, using an anonymous local workspace (--page-sz %s --page-cnt %lu --near-cpu %lu)",
-                    _page_sz, page_cnt, near_cpu ));
-    wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, near_cpu, "wksp", 0UL );
-  }
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 8UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   FD_LOG_NOTICE(( "Creating vinyl tile" ));
@@ -1092,8 +1081,8 @@ main( int     argc,
   fd_wksp_free_laddr( _dev     );
   fd_wksp_free_laddr( _io      );
 
-  if( _wksp ) fd_wksp_detach( wksp );
-  else        fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/waltz/mib/test_netdev_netlink.c
+++ b/src/waltz/mib/test_netdev_netlink.c
@@ -7,23 +7,14 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL,                     "normal" );
-  ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL,                       4096UL );
-  ulong        numa_idx   = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-  ulong        dev_cnt    = fd_env_strip_cmdline_ulong( &argc, &argv, "--dev-cnt",  NULL,                        256UL );
-  ulong        bond_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--bond-cnt", NULL,                          4UL );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
+  ulong dev_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--dev-cnt",  NULL, 256UL );
+  ulong bond_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--bond-cnt", NULL,   4UL );
 
   if( FD_UNLIKELY( !dev_cnt  ) ) FD_LOG_ERR(( "unsupported --dev-cnt"  ));
   if( FD_UNLIKELY( !bond_cnt ) ) FD_LOG_ERR(( "unsupported --bond-cnt" ));
 
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 4096UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   ulong tbl_fp = fd_netdev_tbl_footprint( dev_cnt, bond_cnt );
@@ -53,7 +44,8 @@ main( int     argc,
   fd_netlink_fini( netlink );
   fd_netdev_tbl_leave( tbl );
   fd_wksp_free_laddr( fd_netdev_tbl_delete( tbl_mem ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/waltz/neigh/test_neigh4_netlink.c
+++ b/src/waltz/neigh/test_neigh4_netlink.c
@@ -193,18 +193,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",  NULL, "gigantic"                 );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt", NULL, 1UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx(cpu_idx) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating anonymous workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_netlink_t _netlink[2];
@@ -234,7 +224,8 @@ main( int     argc,
   fd_neigh4_hmap_leave( map );
 
   fd_wksp_free_laddr( fd_neigh4_hmap_delete( hmap_mem ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/waltz/quic/tests/test_quic_bw.c
+++ b/src/waltz/quic/tests/test_quic_bw.c
@@ -88,25 +88,16 @@ main( int     argc,
 
   fd_clock_tile_init( clock );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
 # define FRAG_SZ (1163UL) /* Usable QUIC stream data space FIXME increase IPv4 MTU */
 
-  char const * _page_sz = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-  float        loss     = fd_env_strip_cmdline_float ( &argc, &argv, "--loss",      NULL, 0.0f                         );
-  float        reorder  = fd_env_strip_cmdline_float ( &argc, &argv, "--reorder",   NULL, 0.0f                         );
-  float        duration = fd_env_strip_cmdline_float ( &argc, &argv, "--duration",  NULL, 10.0f                        );
-  ushort       sz       = fd_env_strip_cmdline_ushort( &argc, &argv, "--sz",        NULL, 1UL<<10                      );
+  float        loss     = fd_env_strip_cmdline_float ( &argc, &argv, "--loss",      NULL, 0.0f    );
+  float        reorder  = fd_env_strip_cmdline_float ( &argc, &argv, "--reorder",   NULL, 0.0f    );
+  float        duration = fd_env_strip_cmdline_float ( &argc, &argv, "--duration",  NULL, 10.0f   );
+  ushort       sz       = fd_env_strip_cmdline_ushort( &argc, &argv, "--sz",        NULL, 1UL<<10 );
   FD_TEST( sz<=FRAG_SZ );
 
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   /* Tune QUIC client and server such that server ACKs just before
@@ -277,7 +268,8 @@ main( int     argc,
   fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( client_quic ) ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_clock_leave( clock->clock );
   fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );

--- a/src/waltz/quic/tests/test_quic_client_flood.c
+++ b/src/waltz/quic/tests/test_quic_client_flood.c
@@ -238,20 +238,11 @@ main( int argc, char ** argv ) {
 
   fd_clock_tile_init( clock );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",        NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt",       NULL, 1UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx",       NULL, fd_shmem_numa_idx(cpu_idx)   );
-  char const * _dst_ip   = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--dst-ip",         NULL, NULL                         );
-  ushort       dst_port  = fd_env_strip_cmdline_ushort( &argc, &argv, "--dst-port",       NULL, 9090U                        );
-  char const * _gateway  = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--gateway",        NULL, "00:00:00:00:00:00"          );
-  uint         batch     = fd_env_strip_cmdline_uint  ( &argc, &argv, "--batch",          NULL, 16U                          );
+  char const * _dst_ip   = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--dst-ip",   NULL, NULL               );
+  ushort       dst_port  = fd_env_strip_cmdline_ushort( &argc, &argv, "--dst-port", NULL, 9090U              );
+  char const * _gateway  = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--gateway",  NULL, "00:00:00:00:00:00" );
+  uint         batch     = fd_env_strip_cmdline_uint  ( &argc, &argv, "--batch",    NULL, 16U                );
   /*         */g_unreliable = (_Bool)fd_env_strip_cmdline_contains( &argc, &argv, "--unreliable" );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
 
   if( FD_UNLIKELY( !_dst_ip  ) ) FD_LOG_ERR(( "missing --dst-ip"   ));
   if( FD_UNLIKELY( !dst_port ) ) FD_LOG_ERR(( "missing --dst-port" ));
@@ -264,8 +255,8 @@ main( int argc, char ** argv ) {
   uint dst_ip;
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( _dst_ip, &dst_ip  ) ) ) FD_LOG_ERR(( "invalid --dst-ip" ));
 
-  FD_LOG_NOTICE(( "Creating workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t quic_limits = {0};
@@ -298,7 +289,8 @@ main( int argc, char ** argv ) {
 
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( quic ) ) );
   fd_quic_udpsock_destroy( udpsock );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_clock_leave( clock->clock );
   fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );

--- a/src/waltz/quic/tests/test_quic_concurrency.c
+++ b/src/waltz/quic/tests/test_quic_concurrency.c
@@ -20,27 +20,15 @@ main( int     argc,
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
   fd_clock_tile_t clock[1];
   fd_clock_tile_init( clock );
 
-  char const * _page_sz   = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"                   );
-  ulong        page_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                          );
-  ulong        numa_idx   = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( cpu_idx ) );
-  ulong        conn_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--conn-cnt", NULL, 100000UL                     );
-  float        duration   = fd_env_strip_cmdline_float( &argc, &argv, "--duration", NULL, 3.0f                         );
-  ulong        conn_burst = fd_env_strip_cmdline_ulong( &argc, &argv, "--burst",    NULL, 16UL                         );
+  ulong        conn_cnt   = fd_env_strip_cmdline_ulong( &argc, &argv, "--conn-cnt", NULL, 100000UL );
+  float        duration   = fd_env_strip_cmdline_float( &argc, &argv, "--duration", NULL, 3.0f     );
+  ulong        conn_burst = fd_env_strip_cmdline_ulong( &argc, &argv, "--burst",    NULL, 16UL     );
   if( !conn_burst ) conn_burst = 1UL;
 
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  /* Join a large page backed workspace for predictable performance */
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
   ulong const wksp_tag = 1UL;
 

--- a/src/waltz/quic/tests/test_quic_conformance.c
+++ b/src/waltz/quic/tests/test_quic_conformance.c
@@ -935,16 +935,6 @@ main( int     argc,
 
   fd_rng_t _rng[1]; rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",  NULL, "gigantic"                 );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt", NULL, 2UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx(cpu_idx) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
   fd_quic_limits_t quic_limits = {
     .conn_cnt                    =  4UL,
     .handshake_cnt               =  1UL,
@@ -959,8 +949,8 @@ main( int     argc,
   ulong const pkt_cnt = 128UL;
   ulong const pkt_mtu = 1500UL;
 
-  FD_LOG_NOTICE(( "Creating anonymous workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   /* Allocate a sandbox object */
@@ -979,7 +969,8 @@ main( int     argc,
   /* Wind down */
 
   fd_wksp_free_laddr( fd_quic_sandbox_delete( sandbox ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_conn.c
+++ b/src/waltz/quic/tests/test_quic_conn.c
@@ -107,18 +107,8 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
@@ -269,7 +259,8 @@ main( int argc, char ** argv ) {
   fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( client_quic ) ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_hs.c
+++ b/src/waltz/quic/tests/test_quic_hs.c
@@ -384,18 +384,8 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
@@ -440,7 +430,8 @@ main( int argc, char ** argv ) {
   fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( server_quic ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( client_quic ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_keep_alive.c
+++ b/src/waltz/quic/tests/test_quic_keep_alive.c
@@ -177,17 +177,8 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
@@ -233,7 +224,8 @@ main( int argc, char ** argv ) {
   fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( client_quic ) ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_key_phase.c
+++ b/src/waltz/quic/tests/test_quic_key_phase.c
@@ -228,18 +228,8 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "normal"                     );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 800UL                        );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 800UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   FD_LOG_INFO(( "Creating server QUIC" ));
@@ -317,7 +307,8 @@ main( int argc, char ** argv ) {
   fd_quic_virtual_pair_fini( &vp );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( server_quic ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( client_quic ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_pkt_meta.c
+++ b/src/waltz/quic/tests/test_quic_pkt_meta.c
@@ -187,14 +187,9 @@ main( int argc, char ** argv ) {
   fd_boot          ( &argc, &argv );
   fd_quic_test_boot( &argc, &argv );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
 
   ulong        max_inflight = fd_env_strip_cmdline_ulong( &argc, &argv, "--max-inflight",  NULL, 100UL                        );
   ulong        range_sz     = fd_env_strip_cmdline_ulong( &argc, &argv, "--range-sz",      NULL, 10UL                         );
-  char const * _page_sz     = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",       NULL, "gigantic"                   );
-  ulong        page_cnt     = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",      NULL, 1UL                          );
-  ulong        numa_idx     = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",      NULL, fd_shmem_numa_idx( cpu_idx ) );
 
   FD_LOG_INFO(("booted"));
 
@@ -210,11 +205,7 @@ main( int argc, char ** argv ) {
     .stream_id_cnt      = 10
   };
 
-  fd_wksp_t * wksp = fd_wksp_join(
-                        fd_wksp_new_anonymous(
-                          fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL
-                        )
-                     );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
 
   uchar * laddr = (uchar*)wksp;

--- a/src/waltz/quic/tests/test_quic_pkt_meta_lifecycle.c
+++ b/src/waltz/quic/tests/test_quic_pkt_meta_lifecycle.c
@@ -566,16 +566,6 @@ main( int     argc,
   fd_rng_t _rng[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"                 );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 2UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx(cpu_idx) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
   fd_quic_limits_t quic_limits = {
     .conn_cnt                    =   4UL,
     .handshake_cnt               =   1UL,
@@ -589,8 +579,8 @@ main( int     argc,
   ulong const pkt_cnt = 128UL;
   ulong const pkt_mtu = 1500UL;
 
-  FD_LOG_NOTICE(( "Creating workspace" ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   void * sandbox_mem = fd_wksp_alloc_laddr( wksp, fd_quic_sandbox_align(),
@@ -617,7 +607,8 @@ main( int     argc,
   test_validate_after_each_op    ( sandbox, rng );
 
   fd_wksp_free_laddr( fd_quic_sandbox_delete( sandbox ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_retry_integration.c
+++ b/src/waltz/quic/tests/test_quic_retry_integration.c
@@ -202,18 +202,8 @@ main( int argc, char ** argv ) {
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 1UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t const quic_limits = {
@@ -266,7 +256,8 @@ main( int argc, char ** argv ) {
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini ( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini ( client_quic ) ) ) );
 
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_retx.c
+++ b/src/waltz/quic/tests/test_quic_retx.c
@@ -364,18 +364,7 @@ main( int     argc,
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, NULL );
   FD_TEST( wksp );
 
   fd_quic_limits_t const server_limits = {

--- a/src/waltz/quic/tests/test_quic_server.c
+++ b/src/waltz/quic/tests/test_quic_server.c
@@ -13,21 +13,11 @@ main( int argc, char ** argv ) {
 
   fd_clock_tile_init( clock );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>=fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz = fd_env_strip_cmdline_cstr  ( &argc, &argv, "--page-sz",  NULL, "gigantic"                 );
-  ulong        page_cnt = fd_env_strip_cmdline_ulong ( &argc, &argv, "--page-cnt", NULL, 2UL                        );
-  ulong        numa_idx = fd_env_strip_cmdline_ulong ( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx(cpu_idx) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
   fd_quic_limits_t quic_limits = {0};
   fd_quic_limits_from_env( &argc, &argv, &quic_limits);
 
-  FD_LOG_NOTICE(( "Creating workspace with --page-cnt %lu --page-sz %s pages on --numa-idx %lu", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   FD_LOG_NOTICE(( "Creating server QUIC" ));
@@ -96,7 +86,8 @@ main( int argc, char ** argv ) {
 
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( quic ) ) );
   fd_quic_udpsock_destroy( udpsock );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_clock_leave( clock->clock );
   fd_clock_delete( clock->shmem );
   fd_rng_delete( fd_rng_leave( rng ) );

--- a/src/waltz/quic/tests/test_quic_streams.c
+++ b/src/waltz/quic/tests/test_quic_streams.c
@@ -81,18 +81,8 @@ main( int     argc,
 
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz  = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",   NULL, "gigantic"                   );
-  ulong        page_cnt  = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",  NULL, 2UL                          );
-  ulong        numa_idx  = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",  NULL, fd_shmem_numa_idx( cpu_idx ) );
-
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz" ));
-
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 2UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   FD_LOG_NOTICE(( "Creating server QUIC" ));
@@ -196,7 +186,8 @@ main( int     argc,
   fd_quic_stream_spam_delete( fd_quic_stream_spam_delete( spammer ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( server_quic ) ) ) );
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( fd_quic_fini( client_quic ) ) ) );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
   fd_rng_delete( fd_rng_leave( rng ) );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/waltz/quic/tests/test_quic_txns.c
+++ b/src/waltz/quic/tests/test_quic_txns.c
@@ -208,11 +208,8 @@ main( int argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  fd_wksp_t * wksp = fd_wksp_new_anonymous( FD_SHMEM_NORMAL_PAGE_SZ,
-                                            1UL << 15,
-                                            fd_shmem_cpu_idx( 0 ),
-                                            "wksp",
-                                            0UL );
+  int is_anon;
+  fd_wksp_t * wksp = fd_wksp_from_env( &argc, &argv, "normal", 32768UL, "wksp", 0UL, &is_anon );
   FD_TEST( wksp );
 
   fd_quic_limits_t quic_limits = {
@@ -249,7 +246,8 @@ main( int argc,
 
   fd_wksp_free_laddr( fd_quic_delete( fd_quic_leave( quic ) ) );
   fd_quic_udpsock_destroy( udpsock );
-  fd_wksp_delete_anonymous( wksp );
+  if( is_anon ) fd_wksp_delete_anon( wksp );
+  else          fd_wksp_detach( wksp );
 
   fd_halt();
 

--- a/src/wiredancer/test/test_wiredancer_demo.c
+++ b/src/wiredancer/test/test_wiredancer_demo.c
@@ -1021,7 +1021,8 @@ main( int     argc,
   cfg->test_version = test_version;
 
   /* Workspace */
-  cfg->wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
+  int is_anon;
+  cfg->wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, &is_anon );
   FD_TEST( cfg->wksp );
 
   /* Configure replay fseq */
@@ -1284,7 +1285,8 @@ main( int     argc,
   if( !!v__wd_enabled ) { fd_wksp_free_laddr( fd_mcache_delete( fd_mcache_leave( cfg->v__wd_mcache  ) ) ); }
   if( !!vcheck_enabled ) { fd_wksp_free_laddr( fd_cnc_delete   ( fd_cnc_leave   ( cfg->vcheck_cnc     ) ) ); }
   
-  fd_wksp_delete_anon( cfg->wksp );
+  if( is_anon ) fd_wksp_delete_anon( cfg->wksp );
+  else          fd_wksp_detach     ( cfg->wksp );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/wiredancer/test/test_wiredancer_demo.c
+++ b/src/wiredancer/test/test_wiredancer_demo.c
@@ -975,12 +975,6 @@ main( int     argc,
     FD_TEST( fd_replay_tile_scratch_footprint( out_cnt )==FD_REPLAY_TILE_SCRATCH_FOOTPRINT( out_cnt ) );
   }
 
-  ulong cpu_idx = fd_tile_cpu_id( fd_tile_idx() );
-  if( cpu_idx>fd_shmem_cpu_cnt() ) cpu_idx = 0UL;
-
-  char const * _page_sz         = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",          NULL, "gigantic"                    );
-  ulong        page_cnt         = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt",         NULL, 1UL                           );
-  ulong        numa_idx         = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx",         NULL, fd_shmem_numa_idx( cpu_idx )  );
   char const * replay_pcap      = fd_env_strip_cmdline_cstr ( &argc, &argv, "--replay-pcap",      NULL, NULL                          );
   ulong        replay_mtu       = fd_env_strip_cmdline_ulong( &argc, &argv, "--replay-mtu",       NULL, 1542UL                        );
   ulong        replay_orig      = fd_env_strip_cmdline_ulong( &argc, &argv, "--replay-orig",      NULL, 0UL                           );
@@ -1003,8 +997,6 @@ main( int     argc,
   int          parser_enabled   = 1;
   int          vcheck_enabled   = 1;
 
-  ulong page_sz = fd_cstr_to_shmem_page_sz( _page_sz );
-  if( FD_UNLIKELY( !page_sz ) ) FD_LOG_ERR(( "unsupported --page-sz"  ));
   if( FD_UNLIKELY( !replay_pcap ) ) FD_LOG_ERR(( "--replay-pcap not specified" ));
 
   /* Check minimum number of tiles */
@@ -1029,8 +1021,7 @@ main( int     argc,
   cfg->test_version = test_version;
 
   /* Workspace */
-  FD_LOG_NOTICE(( "Creating workspace (--page-cnt %lu, --page-sz %s, --numa-idx %lu)", page_cnt, _page_sz, numa_idx ));
-  cfg->wksp = fd_wksp_new_anonymous( page_sz, page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  cfg->wksp = fd_wksp_from_env( &argc, &argv, "gigantic", 1UL, "wksp", 0UL, NULL );
   FD_TEST( cfg->wksp );
 
   /* Configure replay fseq */
@@ -1293,7 +1284,7 @@ main( int     argc,
   if( !!v__wd_enabled ) { fd_wksp_free_laddr( fd_mcache_delete( fd_mcache_leave( cfg->v__wd_mcache  ) ) ); }
   if( !!vcheck_enabled ) { fd_wksp_free_laddr( fd_cnc_delete   ( fd_cnc_leave   ( cfg->vcheck_cnc     ) ) ); }
   
-  fd_wksp_delete_anonymous( cfg->wksp );
+  fd_wksp_delete_anon( cfg->wksp );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 


### PR DESCRIPTION
## Problem

Test harnesses across `choreo`, `disco`, `discof`, and `flamenco` hardcoded workspace parameters (`page_sz`, `page_cnt`, `numa_idx`) as compile-time constants, making it impossible to override them at runtime without recompiling.

Closes https://github.com/firedancer-io/firedancer/issues/10076

## Solution

Added `fd_wksp_from_env()` to `fd_wksp.h`. The helper:

- Strips `--wksp`, `--page-sz`, `--page-cnt`, and `--numa-idx` from `argv`.
- If `--wksp` is given, attaches to the named workspace (`*opt_is_anon = 0`); otherwise creates an anonymous workspace (`*opt_is_anon = 1`).
- If `--page-cnt` is given, uses it directly; otherwise scales `default_page_cnt * default_page_sz` bytes to the requested page type.
- `opt_is_anon` may be `NULL` when the caller relies on process exit for cleanup.

Migrated 62 existing tests to `fd_wksp_from_env`. Hardcoded page-size/count/numa variables are replaced by caller-supplied defaults, which the runner can override at runtime via `--page-sz`, `--page-cnt`, and `--numa-idx`. Teardown uses the `is_anon` flag to call `fd_wksp_delete_anon` or `fd_wksp_detach` as appropriate.

Files intentionally left unconverted: 
- `test_wksp.c`, `test_wksp_tpool.c`, `test_wksp_helper.c` (workspace self-tests that need direct API control)
- `test_sol_compat.c` (demand-paged / seeded workspace)
- `test_snapin_tile.c` (hardcoded inline helper, no cmdline args).

## Changes

- `src/util/wksp/fd_wksp.h` - new `fd_wksp_from_env()` static inline helper
- `doc/testing.md` - updated memory allocation guidance to document `fd_wksp_from_env`
- 62 test files across `src/choreo`, `src/disco`, `src/discof`, `src/flamenco`, `src/funk`, `src/tango`, `src/util`, `src/vinyl`, `src/waltz`, `src/wiredancer` - migrated to `fd_wksp_from_env`

## Testing

- Relevant checks pass locally:
  - run-unit-test TEST_OPTS="--page-sz normal" now passes without any pre-allocation
  - run-unit-test TEST_OPTS="--page-sz huge" now passes with huge pre-allocation
  - run-unit-test passes with gigantic pre-allocation