### PR TITLE
quic: PTO expiry spec compliance

### DIFF
--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -42,6 +42,11 @@
 
 #define FD_QUIC_MAGIC (0xdadf8cfa01cc5460UL)
 
+/* RFC 9002 retransmit constants */
+
+#define FD_QUIC_K_TIME_THRESHOLD 1.125f
+#define FD_QUIC_K_GRANULARITY_NS 1000000L
+
 /* fd_quic_state_t is the internal state of an fd_quic_t.  Valid for
    lifetime of join. */
 
@@ -396,33 +401,33 @@ fd_quic_sample_rtt( fd_quic_conn_t * conn, long rtt_ns, long ack_delay ) {
 
 static inline long
 fd_quic_calc_expiry_duration( fd_quic_conn_t * conn, int ack_driven, int is_server ) {
-  /*  For server, we want to be conservative and minimize spam risk, so we stick
-      with the hardcoded 500ms expiry. The following only applies to client.
-
-     If this calculation is ack-driven, use the time threshold:
-     6.1.2 Time Threshold
-     max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)
-     The RECOMMENDED time threshold (kTimeThreshold), expressed as an RTT multiplier, is 9/8 */
-     #define FD_QUIC_K_TIME_THRESHOLD 1.125f
-  /* Otherwise, calculate the expiry time according to the PTO spec
-     6.2.1. Computing PTO
-     When an ack-eliciting packet is transmitted, the sender schedules
-     a timer for the PTO period as follows:
-     PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay
-
-     Our granularity is O(ns), while recommended is 1ms --> We don't
-     have to worry about kGranularity.
-*/
-
+  /* For server, we want to be conservative and minimize spam risk, so we stick
+     with the hardcoded 500ms expiry. The following only applies to client. */
   if( is_server ) return 500e6L;
+
+  /* If this calculation is ack-driven, use the time threshold:
+
+     > 6.1.2 Time Threshold
+     > max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)
+     > The RECOMMENDED time threshold (kTimeThreshold), expressed as an RTT multiplier, is 9/8
+
+     Otherwise, calculate the expiry time according to the PTO spec
+
+     > 6.2.1. Computing PTO
+     > When an ack-eliciting packet is transmitted, the sender schedules
+     > a timer for the PTO period as follows:
+     > PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay */
 
   fd_rtt_estimate_t * rtt = conn->rtt;
 
-  long pto_duration  = (long)( rtt->smoothed_rtt     +
-                                (4.0f * rtt->var_rtt) +
-                                conn->peer_max_ack_delay_ns );
+  float pto_rttvar = fmaxf( 4.0f * rtt->var_rtt, (float)FD_QUIC_K_GRANULARITY_NS );
+  long pto_duration = (long)( rtt->smoothed_rtt +
+                              pto_rttvar        +
+                              conn->peer_max_ack_delay_ns );
 
-  long loss_duration = (long)( FD_QUIC_K_TIME_THRESHOLD * fmaxf( rtt->smoothed_rtt, rtt->latest_rtt ) );
+  long loss_duration = fd_long_max(
+      (long)( FD_QUIC_K_TIME_THRESHOLD * fmaxf( rtt->smoothed_rtt, rtt->latest_rtt ) ),
+      FD_QUIC_K_GRANULARITY_NS );
 
   long duration = fd_long_if( ack_driven, loss_duration, pto_duration );
 

--- a/src/waltz/quic/tests/test_quic_retx.c
+++ b/src/waltz/quic/tests/test_quic_retx.c
@@ -146,6 +146,9 @@ test_rtt_update( fd_quic_conn_t * client_conn, fd_quic_t * server_quic ) {
     .var_rtt      = 0.0f,
     .min_rtt      = TEST_DEFAULT_ONE_WAY_LATENCY,
   };
+  FD_TEST( fd_quic_calc_expiry_duration( client_conn, 1, 0 ) == FD_QUIC_K_GRANULARITY_NS );
+  FD_TEST( fd_quic_calc_expiry_duration( client_conn, 0, 0 ) ==
+           (long)( TEST_DEFAULT_ONE_WAY_LATENCY + (float)FD_QUIC_K_GRANULARITY_NS + client_conn->peer_max_ack_delay_ns ) );
   FD_LOG_NOTICE(( "test_rtt_update: pass" ));
 }
 
@@ -165,7 +168,11 @@ test_retx_pto( fd_quic_conn_t * client_conn, fd_quic_t * server_quic FD_PARAM_UN
     float rtt_var       = client_conn->rtt->var_rtt;
     ulong orig_retx_cnt = client_quic->metrics.pkt_retransmissions_cnt[3];
 
-    long pto_duration = (long)( smoothed_rtt + (4.0f * rtt_var) + client_conn->peer_max_ack_delay_ns );
+    long pto_duration = fd_quic_calc_expiry_duration( client_conn, 0, 0 );
+    FD_TEST( pto_duration ==
+             (long)( smoothed_rtt +
+                     fmaxf( 4.0f * rtt_var, (float)FD_QUIC_K_GRANULARITY_NS ) +
+                     client_conn->peer_max_ack_delay_ns ) );
     long expiry_time  = send_time + pto_duration;
          now          = expiry_time-1;
     fd_quic_service( client_quic, now );
@@ -252,7 +259,7 @@ test_loss_time_threshold( fd_quic_conn_t * client_conn, fd_quic_t * server_quic 
     fd_quic_service( server_quic, now );
 
     /* assert retx fires when time \in (time_threshold_expiry, pkt_meta->expiry) */
-    long loss_duration = (long)( 1.125f * fmaxf( client_conn->rtt->smoothed_rtt, client_conn->rtt->latest_rtt ) );
+    long loss_duration = fd_quic_calc_expiry_duration( client_conn, 1, 0 );
     long time_threshold_expiry = first_send_time + loss_duration;
 
     FD_TEST( now < time_threshold_expiry );


### PR DESCRIPTION
fd_quic was deliberately missing the kGranularity constant from
RFC 9002. Add it back to decrease risk of fd_quic client packet
floods.
