### PR TITLE
util: added fd_wksp_gaddr_{lo,hi} APIs

### DIFF
--- a/src/util/wksp/fd_wksp.h
+++ b/src/util/wksp/fd_wksp.h
@@ -282,12 +282,17 @@ fd_wksp_delete( void * shwksp );
    Assumes wksp is a current local join.
 
    fd_wksp_{part_max,data_max} returns {part_max,data_max} used at
-   creation.  Assumes wksp is a current local join. */
+   creation.  Assumes wksp is a current local join.
+
+   [fd_wksp_gaddr_lo,fd_wksp_gaddr_hi) is the range of valid wksp gaddr.
+   lo is guaranteed to be non-zero.  hi = lo + data_max.  */
 
 FD_FN_CONST char const * fd_wksp_name    ( fd_wksp_t const * wksp );
 FD_FN_PURE  uint         fd_wksp_seed    ( fd_wksp_t const * wksp );
 FD_FN_PURE  ulong        fd_wksp_part_max( fd_wksp_t const * wksp );
 FD_FN_PURE  ulong        fd_wksp_data_max( fd_wksp_t const * wksp );
+FD_FN_PURE  ulong        fd_wksp_gaddr_lo( fd_wksp_t const * wksp );
+FD_FN_PURE  ulong        fd_wksp_gaddr_hi( fd_wksp_t const * wksp );
 
 /* fd_wksp_owner returns the id of the thread group that was currently
    in a wksp operation (0 indicates the wksp was in the process of being

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -288,6 +288,8 @@ char const * fd_wksp_name    ( fd_wksp_t const * wksp ) { return wksp->name;    
 uint         fd_wksp_seed    ( fd_wksp_t const * wksp ) { return wksp->seed;     }
 ulong        fd_wksp_part_max( fd_wksp_t const * wksp ) { return wksp->part_max; }
 ulong        fd_wksp_data_max( fd_wksp_t const * wksp ) { return wksp->data_max; }
+ulong        fd_wksp_gaddr_lo( fd_wksp_t const * wksp ) { return wksp->gaddr_lo; }
+ulong        fd_wksp_gaddr_hi( fd_wksp_t const * wksp ) { return wksp->gaddr_hi; }
 
 ulong
 fd_wksp_owner( fd_wksp_t const * wksp ) {

--- a/src/util/wksp/test_wksp_admin.c
+++ b/src/util/wksp/test_wksp_admin.c
@@ -85,9 +85,11 @@ main( int     argc,
 
   FD_TEST( !strcmp( fd_wksp_name( wksp ), name ) );
 
-  FD_TEST( fd_wksp_seed    ( wksp )==seed        );
-  FD_TEST( fd_wksp_part_max( wksp )==part_max    );
-  FD_TEST( fd_wksp_data_max( wksp )==data_max    );
+  FD_TEST( fd_wksp_seed    ( wksp )==seed                                );
+  FD_TEST( fd_wksp_part_max( wksp )==part_max                            );
+  FD_TEST( fd_wksp_data_max( wksp )==data_max                            );
+  FD_TEST( fd_wksp_gaddr_lo( wksp )> 0UL                                 );
+  FD_TEST( fd_wksp_gaddr_hi( wksp )==fd_wksp_gaddr_lo( wksp ) + data_max );
 
   /* Note that rebuild and verify are tested in user aggressively */
 


### PR DESCRIPTION
Allows workspace users to learn the range of valid global addresses for workspace without having to use fd_wksp_private.h.