### PR TITLE
tower: refuse to vote if identity and vote account mismatch

### DIFF
--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -349,16 +349,25 @@ typedef struct fd_tower_tile fd_tower_tile_t;
 ulong QUERY_TOWERS( fd_tower_tile_t *, fd_replay_slot_completed_t *, fd_ghost_blk_t *, int *, ulong * );
 void  QUERY_VOTERS( fd_tower_tile_t *, fd_replay_slot_completed_t *, ulong );
 
-static int
-deser_auth_vtr( fd_tower_tile_t * ctx,
-                uchar const *     data,
-                ulong             data_sz,
-                ulong             epoch,
-                int               vote_acc_found,
-                fd_pubkey_t *     authority_out,
-                ulong *           authority_idx_out ) {
+/* vote_account_config extracts configuration of this validator's vote
+   account (on-chain state).  data points to the first byte of the
+   vote account's data.  Sets:
+   - *authority_out to the selected authorized voter's public key
+   - *authority_idx_out to the tile's auth_vtr index (matches sign tile)
+     or ULONG_MAX it the authorized voter is the node identity
+     or LONG_MAX if it matches neither
+   - *node_pubkey to the vote account's pubkey
+  Returns 1 if the validator has a key for the found vote authority,
+  and 0 otherwise. */
 
-  if( FD_UNLIKELY( !vote_acc_found ) ) return 0;
+static int
+vote_account_config( fd_tower_tile_t * ctx,
+                     uchar const *     data,
+                     ulong             data_sz,
+                     ulong             epoch,
+                     fd_pubkey_t *     authority_out,
+                     ulong *           authority_idx_out,
+                     fd_pubkey_t *     node_pubkey_out ) {
 
   fd_vote_state_versioned_t vsv[1];
   FD_CHECK_CRIT( fd_vote_state_versioned_deserialize( vsv, data, data_sz ), "unable to decode vote state versioned" );
@@ -366,6 +375,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
   fd_pubkey_t const * auth_vtr_addr = NULL;
   switch( vsv->kind ) {
     case fd_vote_state_versioned_enum_v1_14_11:
+      *node_pubkey_out = vsv->v1_14_11.node_pubkey;
       for( fd_vote_authorized_voters_treap_rev_iter_t iter = fd_vote_authorized_voters_treap_rev_iter_init( vsv->v1_14_11.authorized_voters.treap, vsv->v1_14_11.authorized_voters.pool );
            !fd_vote_authorized_voters_treap_rev_iter_done( iter );
            iter = fd_vote_authorized_voters_treap_rev_iter_next( iter, vsv->v1_14_11.authorized_voters.pool ) ) {
@@ -377,6 +387,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
       }
       break;
     case fd_vote_state_versioned_enum_v3:
+      *node_pubkey_out = vsv->v3.node_pubkey;
       for( fd_vote_authorized_voters_treap_rev_iter_t iter = fd_vote_authorized_voters_treap_rev_iter_init( vsv->v3.authorized_voters.treap, vsv->v3.authorized_voters.pool );
           !fd_vote_authorized_voters_treap_rev_iter_done( iter );
           iter = fd_vote_authorized_voters_treap_rev_iter_next( iter, vsv->v3.authorized_voters.pool ) ) {
@@ -388,6 +399,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
       }
       break;
     case fd_vote_state_versioned_enum_v4:
+      *node_pubkey_out = vsv->v4.node_pubkey;
       for( fd_vote_authorized_voters_treap_rev_iter_t iter = fd_vote_authorized_voters_treap_rev_iter_init( vsv->v4.authorized_voters.treap, vsv->v4.authorized_voters.pool );
           !fd_vote_authorized_voters_treap_rev_iter_done( iter );
           iter = fd_vote_authorized_voters_treap_rev_iter_next( iter, vsv->v4.authorized_voters.pool ) ) {
@@ -416,6 +428,7 @@ deser_auth_vtr( fd_tower_tile_t * ctx,
     return 1;
   }
 
+  *authority_idx_out = LONG_MAX;
   return 0;
 }
 
@@ -597,8 +610,16 @@ publish_slot_done( fd_tower_tile_t *            ctx,
 
   ulong       authority_idx = ULONG_MAX;
   fd_pubkey_t authority[1];
-  int         found_authority = deser_auth_vtr( ctx, ctx->our_vote_acct, ctx->our_vote_acct_sz, slot_completed->epoch, found, authority, &authority_idx );
-  if( FD_LIKELY( out->vote_slot!=ULONG_MAX && found_authority && !fd_tower_vote_empty( ctx->tower->votes ) ) ) {
+  fd_pubkey_t identity[1];
+  /* Refuse to vote if we don't have a matching vote authority key */
+  int found_authority  = found && vote_account_config( ctx, ctx->our_vote_acct, ctx->our_vote_acct_sz, slot_completed->epoch, authority, &authority_idx, identity );
+  /* Refuse to vote if our node identity does not match the one
+     specified in the vote account (hot spare check) */
+  int identity_matches = found_authority && fd_pubkey_eq( identity, ctx->identity_key );
+  if( FD_LIKELY( out->vote_slot!=ULONG_MAX &&
+                 found_authority &&
+                 identity_matches &&
+                 !fd_tower_vote_empty( ctx->tower->votes ) ) ) {
     msg->has_vote_txn = 1;
     fd_txn_p_t          txn[1];
     fd_tower_to_vote_txn( ctx->tower, &out->vote_bank_hash, &out->vote_block_id, &out->vote_block_hash, ctx->identity_key, authority, ctx->vote_account, txn );
@@ -1041,8 +1062,9 @@ query_epoch_voters( fd_tower_tile_t *      ctx,
 
     fd_acc_t ro = fd_accdb_read_one( ctx->accdb, fork_id, pubkey.uc );
     if( FD_LIKELY( ro.lamports ) ) {
+      fd_pubkey_t identity[1];
       ulong dummy_idx;
-      deser_auth_vtr( ctx, ro.data, ro.data_len, epoch, 1, &vtr->auth_vtr, &dummy_idx );
+      vote_account_config( ctx, ro.data, ro.data_len, epoch, &vtr->auth_vtr, &dummy_idx, identity );
       if( update_id_keys_vote_accs ) {
         FD_TEST( 0==fd_vote_account_node_pubkey( ro.data, ro.data_len, &ctx->id_keys[ctx->vtr_cnt] ) ); /* check vote account is not corrupt */
         ctx->vote_accs[ctx->vtr_cnt] = pubkey;

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -54,6 +54,97 @@ mock_vote_txn( ulong               root,
   return (fd_txn_t const *)txn_out;
 }
 
+static ulong
+mock_vote_account( fd_pubkey_t const * node_pubkey,
+                   fd_pubkey_t const * authorized_voter,
+                   uchar               vote_state_data[ static FD_VOTE_STATE_DATA_MAX ] ) {
+  fd_vote_state_versioned_t versioned[1];
+  FD_TEST( fd_vote_state_versioned_new( versioned, fd_vote_state_versioned_enum_v3 ) );
+  fd_memset( vote_state_data, 0, FD_VOTE_STATE_DATA_MAX );
+
+  fd_vote_state_v3_t * vote_state   = &versioned->v3;
+  vote_state->node_pubkey           = *node_pubkey;
+  vote_state->authorized_withdrawer = *authorized_voter;
+  vote_state->commission            = 100;
+  vote_state->prior_voters.idx      = 31;
+  vote_state->prior_voters.is_empty = 1;
+
+  fd_vote_authorized_voter_t * voter = fd_vote_authorized_voters_pool_ele_acquire( vote_state->authorized_voters.pool );
+  fd_memset( voter, 0, sizeof(fd_vote_authorized_voter_t) );
+  voter->epoch  = 0UL;
+  voter->pubkey = *authorized_voter;
+  voter->prio   = authorized_voter->uc[0];
+  fd_vote_authorized_voters_treap_ele_insert( vote_state->authorized_voters.treap, voter, vote_state->authorized_voters.pool );
+
+  FD_TEST( !fd_vote_state_versioned_serialize( versioned, vote_state_data, FD_VOTE_STATE_DATA_MAX ) );
+  return FD_VOTE_STATE_DATA_MAX;
+}
+
+static void
+test_publish_slot_done_identity_mismatch( void ) {
+  static fd_tower_tile_t ctx[1];
+  static uchar tower_mem[ 65536 ] __attribute__((aligned(128)));
+  static uchar publishes_mem[ 65536 ] __attribute__((aligned(128)));
+
+  memset( ctx, 0, sizeof(*ctx) );
+  memset( ctx->identity_key, 0x11, sizeof(fd_pubkey_t) );
+  memset( ctx->vote_account, 0x22, sizeof(fd_pubkey_t) );
+
+  fd_wksp_t * wksp = fd_wksp_new_anonymous( FD_SHMEM_NORMAL_PAGE_SZ, 4096UL, 0UL, "tower_id_test", 0UL );
+  FD_TEST( wksp );
+
+  void * ghost_mem = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( 2UL, 2UL ), 1UL );
+  FD_TEST( ghost_mem );
+
+  ctx->tower     = fd_tower_join( fd_tower_new( tower_mem, 2UL, 2UL, 0UL ) );
+  ctx->ghost     = fd_ghost_join( fd_ghost_new( ghost_mem, 2UL, 2UL, 0UL ) );
+  ctx->publishes = publishes_join( publishes_new( publishes_mem, 2UL ) );
+  FD_TEST( ctx->tower );
+  FD_TEST( ctx->ghost );
+  FD_TEST( ctx->publishes );
+
+  ctx->tower->root = 0UL;
+  fd_tower_vote_push_tail( ctx->tower->votes, (fd_tower_vote_t){ .slot = 1UL, .conf = 1UL } );
+
+  fd_replay_slot_completed_t sc;
+  memset( &sc, 0, sizeof(sc) );
+  sc.slot     = 1UL;
+  sc.epoch    = 0UL;
+  sc.bank_idx = 123UL;
+
+  fd_tower_out_t out;
+  memset( &out, 0, sizeof(out) );
+  out.vote_slot       = 1UL;
+  out.vote_block_id   = (fd_hash_t){ .ul = { 0x33UL } };
+  out.vote_bank_hash  = (fd_hash_t){ .ul = { 0x44UL } };
+  out.vote_block_hash = (fd_hash_t){ .ul = { 0x55UL } };
+  out.reset_slot      = ULONG_MAX;
+  out.root_slot       = ULONG_MAX;
+
+  /* Matching identity produces votes */
+  ctx->our_vote_acct_sz = mock_vote_account( ctx->identity_key, ctx->identity_key, ctx->our_vote_acct );
+  publish_slot_done( ctx, &sc, &out, 1, 100UL, 0UL, NULL );
+  publish_t * pub = publishes_peek_head( ctx->publishes );
+  FD_TEST( pub );
+  FD_TEST( pub->sig==FD_TOWER_SIG_SLOT_DONE );
+  FD_TEST( pub->msg.slot_done.has_vote_txn==1 );
+  FD_TEST( pub->msg.slot_done.authority_idx==ULONG_MAX );
+  publishes_pop_head_nocopy( ctx->publishes );
+
+  /* Other identity prevents vote publishing */
+  fd_pubkey_t other_identity = { .ul = { 0x99UL } };
+  ctx->our_vote_acct_sz = mock_vote_account( &other_identity, ctx->identity_key, ctx->our_vote_acct );
+  publish_slot_done( ctx, &sc, &out, 1, 100UL, 0UL, NULL );
+  pub = publishes_peek_head( ctx->publishes );
+  FD_TEST( pub );
+  FD_TEST( pub->sig==FD_TOWER_SIG_SLOT_DONE );
+  FD_TEST( pub->msg.slot_done.has_vote_txn==0 );
+
+  fd_wksp_delete( fd_wksp_leave( wksp ) );
+
+  FD_LOG_NOTICE(( "pass: test_publish_slot_done_identity_mismatch" ));
+}
+
 static void
 test_count_vote_txn( void ) {
 
@@ -734,6 +825,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
+  test_publish_slot_done_identity_mismatch();
   test_count_vote_txn();
 
   char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"              );


### PR DESCRIPTION
Increases protection for hot-spare operation, e.g. in the
following scenario:

  Main:    vote_acc=9Diao, identity=DNVZ,  auth_vtr=DNVZ
  Standby: vote_acc=9Diao, identity=Junk1, auth_vtr=DNVZ

On chain state:

  vote_acc=9Diao, node_pubkey=DNVZ, auth_vtr=DNVZ

Previously, this would cause both main and standy to generate
conflicting votes (standby signs twice, main signs once).

Credit to meyerbro / PigsInBlankets validator for reporting this
bug through Votalizer (https://votalizer.vercel.app/)
