### PR TITLE
events: simplify signing domain

### DIFF
--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -529,12 +529,19 @@ fd_event_client_handle_auth_challenge_resp( fd_event_client_t * client,
     return;
   }
 
+  uchar sign_request[ 132 ];
+  static char const sign_prefix[ 100 ] =
+    "                                "  /* 32 spaces */
+    "                                "  /* 32 spaces */
+    "Firedancer event challenge-response\x00";
+  memcpy( sign_request,     sign_prefix,    sizeof(sign_prefix) );
+  memcpy( sign_request+100, challenge_data, 32UL                );
+
   uchar signed_challenge[ 64UL ];
   fd_keyguard_client_sign( client->keyguard_client,
                            signed_challenge,
-                           challenge_data,
-                           32UL,
-                           FD_KEYGUARD_SIGN_TYPE_FD_EVENTS_AUTH_CONCAT_ED25519 );
+                           sign_request, 132UL,
+                           FD_KEYGUARD_SIGN_TYPE_ED25519 );
 
   fd_pb_encoder_t confirm_req[1];
   uchar buffer[ 128UL ];

--- a/src/disco/keyguard/fd_keyguard.h
+++ b/src/disco/keyguard/fd_keyguard.h
@@ -52,11 +52,10 @@ FD_PROTOTYPES_BEGIN
 
 /* Sign types *********************************************************/
 
-#define FD_KEYGUARD_SIGN_TYPE_ED25519                       (0)  /* ed25519_sign(input) */
-#define FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519                (1)  /* ed25519_sign(sha256(data)) */
-#define FD_KEYGUARD_SIGN_TYPE_PUBKEY_CONCAT_ED25519         (2)  /* ed25519_sign(pubkey-data) */
-#define FD_KEYGUARD_SIGN_TYPE_FD_EVENTS_AUTH_CONCAT_ED25519 (3)  /* ed25519_sign(FD_EVENTS_AUTH-data)) */
-#define FD_KEYGUARD_SIGN_TYPE_CNT                           (4)  /* number of sign types */
+#define FD_KEYGUARD_SIGN_TYPE_ED25519               (0)  /* ed25519_sign(input) */
+#define FD_KEYGUARD_SIGN_TYPE_SHA256_ED25519        (1)  /* ed25519_sign(sha256(data)) */
+#define FD_KEYGUARD_SIGN_TYPE_PUBKEY_CONCAT_ED25519 (2)  /* ed25519_sign(pubkey-data) */
+#define FD_KEYGUARD_SIGN_TYPE_CNT                   (3)  /* number of sign types */
 
 /* Type confusion/ambiguity checks ************************************/
 

--- a/src/disco/keyguard/fd_keyguard_match.c
+++ b/src/disco/keyguard/fd_keyguard_match.c
@@ -303,8 +303,14 @@ fd_keyguard_payload_matches_event( uchar const * data,
                                    int           sign_type ) {
   (void)data;
 
-  if( sign_type != FD_KEYGUARD_SIGN_TYPE_FD_EVENTS_AUTH_CONCAT_ED25519 ) return 0;
-  if( sz!=32UL ) return 0;
+  static char const sign_prefix[ 100 ] =
+    "                                "  /* 32 spaces */
+    "                                "  /* 32 spaces */
+    "Firedancer event challenge-response\x00";
+
+  if( sz!=132UL ) return 0;
+  if( sign_type!=FD_KEYGUARD_SIGN_TYPE_ED25519 ) return 0;
+  if( 0!=memcmp( data, sign_prefix, sizeof(sign_prefix) ) ) return 0;
 
   return 1;
 }

--- a/src/disco/keyguard/fd_sign_tile.c
+++ b/src/disco/keyguard/fd_sign_tile.c
@@ -43,8 +43,6 @@ typedef struct {
   ulong public_key_base58_sz;
   uchar concat[ FD_BASE58_ENCODED_32_SZ+1UL+9UL ];
 
-  uchar event_auth_concat[ 15UL+32UL ];
-
   fd_sign_in_ctx_t  in[ MAX_IN ];
   fd_sign_out_ctx_t out[ MAX_IN ];
 
@@ -87,8 +85,6 @@ derive_fields( fd_sign_ctx_t * ctx ) {
 
   fd_base58_encode_32( ctx->public_key, &ctx->public_key_base58_sz, (char *)ctx->concat );
   ctx->concat[ ctx->public_key_base58_sz ] = '-';
-
-  memcpy( ctx->event_auth_concat, "FD_EVENTS_AUTH-", 15UL );
 }
 
 static void FD_FN_SENSITIVE
@@ -244,11 +240,6 @@ after_frag_sensitive( void *              _ctx,
   case FD_KEYGUARD_SIGN_TYPE_PUBKEY_CONCAT_ED25519: {
     memcpy( ctx->concat+ctx->public_key_base58_sz+1UL, ctx->_data, 9UL );
     fd_ed25519_sign( dst, ctx->concat, ctx->public_key_base58_sz+1UL+9UL, ctx->public_key, ctx->private_key, ctx->sha512 );
-    break;
-  }
-  case FD_KEYGUARD_SIGN_TYPE_FD_EVENTS_AUTH_CONCAT_ED25519: {
-    memcpy( ctx->event_auth_concat+15UL, ctx->_data, 32UL );
-    fd_ed25519_sign( dst, ctx->event_auth_concat, 15UL+32UL, ctx->public_key, ctx->private_key, ctx->sha512 );
     break;
   }
   default:


### PR DESCRIPTION
Use a static signing domain instead of a random key.  This makes
it easier to prove that there are no signing confusion bugs.
