### PR TITLE
rserve: drop startup log to INFO

### DIFF
--- a/src/discof/repair/fd_rserve_tile.c
+++ b/src/discof/repair/fd_rserve_tile.c
@@ -513,7 +513,7 @@ privileged_init( fd_topo_t      const * topo,
 
   FD_TEST( fd_rng_secure( &ctx->seed, sizeof(ulong) ) );
 
-  FD_LOG_NOTICE(( "creating shredb (size_limit=%luGiB)", size_limit ));
+  FD_LOG_INFO(( "creating shredb (size_limit=%luGiB)", size_limit ));
   ctx->shredb = fd_shredb_join( fd_shredb_new( ctx->shredb, size_limit, tile->rserve.shredb_path, ctx->seed ) );
   if( FD_UNLIKELY( !ctx->shredb ) ) FD_LOG_ERR(( "failed to initialize shredb" ));
 


### PR DESCRIPTION
NOTICE should only print operator-relevant info