### PR TITLE
repair: silently ignore NULL pubkeys

### DIFF
--- a/src/disco/shred/fd_shred_dest.c
+++ b/src/disco/shred/fd_shred_dest.c
@@ -6,12 +6,10 @@ struct pubkey_to_idx {
 };
 typedef struct pubkey_to_idx pubkey_to_idx_t;
 
-static const fd_pubkey_t null_pubkey = {{ 0 }};
-
 #define MAP_NAME              pubkey_to_idx
 #define MAP_T                 pubkey_to_idx_t
 #define MAP_KEY_T             fd_pubkey_t
-#define MAP_KEY_NULL          null_pubkey
+#define MAP_KEY_NULL          ((fd_pubkey_t){{0}})
 #define MAP_KEY_EQUAL_IS_SLOW 1
 #define MAP_MEMOIZE           0
 #define MAP_KEY_INVAL(k)      MAP_KEY_EQUAL((k),MAP_KEY_NULL)

--- a/src/discof/repair/fd_policy.c
+++ b/src/discof/repair/fd_policy.c
@@ -305,10 +305,7 @@ fd_policy_peer_upsert( fd_policy_t * policy, fd_pubkey_t const * key, fd_ip4_por
 
 fd_policy_peer_t *
 fd_policy_peer_query( fd_policy_t * policy, fd_pubkey_t const * key ) {
-  if( FD_UNLIKELY( memcmp( key->key, null_pubkey.key, 32UL ) == 0 ) ) {
-    FD_LOG_WARNING(( "Repair policy peer with null pubkey." ));
-    return NULL;
-  };
+  if( FD_UNLIKELY( fd_pubkey_check_zero( key ) ) ) return NULL;
   fd_policy_peer_t * pool = policy->peers.pool;
   return fd_policy_peer_map_ele_query( policy->peers.map, key, NULL, pool );
 }

--- a/src/discof/repair/fd_repair.h
+++ b/src/discof/repair/fd_repair.h
@@ -168,8 +168,6 @@ typedef struct fd_repair_ping fd_repair_ping_t;
 
 #define FD_REPAIR_MAX_PREIMAGE_SZ (sizeof(fd_repair_msg_t) - sizeof(fd_ed25519_sig_t))
 
-static const fd_pubkey_t null_pubkey = {{ 0 }};
-
 /* fd_repair_sign_fn defines the function signature for a user-provided
    signing callback. */
 


### PR DESCRIPTION
Fixes remotely-triggerable FD_LOG_WARNING.
