### PR TITLE
quic: use correct type for tpu_reasm allocations

### DIFF
--- a/src/disco/quic/fd_tpu_reasm.c
+++ b/src/disco/quic/fd_tpu_reasm.c
@@ -56,7 +56,7 @@ fd_tpu_reasm_new( void * shmem,
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
   fd_tpu_reasm_t *      reasm     = FD_SCRATCH_ALLOC_APPEND( l, fd_tpu_reasm_align(),         sizeof(fd_tpu_reasm_t)                  );
-  ulong *               pub_slots = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                depth*sizeof(uint)                      );
+  uint *                pub_slots = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                depth*sizeof(uint)                      );
   fd_tpu_reasm_slot_t * slots     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_tpu_reasm_slot_t), slot_cnt*sizeof(fd_tpu_reasm_slot_t)    );
   void *                map_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_tpu_reasm_map_align(),     fd_tpu_reasm_map_footprint( chain_cnt ) );
   FD_SCRATCH_ALLOC_FINI( l, fd_tpu_reasm_align() );


### PR DESCRIPTION
no security/correctness impact, just a consistency nit