### PR TITLE
restore: snapshot minimum content length check

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -529,6 +529,14 @@ init_load( fd_snapct_tile_t *  ctx,
   if( file ) {
     if( full ) ctx->metrics.full.bytes_total = ctx->local_in.full_snapshot_size;
     else       ctx->metrics.incremental.bytes_total = ctx->local_in.incremental_snapshot_size;
+    ulong bytes_total = full ? ctx->metrics.full.bytes_total : ctx->metrics.incremental.bytes_total;
+    if( FD_UNLIKELY( bytes_total<FD_SNAPSHOT_MIN_CONTENT_LENGTH ) ) {
+      FD_LOG_WARNING(( "%s snapshot file size %lu is below minimum %lu, marking malformed",
+                       full ? "full" : "incremental", bytes_total, FD_SNAPSHOT_MIN_CONTENT_LENGTH ));
+      ctx->malformed = 1;
+      fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
+      return;
+    }
   }
 
   if( !file ) {
@@ -1473,9 +1481,10 @@ snapld_frag( fd_snapct_tile_t *  ctx,
     FD_TEST( sz==sizeof(fd_ssctrl_meta_t) );
     fd_ssctrl_meta_t const * meta = fd_chunk_to_laddr_const( ctx->snapld_in_mem, chunk );
 
-    if( FD_UNLIKELY( meta->total_sz==0UL ) ) {
+    if( FD_UNLIKELY( meta->total_sz<FD_SNAPSHOT_MIN_CONTENT_LENGTH ) ) {
       if( FD_UNLIKELY( !ctx->malformed ) ) {
-        FD_LOG_WARNING(( "received zero Content-Length metadata for %s snapshot, marking malformed", full ? "full" : "incremental" ));
+        FD_LOG_WARNING(( "Content-Length %lu for %s snapshot is below minimum %lu, marking malformed",
+                         meta->total_sz, full ? "full" : "incremental", FD_SNAPSHOT_MIN_CONTENT_LENGTH ));
         ctx->malformed = 1;
         fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
       }

--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -339,6 +339,13 @@ after_credit( fd_snapld_tile_t *  ctx,
             fd_sshttp_cancel( ctx->sshttp );
             break;
           }
+          if( FD_UNLIKELY( meta->total_sz<FD_SNAPSHOT_MIN_CONTENT_LENGTH ) ) {
+            FD_LOG_WARNING(( "HTTP Content-Length %lu for %s snapshot is below minimum %lu",
+                             meta->total_sz, ctx->load_full ? "full" : "incremental", FD_SNAPSHOT_MIN_CONTENT_LENGTH ));
+            transition_malformed( ctx, stem );
+            fd_sshttp_cancel( ctx->sshttp );
+            break;
+          }
           ctx->sent_meta = 1;
           fd_stem_publish( stem, 0UL, FD_SNAPSHOT_MSG_META, ctx->out_dc.chunk, sizeof(fd_ssctrl_meta_t), 0UL, 0UL, 0UL );
           ctx->out_dc.chunk = next_chunk;

--- a/src/discof/restore/test_snapct_tile.c
+++ b/src/discof/restore/test_snapct_tile.c
@@ -257,6 +257,53 @@ test_load_complete_signal( void ) {
 }
 
 static void
+test_meta_content_length( void ) {
+  fd_snapct_tile_t ctx[1];
+  memset( ctx, 0, sizeof(fd_snapct_tile_t) );
+
+  fd_ssctrl_meta_t meta[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  ctx->snapld_in_mem = meta;
+
+  /* snapld_frag never dereferences stem in the paths tested below. */
+
+  /* Valid META at exact minimum for full HTTP sets bytes_total. */
+  ctx->state     = FD_SNAPCT_STATE_READING_FULL_HTTP;
+  meta->total_sz = FD_SNAPSHOT_MIN_CONTENT_LENGTH;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_META, sizeof(fd_ssctrl_meta_t), 0UL, NULL );
+  FD_TEST( ctx->metrics.full.bytes_total==FD_SNAPSHOT_MIN_CONTENT_LENGTH );
+
+  /* Valid META for incremental HTTP sets bytes_total. */
+  ctx->state     = FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP;
+  meta->total_sz = FD_SNAPSHOT_MIN_CONTENT_LENGTH + 1UL;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_META, sizeof(fd_ssctrl_meta_t), 0UL, NULL );
+  FD_TEST( ctx->metrics.incremental.bytes_total==FD_SNAPSHOT_MIN_CONTENT_LENGTH + 1UL );
+
+  /* Below-minimum META when already malformed: returns without
+     updating bytes_total or crashing (stem is NULL). */
+  ctx->state                    = FD_SNAPCT_STATE_READING_FULL_HTTP;
+  ctx->malformed                = 1;
+  ctx->metrics.full.bytes_total = 0UL;
+  meta->total_sz                = FD_SNAPSHOT_MIN_CONTENT_LENGTH - 1UL;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_META, sizeof(fd_ssctrl_meta_t), 0UL, NULL );
+  FD_TEST( ctx->metrics.full.bytes_total==0UL );
+  FD_TEST( ctx->malformed==1 );
+  ctx->malformed = 0;
+
+  /* META ignored during flushing reset states. */
+  ctx->state                    = FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET;
+  ctx->metrics.full.bytes_total = 0UL;
+  meta->total_sz                = FD_SNAPSHOT_MIN_CONTENT_LENGTH;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_META, sizeof(fd_ssctrl_meta_t), 0UL, NULL );
+  FD_TEST( ctx->metrics.full.bytes_total==0UL );
+
+  ctx->state                           = FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET;
+  ctx->metrics.incremental.bytes_total = 0UL;
+  meta->total_sz                       = FD_SNAPSHOT_MIN_CONTENT_LENGTH;
+  snapld_frag( ctx, FD_SNAPSHOT_MSG_META, sizeof(fd_ssctrl_meta_t), 0UL, NULL );
+  FD_TEST( ctx->metrics.incremental.bytes_total==0UL );
+}
+
+static void
 test_contact_info_slot_reuse_after_unallowed_peer_expires( void ) {
   void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
 
@@ -514,6 +561,7 @@ main( int     argc,
   test_block_list_contact_info_insert();
   test_contact_info_slot_reuse_after_unallowed_peer_expires();
   test_load_complete_signal();
+  test_meta_content_length();
 
   /* Shared ssping: can only be created once (opens real sockets). */
   ulong ssping_max = 16UL;

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -91,6 +91,8 @@
    that control message until all tiles forward it on, or an ERROR
    message is triggered by any of the tiles and forwarded. */
 
+#define FD_SNAPSHOT_MIN_CONTENT_LENGTH         (1UL<<12) /* 4 KiB - minimum accepted Content-Length for a valid snapshot */
+
 #define FD_SNAPSHOT_STATE_IDLE                 (0UL) /* Performing no work and should receive no data frags */
 #define FD_SNAPSHOT_STATE_PROCESSING           (1UL) /* Performing usual work, no errors / EoF condition encountered */
 #define FD_SNAPSHOT_STATE_FINISHING            (2UL) /* Tile has observed EoF, expects no additional data frags */


### PR DESCRIPTION
Add `FD_SNAPSHOT_MIN_CONTENT_LENGTH` (4 KiB) to reject trivially invalid snapshots before data enters the snapshot-load pipeline.

Closes https://github.com/firedancer-io/firedancer/issues/10258.