### PR TITLE
runtime: shrink test_deprecate_rent_exemption_threshold memory sizing

### DIFF
--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -279,16 +279,16 @@ test_env_create( test_env_t * env,
   ulong const max_account_writes_per_slot = 16UL;
   ulong const partition_cnt               = 1UL;
   ulong const partition_sz                = 16UL<<20;
-  ulong const cache_fp                    = 16UL<<30;
+  ulong const cache_fp                    = 64UL<<20;
   ulong const joiner_cnt                  = 1UL;
   ulong const seed                        = 17UL;
   ulong const max_total_banks             = 4UL;
   ulong const max_fork_width              = 4UL;
 
-  ulong shmem_fp = fd_accdb_shmem_footprint( max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, cache_fp, 640UL, joiner_cnt );
+  ulong shmem_fp = fd_accdb_shmem_footprint( max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, cache_fp, 1UL, joiner_cnt );
   env->accdb_shmem = fd_wksp_alloc_laddr( wksp, fd_accdb_shmem_align(), shmem_fp, env->tag );
   FD_TEST( env->accdb_shmem );
-  FD_TEST( fd_accdb_shmem_new( env->accdb_shmem, max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, partition_sz, cache_fp, 640UL, 0, seed, joiner_cnt ) );
+  FD_TEST( fd_accdb_shmem_new( env->accdb_shmem, max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, partition_sz, cache_fp, 1UL, 0, seed, joiner_cnt ) );
   fd_accdb_shmem_t * shmem = fd_accdb_shmem_join( env->accdb_shmem );
   FD_TEST( shmem );
 
@@ -508,7 +508,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  ulong wksp_sz = 20UL<<30; /* 20 GiB virtual (demand-paged) */
+  ulong wksp_sz = 512UL<<20; /* 512 MiB virtual (demand-paged) */
   FD_LOG_NOTICE(( "Creating workspace (lazy paged, %lu GiB)", wksp_sz>>30 ));
   fd_wksp_t * wksp = fd_wksp_new_lazy( wksp_sz );
   FD_TEST( wksp );

--- a/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
+++ b/src/flamenco/runtime/test_deprecate_rent_exemption_threshold.c
@@ -509,7 +509,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong wksp_sz = 512UL<<20; /* 512 MiB virtual (demand-paged) */
-  FD_LOG_NOTICE(( "Creating workspace (lazy paged, %lu GiB)", wksp_sz>>30 ));
+  FD_LOG_NOTICE(( "Creating workspace (lazy paged, %lu MiB)", wksp_sz>>20 ));
   fd_wksp_t * wksp = fd_wksp_new_lazy( wksp_sz );
   FD_TEST( wksp );
 


### PR DESCRIPTION
Closes #10208 

Reduced `test_deprecate_rent_exemption_threshold` memory sizing to match the small fixture it actually exercises. `cache_fp` was lowered from `16 GiB` to `64 MiB`, `cache_min_reserved` from `640` to `1`, and the lazy workspace size from `20 GiB` to `512 MiB`. 

The test only covers a small rent/epoch transition scenario, so the previous production-scale accdb reservation was unnecessary and failed on smaller machines.

Tested by rebuilding the single unit test target, running `./build/native/gcc/unit-test/test_deprecate_rent_exemption_threshold`, and verifying it also passes under smaller virtual memory cap with `( ulimit -v $((1024*1024)); ./build/native/gcc/unit-test/test_deprecate_rent_exemption_threshold )`.