### PR TITLE
execle/bank: bmtree - prevent 0 leaf condition

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -181,7 +181,7 @@ during_frag( fd_execle_tile_t * ctx,
   ctx->_is_bundle = trailer->is_bundle;
 }
 
-static void
+static uchar *
 hash_transactions( void *       mem,
                    fd_txn_p_t * txns,
                    ulong        txn_cnt,
@@ -198,8 +198,10 @@ hash_transactions( void *       mem,
       fd_bmtree_commit_append( bmtree, node, 1UL );
     }
   }
+  if( FD_UNLIKELY( !fd_bmtree_commit_leaf_cnt( bmtree ) ) ) return NULL; /* fd_bmtree_commit_fini requires a leaf. */
   uchar * root = fd_bmtree_commit_fini( bmtree );
   fd_memcpy( mixin, root, 32UL );
+  return mixin;
 }
 
 static inline void

--- a/src/discof/execle/test_execle_tile.c
+++ b/src/discof/execle/test_execle_tile.c
@@ -659,7 +659,16 @@ test_compute_expected_hash( fd_txn_p_t * txns,
                             ulong        txn_cnt,
                             uchar        expected_hash[32] ) {
   uchar bmtree_mem[ FD_BMTREE_COMMIT_FOOTPRINT(0) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
-  hash_transactions( bmtree_mem, txns, txn_cnt, expected_hash );
+  FD_TEST( hash_transactions( bmtree_mem, txns, txn_cnt, expected_hash )==expected_hash );
+}
+
+FD_UNIT_TEST( execle_hash_transactions_no_executed_txn ) {
+  fd_txn_p_t txn[1];
+  txn->flags = 0U;
+
+  uchar bmtree_mem[ FD_BMTREE_COMMIT_FOOTPRINT(0) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
+  uchar mixin[32];
+  FD_TEST( !hash_transactions( bmtree_mem, txn, 1UL, mixin ) );
 }
 
 static void

--- a/src/discoh/bank/fd_bank_tile.c
+++ b/src/discoh/bank/fd_bank_tile.c
@@ -145,7 +145,7 @@ during_frag( fd_bank_ctx_t * ctx,
   ctx->_is_bundle = trailer->is_bundle;
 }
 
-static void
+static uchar *
 hash_transactions( void *       mem,
                    fd_txn_p_t * txns,
                    ulong        txn_cnt,
@@ -162,8 +162,10 @@ hash_transactions( void *       mem,
       fd_bmtree_commit_append( bmtree, node, 1UL );
     }
   }
+  if( FD_UNLIKELY( !fd_bmtree_commit_leaf_cnt( bmtree ) ) ) return NULL; /* fd_bmtree_commit_fini requires a leaf. */
   uchar * root = fd_bmtree_commit_fini( bmtree );
   fd_memcpy( mixin, root, 32UL );
+  return mixin;
 }
 
 static inline void


### PR DESCRIPTION
## Summary

`fd_bmtree_commit_fini()` requires the commitment to contain at least one leaf. The execle and bank `hash_transactions()` helpers append signature leaves only for transactions with `FD_TXN_P_FLAGS_EXECUTE_SUCCESS`, but previously finalized the bmtree unconditionally.

If a microblock or bundle result contains transactions but none have `EXECUTE_SUCCESS`, the helpers finalize an empty bmtree and violate the bmtree API contract.

This change makes both helpers return `mixin` when a mixin was produced and `NULL` when no leaves were appended. In the `NULL` case, `mixin` is left untouched.

## Root Cause

The empty-success case is possible because the transaction loop filters out failed transactions before appending leaves:

```c
if( FD_UNLIKELY( !(_txn->flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS) ) ) continue;
```

When every transaction is filtered out, `fd_bmtree_commit_leaf_cnt( bmtree )==0`, but the old code still called:

```c
fd_bmtree_commit_fini( bmtree );
```

That violates the documented `fd_bmtree_commit_fini()` precondition requiring at least one leaf.

## Tested Reproduction

Tested on upstream `main` at `b60aa19e51`.

Apply these temporary diagnostic changes to unpatched `main`.

First, add an explicit precondition check in `src/ballet/bmtree/fd_bmtree.c`:

```diff
diff --git a/src/ballet/bmtree/fd_bmtree.c b/src/ballet/bmtree/fd_bmtree.c
@@
 fd_bmtree_commit_fini( fd_bmtree_commit_t * state ) {
   ulong             leaf_cnt = state->leaf_cnt;
   fd_bmtree_node_t * node_buf = state->node_buf;
+  FD_TEST( leaf_cnt );
 
   /* Pointer to root node. */
```

Then add this focused unit test before `execle_seccomp` in `src/discof/execle/test_execle_tile.c`:

```c
FD_UNIT_TEST( execle_empty_success_mixin_repro ) {
  fd_txn_p_t txn[1];
  txn->flags = 0U;

  uchar bmtree_mem[ FD_BMTREE_COMMIT_FOOTPRINT(0) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
  uchar mixin[32];
  hash_transactions( bmtree_mem, txn, 1UL, mixin );
}
```

Build and run:

```sh
make -j4 test_execle_tile
build/native/gcc-12/unit-test/test_execle_tile execle_empty_success_mixin_repro
```

Observed failure on unpatched `main`:

```text
Running execle_empty_success_mixin_repro
fd_bmtree.c(285): FAIL: leaf_cnt
```

This shows `hash_transactions()` can reach `fd_bmtree_commit_fini()` with `txn_cnt > 0` but zero appended leaves when no transaction has `FD_TXN_P_FLAGS_EXECUTE_SUCCESS`.

With the same temporary diagnostic check and repro test applied on this PR commit, the filtered command passes:

```text
Running execle_empty_success_mixin_repro
```

The existing `execle_simple_fee_payer_fail` and several bundle failure tests already exercise this shape through normal execle flow; the old test comments explicitly skipped checking the hash because the bmtree was empty.

## Fix

Both `hash_transactions()` helpers now check `fd_bmtree_commit_leaf_cnt( bmtree )` before finalizing. If no leaves were appended, they return `NULL` without calling `fd_bmtree_commit_fini()` and leave the destination mixin bytes untouched.

When a mixin is produced, the helpers copy the root into `mixin` and return `mixin`. The non-empty transaction hash path is unchanged.

## Validation

On the PR branch:

```sh
git diff --check
make -j4 test_execle_tile
build/native/gcc-12/unit-test/test_execle_tile execle_hash_transactions_no_executed_txn
make -j4 build/native/gcc-12/obj/discoh/bank/fd_bank_tile.o
```
