### PR TITLE
gui: add fd_gui_store

### DIFF
--- a/src/disco/events/Local.mk
+++ b/src/disco/events/Local.mk
@@ -1,10 +1,7 @@
 ifdef FD_HAS_HOSTED
-$(call add-hdrs,fd_circq.h fd_event_report.h)
+$(call add-hdrs,fd_event_report.h)
 $(call add-hdrs,generated/fd_event_gen.h)
-$(call add-objs,fd_circq fd_event_client fd_event_report,fd_disco)
+$(call add-objs,fd_event_client fd_event_report,fd_disco)
 $(call add-objs,generated/fd_event_gen,fd_disco)
 $(call add-objs,fd_event_tile,fd_disco)
-
-$(call make-unit-test,test_circq,test_circq,fd_disco fd_flamenco fd_tango fd_util)
-$(call run-unit-test,test_circq)
 endif

--- a/src/disco/events/fd_event_client.h
+++ b/src/disco/events/fd_event_client.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_fd_src_disco_events_fd_event_client_h
 #define HEADER_fd_src_disco_events_fd_event_client_h
 
-#include "fd_circq.h"
+#include "../../util/circq/fd_circq.h"
 #include "../keyguard/fd_keyguard_client.h"
 #include "../../discof/genesis/fd_genesi_tile.h"
 

--- a/src/disco/events/fd_event_tile.c
+++ b/src/disco/events/fd_event_tile.c
@@ -1,5 +1,4 @@
 #define _GNU_SOURCE
-#include "fd_circq.h"
 #include "fd_event_client.h"
 
 #include "../fd_txn_m.h"
@@ -13,6 +12,7 @@
 #include "../topo/fd_topo.h"
 #include "../../waltz/resolv/fd_netdb.h"
 #include "../../waltz/http/fd_url.h"
+#include "../../util/circq/fd_circq.h"
 #include "../../ballet/lthash/fd_lthash.h"
 #include "../../ballet/pb/fd_pb_encode.h"
 #include "../../tango/tempo/fd_tempo.h"

--- a/src/disco/events/gen_events.py
+++ b/src/disco/events/gen_events.py
@@ -347,7 +347,7 @@ def generate_c_header(schemas: List[Schema]) -> str:
         "#ifndef HEADER_fd_src_disco_events_generated_fd_event_gen_h",
         "#define HEADER_fd_src_disco_events_generated_fd_event_gen_h",
         "",
-        '#include "../fd_circq.h"',
+        '#include "../../../util/circq/fd_circq.h"',
         '#include "../fd_event_client.h"',
         '#include "../fd_event_report.h"',
         "",

--- a/src/disco/events/generated/fd_event_gen.h
+++ b/src/disco/events/generated/fd_event_gen.h
@@ -2,7 +2,7 @@
 #ifndef HEADER_fd_src_disco_events_generated_fd_event_gen_h
 #define HEADER_fd_src_disco_events_generated_fd_event_gen_h
 
-#include "../fd_circq.h"
+#include "../../../util/circq/fd_circq.h"
 #include "../fd_event_client.h"
 #include "../fd_event_report.h"
 

--- a/src/disco/gui/Local.mk
+++ b/src/disco/gui/Local.mk
@@ -2,8 +2,12 @@ ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_gui.h fd_gui_printf.h fd_gui_peers.h fd_gui_config_parse.h fd_gui_metrics.h)
 $(call add-objs,fd_gui fd_gui_printf fd_gui_peers fd_gui_config_parse fd_gui_tile generated/http_import_dist,fd_disco)
 $(OBJDIR)/obj/disco/gui/fd_gui_tile.o: book/public/fire.svg
+$(call add-hdrs,fd_gui_store_tmpl.c)
 $(call make-unit-test,test_live_table,test_live_table,fd_disco fd_util)
+$(call make-unit-test,test_gui_store,test_gui_store,fd_disco fd_util)
+$(call run-unit-test,test_gui_store)
 $(call make-fuzz-test,fuzz_config_parser,fuzz_config_parser,fd_disco fd_ballet fd_util)
+$(call make-fuzz-test,fuzz_gui_store,fuzz_gui_store,fd_disco fd_util)
 
 src/disco/gui/dist_cmp/%.zst: src/disco/gui/dist/%
 	mkdir -p $(@D);

--- a/src/disco/gui/fd_gui_store_tmpl.c
+++ b/src/disco/gui/fd_gui_store_tmpl.c
@@ -1,0 +1,1507 @@
+/* Generate prototypes, inlines and implementations for a keyed store
+   with variable-sized elements backed by a file-backed write-back LRU
+   cache.  Any append that can fit in the store must always succeed.
+   Entries are evicted in FIFO order to make room for new inserts.
+
+   Includes an asynchronous batch pre-eviction API which moves the cost
+   of cache eviction off the critical path reducing the amortized cost
+   of disk I/O.
+
+   The store occupies two distinct regions.  The in-memory allocation
+   (1) holds an index and a cache; the file-backed allocation (2) lives
+   in an independent caller-provided file region.
+
+   1) In-Memory Allocation
+
+   The index is a map of up to ele_max records, each tracking a value
+   that lives either in the in-mem cache (fd_circq) or on disk.  Both
+   the cache and disk allocation are fixed-size ring buffers. The cache
+   uses an LRU eviction policy while the file buffer evicts in FIFO
+   order.
+
+   +===================================================================+
+   |  index                                                            |
+   |    record0: val0_ptr (value0 lives in in-mem circq)               |
+   |    record1: val1_off (value1 lives on-disk)                       |
+   |    ...                                                            |
+   +===================================================================+
+   |  cache (fd_circq)                                                 |
+   |    +-------+-----+------+-----+-----+-------+-----+------+-----+  |
+   |    | meta0 | pad | val0 | pad | ... | metaN | pad | valN | pad |  |
+   |    +-------+-----+------+-----+-----+-------+-----+------+-----+  |
+   +===================================================================+
+
+   2) On-Disk Allocation
+
+   +===================================================================+
+   |  superblock                                                       |
+   |    magic | version | head | tail | cnt | gen | checksum | (pad)   |
+   +===================================================================+
+   |  ring buffer                                                      |
+   |    +-------+------+-----+-----+-------+-----+------+              |
+   |    | metaN | valN | pad | ... | meta1 | val1 | pad |              |
+   |    +-------+------+-----+-----+-------+-----+------+              |
+   |                         ^     ^                                   |
+   |              ftail (next)     fhead (oldest)                      |
+   |                                                                   |
+   |  record [meta | val | pad]                                        |
+   |    +-------+----+-----+-------+-----+                             |
+   |    | align | sz | key | value | pad |                             |
+   |    +-------+----+-----+-------+-----+                             |
+   +===================================================================+
+
+   Typical usage:
+
+    struct myrec_key {
+      ulong slot;
+      ulong block_id;
+    };
+    typedef struct myrec_key myrec_key_t;
+
+    #define GUI_STORE_NAME             myrec_store
+    #define GUI_STORE_KEY_T            myrec_key_t
+    #define GUI_STORE_KEY_HASH(k,seed) fd_ulong_hash( (k)->slot ^ fd_ulong_rotate_left( (k)->block_id, 32 ) ^ (seed) )
+    #define GUI_STORE_KEY_EQ(k0,k1)    ( ((k0)->slot==(k1)->slot) & ((k0)->block_id==(k1)->block_id) )
+    #include "fd_gui_store_tmpl.c"
+
+  declares the following header-only library in the current translation
+  unit (myrec_store_* prefix from GUI_STORE_NAME):
+
+    // A myrec_store_t is a quasi-opaque handle for a local join.  Its
+    // contents should not be used directly.
+
+    typedef struct myrec_store_private myrec_store_t;
+
+    // align/footprint - Return the alignment/footprint required for a
+    // memory region to be used as a myrec_store that can hold up to
+    // ele_max records with a cache_sz byte cache.  cache_sz must be
+    // larger than the largest storeable key+value (including extra
+    // space for alignment padding and a seq).  For good performance, a
+    // cache_sz several times larger then the average element footrpint
+    // is recommended.  footprint does not include the caller-provided
+    // on-disk allocation.
+    //
+    // new - Format a memory region pointed to by shmem into a
+    // myrec_store.  Assumes shmem points to a region with the required
+    // alignment and footprint.  seed is the hash seed passed into
+    // GUI_STORE_KEY_HASH.  file_len==0 makes the store cache-only.
+    // Otherwise it occupies [file_base_off,file_base_off+file_len) of
+    // the file passed to join.  Caller is not joined on return.
+    // Returns shmem.
+    //
+    // join - Join a myrec_store.  Assumes shstore points at a region
+    // formatted as a myrec_store.  fd is the descriptor of the backing
+    // file for a file-backed store, or -1 for a mem-only store (must
+    // match new).  The caller retains ownership of fd, but must keep it
+    // open for the lifetime of the myrec_store.  Returns a handle of
+    // the caller's join.
+    //
+    // leave - Leave a join.  Returns a pointer to the underlying memory
+    // region. Does not close caller-owned fd passed into join.
+    //
+    // delete - Unformat a memory region used as a myrec_store.  Returns a
+    // pointer to the unformatted memory region.
+
+    ulong           myrec_store_align    ( void );
+    ulong           myrec_store_footprint( ulong ele_max, ulong cache_sz, ulong file_len );
+    void *          myrec_store_new      ( void * shmem, ulong ele_max, ulong cache_sz, ulong seed,
+                                           ulong file_base_off, ulong file_len );
+    myrec_store_t * myrec_store_join     ( void * shstore, int fd );
+    void *          myrec_store_leave    ( myrec_store_t * join );
+    void *          myrec_store_delete   ( void * shstore );
+
+    // append - Insert a new key into the store, reserving footprint
+    // bytes (with alignment align) for its value.  Returns a writable
+    // pointer for the caller to fill in the value, or NULL on failure.
+    // Failure can happen if the key is already in the store, the value
+    // is individually larger than cache_sz, or align is not a power of
+    // two.
+
+    void * myrec_store_append( myrec_store_t *     join,
+                               myrec_key_t const * key,
+                               ulong               align,
+                               ulong               footprint );
+
+    // get - Query the store for key.  Return a pointer to the value
+    // bytes, or NULL if key is not in the store.  If opt_out_sz is
+    // non-NULL, the value size is written to *opt_out_sz on success.
+    // get_ro returns a read-only pointer; get_mut returns a writable
+    // pointer, in which case the caller is free to modify the value
+    // bytes in place.  Assumes join is a current join.
+
+    void const * myrec_store_get_ro ( myrec_store_t *       join,
+                                      myrec_key_t const *   key,
+                                      ulong *               opt_out_sz );
+    void *       myrec_store_get_mut( myrec_store_t *       join,
+                                      myrec_key_t const *   key,
+                                      ulong *               opt_out_sz );
+
+    // Pre-eviction.  Drains internal data structures that are at or
+    // above their LOAD_FACTOR high watermark down to their low
+    // watermark (LOAD_FACTOR - EVICT_PCT), evicting the oldest entries.
+    //
+    // This may be called periodically so that the synchronous critical
+    // path evicts rarely.  Safe to call any time; a no-op when
+    // everything is below its high watermark. Assumes join is a current
+    // join.
+    //
+    // Note: draining the cache writes dirty entries into the disk ring,
+    // so a single pre_evict may leave the disk ring above its high
+    // watermark; call again if a strict bound is required.
+
+    void myrec_store_pre_evict( myrec_store_t * join );
+
+    // verify - Check that all store invariants hold.  Returns 0 if the
+    // store is internally consistent, and -1 otherwise (after an
+    // FD_LOG_WARNING describing the first failing invariant).  This is
+    // a read-only consistency check (it does not mutate store state,
+    // beyond transiently using the circq iteration cursor as scratch)
+    // intended to be called periodically while the store is quiescent,
+    // i.e. between top-level public API calls.  Assumes join is a
+    // current join.
+
+    int myrec_store_verify( myrec_store_t * join );
+
+  Do this as often as desired in a compilation unit to get different
+  stores. */
+
+#ifndef GUI_STORE_NAME
+#error "need to define GUI_STORE_NAME"
+#endif
+
+#ifndef GUI_STORE_KEY_T
+#error "need to define GUI_STORE_KEY_T"
+#endif
+
+#ifndef GUI_STORE_KEY_HASH
+#error "need to define GUI_STORE_KEY_HASH"
+#endif
+
+#ifndef GUI_STORE_KEY_EQ
+#error "need to define GUI_STORE_KEY_EQ"
+#endif
+
+#define GUI_STORE_(n) FD_EXPAND_THEN_CONCAT3(GUI_STORE_NAME,_,n)
+
+#ifndef GUI_STORE_IMPL_STYLE
+#define GUI_STORE_IMPL_STYLE 0
+#endif
+
+#if GUI_STORE_IMPL_STYLE==0
+#define GUI_STORE_STATIC static FD_FN_UNUSED
+#else
+#define GUI_STORE_STATIC
+#endif
+
+/* GUI_STORE_TIER_{MEM/FILE} name the storage tier holding a given
+   value.  MEM values live in the embedded fd_circq and are referenced
+   by pointer. FILE values live in the on-disk buffer and are referenced
+   by byte offset. */
+
+#define GUI_STORE_TIER_MEM  (0U)
+#define GUI_STORE_TIER_FILE (1U)
+
+#define GUI_STORE_MAGIC        (0x4753545200000001UL) /* "GSTR" + version */
+#define GUI_STORE_VERSION      (1UL)
+#define GUI_STORE_SUPERBLOCK_SZ (64UL)
+
+/* Eviction watermarks. TODO derive these better. */
+
+#ifndef GUI_STORE_IDX_LOAD_FACTOR
+#define GUI_STORE_IDX_LOAD_FACTOR (50UL)
+#endif
+#ifndef GUI_STORE_IDX_EVICT_PCT
+#define GUI_STORE_IDX_EVICT_PCT (20UL)
+#endif
+
+#ifndef GUI_STORE_CACHE_LOAD_FACTOR
+#define GUI_STORE_CACHE_LOAD_FACTOR (90UL)
+#endif
+#ifndef GUI_STORE_CACHE_EVICT_PCT
+#define GUI_STORE_CACHE_EVICT_PCT (20UL)
+#endif
+
+#ifndef GUI_STORE_DISK_LOAD_FACTOR
+#define GUI_STORE_DISK_LOAD_FACTOR (95UL)
+#endif
+#ifndef GUI_STORE_DISK_EVICT_PCT
+#define GUI_STORE_DISK_EVICT_PCT (5UL)
+#endif
+
+#include "../../util/log/fd_log.h"          /* failure logs            */
+#include "../../util/bits/fd_bits.h"        /* fd_ulong_*, FD_LAYOUT_* */
+#include "../../util/circq/fd_circq.h"      /* cache                   */
+#include "../../util/io/fd_io.h"            /* fd_io_strerror          */
+
+/* The translation unit that instantiates this template must define
+   _GNU_SOURCE (or another macro implying _DEFAULT_SOURCE), since
+   pwritev(2) support is required. */
+#include <errno.h>                          /* errno                   */
+#include <unistd.h>                         /* pread/pwrite/fdatasync  */
+#include <sys/uio.h>                        /* pwritev / struct iovec  */
+#include <limits.h>                         /* IOV_MAX                 */
+
+#define GUI_STORE_MAX_WRITEBACK_IOV (3UL*FD_CIRCQ_EVICT_BATCH_MAX)
+FD_STATIC_ASSERT( GUI_STORE_MAX_WRITEBACK_IOV<=IOV_MAX, gui_store_writeback_iov_fits );
+
+/* On-disk record header. */
+struct __attribute__((aligned(8UL))) GUI_STORE_(rechdr) {
+  ulong           align;  /* value align                                 */
+  ulong           sz;     /* value size in bytes (excludes this header)  */
+  GUI_STORE_KEY_T key;    /* full key */
+};
+typedef struct GUI_STORE_(rechdr) GUI_STORE_(rechdr_t);
+
+/* The per-message cache header.  key lets the evict callback recover
+   the map element; seq is a sequence number incremented on every push. */
+struct __attribute__((packed,aligned(8UL))) GUI_STORE_(msghdr) {
+  GUI_STORE_KEY_T key;
+  ulong           seq;
+};
+typedef struct GUI_STORE_(msghdr) GUI_STORE_(msghdr_t);
+
+struct __attribute__((packed,aligned(8UL))) GUI_STORE_(ele) {
+  GUI_STORE_KEY_T key;          /* full composite key, inline (MAP_KEY) */
+  uchar *         mem;          /* direct pointer to the value bytes (past the msg header) in the circq; valid iff tier==MEM. */
+  ulong           off;          /* on-disk record offset (data-region relative); valid iff has_disk. */
+  ulong           sz;           /* value size in bytes (excludes msg header) */
+  ulong           seq;          /* seq of the authoritative cache message; valid iff tier==MEM */
+  ushort          align;        /* caller's value align; recovers val_off=align_up(hdr_sz,align) at warm/write-back  */
+  uint            free     : 1; /* 1 => this ele is unused in the map */
+  uint            tier     : 1; /* GUI_STORE_TIER_{MEM,FILE} */
+  uint            dirty    : 1; /* 1 => map copy differs from disk */
+  uint            has_disk : 1; /* 1 => a disk copy exists at off */
+};
+typedef struct GUI_STORE_(ele) GUI_STORE_(ele_t);
+
+#define MAP_NAME             GUI_STORE_(map)
+#define MAP_ELE_T            GUI_STORE_(ele_t)
+#define MAP_KEY_T            GUI_STORE_KEY_T
+#define MAP_KEY              key
+#define MAP_KEY_HASH(k,seed) GUI_STORE_KEY_HASH( (k), (seed) )
+#define MAP_KEY_EQ(k0,k1)    GUI_STORE_KEY_EQ( (k0), (k1) )
+#define MAP_ELE_IS_FREE(ele) ( (ele)->free )
+#define MAP_ELE_FREE(ctx,ele) do { (void)(ctx); (ele)->free = 1U; } while(0)
+
+/* The default MAP_ELE_MOVE shallow copies and zeroes the moved-from
+   key. We need to overwrite it to correctly manage free bit lifetime. */
+#define MAP_ELE_MOVE(ctx,dst,src) do { \
+    (void)(ctx);                       \
+    GUI_STORE_(ele_t) * _src = (src);  \
+    *(dst) = *_src;                    \
+    _src->free = 1U;                   \
+  } while(0)
+#include "../../util/tmpl/fd_map_slot.c"
+
+struct GUI_STORE_(private) {
+  GUI_STORE_(map_t) map[1];        /* map local join state (lmem)              */
+  ulong             seed;          /* hash seed                                */
+  ulong             ele_max;       /* map element capacity (power of two)      */
+  fd_circq_t *      circq;         /* join to cache fd_circq (caller addr sp.) */
+  ulong             cache_sz;      /* embedded circq capacity in bytes         */
+
+  ulong             live_cnt;      /* live index map entries (MEM + FILE); used to drive index pre-eviction watermarks    */
+
+  int               fd;            /* backing file descriptor, -1 if mem-only  */
+  ulong             file_base_off; /* file region base byte offset             */
+  ulong             file_len;      /* file region length in bytes; 0 => mem    */
+
+  ulong             fhead;         /* file data-region offset of oldest record */
+  ulong             ftail;         /* file data-region offset of next write    */
+  ulong             fcnt;          /* file record count                        */
+  ulong             fbytes;        /* file bytes used                          */
+  ulong             fdata_end;     /* upper-segment end; ==data_sz unless a tail gap from a wrap exists. TODO persist in the superblock. */
+  ulong             gen;           /* superblock generation                    */
+
+  ulong             msg_seq;       /* monotonic cache-message liveness counter;
+                                      next push assigns this value then bumps   */
+
+  int               drop_cache_evictions; /* 1 => The cache evict callback removes (map_remove) evicted entries instead of demoting them to disk.
+                                             0 => The cache evict callback copies evicted entries to disk.  */
+
+  /* Write-back coalescing state used by private_evict_cb. */
+  GUI_STORE_(rechdr_t) wb_hdr[ FD_CIRCQ_EVICT_BATCH_MAX ];    /* staged record headers */
+  struct iovec         wb_iov[ GUI_STORE_MAX_WRITEBACK_IOV ]; /* header + value + pad per record */
+  ulong                wb_run_lo;                             /* staged run start (data-region offset) */
+  ulong                wb_run_hi;                             /* staged run end   (data-region offset) */
+};
+
+typedef struct GUI_STORE_(private) GUI_STORE_(t);
+
+FD_PROTOTYPES_BEGIN
+
+GUI_STORE_STATIC ulong           GUI_STORE_(align)    ( void );
+GUI_STORE_STATIC ulong           GUI_STORE_(footprint)( ulong ele_max, ulong cache_sz, ulong file_len );
+GUI_STORE_STATIC void *          GUI_STORE_(new)      ( void * shmem, ulong ele_max, ulong cache_sz, ulong seed, ulong file_base_off, ulong file_len );
+GUI_STORE_STATIC GUI_STORE_(t) * GUI_STORE_(join)     ( void * shstore, int fd );
+GUI_STORE_STATIC void *          GUI_STORE_(leave)    ( GUI_STORE_(t) * join );
+GUI_STORE_STATIC void *          GUI_STORE_(delete)   ( void * shstore );
+
+GUI_STORE_STATIC void * GUI_STORE_(append)( GUI_STORE_(t) *         join,
+                                            GUI_STORE_KEY_T const * key,
+                                            ulong                   align,
+                                            ulong                   footprint );
+
+GUI_STORE_STATIC void const * GUI_STORE_(get_ro)( GUI_STORE_(t) *         join,
+                                                  GUI_STORE_KEY_T const * key,
+                                                  ulong *                 opt_out_sz );
+
+GUI_STORE_STATIC void * GUI_STORE_(get_mut)( GUI_STORE_(t) *         join,
+                                             GUI_STORE_KEY_T const * key,
+                                             ulong *                 opt_out_sz );
+
+GUI_STORE_STATIC void GUI_STORE_(pre_evict)( GUI_STORE_(t) * join );
+
+GUI_STORE_STATIC int GUI_STORE_(verify)( GUI_STORE_(t) * join );
+
+static void GUI_STORE_(private_evict_cb)( void * ctx, fd_circq_evict_entry_t const * batch, ulong cnt );
+
+static void GUI_STORE_(index_evict_oldest)( GUI_STORE_(t) * store );
+
+static int
+GUI_STORE_(pread_all)( int    fd,
+                       void * buf,
+                       ulong  sz,
+                       ulong  off ) {
+  uchar * p   = (uchar *)buf;
+  ulong   rem = sz;
+  while( rem ) {
+    long n = pread( fd, p, rem, (long)off );
+    if( FD_UNLIKELY( n<0L ) ) {
+      if( FD_UNLIKELY( errno==EINTR ) ) continue;
+      FD_LOG_WARNING(( "pread failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      return errno;
+    }
+    if( FD_UNLIKELY( !n ) ) {
+      FD_LOG_WARNING(( "pread hit EOF short by %lu bytes", rem ));
+      return EIO;
+    }
+    p   += (ulong)n;
+    off += (ulong)n;
+    rem -= (ulong)n;
+  }
+  return 0;
+}
+
+static int
+GUI_STORE_(pwrite_all)( int          fd,
+                        void const * buf,
+                        ulong        sz,
+                        ulong        off ) {
+  uchar const * p   = (uchar const *)buf;
+  ulong         rem = sz;
+  while( rem ) {
+    long n = pwrite( fd, p, rem, (long)off );
+    if( FD_UNLIKELY( n<0L ) ) {
+      if( FD_UNLIKELY( errno==EINTR ) ) continue;
+      FD_LOG_WARNING(( "pwrite failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      return errno;
+    }
+    if( FD_UNLIKELY( !n ) ) {
+      FD_LOG_WARNING(( "pwrite returned 0" ));
+      return EIO;
+    }
+    p   += (ulong)n;
+    off += (ulong)n;
+    rem -= (ulong)n;
+  }
+  return 0;
+}
+
+/* GUI_STORE_(iov_advance) consumes n bytes from the gathered buffer
+   described by iov[*pi..iovcnt), advancing *pi past any iovec fully
+   covered by n and trimming iov_base/iov_len of the first partially
+   covered iovec.  On return *pi indexes the first not-yet-consumed
+   iovec (== iovcnt iff n covered the whole remaining buffer). */
+static inline void
+GUI_STORE_(iov_advance)( struct iovec * iov,
+                         int            iovcnt,
+                         int *          pi,
+                         ulong          n ) {
+  int i = *pi;
+  while( n && i<iovcnt ) {
+    if( n>=iov[ i ].iov_len ) {
+      n -= iov[ i ].iov_len;
+      i++;
+    } else {
+      iov[ i ].iov_base = (uchar *)iov[ i ].iov_base + n;
+      iov[ i ].iov_len -= n;
+      n = 0UL;
+    }
+  }
+  *pi = i;
+}
+
+/* GUI_STORE_(pwritev_all) writes the gathered contents of iov[0..iovcnt)
+   to fd starting at byte offset off, handling partial writes (advancing
+   into and within the iovec array) and retrying on EINTR.  iov is
+   mutated in place. Returns 0 on success or an errno on failure. */
+static int
+GUI_STORE_(pwritev_all)( int            fd,
+                         struct iovec * iov,
+                         int            iovcnt,
+                         ulong          off ) {
+  int i = 0;  /* index of first not-fully-written iovec */
+  while( i<iovcnt ) {
+    /* Skip empty iovecs. */
+    while( i<iovcnt && !iov[ i ].iov_len ) i++;
+    if( i>=iovcnt ) break;
+    int cnt = iovcnt - i;
+    if( FD_UNLIKELY( cnt>IOV_MAX ) ) cnt = IOV_MAX;
+    long n = pwritev( fd, iov+i, cnt, (long)off );
+    if( FD_UNLIKELY( n<0L ) ) {
+      if( FD_UNLIKELY( errno==EINTR ) ) continue;
+      FD_LOG_WARNING(( "pwritev failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+      return errno;
+    }
+    if( FD_UNLIKELY( !n ) ) {
+      FD_LOG_WARNING(( "pwritev returned 0" ));
+      return EIO;
+    }
+    off += (ulong)n;
+    GUI_STORE_(iov_advance)( iov, iovcnt, &i, (ulong)n );
+  }
+  return 0;
+}
+
+static int
+GUI_STORE_(file_superblock_write)( GUI_STORE_(t) * store,
+                                   ulong           gen ) {
+  ulong sb[ GUI_STORE_SUPERBLOCK_SZ / sizeof(ulong) ];
+  memset( sb, 0, sizeof(sb) );
+  sb[ 0 ] = GUI_STORE_MAGIC;
+  sb[ 1 ] = GUI_STORE_VERSION;
+  sb[ 2 ] = store->fhead;
+  sb[ 3 ] = store->ftail;
+  sb[ 4 ] = store->fcnt;
+  sb[ 5 ] = gen;
+  sb[ 6 ] = sb[ 0 ] ^ sb[ 1 ] ^ sb[ 2 ] ^ sb[ 3 ] ^ sb[ 4 ] ^ sb[ 5 ]; /* checksum */
+  return GUI_STORE_(pwrite_all)( store->fd, sb, sizeof(sb), store->file_base_off );
+}
+
+/* Lifecycle ********************************************************/
+
+GUI_STORE_STATIC ulong
+GUI_STORE_(align)( void ) {
+  ulong a = 1UL;
+  a = fd_ulong_max( a, alignof(GUI_STORE_(t)) );
+  a = fd_ulong_max( a, GUI_STORE_(map_align)() );
+  a = fd_ulong_max( a, fd_circq_align() );
+  return a;
+}
+
+/* GUI_STORE_(file_len_min) is the smallest legal file region: the
+   superblock plus room for one maximally-sized record (a header plus a
+   value as large as the circq can hold). */
+static inline ulong
+GUI_STORE_(file_len_min)( ulong cache_sz ) {
+  return GUI_STORE_SUPERBLOCK_SZ + sizeof(GUI_STORE_(rechdr_t)) + fd_ulong_align_up( cache_sz, 8UL );
+}
+
+GUI_STORE_STATIC ulong
+GUI_STORE_(footprint)( ulong ele_max,
+                       ulong cache_sz,
+                       ulong file_len ) {
+  ele_max = fd_ulong_pow2_up( fd_ulong_max( ele_max, 1UL ) );
+  ulong map_fp = GUI_STORE_(map_footprint)( ele_max );
+  if( FD_UNLIKELY( !map_fp ) ) return 0UL;
+
+  if( file_len && FD_UNLIKELY( file_len<GUI_STORE_(file_len_min)( cache_sz ) ) ) {
+    FD_LOG_WARNING(( "file_len %lu too small (need >= %lu)", file_len, GUI_STORE_(file_len_min)( cache_sz ) ));
+    return 0UL;
+  }
+
+  ulong l = FD_LAYOUT_INIT;
+  l = FD_LAYOUT_APPEND( l, alignof(GUI_STORE_(t)),    sizeof(GUI_STORE_(t))          );
+  l = FD_LAYOUT_APPEND( l, GUI_STORE_(map_align)(),   map_fp                         );
+  l = FD_LAYOUT_APPEND( l, fd_circq_align(),          fd_circq_footprint( cache_sz ) );
+  return FD_LAYOUT_FINI( l, GUI_STORE_(align)() );
+}
+
+GUI_STORE_STATIC void *
+GUI_STORE_(new)( void * shmem,
+                 ulong  ele_max,
+                 ulong  cache_sz,
+                 ulong  seed,
+                 ulong  file_base_off,
+                 ulong  file_len ) {
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, GUI_STORE_(align)() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+
+  ele_max = fd_ulong_pow2_up( fd_ulong_max( ele_max, 1UL ) );
+  ulong map_fp = GUI_STORE_(map_footprint)( ele_max );
+  if( FD_UNLIKELY( !map_fp ) ) {
+    FD_LOG_WARNING(( "bad ele_max" ));
+    return NULL;
+  }
+
+  if( file_len && FD_UNLIKELY( file_len<GUI_STORE_(file_len_min)( cache_sz ) ) ) {
+    FD_LOG_WARNING(( "file_len %lu too small (need >= %lu)", file_len, GUI_STORE_(file_len_min)( cache_sz ) ));
+    return NULL;
+  }
+
+  FD_SCRATCH_ALLOC_INIT( l, shmem );
+  GUI_STORE_(t) *     store = FD_SCRATCH_ALLOC_APPEND( l, alignof(GUI_STORE_(t)),  sizeof(GUI_STORE_(t))          );
+  void *              ele0  = FD_SCRATCH_ALLOC_APPEND( l, GUI_STORE_(map_align)(), map_fp                         );
+  void *              cq    = FD_SCRATCH_ALLOC_APPEND( l, fd_circq_align(),        fd_circq_footprint( cache_sz ) );
+  FD_SCRATCH_ALLOC_FINI( l, GUI_STORE_(align)() );
+
+  GUI_STORE_(ele_t) * eles = GUI_STORE_(map_new)( ele0, ele_max, 0 );
+  if( FD_UNLIKELY( !eles ) ) {
+    FD_LOG_WARNING(( "map new failed" ));
+    return NULL;
+  }
+  for( ulong i=0UL; i<ele_max; i++ ) eles[ i ].free = 1U; /* Set free bit */
+
+  if( FD_UNLIKELY( !fd_circq_new( cq, cache_sz ) ) ) {
+    FD_LOG_WARNING(( "circq new failed" ));
+    return NULL;
+  }
+
+  store->circq         = NULL;
+  store->seed          = seed;
+  store->ele_max       = ele_max;
+  store->cache_sz      = cache_sz;
+
+  store->fd            = -1;
+  store->file_base_off = file_len ? file_base_off : 0UL;
+  store->file_len      = file_len;
+
+  store->fhead         = 0UL;
+  store->ftail         = 0UL;
+  store->fcnt          = 0UL;
+  store->fbytes        = 0UL;
+  store->fdata_end     = file_len ? file_len - GUI_STORE_SUPERBLOCK_SZ : 0UL;
+  store->gen           = 0UL;
+  store->msg_seq       = 0UL;
+  store->live_cnt       = 0UL;
+
+  store->drop_cache_evictions = 0;
+
+  return shmem;
+}
+
+GUI_STORE_STATIC GUI_STORE_(t) *
+GUI_STORE_(join)( void * shstore,
+                  int    fd ) {
+  if( FD_UNLIKELY( !shstore ) ) {
+    FD_LOG_WARNING(( "NULL shstore" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shstore, GUI_STORE_(align)() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shstore" ));
+    return NULL;
+  }
+
+  GUI_STORE_(t) * store = (GUI_STORE_(t) *)shstore;
+
+  if( FD_UNLIKELY( store->file_len && fd<0 ) ) {
+    FD_LOG_ERR(( FD_EXPAND_THEN_STRINGIFY( GUI_STORE_(new) ) " used file_len!=0; "
+                 FD_EXPAND_THEN_STRINGIFY( GUI_STORE_(join) ) " requires a valid fd" ));
+  }
+  if( FD_UNLIKELY( !store->file_len && fd>=0 ) ) {
+    FD_LOG_ERR(( FD_EXPAND_THEN_STRINGIFY( GUI_STORE_(new) ) " used file_len=0; "
+                 FD_EXPAND_THEN_STRINGIFY( GUI_STORE_(join) ) " requires fd<0" ));
+  }
+
+  FD_SCRATCH_ALLOC_INIT( l, shstore );
+  /**/                       FD_SCRATCH_ALLOC_APPEND( l, alignof(GUI_STORE_(t)),  sizeof(GUI_STORE_(t))                       );
+  void *              ele0 = FD_SCRATCH_ALLOC_APPEND( l, GUI_STORE_(map_align)(), GUI_STORE_(map_footprint)( store->ele_max ) );
+  void *              cq   = FD_SCRATCH_ALLOC_APPEND( l, fd_circq_align(),        fd_circq_footprint( store->cache_sz )       );
+  FD_SCRATCH_ALLOC_FINI( l, GUI_STORE_(align)() );
+
+  if( FD_UNLIKELY( !GUI_STORE_(map_join)( store->map, ele0, store->ele_max, GUI_STORE_(map_probe_max_est)( store->ele_max ), store->seed ) ) ) {
+    FD_LOG_WARNING(( "map join failed" ));
+    return NULL;
+  }
+
+  store->circq = fd_circq_join( cq );
+  if( FD_UNLIKELY( !store->circq ) ) {
+    FD_LOG_WARNING(( "circq join failed" ));
+    GUI_STORE_(map_leave)( store->map );
+    return NULL;
+  }
+
+  fd_circq_set_batch_evict_cb( store->circq, GUI_STORE_(private_evict_cb), store );
+
+  if( FD_UNLIKELY( fd<0 ) ) {
+    store->fd = -1;
+    return store;
+  }
+
+  /* TODO: joining persisted file on restart */
+  store->fd = fd;
+  if( FD_UNLIKELY( GUI_STORE_(file_superblock_write)( store, store->gen ) ) ) {
+    FD_LOG_WARNING(( "superblock write failed" ));
+    fd_circq_set_batch_evict_cb( store->circq, NULL, NULL );
+    fd_circq_leave( store->circq );
+    store->circq = NULL;
+    GUI_STORE_(map_leave)( store->map );
+    return NULL;
+  }
+
+  return store;
+}
+
+GUI_STORE_STATIC void *
+GUI_STORE_(leave)( GUI_STORE_(t) * join ) {
+  if( FD_UNLIKELY( !join ) ) {
+    FD_LOG_WARNING(( "NULL join" ));
+    return NULL;
+  }
+
+  fd_circq_leave( join->circq );
+  join->circq = NULL;
+  join->fd    = -1; /* caller owns the fd; do not close it */
+  GUI_STORE_(map_leave)( join->map );
+
+  return (void *)join;
+}
+
+GUI_STORE_STATIC void *
+GUI_STORE_(delete)( void * shstore ) {
+  if( FD_UNLIKELY( !shstore ) ) {
+    FD_LOG_WARNING(( "NULL shstore" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shstore, GUI_STORE_(align)() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shstore" ));
+    return NULL;
+  }
+
+  return shstore;
+}
+
+/* append / get ******************************************************/
+
+GUI_STORE_STATIC void *
+GUI_STORE_(append)( GUI_STORE_(t) *         join,
+                    GUI_STORE_KEY_T const * key,
+                    ulong                   align,
+                    ulong                   footprint ) {
+  if( FD_UNLIKELY( !fd_ulong_is_pow2( align ) ) ) {
+    FD_LOG_WARNING(( "align is not a power of two" ));
+    return NULL;
+  }
+
+  /* A key that already exists is not supported by the API */
+  if( FD_UNLIKELY( GUI_STORE_(map_query)( join->map, key ) ) ) return NULL;
+
+  ulong hdr_sz    = sizeof(GUI_STORE_(msghdr_t));
+  ulong val_off   = fd_ulong_align_up( hdr_sz, align ); /* header + pad, base-relative */
+  ulong msg_fp    = val_off + footprint;
+  ulong msg_align = fd_ulong_max( alignof(GUI_STORE_(msghdr_t)), align );
+
+  /* Push the value into the cache first, which may fire the eviction
+     callback synchronously updating the index.  Because we hold no map
+     element pointer here, the relocation is harmless. */
+  uchar * base = fd_circq_push_back( join->circq, msg_align, msg_fp );
+  if( FD_UNLIKELY( !base ) ) {
+    FD_LOG_WARNING(( "value too large for circq (msg footprint %lu)", msg_fp ));
+    return NULL;
+  }
+
+  /* Stamp a valid header immediately: the message now exists in the
+     cache regardless of whether the index insert succeeds.  If the
+     insert fails this slot becomes an orphan, but with a real header
+     its seq matches no live element, so the eviction callback and
+     verify correctly treat it as stale. */
+  ulong seq = join->msg_seq++;
+  GUI_STORE_(msghdr_t) mhdr;
+  fd_memcpy( &mhdr.key, key, sizeof(GUI_STORE_KEY_T) );
+  mhdr.seq = seq;
+  fd_memcpy( base, &mhdr, hdr_sz );
+
+  GUI_STORE_(ele_t) * ele = GUI_STORE_(map_insert)( join->map, key );
+  if( FD_UNLIKELY( !ele ) ) {
+    /* Slow eviction path: the map has no free probe slot for this key. */
+    GUI_STORE_(index_evict_oldest)( join );
+    ele = GUI_STORE_(map_insert)( join->map, key );
+  }
+  if( FD_UNLIKELY( !ele ) ) {
+    FD_LOG_WARNING(( "index too full to seat key (msg footprint %lu)", msg_fp ));
+    return NULL;
+  }
+
+  join->live_cnt++;
+
+  uchar * val = base + val_off;
+
+  ele->mem      = val;
+  ele->sz       = footprint;
+  ele->off      = 0UL;
+  ele->seq      = seq;
+  ele->align    = (ushort)align;
+  ele->free     = 0U;
+  ele->tier     = GUI_STORE_TIER_MEM;
+  ele->dirty    = 1U; /* A fresh insert is dirty */
+  ele->has_disk = 0U;
+
+  return (void *)val;
+}
+
+/* GUI_STORE_(warm) brings a FILE element's value back into the cache and
+   sets dirty=0.  Returns a pointer to the value bytes in the cache.
+   *out_ele is set to the re-resolved index element. */
+
+static uchar *
+GUI_STORE_(warm)( GUI_STORE_(t) *         join,
+                  GUI_STORE_KEY_T const * key,
+                  GUI_STORE_(ele_t) *     ele,
+                  GUI_STORE_(ele_t) **    out_ele ) {
+  ulong hdr_sz    = sizeof(GUI_STORE_(msghdr_t));
+  ulong align     = (ulong)ele->align;
+  ulong sz        = ele->sz;
+  ulong off       = ele->off;
+  ulong val_off   = fd_ulong_align_up( hdr_sz, align );
+  ulong msg_fp    = val_off + sz;
+  ulong msg_align = fd_ulong_max( alignof(GUI_STORE_(msghdr_t)), align );
+
+  if( FD_UNLIKELY( !ele->has_disk ) ) FD_LOG_ERR(( "warm of FILE element with no disk copy" ));
+
+  uchar * base = fd_circq_push_back( join->circq, msg_align, msg_fp );
+  if( FD_UNLIKELY( !base ) ) FD_LOG_ERR(( "warm push_back failed: value larger than circq" ));
+
+  /* Write the msg header.  The disk record at off is left intact: a
+     later dirty write-back goes back into the same spot on disk. */
+  ulong seq = join->msg_seq++;
+  GUI_STORE_(msghdr_t) mhdr;
+  fd_memcpy( &mhdr.key, key, sizeof(GUI_STORE_KEY_T) );
+  mhdr.seq = seq;
+  fd_memcpy( base, &mhdr, hdr_sz );
+  uchar * val = base + val_off;
+
+  ulong rec_off = join->file_base_off + GUI_STORE_SUPERBLOCK_SZ + off + sizeof(GUI_STORE_(rechdr_t));
+  if( FD_UNLIKELY( GUI_STORE_(pread_all)( join->fd, val, sz, rec_off ) ) ) {
+    FD_LOG_ERR(( "warm pread failed" ));
+  }
+
+  /* Evicting dirty entries to disk can wrap the disk ring and drop the
+     oldest disk record -- possibly this very key's -- so it may no
+     longer be in the index.  Treat that as not-found. */
+  GUI_STORE_(ele_t) * s = GUI_STORE_(map_update)( join->map, key );
+  if( FD_UNLIKELY( !s ) ) { *out_ele = NULL; return NULL; }
+
+  s->mem   = val;
+  s->seq   = seq;
+  s->tier  = GUI_STORE_TIER_MEM;
+  s->dirty = 0U; /* warm-in is clean */
+  /* off / has_disk preserved */
+
+  *out_ele = s;
+  return val;
+}
+
+GUI_STORE_STATIC void const *
+GUI_STORE_(get_ro)( GUI_STORE_(t) *         join,
+                    GUI_STORE_KEY_T const * key,
+                    ulong *                 opt_out_sz ) {
+  GUI_STORE_(ele_t) * ele = GUI_STORE_(map_update)( join->map, key );
+  if( FD_UNLIKELY( !ele ) ) return NULL;
+
+  if( opt_out_sz ) *opt_out_sz = ele->sz;
+
+  if( FD_LIKELY( ele->tier==GUI_STORE_TIER_MEM ) ) return (void const *)ele->mem;
+
+  if( FD_UNLIKELY( !join->file_len ) ) FD_LOG_ERR(( "Encountered FILE element in a mem-only store" ));
+
+  GUI_STORE_(ele_t) * warmed = NULL;
+  return (void const *)GUI_STORE_(warm)( join, key, ele, &warmed );
+}
+
+GUI_STORE_STATIC void *
+GUI_STORE_(get_mut)( GUI_STORE_(t) *         join,
+                     GUI_STORE_KEY_T const * key,
+                     ulong *                 opt_out_sz ) {
+  /* map_update returns a mutable element so we can set the dirty bit. */
+  GUI_STORE_(ele_t) * ele = GUI_STORE_(map_update)( join->map, key );
+  if( FD_UNLIKELY( !ele ) ) return NULL;
+
+  if( FD_LIKELY( opt_out_sz ) ) *opt_out_sz = ele->sz;
+
+  if( FD_LIKELY( ele->tier==GUI_STORE_TIER_MEM ) ) {
+    ele->dirty = 1U;
+    return (void *)ele->mem;
+  }
+
+  if( FD_UNLIKELY( !join->file_len ) ) FD_LOG_ERR(( "FILE element in a mem-only store" ));
+
+  GUI_STORE_(ele_t) * warmed = NULL;
+  uchar * val = GUI_STORE_(warm)( join, key, ele, &warmed );
+  if( FD_UNLIKELY( !warmed ) ) return NULL; /* self-evicted during warm */
+  warmed->dirty = 1U;
+  return (void *)val;
+}
+
+FD_PROTOTYPES_END
+
+/* The on-disk ring is a FIFO of variable-size records living in the
+   data region [0,data_sz).  Its state is fully described by:
+
+     fcnt      number of live records (0 => empty, the unambiguous
+               empty/full discriminator),
+     fbytes    sum of live record footprints (never counts the gap),
+     fhead     offset of the oldest record,
+     ftail     offset where the next record will be written,
+     fdata_end one past the last byte the upper run uses; equals data_sz
+               unless a wrap left a tail gap [fdata_end,data_sz).
+
+   Records are written contiguously and never straddle data_sz.  The live
+   bytes therefore occupy, in physical order, either one run [fhead,ftail)
+   (when fhead<ftail, or the lone full case) or two runs
+   [fhead,fdata_end) and [0,ftail) (when the ring wraps).  All occupancy
+   decisions are driven by fcnt/fbytes, not by comparing fhead to ftail
+   (which is ambiguous when they are equal). */
+
+/* GUI_STORE_(disk_record_fp) reads the record header at data-region
+   offset off and returns its 8-byte-aligned total footprint. */
+static ulong
+GUI_STORE_(disk_record_fp)( GUI_STORE_(t) * store,
+                            ulong           off,
+                            GUI_STORE_(rechdr_t) * out_hdr ) {
+  ulong hdr_off = store->file_base_off + GUI_STORE_SUPERBLOCK_SZ + off;
+  if( FD_UNLIKELY( GUI_STORE_(pread_all)( store->fd, out_hdr, sizeof(*out_hdr), hdr_off ) ) ) {
+    FD_LOG_ERR(( "disk record header read failed" ));
+  }
+  return fd_ulong_align_up( sizeof(GUI_STORE_(rechdr_t)) + out_hdr->sz, 8UL );
+}
+
+/* GUI_STORE_(disk_drop_oldest_record) drops the single oldest live
+   on-disk record (the one at fhead): it reads the victim header, removes
+   the victim's index element, advances fhead past it (wrapping at
+   fdata_end), and decrements fcnt/fbytes.  When the ring becomes empty
+   it is reset (fhead=ftail=0, fdata_end=data_sz).  Assumes fcnt>0.
+
+   A disk eviction evicts the key from EVERYWHERE: the element is removed
+   even if the value is currently warmed into the cache.  It is left in
+   the cache as a stale orphan and no-op'd by the seq check in
+   private_evict_cb when it is later popped. */
+static void
+GUI_STORE_(disk_drop_oldest_record)( GUI_STORE_(t) * store ) {
+  ulong data_sz = store->file_len - GUI_STORE_SUPERBLOCK_SZ;
+  ulong vhead   = store->fhead;
+
+  GUI_STORE_(rechdr_t) vhdr;
+  ulong vfp = GUI_STORE_(disk_record_fp)( store, vhead, &vhdr );
+
+  GUI_STORE_(ele_t) * vele = GUI_STORE_(map_update)( store->map, &vhdr.key );
+  if( FD_LIKELY( vele && vele->has_disk && vele->off==vhead ) ) {
+    GUI_STORE_(map_remove)( store->map, vele );
+    store->live_cnt--;
+  }
+
+  store->fcnt--;
+  store->fbytes -= vfp;
+
+  if( FD_UNLIKELY( !store->fcnt ) ) { /* ring empty; reset to canonical buffer */
+    store->fhead     = 0UL;
+    store->ftail     = 0UL;
+    store->fdata_end = data_sz;
+    return;
+  }
+
+  /* Advance past end of the file.  Reclaim any padding added to the end
+     during a wrap. */
+  ulong vnext = vhead + vfp;
+  if( FD_UNLIKELY( vnext>=store->fdata_end ) ) {
+    vnext            = 0UL;
+    store->fdata_end = data_sz;
+  }
+  store->fhead = vnext;
+}
+
+/* GUI_STORE_RESERVE_FAIL is the sentinel offset returned by
+   GUI_STORE_(disk_ring_reserve) when the reservation cannot proceed.
+   ULONG_MAX is never a valid data-region offset. */
+#define GUI_STORE_RESERVE_FAIL (ULONG_MAX)
+
+/* GUI_STORE_(disk_ring_reserve) reserves enough space on disk for
+   appending one record [align|sz|key|value] at the tail -- wrapping and
+   dropping older live records as needed -- without issuing any disk I/O.
+   On success it fills *out_hdr with the record header, sets *opt_footprint
+   (if given) to the record's total footprint, and returns the data-region
+   offset at which the record's bytes belong.
+
+   The reservation fails (returns GUI_STORE_RESERVE_FAIL, mutating no
+   state) when making room would require dropping (or reading the header
+   of) a record that is still only staged in the caller's pending
+   write-back run -- i.e. an offset in [wb_run_lo,wb_run_hi) whose bytes
+   are not on disk yet.  The caller must flush its run (clearing the
+   pending span) and reserve again.  This only happens when the cache is
+   small enough that a single batch wraps onto its own not-yet-written
+   records.
+
+   Evicting can relocate map elements, so a caller holding an element
+   pointer must re-resolve it after this returns. */
+static ulong
+GUI_STORE_(disk_ring_reserve)( GUI_STORE_(t) *         store,
+                               GUI_STORE_KEY_T const * key,
+                               ulong                   align,
+                               ulong                   sz,
+                               GUI_STORE_(rechdr_t) *  out_hdr,
+                               ulong *                 opt_footprint ) {
+  ulong data_sz = store->file_len - GUI_STORE_SUPERBLOCK_SZ;
+  ulong rec_fp  = fd_ulong_align_up( sizeof(GUI_STORE_(rechdr_t)) + sz, 8UL );
+
+  /* Choose the slot.  A record never straddles data_sz, so if it does
+     not fit in the contiguous run [ftail,data_sz) the tail wraps to 0
+     and [ftail,data_sz) becomes an abandoned gap.  rec_off is the
+     chosen start; gap_lo marks the start of the abandoned tail
+     (==data_sz when not wrapping, so the gap is empty). */
+  int   wrap    = ( store->fcnt && store->ftail + rec_fp > data_sz );
+  ulong rec_off = wrap ? 0UL : store->ftail;
+  ulong rec_end = rec_off + rec_fp;
+  ulong gap_lo  = wrap ? store->ftail : data_sz;
+
+  /* Drop the oldest records until neither the new slot [rec_off,rec_end)
+     nor the abandoned tail [gap_lo,data_sz) contains any live record.
+     Records are scanned oldest-first from fhead and compared as concrete
+     byte ranges (unambiguous).  Terminates because each drop frees bytes
+     and the slot fits in data_sz (guaranteed by file_len_min). */
+  while( store->fcnt ) {
+    ulong voff = store->fhead;
+
+    if( FD_UNLIKELY( store->wb_run_hi>store->wb_run_lo && voff>=store->wb_run_lo && voff<store->wb_run_hi ) ) {
+      return GUI_STORE_RESERVE_FAIL;
+    }
+
+    GUI_STORE_(rechdr_t) vhdr;
+    ulong vfp = GUI_STORE_(disk_record_fp)( store, voff, &vhdr );
+    int   hits_slot = ( rec_off<voff+vfp && voff<rec_end );
+    int   hits_gap  = ( gap_lo <voff+vfp && voff<data_sz );
+    if( FD_LIKELY( !hits_slot && !hits_gap ) ) break;
+    GUI_STORE_(disk_drop_oldest_record)( store );
+  }
+
+  /* If this reservation wraps, freeze the upper run end at the abandoned
+     tail (creating the gap) before moving the tail to 0. */
+  if( FD_UNLIKELY( wrap ) ) store->fdata_end = store->ftail;
+
+  memset( out_hdr, 0, sizeof(*out_hdr) );
+  out_hdr->align = align;
+  out_hdr->sz    = sz;
+  fd_memcpy( &out_hdr->key, key, sizeof(GUI_STORE_KEY_T) );
+
+  ulong new_tail = rec_off + rec_fp;
+  if( FD_UNLIKELY( !store->fcnt ) ) store->fhead = rec_off; /* first record */
+  store->fcnt++;
+  store->fbytes += rec_fp;
+
+  /* A record that fills exactly to data_sz leaves no gap and the next
+     write wraps to 0; normalize ftail so it is always a valid offset. */
+  int exact_fill = ( new_tail==data_sz );
+  store->ftail = exact_fill ? 0UL : new_tail;
+
+  /* No gap exists while the live region is one contiguous run that
+     reaches the buffer end -- i.e. it does not wrap, or it wraps only
+     because the last record filled exactly to data_sz. Reclaim any
+     stale gap here. */
+  if( new_tail>store->fhead || exact_fill ) store->fdata_end = data_sz;
+
+  if( opt_footprint ) *opt_footprint = rec_fp;
+  return rec_off;
+}
+
+/* GUI_STORE_(disk_ring_writeback_inplace) writes a record with an
+   already-existing disk reservation back to disk.
+
+   Values are not resizable, so the slot footprint is unchanged; only the
+   value bytes are rewritten (the header at off is already correct). */
+static void
+GUI_STORE_(disk_ring_writeback_inplace)( GUI_STORE_(t) * store,
+                                         ulong           off,
+                                         ulong           sz,
+                                         uchar const *   val ) {
+  ulong val_off = store->file_base_off + GUI_STORE_SUPERBLOCK_SZ + off + sizeof(GUI_STORE_(rechdr_t));
+  if( FD_UNLIKELY( GUI_STORE_(pwrite_all)( store->fd, val, sz, val_off ) ) ) {
+    FD_LOG_ERR(( "in-place write-back value pwrite failed" ));
+  }
+}
+
+/* Eviction callback.  Invoked immediately before a contiguous run of
+   messages is dropped from the front of the circq (from inside
+   fd_circq_push_back).
+
+   drop_cache_evictions=0
+     Dirty values are written back to disk before the value is evicted.
+     Note that disk may itself wrap and drop older live records, which
+     then trigger further cache evictions, so this function is
+     reentrant-safe. Clean entries already have a byte-identical copy on
+     disk, so nothing is written back.
+
+   drop_cache_evictions=1
+     Value and index element are removed without being written to disk.
+     This mode is an optimization used when we're deliberately dropping
+     an entry from the index. We don't want to write an evicted copy to
+     disk only to have to clean it up right after.
+
+   If the store is not file-backed evictions are dropped. This callback
+   must not push to or otherwise mutate the circq.  It may pwrite/pread
+   and map_update/map_remove. */
+static void
+GUI_STORE_(private_evict_cb)( void *                         ctx,
+                              fd_circq_evict_entry_t const * batch,
+                              ulong                          cnt ) {
+  GUI_STORE_(t) * store = (GUI_STORE_(t) *)ctx;
+
+  /* Consecutive fresh appends form one contiguous span.  We flush all
+     the collected headers and values with a single gathered pwritev.
+     The run is broken (flushed) whenever a reservation reports it is no
+     longer contiguous (i.e. ring wrap).
+
+     A batch holds at most FD_CIRCQ_EVICT_BATCH_MAX entries, so at most
+     that many records (up to 3 iovecs each) are ever staged at once.  The
+     staging arrays live in the context (store->wb_*) to keep this
+     eviction-path stack frame small regardless of the batch size. */
+
+  GUI_STORE_(rechdr_t) * run_hdr    = store->wb_hdr; /* stable header storage */
+  struct iovec *         run_iov    = store->wb_iov; /* header + value + pad per record */
+  int                    run_iovcnt = 0;
+  ulong                  run_base   = 0UL; /* file byte offset of first staged record */
+  ulong                  run_end    = 0UL; /* file byte offset just past the staged run */
+  ulong                  run_recs   = 0UL; /* staged record (header) count */
+
+  store->wb_run_lo = store->wb_run_hi = 0UL; /* nothing staged yet */
+
+  /* Zero source for trailing record padding */
+  static uchar const GUI_STORE_(zero_pad)[ 8 ] = { 0 };
+
+# define FLUSH_RUN() do { \
+  if( run_iovcnt ) { \
+    if( FD_UNLIKELY( GUI_STORE_(pwritev_all)( store->fd, run_iov, run_iovcnt, run_base ) ) ) { \
+      FD_LOG_ERR(( "write-back pwritev failed" )); \
+    } \
+    run_iovcnt = 0; \
+    run_recs   = 0UL; \
+  } \
+  store->wb_run_lo = store->wb_run_hi = 0UL; /* staged bytes are now on disk */ \
+  } while(0)
+
+  for( ulong i=0UL; i<cnt; i++ ) {
+    GUI_STORE_(msghdr_t) mhdr;
+    fd_memcpy( &mhdr, batch[ i ].payload, sizeof(mhdr) );
+
+    GUI_STORE_(ele_t) * ele = GUI_STORE_(map_update)( store->map, &mhdr.key );
+    if( FD_UNLIKELY( !ele ) ) continue; /* orphan (e.g. failed append) */
+
+    /* Skip stale entries (records with an old seq). */
+    if( FD_UNLIKELY( ele->tier!=GUI_STORE_TIER_MEM || ele->seq!=mhdr.seq ) ) continue;
+
+    /* Drop without writeback */
+    if( !store->file_len || store->drop_cache_evictions ) {
+      FLUSH_RUN();
+      GUI_STORE_(map_remove)( store->map, ele );
+      store->live_cnt--;
+      continue;
+    }
+
+    if( FD_LIKELY( ele->dirty ) ) {
+      /* Snapshot the fields we need before any disk_ring_reserve below:
+         reserve can evict and relocate map elements, invalidating ele. */
+      ulong align   = (ulong)ele->align;
+      ulong sz      = ele->sz;
+      ulong val_off = fd_ulong_align_up( sizeof(GUI_STORE_(msghdr_t)), align );
+      uchar const * val = batch[ i ].payload + val_off;
+
+      if( FD_UNLIKELY( ele->has_disk ) ) {
+        /* Dirty writeback to disk */
+        FLUSH_RUN();
+        GUI_STORE_(disk_ring_writeback_inplace)( store, ele->off, sz, val );
+        ele->tier  = GUI_STORE_TIER_FILE;
+        ele->dirty = 0U;
+        /* off / has_disk preserved */
+      } else {
+        /* Append to disk. */
+        GUI_STORE_(rechdr_t) hdr;
+        ulong rec_fp;
+        ulong rec_off = GUI_STORE_(disk_ring_reserve)( store, &mhdr.key, align, sz, &hdr, &rec_fp );
+        if( FD_UNLIKELY( rec_off==GUI_STORE_RESERVE_FAIL ) ) {
+          FLUSH_RUN(); /* free the pending span, then the reserve succeeds */
+          rec_off = GUI_STORE_(disk_ring_reserve)( store, &mhdr.key, align, sz, &hdr, &rec_fp );
+        }
+        ulong base_off = store->file_base_off + GUI_STORE_SUPERBLOCK_SZ + rec_off;
+        ulong pad      = rec_fp - sizeof(GUI_STORE_(rechdr_t)) - sz;
+
+        /* Coalesce into the current run only if this record's bytes
+           start exactly where the last record ends */
+        if( FD_UNLIKELY( run_iovcnt && base_off!=run_end ) ) FLUSH_RUN();
+        if( FD_UNLIKELY( !run_iovcnt ) ) { run_base = base_off; store->wb_run_lo = rec_off; }
+        run_end          = base_off + rec_fp;
+        store->wb_run_hi = rec_off + rec_fp;
+
+        run_hdr[ run_recs ] = hdr;
+        run_iov[ run_iovcnt ].iov_base = &run_hdr[ run_recs ];
+        run_iov[ run_iovcnt ].iov_len  = sizeof(GUI_STORE_(rechdr_t));
+        run_iovcnt++;
+        run_iov[ run_iovcnt ].iov_base = (void *)val;
+        run_iov[ run_iovcnt ].iov_len  = sz;
+        run_iovcnt++;
+        if( pad ) {
+          run_iov[ run_iovcnt ].iov_base = (void *)GUI_STORE_(zero_pad);
+          run_iov[ run_iovcnt ].iov_len  = pad;
+          run_iovcnt++;
+        }
+        run_recs++;
+
+        /* The reserve may have dropped (and thus map_removed) other
+           elements, relocating map elements.  Re-resolve this element
+           before updating it. */
+        GUI_STORE_(ele_t) * s = GUI_STORE_(map_update)( store->map, &mhdr.key );
+        if( FD_UNLIKELY( !s ) ) FD_LOG_ERR(( "evicted dirty element vanished during write-back" ));
+
+        s->off      = rec_off;
+        s->tier     = GUI_STORE_TIER_FILE;
+        s->dirty    = 0U;
+        s->has_disk = 1U;
+      }
+    } else {
+      /* A byte-identical disk copy already exists. Demote to FILE
+         pointing at that existing record. */
+      if( FD_UNLIKELY( !ele->has_disk ) ) {
+        FD_LOG_ERR(( "clean mem eviction with no disk copy" ));
+      }
+      ele->tier = GUI_STORE_TIER_FILE;
+      /* dirty already 0; off / has_disk preserved. */
+    }
+  }
+
+  FLUSH_RUN();
+# undef FLUSH_RUN
+}
+
+/* GUI_STORE_(cache_pop_oldest) pops up to n oldest cache (fd_circq)
+   messages from the front.  Returns the number of messages actually
+   popped (!=n if the cache had <n message to begin with). */
+static ulong
+GUI_STORE_(cache_pop_oldest)( GUI_STORE_(t) * store,
+                              ulong           n ) {
+  if( FD_UNLIKELY( !n ) ) return 0UL;
+
+  fd_circq_reset_cursor( store->circq );
+
+  ulong m        = 0UL;
+  ulong last_seq = 0UL;
+  int   has_any  = 0;
+  for( ulong i=0UL; i<n; i++ ) {
+    ulong msg_sz = 0UL;
+    if( FD_UNLIKELY( !fd_circq_cursor_advance( store->circq, &msg_sz ) ) ) break;
+    last_seq = fd_circq_cursor( store->circq ) - 1UL; /* this msg's seq */
+    has_any  = 1;
+    m++;
+  }
+  if( FD_LIKELY( has_any ) ) fd_circq_pop_until( store->circq, last_seq );
+
+  return m;
+}
+
+/* GUI_STORE_(index_evict_oldest) frees a single map element by dropping
+   the oldest live entry.  Prefers dropping the oldest disk record; if
+   there are none it drops the oldest cache entry. */
+static void
+GUI_STORE_(index_evict_oldest)( GUI_STORE_(t) * store ) {
+  ulong before = store->live_cnt;
+
+  /* Drain the disk FIFO oldest-first until a live slot is freed. */
+  while( store->fcnt ) {
+    GUI_STORE_(disk_drop_oldest_record)( store );
+    if( FD_LIKELY( store->live_cnt<before ) ) return;
+  }
+
+  /* No disk records -- fall back to popping the oldest cache entries
+     one at a time, stopping the instant a slot is reclaimed. */
+  int saved = store->drop_cache_evictions;
+  store->drop_cache_evictions = 1;
+  while( store->live_cnt==before ) {
+    if( FD_UNLIKELY( !GUI_STORE_(cache_pop_oldest)( store, 1UL ) ) ) break; /* cache empty */
+  }
+  store->drop_cache_evictions = saved;
+}
+
+/* GUI_STORE_(pre_evict) is the public batched pre-eviction entry point.
+   It drains each data structure that is at or above its high watermark
+   (LOAD_FACTOR) down to its low watermark (LOAD_FACTOR-EVICT_PCT),
+   evicting the OLDEST entries.  Data structures are processed bottom-up
+   (disk -> cache -> index). A no-op when every resource is below its
+   high watermark. */
+GUI_STORE_STATIC void
+GUI_STORE_(pre_evict)( GUI_STORE_(t) * store ) {
+  if( FD_LIKELY( store->file_len ) ) {
+    ulong data_sz = store->file_len - GUI_STORE_SUPERBLOCK_SZ;
+    ulong hi      = (data_sz*GUI_STORE_DISK_LOAD_FACTOR)/100UL;
+    ulong drain   = (data_sz*GUI_STORE_DISK_EVICT_PCT  )/100UL;
+    ulong lo      = hi>drain ? hi-drain : 0UL;
+    if( FD_UNLIKELY( store->fbytes>=hi ) ) {
+      while( store->fbytes>lo && store->fcnt ) {
+        GUI_STORE_(disk_drop_oldest_record)( store );
+      }
+    }
+  }
+
+  {
+    ulong size  = store->cache_sz;
+    ulong hi    = (size*GUI_STORE_CACHE_LOAD_FACTOR)/100UL;
+    ulong drain = (size*GUI_STORE_CACHE_EVICT_PCT  )/100UL;
+    ulong lo    = hi>drain ? hi-drain : 0UL;
+    if( FD_UNLIKELY( fd_circq_bytes_used( store->circq )>=hi ) ) {
+      while( fd_circq_bytes_used( store->circq )>lo ) {
+        if( FD_UNLIKELY( !GUI_STORE_(cache_pop_oldest)( store, FD_CIRCQ_EVICT_BATCH_MAX ) ) ) break;
+      }
+    }
+  }
+
+  {
+    ulong ele_max = store->ele_max;
+    ulong hi      = (ele_max*GUI_STORE_IDX_LOAD_FACTOR)/100UL;
+    ulong drain   = (ele_max*GUI_STORE_IDX_EVICT_PCT  )/100UL;
+    ulong lo      = hi>drain ? hi-drain : 0UL;
+    if( FD_UNLIKELY( store->live_cnt>=hi ) ) {
+      while( store->live_cnt>lo && store->fcnt ) {
+        GUI_STORE_(disk_drop_oldest_record)( store );
+      }
+      if( FD_LIKELY( store->live_cnt>lo ) ) {
+        int saved = store->drop_cache_evictions;
+        store->drop_cache_evictions = 1;
+        while( store->live_cnt>lo ) {
+          ulong want = store->live_cnt - lo;
+          if( FD_UNLIKELY( !GUI_STORE_(cache_pop_oldest)( store, want ) ) ) break; /* cache empty */
+        }
+        store->drop_cache_evictions = saved;
+      }
+    }
+  }
+}
+
+/* GUI_STORE_(verify) checks every store invariant and returns 0 if all
+   of them hold, or -1 (after logging the first failing invariant) if any
+   does not.  It is a read-only consistency check meant to be called while
+   the store is quiescent (between top-level public API calls).  It does
+   not mutate store state; it does walk the circq iteration cursor (which
+   is scratch shared with the eviction drains) and resets it on return. */
+GUI_STORE_STATIC int
+GUI_STORE_(verify)( GUI_STORE_(t) * store ) {
+
+# define VERIFY_TEST(c) do { if( FD_UNLIKELY( !(c) ) ) { FD_LOG_WARNING(( "FAIL: %s", #c )); return -1; } } while(0)
+
+  VERIFY_TEST( store );
+
+  /* Static layout invariants */
+
+  VERIFY_TEST( (GUI_STORE_SUPERBLOCK_SZ % 8UL)==0UL                  );
+  VERIFY_TEST( GUI_STORE_SUPERBLOCK_SZ >= 7UL*sizeof(ulong)          );
+  VERIFY_TEST( (sizeof(GUI_STORE_(rechdr_t)) % 8UL)==0UL             );
+
+  /* Map structural integrity (unique keys -> unique slots, bounded
+     probe length).  Do this first so subsequent map_query lookups are
+     trustworthy. */
+
+  VERIFY_TEST( !GUI_STORE_(map_verify)( store->map ) );
+
+  GUI_STORE_(ele_t) const * eles    = GUI_STORE_(map_ele0)( store->map );
+  ulong                     ele_max = GUI_STORE_(map_ele_max)( store->map );
+
+  /* Struct scalars */
+
+  VERIFY_TEST( fd_ulong_is_pow2( store->ele_max )                );
+  VERIFY_TEST( ele_max==store->ele_max                           );
+  VERIFY_TEST( store->cache_sz > 0UL                             );
+  VERIFY_TEST( (store->file_len==0UL)==(store->fd<0)             );
+  VERIFY_TEST( store->file_len!=0UL || store->file_base_off==0UL );
+  VERIFY_TEST( store->fcnt!=0UL || store->fbytes==0UL            );
+  if( store->file_len ) VERIFY_TEST( store->file_len >= GUI_STORE_(file_len_min)( store->cache_sz ) );
+
+  ulong data_sz = store->file_len ? store->file_len - GUI_STORE_SUPERBLOCK_SZ : 0UL;
+
+  /* Map / element scan.  Count the live elements (and, of those, the
+     ones that are MEM-tier) so the cache walk and live_cnt can be
+     cross-checked below. */
+
+  ulong live     = 0UL; /* # live (free==0) elements                      */
+  ulong mem_live = 0UL; /* # live elements whose value lives in the cache */
+
+  for( ulong i=0UL; i<ele_max; i++ ) {
+    GUI_STORE_(ele_t) const * e = &eles[ i ];
+    if( e->free ) continue;
+    live++;
+
+    VERIFY_TEST( e->tier==GUI_STORE_TIER_MEM || e->tier==GUI_STORE_TIER_FILE );
+    VERIFY_TEST( e->align!=0 && fd_ulong_is_pow2( (ulong)e->align ) );
+
+    /* The whole message (header + alignment pad + value) must fit in
+       the cache, since any FILE element can be warmed back in. */
+    VERIFY_TEST( fd_ulong_align_up( sizeof(GUI_STORE_(msghdr_t)), (ulong)e->align ) + e->sz <= store->cache_sz );
+
+    if( e->tier==GUI_STORE_TIER_MEM ) {
+      VERIFY_TEST( e->mem!=NULL          );
+      VERIFY_TEST( e->seq < store->msg_seq );
+      mem_live++;
+    } else { /* GUI_STORE_TIER_FILE */
+      VERIFY_TEST( e->has_disk==1U       );
+      VERIFY_TEST( store->file_len!=0UL  );
+      VERIFY_TEST( e->off < data_sz      );
+      VERIFY_TEST( (e->off % 8UL)==0UL   );
+    }
+
+    /* a FILE element is never dirty (its disk copy is authoritative) */
+    VERIFY_TEST( !( e->tier==GUI_STORE_TIER_FILE && e->dirty ) );
+
+    /* a MEM that is clean must have an disk allocation */
+    VERIFY_TEST( !( e->tier==GUI_STORE_TIER_MEM && !e->dirty && !e->has_disk ) );
+
+    /* The element must be the one the map resolves its own key to. */
+    VERIFY_TEST( GUI_STORE_(map_query)( store->map, &e->key )==&eles[ i ] );
+
+    /* In a mem-only store nothing can ever be on disk. */
+    if( !store->file_len ) {
+      VERIFY_TEST( e->tier==GUI_STORE_TIER_MEM );
+      VERIFY_TEST( e->has_disk==0U             );
+    }
+  }
+
+  VERIFY_TEST( store->live_cnt==live          );
+  VERIFY_TEST( store->live_cnt<=store->ele_max );
+
+  if( !store->file_len ) {
+    VERIFY_TEST( store->fcnt==0UL   );
+    VERIFY_TEST( store->fbytes==0UL );
+    VERIFY_TEST( store->fhead==0UL  );
+    VERIFY_TEST( store->ftail==0UL  );
+  }
+
+  /* Cache walk.  Every cache message carries a copy of the msg header.
+     A message is not stale iff its key resolves to a live cache
+     element whose seq matches and whose mem pointer points at this
+     message's value bytes. */
+
+  VERIFY_TEST( fd_circq_bytes_used( store->circq )<=store->cache_sz );
+
+  ulong auth = 0UL; /* # authoritative messages */
+
+  fd_circq_reset_cursor( store->circq );
+  for(;;) {
+    ulong         msg_sz  = 0UL;
+    uchar const * payload = fd_circq_cursor_advance( store->circq, &msg_sz );
+    if( !payload ) break;
+    (void)msg_sz;
+
+    GUI_STORE_(msghdr_t) mhdr;
+    fd_memcpy( &mhdr, payload, sizeof(mhdr) );
+
+    if( FD_UNLIKELY( !(mhdr.seq < store->msg_seq) ) ) {
+      FD_LOG_WARNING(( "FAIL: cache message seq %lu >= msg_seq %lu", mhdr.seq, store->msg_seq ));
+      fd_circq_reset_cursor( store->circq );
+      return -1;
+    }
+
+    GUI_STORE_(ele_t) const * e = GUI_STORE_(map_query)( store->map, &mhdr.key );
+    if( !e ) continue; /* orphan of an evicted key */
+
+    int authoritative = ( e->tier==GUI_STORE_TIER_MEM ) &&
+                        ( e->seq==mhdr.seq            ) &&
+                        ( e->mem==payload + fd_ulong_align_up( sizeof(GUI_STORE_(msghdr_t)), (ulong)e->align ) );
+    if( authoritative ) auth++;
+  }
+  fd_circq_reset_cursor( store->circq );
+
+  VERIFY_TEST( auth==mem_live );
+
+  if( store->file_len ) {
+
+    VERIFY_TEST( store->fhead < data_sz );
+    VERIFY_TEST( store->ftail < data_sz );
+    VERIFY_TEST( store->fbytes <= data_sz );
+
+    /* The upper segment ends at fdata_end; bytes in [fdata_end,data_sz)
+       are an abandoned tail gap left by a wrap. */
+    VERIFY_TEST( store->fdata_end<=data_sz );
+    VERIFY_TEST( store->fdata_end>=store->ftail );
+
+    /* Validate on-disk footprint/align fields, walking head->tail and
+       wrapping at fdata_end (not data_sz) so the walk skips the gap. */
+    ulong off = store->fhead;
+    ulong sum = 0UL;
+    for( ulong r=0UL; r<store->fcnt; r++ ) {
+      GUI_STORE_(rechdr_t) hdr;
+      ulong hdr_off = store->file_base_off + GUI_STORE_SUPERBLOCK_SZ + off;
+      if( FD_UNLIKELY( GUI_STORE_(pread_all)( store->fd, &hdr, sizeof(hdr), hdr_off ) ) ) {
+        FD_LOG_WARNING(( "FAIL: disk ring header read at off %lu", off ));
+        return -1;
+      }
+
+      ulong rec_fp = fd_ulong_align_up( sizeof(GUI_STORE_(rechdr_t)) + hdr.sz, 8UL );
+      VERIFY_TEST( (rec_fp % 8UL)==0UL                       );
+      VERIFY_TEST( rec_fp >= sizeof(GUI_STORE_(rechdr_t))    );
+
+      sum += rec_fp;
+      off += rec_fp;
+      if( FD_UNLIKELY( off>=store->fdata_end ) ) off = 0UL;
+    }
+    VERIFY_TEST( sum==store->fbytes );
+    VERIFY_TEST( off==store->ftail  );
+
+    /* On-disk offsets/flags match cache */
+    for( ulong i=0UL; i<ele_max; i++ ) {
+      GUI_STORE_(ele_t) const * e = &eles[ i ];
+      if( e->free || !e->has_disk ) continue;
+
+      for( ulong j=i+1UL; j<ele_max; j++ ) {
+        GUI_STORE_(ele_t) const * o = &eles[ j ];
+        if( o->free || !o->has_disk ) continue;
+        VERIFY_TEST( o->off!=e->off );
+      }
+
+      GUI_STORE_(rechdr_t) hdr;
+      ulong hdr_off = store->file_base_off + GUI_STORE_SUPERBLOCK_SZ + e->off;
+      if( FD_UNLIKELY( GUI_STORE_(pread_all)( store->fd, &hdr, sizeof(hdr), hdr_off ) ) ) {
+        FD_LOG_WARNING(( "FAIL: disk record header read at off %lu", e->off ));
+        return -1;
+      }
+      VERIFY_TEST( GUI_STORE_KEY_EQ( &hdr.key, &e->key ) );
+      VERIFY_TEST( hdr.sz==e->sz                         );
+      VERIFY_TEST( hdr.align==(ulong)e->align            );
+    }
+
+    /* Superblock.  Validate the self-describing fields and the checksum. */
+    ulong sb[ GUI_STORE_SUPERBLOCK_SZ / sizeof(ulong) ];
+    if( FD_UNLIKELY( GUI_STORE_(pread_all)( store->fd, sb, sizeof(sb), store->file_base_off ) ) ) {
+      FD_LOG_WARNING(( "FAIL: superblock read" ));
+      return -1;
+    }
+    VERIFY_TEST( sb[ 0 ]==GUI_STORE_MAGIC   );
+    VERIFY_TEST( sb[ 1 ]==GUI_STORE_VERSION );
+    VERIFY_TEST( sb[ 6 ]==( sb[ 0 ] ^ sb[ 1 ] ^ sb[ 2 ] ^ sb[ 3 ] ^ sb[ 4 ] ^ sb[ 5 ] ) );
+  }
+
+# undef VERIFY_TEST
+
+  return 0;
+}
+
+#undef GUI_STORE_NAME
+#undef GUI_STORE_KEY_T
+#undef GUI_STORE_KEY_HASH
+#undef GUI_STORE_KEY_EQ
+#undef GUI_STORE_IMPL_STYLE
+#undef GUI_STORE_STATIC
+#undef GUI_STORE_TIER_MEM
+#undef GUI_STORE_TIER_FILE
+#undef GUI_STORE_MAGIC
+#undef GUI_STORE_VERSION
+#undef GUI_STORE_SUPERBLOCK_SZ
+#undef GUI_STORE_RESERVE_FAIL
+#undef GUI_STORE_IDX_LOAD_FACTOR
+#undef GUI_STORE_IDX_EVICT_PCT
+#undef GUI_STORE_CACHE_LOAD_FACTOR
+#undef GUI_STORE_CACHE_EVICT_PCT
+#undef GUI_STORE_DISK_LOAD_FACTOR
+#undef GUI_STORE_DISK_EVICT_PCT
+#undef GUI_STORE_MAX_WRITEBACK_IOV
+#undef GUI_STORE_

--- a/src/disco/gui/fuzz_gui_store.c
+++ b/src/disco/gui/fuzz_gui_store.c
@@ -1,0 +1,273 @@
+#define _GNU_SOURCE   /* pwritev (see fd_gui_store_tmpl.c) */
+
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h> /* memfd_create        */
+#include <unistd.h>   /* ftruncate / close   */
+
+#include "../fd_disco.h"
+#include "../../util/sanitize/fd_fuzz.h"
+
+/* Instantiate the keyed store with the (slot, block_id) composite key
+   from the template's header docs, exactly as test_gui_store.c does. */
+
+struct myrec_key {
+  ulong slot;
+  ulong block_id;
+};
+typedef struct myrec_key myrec_key_t;
+
+#define GUI_STORE_NAME             myrec_store
+#define GUI_STORE_KEY_T            myrec_key_t
+#define GUI_STORE_KEY_HASH(k,seed) fd_ulong_hash( (k)->slot ^ \
+                                     fd_ulong_rotate_left( (k)->block_id, 32 ) ^ (seed) )
+#define GUI_STORE_KEY_EQ(k0,k1)    ( ((k0)->slot==(k1)->slot) & \
+                                     ((k0)->block_id==(k1)->block_id) )
+#include "fd_gui_store_tmpl.c"
+
+/* Bounded key space so collisions, dup-insert rejection and key reuse
+   after eviction all occur frequently.  KEY_CNT keys total. */
+
+#define KEY_SLOTS  (4UL)
+#define KEY_BLOCKS (8UL)
+#define KEY_CNT    (KEY_SLOTS*KEY_BLOCKS)
+
+#define MAX_OPS     (4096UL)
+#define MAX_CACHE   (8192UL)
+
+static uchar shmem[ 1UL<<20 ] __attribute__((aligned(4096UL)));
+
+/* Byte-stream reader.  When the fuzz input is exhausted, fall back to a
+   seeded LCG so short inputs still drive long op sequences. */
+
+typedef struct {
+  uchar const * data;
+  ulong         data_sz;
+  ulong         off;
+  ulong         salt;
+} reader_t;
+
+static uchar
+read_uchar( reader_t * r ) {
+  if( FD_LIKELY( r->off<r->data_sz ) ) return r->data[ r->off++ ];
+  r->salt = 6364136223846793005UL*r->salt + 1442695040888963407UL;
+  return (uchar)( r->salt >> 56 );
+}
+
+static ulong
+read_range( reader_t * r, ulong max ) {
+  if( FD_UNLIKELY( !max ) ) return 0UL;
+  return (ulong)read_uchar( r ) % max;
+}
+
+/* Reference model: per key, what we believe is stored and its value
+   pattern id.  The value bytes are deterministic given (key, pat, sz). */
+
+typedef struct {
+  int   present;
+  ulong sz;
+  ulong align;
+  uchar pat;
+} model_t;
+
+static void
+key_of( myrec_key_t * k, ulong idx ) {
+  k->slot     = idx / KEY_BLOCKS;
+  k->block_id = idx % KEY_BLOCKS;
+}
+
+static void
+fill( uchar * buf, myrec_key_t const * key, ulong sz, uchar pat ) {
+  for( ulong i=0UL; i<sz; i++ ) {
+    buf[ i ] = (uchar)( key->slot*31UL + key->block_id*7UL + i + pat*131UL );
+  }
+}
+
+static int
+check( uchar const * buf, myrec_key_t const * key, ulong sz, uchar pat ) {
+  for( ulong i=0UL; i<sz; i++ ) {
+    if( buf[ i ]!=(uchar)( key->slot*31UL + key->block_id*7UL + i + pat*131UL ) ) return 0;
+  }
+  return 1;
+}
+
+static int
+tmpfile_fd( ulong len ) {
+  int fd = memfd_create( "fuzz_gui_store", 0U );
+  FD_TEST( fd>=0 );
+  FD_TEST( !ftruncate( fd, (long)len ) );
+  return fd;
+}
+
+/* footprint-with-header of a value: this is what must fit in cache_sz
+   for an append to be guaranteed to succeed. */
+
+static ulong
+msg_fp( ulong align, ulong footprint ) {
+  return fd_ulong_align_up( sizeof(myrec_store_msghdr_t), align ) + footprint;
+}
+
+static void
+run_case( uchar const * data, ulong size ) {
+  reader_t r[1] = {{ .data=data, .data_sz=size, .off=0UL, .salt=0x243f6a8885a308d3UL }};
+
+  ulong const aligns[] = { 1UL,2UL,4UL,8UL,16UL,32UL,64UL };
+
+  ulong ele_max  = 1UL << ( 1UL + read_range( r, 5UL ) );    /* {2,4,8,16,32} */
+  ulong cache_sz = 512UL + read_range( r, MAX_CACHE-512UL ); /* [512, 8192)   */
+  ulong seed     = (ulong)read_uchar( r );
+  int   file_bk  = (int)read_range( r, 2UL );
+
+  if( FD_UNLIKELY( myrec_store_footprint( ele_max, cache_sz, 0UL )>sizeof(shmem) ) ) return;
+
+  int   fd       = -1;
+  ulong file_len = 0UL;
+  if( file_bk ) {
+    /* file_len in [min, min + cache_sz*8): enough to force disk FIFO
+       eviction during a long run. */
+    ulong fmin = myrec_store_file_len_min( cache_sz );
+    file_len   = fmin + read_range( r, cache_sz*8UL );
+    file_len   = fd_ulong_align_up( file_len, 8UL );
+    if( FD_UNLIKELY( myrec_store_footprint( ele_max, cache_sz, file_len )==0UL ) ) return;
+    fd = tmpfile_fd( file_len );
+  }
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, cache_sz, seed, 0UL, file_len ), fd );
+  FD_TEST( store );
+  FD_TEST( !myrec_store_verify( store ) );
+
+  model_t model[ KEY_CNT ];
+  memset( model, 0, sizeof(model) );
+
+  ulong nops = read_range( r, MAX_OPS )+1UL;
+  for( ulong op=0UL; op<nops; op++ ) {
+    ulong       which = read_range( r, 16UL );
+    ulong       kidx  = read_range( r, KEY_CNT );
+    myrec_key_t key; key_of( &key, kidx );
+
+    if( which<7UL ) { /* APPEND */
+      ulong align = aligns[ read_range( r, sizeof(aligns)/sizeof(aligns[0]) ) ];
+
+      /* Bias footprint toward boundaries of cache_sz. */
+      ulong footprint;
+      switch( read_range( r, 8UL ) ) {
+        case 0:  footprint = 0UL;                             break;
+        case 1:  footprint = 1UL;                             break;
+        case 2:  footprint = 8UL;                             break;
+        case 3:  footprint = cache_sz;                        break; /* exact -> reject */
+        case 4:  footprint = cache_sz+read_range(r,256UL);    break; /* oversize -> reject */
+        default: footprint = read_range( r, cache_sz );       break;
+      }
+
+      /* Confirm the store's view of the key before appending so a NULL
+         result can be attributed: the model's present flag is optimistic
+         (a key may have been silently evicted), but get_ro is ground
+         truth. */
+      int really_present = !!myrec_store_get_ro( store, &key, NULL );
+      model[ kidx ].present = really_present;
+
+      uchar * v = myrec_store_append( store, &key, align, footprint );
+
+      if( v ) {
+        /* Success implies the key was absent and the value fit. */
+        FD_TEST( !really_present );
+        FD_TEST( msg_fp( align, footprint )<=cache_sz );
+        uchar pat = (uchar)read_uchar( r );
+        fill( v, &key, footprint, pat );
+        model[ kidx ] = (model_t){ .present=1, .sz=footprint, .align=align, .pat=pat };
+      } else {
+        /* A NULL append is legal for three reasons: the key is already
+           present (dup), the value cannot fit the cache, or the bounded
+           index could not seat the key even after evicting its oldest. */
+        if( really_present ) {
+          /* dup: the existing entry must be untouched */
+          FD_TEST( myrec_store_get_ro( store, &key, NULL ) );
+        } else {
+          /* a failed insert never leaves a partial entry */
+          FD_TEST( !myrec_store_get_ro( store, &key, NULL ) );
+          model[ kidx ].present = 0;
+        }
+      }
+
+    } else if( which<11UL ) { /* GET_RO */
+      ulong         sz = ~0UL;
+      uchar const * g  = myrec_store_get_ro( store, &key, &sz );
+      if( g ) {
+        FD_TEST( model[ kidx ].present );
+        FD_TEST( sz==model[ kidx ].sz );
+        FD_TEST( check( g, &key, sz, model[ kidx ].pat ) );
+      } else {
+        /* NULL is only legal if the key was evicted; downgrade model. */
+        model[ kidx ].present = 0;
+      }
+
+    } else if( which<14UL ) { /* GET_MUT (+ optional rewrite) */
+      ulong   sz = ~0UL;
+      uchar * g  = myrec_store_get_mut( store, &key, &sz );
+      if( g ) {
+        FD_TEST( model[ kidx ].present );
+        FD_TEST( sz==model[ kidx ].sz );
+        FD_TEST( check( g, &key, sz, model[ kidx ].pat ) );
+        if( read_range( r, 2UL ) ) { /* rewrite in place; must persist */
+          uchar pat = (uchar)read_uchar( r );
+          fill( g, &key, sz, pat );
+          model[ kidx ].pat = pat;
+        }
+      } else {
+        model[ kidx ].present = 0;
+      }
+
+    } else { /* PRE_EVICT */
+      myrec_store_pre_evict( store );
+    }
+
+    FD_TEST( !myrec_store_verify( store ) );
+    FD_TEST( store->live_cnt<=store->ele_max );
+    FD_TEST( fd_circq_bytes_used( store->circq )<=store->cache_sz );
+  }
+
+  /* Final pass: every key the model still believes is present must read
+     back with the correct size and bytes (eviction only ever produces
+     NULL, never corruption or resurrection of stale data). */
+  for( ulong kidx=0UL; kidx<KEY_CNT; kidx++ ) {
+    myrec_key_t key; key_of( &key, kidx );
+    ulong         sz = ~0UL;
+    uchar const * g  = myrec_store_get_ro( store, &key, &sz );
+    if( g ) {
+      FD_TEST( model[ kidx ].present );
+      FD_TEST( sz==model[ kidx ].sz );
+      FD_TEST( check( g, &key, sz, model[ kidx ].pat ) );
+    }
+  }
+
+  FD_TEST( !myrec_store_verify( store ) );
+  FD_TEST( myrec_store_leave( store )==(void *)store );
+  FD_TEST( myrec_store_delete( shmem )==shmem );
+  if( fd>=0 ) FD_TEST( !close( fd ) );
+}
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
+  fd_boot( argc, argv );
+  /* Keep FD_LOG_WARNING (used for expected rejections in the template)
+     non-fatal; FD_LOG_ERR (genuine internal impossibilities) still
+     aborts. */
+  fd_log_level_core_set( 3 );
+  atexit( fd_halt );
+  return 0;
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         size ) {
+  run_case( data, size );
+  return 0;
+}

--- a/src/disco/gui/test_gui_store.c
+++ b/src/disco/gui/test_gui_store.c
@@ -1,0 +1,1071 @@
+#define _GNU_SOURCE   /* pwritev (see fd_gui_store_tmpl.c) */
+
+#include "../fd_disco.h"
+
+#include <sys/mman.h> /* memfd_create                             */
+#include <unistd.h>   /* ftruncate / close                        */
+
+struct myrec_key {
+  ulong slot;
+  ulong block_id;
+};
+typedef struct myrec_key myrec_key_t;
+
+#define GUI_STORE_NAME             myrec_store
+#define GUI_STORE_KEY_T            myrec_key_t
+#define GUI_STORE_KEY_HASH(k,seed) fd_ulong_hash( (k)->slot ^ \
+                                     fd_ulong_rotate_left( (k)->block_id, 32 ) ^ (seed) )
+#define GUI_STORE_KEY_EQ(k0,k1)    ( ((k0)->slot==(k1)->slot) & \
+                                     ((k0)->block_id==(k1)->block_id) )
+#include "fd_gui_store_tmpl.c"
+
+#define TEST_IDX_LOAD_FACTOR   (50UL)
+#define TEST_IDX_EVICT_PCT     (20UL)
+#define TEST_DISK_LOAD_FACTOR  (95UL)
+#define TEST_DISK_EVICT_PCT    (5UL)
+
+/* TEST_ELE_MAX is sized generously so the index never becomes the
+   binding constraint in the tier/eviction-mechanics tests below (max ~64
+   distinct keys << 256).  Index slow-path (minimum-fit) eviction and
+   watermark pre-eviction are exercised by their own dedicated tests,
+   which size ele_max small. */
+#define TEST_ELE_MAX  (256UL)
+#define TEST_CIRCQ_SZ (4096UL)
+
+#if FD_TMPL_USE_HANDHOLDING
+#define VERIFY( store ) FD_TEST( !myrec_store_verify( (store) ) )
+#else
+#define VERIFY( store ) do { (void)(store); } while(0)
+#endif
+
+static uchar shmem [ 1UL<<20 ] __attribute__((aligned(4096UL)));
+static uchar shmem2[ 1UL<<20 ] __attribute__((aligned(4096UL)));
+
+/* fill/check writes/validates a hash derived from key+sz in buf */
+static void
+fill( uchar *             buf,
+      myrec_key_t const * key,
+      ulong               sz ) {
+  for( ulong i=0UL; i<sz; i++ ) {
+    buf[ i ] = (uchar)fd_ulong_hash( key->slot ^ fd_ulong_rotate_left( key->block_id, 32 ) ^ i );
+  }
+}
+
+static int
+check( uchar const *       buf,
+       myrec_key_t const * key,
+       ulong               sz ) {
+  for( ulong i=0UL; i<sz; i++ ) {
+    if( buf[ i ]!=(uchar)fd_ulong_hash( key->slot ^ fd_ulong_rotate_left( key->block_id, 32 ) ^ i ) ) return 0;
+  }
+  return 1;
+}
+
+/* tmpfile_fd creates an anonymous in-memory file. */
+static int
+tmpfile_fd( ulong len ) {
+  int fd = memfd_create( "test_gui_store", 0U );
+  FD_TEST( fd>=0 );
+  FD_TEST( !ftruncate( fd, (long)len ) );
+  return fd;
+}
+
+static void
+test_lifecycle( void ) {
+  ulong align     = myrec_store_align();
+  ulong footprint = myrec_store_footprint( TEST_ELE_MAX, TEST_CIRCQ_SZ, 0UL );
+
+  FD_TEST( align>0UL );
+  FD_TEST( fd_ulong_is_pow2( align ) );
+  FD_TEST( footprint>0UL );
+  FD_TEST( fd_ulong_is_aligned( footprint, align ) );
+  FD_TEST( footprint<=sizeof(shmem) );
+
+  void * shstore = myrec_store_new( shmem, TEST_ELE_MAX, TEST_CIRCQ_SZ, 1234UL, 0UL, 0UL );
+  FD_TEST( shstore==shmem );
+
+  myrec_store_t * store = myrec_store_join( shstore, -1 );
+  FD_TEST( store );
+
+  VERIFY( store ); /* a freshly joined store is consistent */
+
+  FD_TEST( myrec_store_leave( store )==(void *)store );
+  FD_TEST( myrec_store_delete( shstore )==shstore );
+}
+
+static void
+test_append_get_ro( void ) {
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, TEST_CIRCQ_SZ, 7UL, 0UL, 0UL ), -1 );
+
+  myrec_key_t keys[] = {
+    { .slot = 10UL, .block_id = 0UL },
+    { .slot = 11UL, .block_id = 1UL },
+    { .slot = 12UL, .block_id = 2UL },
+  };
+  ulong szs[] = { 1UL, 17UL, 64UL };
+
+  for( ulong i=0UL; i<3UL; i++ ) {
+    uchar * v = myrec_store_append( store, &keys[ i ], 8UL, szs[ i ] );
+    FD_TEST( v );
+    fill( v, &keys[ i ], szs[ i ] );
+  }
+
+  VERIFY( store );
+
+  for( ulong i=0UL; i<3UL; i++ ) {
+    ulong out_sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &keys[ i ], &out_sz );
+    FD_TEST( v );
+    FD_TEST( out_sz==szs[ i ] );
+    FD_TEST( check( v, &keys[ i ], szs[ i ] ) );
+  }
+
+  /* A key never appended is absent. */
+  myrec_key_t absent = { .slot = 99UL, .block_id = 99UL };
+  FD_TEST( !myrec_store_get_ro( store, &absent, NULL ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_duplicate_key( void ) {
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, TEST_CIRCQ_SZ, 2UL, 0UL, 0UL ), -1 );
+
+  myrec_key_t key = { .slot = 5UL, .block_id = 6UL };
+
+  uchar * v = myrec_store_append( store, &key, 8UL, 32UL );
+  FD_TEST( v );
+  fill( v, &key, 32UL );
+
+  /* Duplicate append rejected. */
+  FD_TEST( !myrec_store_append( store, &key, 8UL, 8UL ) );
+
+  VERIFY( store ); /* the rejected append must not corrupt the store */
+
+  /* Original still retrievable and unchanged. */
+  ulong out_sz = 0UL;
+  uchar const * got = myrec_store_get_ro( store, &key, &out_sz );
+  FD_TEST( got );
+  FD_TEST( out_sz==32UL );
+  FD_TEST( check( got, &key, 32UL ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_get_mut( void ) {
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, TEST_CIRCQ_SZ, 8UL, 0UL, 0UL ), -1 );
+
+  myrec_key_t key = { .slot = 13UL, .block_id = 14UL };
+
+  uchar * v = myrec_store_append( store, &key, 8UL, 32UL );
+  FD_TEST( v );
+  fill( v, &key, 32UL );
+
+  /* Initially retrievable with the appended bytes. */
+  ulong sz = 0UL;
+  uchar const * ro = myrec_store_get_ro( store, &key, &sz );
+  FD_TEST( ro && sz==32UL && check( ro, &key, 32UL ) );
+
+  /* Edit in place through get_mut using a different key's pattern so the
+     change is unambiguous. */
+  myrec_key_t alt = { .slot = 77UL, .block_id = 88UL };
+  ulong msz = 0UL;
+  uchar * mut = myrec_store_get_mut( store, &key, &msz );
+  FD_TEST( mut && msz==32UL );
+  fill( mut, &alt, 32UL );
+
+  VERIFY( store ); /* an in-place edit leaves the store consistent */
+
+  /* The new bytes are visible via get_ro. */
+  ulong rsz = 0UL;
+  uchar const * ro2 = myrec_store_get_ro( store, &key, &rsz );
+  FD_TEST( ro2 && rsz==32UL );
+  FD_TEST( check( ro2, &alt, 32UL ) );          /* new pattern present  */
+  FD_TEST( !check( ro2, &key, 32UL ) );         /* old pattern gone     */
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_tiny_cache( void ) {
+  /* Small circq so a handful of fixed-size values exceeds capacity. */
+  ulong circq_sz = 1024UL;
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 5UL, 0UL, 0UL ), -1 );
+
+  ulong const N      = 64UL;
+  ulong const val_sz = 96UL; /* header (16) + pad + value (96) + circq meta */
+
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 0UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+
+    VERIFY( store ); /* invariants hold through every eviction step */
+
+    ulong live = store->circq->cnt;
+    ulong seen = 0UL;
+    for( ulong j=0UL; j<=i; j++ ) {
+      myrec_key_t k = { .slot = 0UL, .block_id = j };
+      if( myrec_store_get_ro( store, &k, NULL ) ) seen++;
+    }
+    FD_TEST( seen==live );
+
+    for( ulong j=0UL; j<=i; j++ ) {
+      myrec_key_t k  = { .slot = 0UL, .block_id = j };
+      ulong       sz = 0UL;
+      uchar const * g = myrec_store_get_ro( store, &k, &sz );
+      if( j+live > i ) { /* j in the newest `live` window */
+        FD_TEST( g && sz==val_sz && check( g, &k, val_sz ) );
+      } else {           /* evicted */
+        FD_TEST( !g );
+      }
+    }
+  }
+
+  /* Eviction must have happened (otherwise the test proves nothing). */
+  FD_TEST( store->circq->cnt<N );
+
+  ulong live = store->circq->cnt;
+  for( ulong i=0UL; i<N-live; i++ ) {
+    myrec_key_t key = { .slot = 0UL, .block_id = i };
+    FD_TEST( !myrec_store_get_ro( store, &key, NULL ) );
+  }
+
+  ulong seen = 0UL;
+  for( ulong i=N-live; i<N; i++ ) {
+    myrec_key_t key = { .slot = 0UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    FD_TEST( v );
+    FD_TEST( sz==val_sz );
+    FD_TEST( check( v, &key, val_sz ) );
+    seen++;
+  }
+  FD_TEST( seen==live );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_oversized_append( void ) {
+  ulong circq_sz = 1024UL;
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 6UL, 0UL, 0UL ), -1 );
+
+  /* A value clearly larger than the whole circq can never fit. */
+  myrec_key_t big = { .slot = 7UL, .block_id = 0UL };
+  FD_TEST( !myrec_store_append( store, &big, 8UL, circq_sz*2UL ) );
+
+  /* The rejected append must not have inserted an index slot. */
+  FD_TEST( !myrec_store_get_ro( store, &big, NULL ) );
+
+  VERIFY( store ); /* the rejected oversize append left no debris */
+
+  /* Store remains usable: a reasonable value still appends and reads. */
+  myrec_key_t ok = { .slot = 7UL, .block_id = 1UL };
+  uchar * v = myrec_store_append( store, &ok, 8UL, 64UL );
+  FD_TEST( v );
+  fill( v, &ok, 64UL );
+
+  ulong sz = 0UL;
+  uchar const * got = myrec_store_get_ro( store, &ok, &sz );
+  FD_TEST( got );
+  FD_TEST( sz==64UL );
+  FD_TEST( check( got, &ok, 64UL ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_write_back_on_eviction( void ) {
+  ulong circq_sz = 1024UL;
+  ulong file_len = 1UL<<16; /* ample disk ring (no true eviction) */
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 11UL, 0UL, file_len ), fd );
+
+  ulong const N      = 40UL;
+  ulong const val_sz = 96UL;
+
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 1UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+  }
+
+  /* The circq cannot hold all N values, so some were evicted to disk. */
+  FD_TEST( store->circq->cnt<N );
+
+  VERIFY( store ); /* index/cache/disk-ring/superblock all consistent */
+
+  /* Every key remains retrievable with correct bytes (RAM hits and FILE
+     warms both serve correctly). */
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 1UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    FD_TEST( v );
+    FD_TEST( sz==val_sz );
+    FD_TEST( check( v, &key, val_sz ) );
+  }
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+/* test_warm_then_edit will evict a value to FILE, get_mut it (warms
+   + dirties), write new bytes, force eviction again (more appends),
+   get_ro it back, assert the EDITED bytes are returned. */
+
+static void
+test_warm_then_edit( void ) {
+  ulong circq_sz = 1024UL;
+  ulong file_len = 1UL<<16;
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 12UL, 0UL, file_len ), fd );
+
+  ulong const val_sz = 96UL;
+
+  myrec_key_t target = { .slot = 2UL, .block_id = 0UL };
+  uchar * v = myrec_store_append( store, &target, 8UL, val_sz );
+  FD_TEST( v );
+  fill( v, &target, val_sz );
+
+  /* Append more to evict target to FILE. */
+  for( ulong i=1UL; i<20UL; i++ ) {
+    myrec_key_t key = { .slot = 2UL, .block_id = i };
+    uchar * w = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( w );
+    fill( w, &key, val_sz );
+  }
+
+  /* get_mut target: warms it (clean) then marks dirty.  Edit it with a
+     distinct pattern. */
+  myrec_key_t alt = { .slot = 222UL, .block_id = 333UL };
+  ulong msz = 0UL;
+  uchar * mut = myrec_store_get_mut( store, &target, &msz );
+  FD_TEST( mut && msz==val_sz );
+  fill( mut, &alt, val_sz );
+
+  VERIFY( store ); /* warmed-then-dirtied element (MEM + existing disk copy) */
+
+  /* Force eviction again: the dirty edit must be written back. */
+  for( ulong i=20UL; i<40UL; i++ ) {
+    myrec_key_t key = { .slot = 2UL, .block_id = i };
+    uchar * w = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( w );
+    fill( w, &key, val_sz );
+  }
+
+  /* The edited bytes come back. */
+  ulong rsz = 0UL;
+  uchar const * ro = myrec_store_get_ro( store, &target, &rsz );
+  FD_TEST( ro && rsz==val_sz );
+  FD_TEST( check( ro, &alt, val_sz ) );  /* edited pattern present */
+  FD_TEST( !check( ro, &target, val_sz ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+/* test_clean_evict will get_ro a FILE value (warms clean), then force
+   eviction; get_ro again; assert original bytes still returned (clean
+   eviction did not corrupt value on disk). */
+
+static void
+test_clean_evict( void ) {
+  ulong circq_sz = 1024UL;
+  ulong file_len = 1UL<<16;
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 13UL, 0UL, file_len ), fd );
+
+  ulong const val_sz = 96UL;
+
+  myrec_key_t target = { .slot = 3UL, .block_id = 0UL };
+  uchar * v = myrec_store_append( store, &target, 8UL, val_sz );
+  FD_TEST( v );
+  fill( v, &target, val_sz );
+
+  /* Evict target to FILE. */
+  for( ulong i=1UL; i<20UL; i++ ) {
+    myrec_key_t key = { .slot = 3UL, .block_id = i };
+    uchar * w = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( w );
+    fill( w, &key, val_sz );
+  }
+
+  /* get_ro warms it CLEAN (no dirty). */
+  ulong sz = 0UL;
+  uchar const * ro = myrec_store_get_ro( store, &target, &sz );
+  FD_TEST( ro && sz==val_sz && check( ro, &target, val_sz ) );
+
+  VERIFY( store ); /* warmed-clean element (MEM, dirty==0, has_disk==1) */
+
+  /* Force eviction again: a CLEAN eviction must NOT rewrite; it demotes
+     to the existing disk record. */
+  for( ulong i=20UL; i<40UL; i++ ) {
+    myrec_key_t key = { .slot = 3UL, .block_id = i };
+    uchar * w = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( w );
+    fill( w, &key, val_sz );
+  }
+
+  /* Original bytes still come back. */
+  ulong rsz = 0UL;
+  uchar const * ro2 = myrec_store_get_ro( store, &target, &rsz );
+  FD_TEST( ro2 && rsz==val_sz && check( ro2, &target, val_sz ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+/* test_warm_cascade warms a FILE value triggering eviction/write-back
+   of other dirty RAM values; all involved keys should remain
+   retrievable with correct bytes. */
+
+static void
+test_warm_cascade( void ) {
+  ulong circq_sz = 1024UL;
+  ulong file_len = 1UL<<16;
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 14UL, 0UL, file_len ), fd );
+
+  ulong const N      = 50UL;
+  ulong const val_sz = 96UL;
+
+  /* Many dirty appends.  Some live in the circq, the rest on disk. */
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 4UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+  }
+
+  VERIFY( store );
+
+  /* Interleave warms of old (FILE) keys with the resident set so each
+     warm push_back evicts and writes back currently-dirty RAM entries.
+     Every key must remain correct throughout. */
+  for( ulong pass=0UL; pass<3UL; pass++ ) {
+    for( ulong i=0UL; i<N; i++ ) {
+      myrec_key_t key = { .slot = 4UL, .block_id = i };
+      ulong sz = 0UL;
+      uchar const * v = myrec_store_get_ro( store, &key, &sz );
+      FD_TEST( v );
+      FD_TEST( sz==val_sz );
+      FD_TEST( check( v, &key, val_sz ) );
+    }
+    VERIFY( store ); /* re-entrant warm/write-back cascades stay consistent */
+  }
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+static void
+test_disk_ring_drop( void ) {
+  ulong circq_sz = 1024UL;
+  ulong val_sz   = 96UL;
+
+  /* Disk ring sized to the precondition minimum (superblock + room for
+     one max record).  The internal superblock / record-header sizes are
+     private, so use a conservative upper bound here: the key is 16 bytes
+     so the record header is at most 64 bytes and the superblock is at
+     most 256 bytes.  This gives a small data region (>= circq_sz) that a
+     long run of distinct appends wraps over its own live records,
+     forcing true eviction. */
+  ulong file_len = 256UL + 64UL + fd_ulong_align_up( circq_sz, 8UL );
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, TEST_ELE_MAX, circq_sz, 15UL, 0UL, file_len ), fd );
+
+  ulong const N = 40UL;
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 5UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+  }
+
+  VERIFY( store ); /* ring wrapped + true-evicted oldest records */
+
+  /* Census: count how many of the N keys are still live, and verify the
+     ones that survive read back correctly.  Because the disk ring (plus
+     the circq) cannot hold all N, the oldest keys must have been truly
+     evicted (slot removed).  We scan newest-first so reads do not
+     themselves disturb the survivors via warm cascades before we have
+     observed them.
+
+     A surviving set must be a contiguous suffix: once a key reads NULL,
+     every older key must also be NULL (the disk ring evicts strictly
+     oldest-first). */
+  ulong live    = 0UL;
+  int   saw_gap = 0;
+  for( ulong ii=0UL; ii<N; ii++ ) {
+    ulong i = N-1UL-ii;
+    myrec_key_t key = { .slot = 5UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    if( v ) {
+      FD_TEST( !saw_gap ); /* survivors form a contiguous newest suffix */
+      FD_TEST( sz==val_sz && check( v, &key, val_sz ) );
+      live++;
+    } else {
+      saw_gap = 1;
+    }
+  }
+
+  /* True eviction happened (not all N retained) and the oldest is gone. */
+  FD_TEST( live<N );
+  FD_TEST( saw_gap );
+  {
+    myrec_key_t oldest = { .slot = 5UL, .block_id = 0UL };
+    FD_TEST( !myrec_store_get_ro( store, &oldest, NULL ) );
+  }
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+/* test_multi_store_one_file tests two file-enabled stores on disjoint
+   [base,len) regions of one fd; interleave appends / evictions; assert
+   isolation (each returns only its own correct values). */
+
+static void
+test_multi_store_one_file( void ) {
+  ulong circq_sz = 1024UL;
+  ulong val_sz   = 96UL;
+  ulong region   = 1UL<<16;
+  ulong file_len = region*2UL;
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * sa = myrec_store_join(
+      myrec_store_new( shmem,  TEST_ELE_MAX, circq_sz, 16UL, 0UL,    region ), fd );
+  myrec_store_t * sb = myrec_store_join(
+      myrec_store_new( shmem2, TEST_ELE_MAX, circq_sz, 17UL, region, region ), fd );
+
+  ulong const N = 40UL;
+
+  /* Store A uses slot 6, store B uses slot 7 (distinct key spaces). */
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t ka = { .slot = 6UL, .block_id = i };
+    myrec_key_t kb = { .slot = 7UL, .block_id = i };
+    uchar * a = myrec_store_append( sa, &ka, 8UL, val_sz ); FD_TEST( a ); fill( a, &ka, val_sz );
+    uchar * b = myrec_store_append( sb, &kb, 8UL, val_sz ); FD_TEST( b ); fill( b, &kb, val_sz );
+  }
+
+  VERIFY( sa );
+  VERIFY( sb ); /* store B lives at a non-zero file_base_off */
+
+  /* Each store serves only its own keys with correct bytes, and never
+     the other store's keys. */
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t ka = { .slot = 6UL, .block_id = i };
+    myrec_key_t kb = { .slot = 7UL, .block_id = i };
+
+    ulong sz = 0UL;
+    uchar const * a = myrec_store_get_ro( sa, &ka, &sz );
+    FD_TEST( a && sz==val_sz && check( a, &ka, val_sz ) );
+    /* Store A must not know store B's key. */
+    FD_TEST( !myrec_store_get_ro( sa, &kb, NULL ) );
+
+    sz = 0UL;
+    uchar const * b = myrec_store_get_ro( sb, &kb, &sz );
+    FD_TEST( b && sz==val_sz && check( b, &kb, val_sz ) );
+    FD_TEST( !myrec_store_get_ro( sb, &ka, NULL ) );
+  }
+
+  VERIFY( sa );
+  VERIFY( sb );
+
+  myrec_store_leave( sa );
+  myrec_store_leave( sb );
+  FD_TEST( !close( fd ) );
+}
+
+static void
+test_eviction_idx( void ) {
+  ulong ele_max  = 16UL;
+  ulong circq_sz = 64UL*1024UL;   /* ample: never the binding constraint */
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, circq_sz, 21UL, 0UL, 0UL ), -1 );
+
+  ulong const N      = 200UL;
+  ulong const val_sz = 24UL;
+
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 9UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );                        /* never wedges */
+    fill( v, &key, val_sz );
+    FD_TEST( store->live_cnt<=ele_max ); /* index capacity respected */
+    VERIFY( store );                     /* index slow-path drop is consistent */
+  }
+
+  /* Survivors form a contiguous newest suffix; older keys were dropped. */
+  ulong live    = 0UL;
+  int   saw_gap = 0;
+  for( ulong ii=0UL; ii<N; ii++ ) {
+    ulong i = N-1UL-ii;
+    myrec_key_t key = { .slot = 9UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    if( v ) {
+      FD_TEST( !saw_gap );
+      FD_TEST( sz==val_sz && check( v, &key, val_sz ) );
+      live++;
+    } else {
+      saw_gap = 1;
+    }
+  }
+
+  FD_TEST( live<=ele_max );
+  FD_TEST( live>=1UL );
+  FD_TEST( saw_gap );   /* oldest keys were truly evicted */
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_pre_evict_idx( void ) {
+  ulong ele_max  = 16UL;
+  ulong circq_sz = 64UL*1024UL;
+  ulong hi       = (ele_max*TEST_IDX_LOAD_FACTOR)/100UL;
+  ulong lo       = hi-(ele_max*TEST_IDX_EVICT_PCT)/100UL;
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, circq_sz, 24UL, 0UL, 0UL ), -1 );
+
+  ulong const val_sz = 24UL;
+  for( ulong i=0UL; i<ele_max; i++ ) {
+    myrec_key_t key = { .slot = 9UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+  }
+  FD_TEST( store->live_cnt==ele_max );
+
+  VERIFY( store ); /* index full */
+
+  myrec_store_pre_evict( store );
+
+  FD_TEST( store->live_cnt>=lo && store->live_cnt<=hi );
+
+  VERIFY( store ); /* index drained to its low watermark */
+
+  /* The newest lo keys must still be live and correct. */
+  for( ulong k=0UL; k<store->live_cnt; k++ ) {
+    ulong i = ele_max-1UL-k;
+    myrec_key_t key = { .slot = 9UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    FD_TEST( v && sz==val_sz && check( v, &key, val_sz ) );
+  }
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_pre_evict_disk( void ) {
+  ulong ele_max  = 256UL;        /* big: index never the binding constraint */
+  ulong circq_sz = 1024UL;       /* small: forces demotion to disk          */
+  ulong file_len = 1UL<<14;      /* modest disk ring so it fills             */
+  int   fd       = tmpfile_fd( file_len );
+
+  ulong data_sz = file_len - 64UL; /* SUPERBLOCK_SZ is private; 64 is exact  */
+  ulong hi      = (data_sz*TEST_DISK_LOAD_FACTOR)/100UL;
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, circq_sz, 25UL, 0UL, file_len ), fd );
+
+  ulong const N      = 120UL;
+  ulong const val_sz = 96UL;
+  for( ulong i=0UL; i<N; i++ ) {
+    myrec_key_t key = { .slot = 3UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );
+    fill( v, &key, val_sz );
+  }
+
+  VERIFY( store );
+
+  /* Drive cache->disk demotion so the disk ring is loaded, then drain. */
+  myrec_store_pre_evict( store );
+  FD_TEST( store->fbytes<=hi ); /* disk drained to/below its high watermark */
+
+  VERIFY( store ); /* disk ring drained to its low watermark */
+
+  /* Survivors (whatever remains) read back correctly and form a newest
+     suffix. */
+  int saw_gap = 0;
+  for( ulong ii=0UL; ii<N; ii++ ) {
+    ulong i = N-1UL-ii;
+    myrec_key_t key = { .slot = 3UL, .block_id = i };
+    ulong sz = 0UL;
+    uchar const * v = myrec_store_get_ro( store, &key, &sz );
+    if( v ) {
+      FD_TEST( !saw_gap );
+      FD_TEST( sz==val_sz && check( v, &key, val_sz ) );
+    } else {
+      saw_gap = 1;
+    }
+  }
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+static void
+test_tiny_idx( void ) {
+  ulong ele_max  = 1UL;
+  ulong circq_sz = 64UL*1024UL;
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, circq_sz, 23UL, 0UL, 0UL ), -1 );
+
+  ulong const val_sz = 8UL;
+  for( ulong i=0UL; i<32UL; i++ ) {
+    myrec_key_t key = { .slot = 1UL, .block_id = i };
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v );                        /* append must never wedge */
+    fill( v, &key, val_sz );
+    FD_TEST( store->live_cnt<=ele_max ); /* capacity respected */
+    VERIFY( store );                     /* capacity-1 evict-then-insert is consistent */
+  }
+
+  /* Only the newest key can be live in a capacity-1 store. */
+  myrec_key_t newest = { .slot = 1UL, .block_id = 31UL };
+  ulong sz = 0UL;
+  uchar const * v = myrec_store_get_ro( store, &newest, &sz );
+  FD_TEST( v && sz==val_sz && check( v, &newest, val_sz ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+static void
+test_disk_writeback_wrap( void ) {
+  ulong const val_szs[] = { 32UL, 96UL, 17UL, 200UL, 64UL, 9UL, 128UL, 48UL };
+  ulong const n_szs     = sizeof(val_szs)/sizeof(val_szs[0]);
+
+  /* ---- Case A: no wrap.  One big contiguous demotion run. ---- */
+  {
+    ulong circq_sz = 1024UL;     /* small: forces demotion to disk        */
+    ulong file_len = 1UL<<16;    /* ample: the demotion run never wraps   */
+    int   fd       = tmpfile_fd( file_len );
+
+    myrec_store_t * store = myrec_store_join(
+        myrec_store_new( shmem, 256UL, circq_sz, 31UL, 0UL, file_len ), fd );
+
+    ulong const N = 60UL;
+    for( ulong i=0UL; i<N; i++ ) {
+      ulong       sz  = val_szs[ i % n_szs ];
+      myrec_key_t key = { .slot = 6UL, .block_id = i };
+      uchar * v = myrec_store_append( store, &key, 8UL, sz );
+      FD_TEST( v );
+      fill( v, &key, sz );
+    }
+
+    VERIFY( store );
+
+    /* Demote the resident cache to disk in one shot. */
+    myrec_store_pre_evict( store );
+    FD_TEST( store->fcnt>1UL ); /* a real multi-record run was written back */
+
+    VERIFY( store ); /* coalesced multi-record write-back is consistent */
+
+    /* Every survivor reads back with its own (size-specific) bytes. */
+    int saw_gap = 0;
+    for( ulong ii=0UL; ii<N; ii++ ) {
+      ulong i  = N-1UL-ii;
+      ulong sz = val_szs[ i % n_szs ];
+      myrec_key_t key = { .slot = 6UL, .block_id = i };
+      ulong out_sz = 0UL;
+      uchar const * v = myrec_store_get_ro( store, &key, &out_sz );
+      if( v ) {
+        FD_TEST( !saw_gap );
+        FD_TEST( out_sz==sz && check( v, &key, sz ) );
+      } else {
+        saw_gap = 1;
+      }
+    }
+
+    VERIFY( store );
+
+    myrec_store_leave( store );
+    FD_TEST( !close( fd ) );
+  }
+
+  /* ---- Case B: ring wraps + drops mid-demotion, forcing a
+     discontinuity flush in the middle of a batch. ---- */
+  {
+    ulong circq_sz = 1024UL;
+    ulong val_sz   = 96UL;
+    ulong file_len = 256UL + 64UL + fd_ulong_align_up( 4UL*circq_sz, 8UL );
+    int   fd       = tmpfile_fd( file_len );
+
+    myrec_store_t * store = myrec_store_join(
+        myrec_store_new( shmem, 256UL, circq_sz, 32UL, 0UL, file_len ), fd );
+
+    ulong const N = 120UL;
+    for( ulong i=0UL; i<N; i++ ) {
+      myrec_key_t key = { .slot = 7UL, .block_id = i };
+      uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+      FD_TEST( v );
+      fill( v, &key, val_sz );
+      myrec_store_pre_evict( store ); /* keep the disk ring churning/wrapping */
+      VERIFY( store ); /* split-pwritev write-back across a ring wrap is consistent */
+    }
+
+    /* Drop must have occurred (ring too small for all N) and
+       survivors form a newest-suffix that reads back correctly. */
+    int   saw_gap = 0;
+    ulong live    = 0UL;
+    for( ulong ii=0UL; ii<N; ii++ ) {
+      ulong i = N-1UL-ii;
+      myrec_key_t key = { .slot = 7UL, .block_id = i };
+      ulong sz = 0UL;
+      uchar const * v = myrec_store_get_ro( store, &key, &sz );
+      if( v ) {
+        FD_TEST( !saw_gap );
+        FD_TEST( sz==val_sz && check( v, &key, val_sz ) );
+        live++;
+      } else {
+        saw_gap = 1;
+      }
+    }
+    FD_TEST( live<N );
+    FD_TEST( saw_gap );
+
+    VERIFY( store );
+
+    myrec_store_leave( store );
+    FD_TEST( !close( fd ) );
+  }
+}
+
+/* Direct unit test of the partial-write bookkeeping (iov_advance).  A
+   regular file never short-writes a pwritev, so this branch is otherwise
+   never exercised; drive it explicitly with crafted byte counts that
+   land on iovec boundaries, mid-iovec, span several iovecs, and consume
+   nothing / everything. */
+
+static void
+test_iov_advance( void ) {
+  uchar a[ 10 ], b[ 20 ], c[ 30 ];
+
+  /* Helper to (re)build a fresh 3-iovec array each case. */
+# define RESET() do {                                  \
+    iov[ 0 ].iov_base = a; iov[ 0 ].iov_len = 10UL;     \
+    iov[ 1 ].iov_base = b; iov[ 1 ].iov_len = 20UL;     \
+    iov[ 2 ].iov_base = c; iov[ 2 ].iov_len = 30UL;     \
+  } while(0)
+  struct iovec iov[ 3 ];
+
+  /* Consume 0 bytes: nothing moves. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 0UL );
+    FD_TEST( i==0 );
+    FD_TEST( iov[ 0 ].iov_base==a && iov[ 0 ].iov_len==10UL ); }
+
+  /* Consume exactly the first iovec: advance to index 1, untouched len. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 10UL );
+    FD_TEST( i==1 );
+    FD_TEST( iov[ 1 ].iov_base==b && iov[ 1 ].iov_len==20UL ); }
+
+  /* Consume part of the first iovec: stay at 0, trimmed base/len. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 4UL );
+    FD_TEST( i==0 );
+    FD_TEST( iov[ 0 ].iov_base==a+4 && iov[ 0 ].iov_len==6UL ); }
+
+  /* Span the first iovec and part of the second. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 15UL ); /* 10 + 5 */
+    FD_TEST( i==1 );
+    FD_TEST( iov[ 1 ].iov_base==b+5 && iov[ 1 ].iov_len==15UL ); }
+
+  /* Span the first two iovecs exactly, leaving the third intact. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 30UL ); /* 10 + 20 */
+    FD_TEST( i==2 );
+    FD_TEST( iov[ 2 ].iov_base==c && iov[ 2 ].iov_len==30UL ); }
+
+  /* Resume from a mid-array index (simulates a second short write after a
+     first one already advanced i to 1 and trimmed iov[1]). */
+  RESET();
+  iov[ 1 ].iov_base = b+5; iov[ 1 ].iov_len = 15UL;
+  { int i = 1; myrec_store_iov_advance( iov, 3, &i, 15UL ); /* finish iov[1] */
+    FD_TEST( i==2 );
+    FD_TEST( iov[ 2 ].iov_base==c && iov[ 2 ].iov_len==30UL ); }
+
+  /* Consume everything remaining: index walks off the end. */
+  RESET();
+  { int i = 0; myrec_store_iov_advance( iov, 3, &i, 60UL ); /* 10 + 20 + 30 */
+    FD_TEST( i==3 ); }
+
+# undef RESET
+}
+
+static void
+test_over_aligned_append( void ) {
+  myrec_store_t * store = myrec_store_join( myrec_store_new( shmem, TEST_ELE_MAX, TEST_CIRCQ_SZ, 99UL, 0UL, 0UL ), -1 );
+
+  ulong const aligns[] = { 16UL, 32UL, 64UL };
+  for( ulong i=0UL; i<sizeof(aligns)/sizeof(aligns[0]); i++ ) {
+    ulong       align = aligns[ i ];
+    myrec_key_t key   = { .slot = 70UL, .block_id = align };
+    ulong       sz    = 48UL;
+
+    uchar * v = myrec_store_append( store, &key, align, sz );
+    FD_TEST( v );
+    FD_TEST( fd_ulong_is_aligned( (ulong)v, align ) );
+    fill( v, &key, sz );
+
+    ulong         got_sz = 0UL;
+    uchar const * g      = myrec_store_get_ro( store, &key, &got_sz );
+    FD_TEST( g );
+    FD_TEST( fd_ulong_is_aligned( (ulong)g, align ) );
+    FD_TEST( got_sz==sz );
+    FD_TEST( check( g, &key, sz ) );
+  }
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+}
+
+/* test_append_past_orphan test a full map whose oldest cache message
+   is a stale orphan. append() must keep evicting until a live slot is
+   actually reclaimed. */
+static void
+test_append_past_orphan( void ) {
+  ulong ele_max  = 4UL;        /* power of two: map capacity is exactly this */
+  ulong circq_sz = 4096UL;     /* ample: holds every message in this test */
+  ulong val_sz   = 16UL;
+  ulong file_len = 1UL<<16;    /* file-backed, but we keep the disk ring empty */
+  int   fd       = tmpfile_fd( file_len );
+
+  myrec_store_t * store = myrec_store_join(
+      myrec_store_new( shmem, ele_max, circq_sz, 24UL, 0UL, file_len ), fd );
+
+  /* 1) Append the soon-to-be orphan; it is the oldest cache message. */
+  myrec_key_t orphan = { .slot = 9UL, .block_id = 0UL };
+  uchar * vo = myrec_store_append( store, &orphan, 8UL, val_sz );
+  FD_TEST( vo ); fill( vo, &orphan, val_sz );
+
+  /* Turn it into a stale orphan: drop the index entry directly, leaving
+     its cache message behind with no live element to match.  fcnt stays
+     0 (nothing was demoted to disk). */
+  myrec_store_ele_t * oe = myrec_store_map_update( store->map, &orphan );
+  FD_TEST( oe );
+  myrec_store_map_remove( store->map, oe );
+  store->live_cnt--;
+  FD_TEST( store->fcnt==0UL );
+  FD_TEST( !myrec_store_get_ro( store, &orphan, NULL ) ); /* gone from index */
+
+  /* 2) Append live MEM keys (each newer than the orphan in the cache)
+     until the map saturates and the next insert must evict to seat the
+     key -- i.e. live_cnt stops growing.  Every append must succeed: the
+     orphan sits at the cache head, so the index slow path is forced to
+     skip past it and reclaim a live slot.  We stop the moment a slot is
+     recycled, which is exactly the wedge-prone case the report
+     describes (full map, fcnt==0, oldest cache message is the orphan). */
+  ulong i        = 0UL;
+  int   recycled = 0;
+  for( ; i<64UL; i++ ) {
+    myrec_key_t key = { .slot = 9UL, .block_id = 100UL+i };
+    ulong before = store->live_cnt;
+
+    uchar * v = myrec_store_append( store, &key, 8UL, val_sz );
+    FD_TEST( v ); /* before the fix this wedged and returned NULL */
+    fill( v, &key, val_sz );
+
+    FD_TEST( store->live_cnt<=ele_max );
+    VERIFY( store );
+
+    if( store->live_cnt==before ) { recycled = 1; break; } /* slow path reclaimed a slot */
+  }
+  FD_TEST( recycled ); /* the saturating append really exercised the slow path */
+
+  /* The just-appended key reads back correctly. */
+  myrec_key_t last = { .slot = 9UL, .block_id = 100UL+i };
+  ulong sz = 0UL;
+  uchar const * g = myrec_store_get_ro( store, &last, &sz );
+  FD_TEST( g && sz==val_sz && check( g, &last, val_sz ) );
+
+  VERIFY( store );
+
+  myrec_store_leave( store );
+  FD_TEST( !close( fd ) );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_lifecycle();              FD_LOG_NOTICE(( "pass: lifecycle"              ));
+  test_append_get_ro();          FD_LOG_NOTICE(( "pass: append_get_ro"          ));
+  test_duplicate_key();          FD_LOG_NOTICE(( "pass: duplicate_key"          ));
+  test_get_mut();                FD_LOG_NOTICE(( "pass: get_mut"                ));
+  test_tiny_cache();             FD_LOG_NOTICE(( "pass: tiny_cache"             ));
+  test_oversized_append();       FD_LOG_NOTICE(( "pass: oversized_append"       ));
+  test_over_aligned_append();    FD_LOG_NOTICE(( "pass: over_aligned_append"    ));
+
+  test_write_back_on_eviction(); FD_LOG_NOTICE(( "pass: write_back_on_eviction" ));
+  test_warm_then_edit();         FD_LOG_NOTICE(( "pass: warm_then_edit"         ));
+  test_clean_evict();            FD_LOG_NOTICE(( "pass: clean_evict"            ));
+  test_warm_cascade();           FD_LOG_NOTICE(( "pass: warm_cascade"           ));
+  test_disk_ring_drop();         FD_LOG_NOTICE(( "pass: disk_ring_drop"         ));
+  test_disk_writeback_wrap();    FD_LOG_NOTICE(( "pass: disk_writeback_wrap"    ));
+  test_multi_store_one_file();   FD_LOG_NOTICE(( "pass: multi_store_one_file"   ));
+
+  test_eviction_idx();           FD_LOG_NOTICE(( "pass: eviction_idx"           ));
+  test_pre_evict_idx();          FD_LOG_NOTICE(( "pass: pre_evict_idx"          ));
+  test_pre_evict_disk();         FD_LOG_NOTICE(( "pass: pre_evict_disk"         ));
+  test_tiny_idx();               FD_LOG_NOTICE(( "pass: tiny_idx"               ));
+  test_append_past_orphan();     FD_LOG_NOTICE(( "pass: append_past_orphan"     ));
+  test_iov_advance();            FD_LOG_NOTICE(( "pass: iov_advance"            ));
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/util/circq/Local.mk
+++ b/src/util/circq/Local.mk
@@ -1,0 +1,6 @@
+ifdef FD_HAS_HOSTED
+$(call add-hdrs,fd_circq.h)
+$(call add-objs,fd_circq,fd_util)
+$(call make-unit-test,test_circq,test_circq,fd_util)
+$(call run-unit-test,test_circq)
+endif

--- a/src/util/circq/fd_circq.c
+++ b/src/util/circq/fd_circq.c
@@ -15,6 +15,17 @@ struct __attribute__((aligned(8UL))) fd_circq_message_private {
 
 typedef struct fd_circq_message_private fd_circq_message_t;
 
+/* msg_payload returns a message->align-aligned pointer to the payload
+   bytes of message. */
+
+static inline uchar *
+msg_payload( fd_circq_t *         circq,
+             ulong                off,
+             fd_circq_message_t * message ) {
+  uchar * buf = (uchar *)(circq+1);
+  return buf + fd_ulong_align_up( off+sizeof( fd_circq_message_t ), message->align );
+}
+
 FD_FN_CONST ulong
 fd_circq_align( void ) {
   return FD_CIRCQ_ALIGN;
@@ -36,6 +47,8 @@ fd_circq_new( void * shmem,
   circq->cursor = ULONG_MAX;
   circq->cursor_seq = 0UL;
   circq->cursor_push_seq = 0UL;
+  circq->batch_evict_cb = NULL;
+  circq->batch_evict_ctx = NULL;
 
   memset( &circq->metrics, 0, sizeof( circq->metrics ) );
 
@@ -95,29 +108,58 @@ overrun_recover( fd_circq_t * circq ) {
   if( FD_UNLIKELY( circq->cursor_seq<=oldest_seq ) ) circq->cursor = ULONG_MAX;
 }
 
+/* evict_one_unrecorded drops the current head message, performing all the
+   per-message bookkeeping. */
+
+static void
+evict_one_unrecorded( fd_circq_t * circq ) {
+  uchar * buf = (uchar *)(circq+1);
+
+  fd_circq_message_t * head = (fd_circq_message_t *)(buf+circq->head);
+
+  circq->cnt--;
+  circq->metrics.drop_cnt++;
+  if( FD_LIKELY( !circq->cnt ) ) circq->head = circq->tail = 0UL;
+  else                           circq->head = head->next;
+  overrun_recover( circq );
+}
+
 static void
 evict( fd_circq_t * circq,
        ulong        from,
        ulong        to ) {
   uchar * buf = (uchar *)(circq+1);
 
+  fd_circq_evict_entry_t pending[ FD_CIRCQ_EVICT_BATCH_MAX ];
+  ulong                  pending_cnt = 0UL;
+  int                    have_cb     = !!circq->batch_evict_cb;
+
   for(;;) {
-    if( FD_UNLIKELY( !circq->cnt ) ) return;
+    if( FD_UNLIKELY( !circq->cnt ) ) break;
 
     fd_circq_message_t * head = (fd_circq_message_t *)(buf+circq->head);
 
     ulong start = circq->head;
     ulong end = fd_ulong_align_up( start + sizeof( fd_circq_message_t ), head->align ) + head->footprint;
 
-    if( FD_UNLIKELY( (start<to && end>from) ) ) {
-      circq->cnt--;
-      circq->metrics.drop_cnt++;
-      if( FD_LIKELY( !circq->cnt ) ) circq->head = circq->tail = 0UL;
-      else                           circq->head = head->next;
-      overrun_recover( circq );
-    } else {
-      break;
+    if( FD_LIKELY( !(start<to && end>from) ) ) break;
+
+    /* Flush a full batch before overflow. */
+    if( FD_UNLIKELY( have_cb ) ) {
+      if( FD_UNLIKELY( pending_cnt==FD_CIRCQ_EVICT_BATCH_MAX ) ) {
+        circq->batch_evict_cb( circq->batch_evict_ctx, pending, pending_cnt );
+        pending_cnt = 0UL;
+      }
+      pending[ pending_cnt ].payload = msg_payload( circq, circq->head, head );
+      pending[ pending_cnt ].sz      = head->footprint;
+      pending_cnt++;
     }
+
+    evict_one_unrecorded( circq );
+  }
+
+  if( FD_UNLIKELY( have_cb && pending_cnt ) ) {
+    circq->batch_evict_cb( circq->batch_evict_ctx, pending, pending_cnt );
   }
 }
 
@@ -149,14 +191,17 @@ fd_circq_push_back( fd_circq_t * circq,
     current = fd_ulong_align_up( fd_ulong_align_up( circq->tail+sizeof( fd_circq_message_t ), message->align )+message->footprint, alignof( fd_circq_message_t ) );
   }
 
-  if( FD_UNLIKELY( current+required>circq->size ) ) {
+  /* The end offset of a message placed at current */
+  ulong current_end = fd_ulong_align_up( current + sizeof( fd_circq_message_t ), align ) + footprint;
+
+  if( FD_UNLIKELY( current_end>circq->size ) ) {
     evict( circq, current, circq->size );
     evict( circq, 0UL, required );
 
     circq->tail = 0UL;
     if( FD_LIKELY( circq->cnt && message ) ) message->next = 0UL;
   } else {
-    evict( circq, current, current+required );
+    evict( circq, current, current_end );
 
     circq->tail = current;
     if( FD_LIKELY( circq->cnt && message ) ) message->next = current;
@@ -168,7 +213,7 @@ fd_circq_push_back( fd_circq_t * circq,
   next_message->footprint = footprint;
   next_message->next = ULONG_MAX;
   circq->cursor_push_seq++;
-  return (uchar *)(next_message+1);
+  return msg_payload( circq, circq->tail, next_message );
 }
 
 void
@@ -204,7 +249,7 @@ fd_circq_cursor_advance( fd_circq_t * circq,
   fd_circq_message_t * current_msg = (fd_circq_message_t *)(buf+circq->cursor);
   circq->cursor_seq++;
   if( FD_LIKELY( msg_sz ) ) *msg_sz = current_msg->footprint;
-  return (uchar *)(current_msg+1);
+  return msg_payload( circq, circq->cursor, current_msg );
 }
 
 int
@@ -217,17 +262,50 @@ fd_circq_pop_until( fd_circq_t * circq,
 
   ulong to_pop = fd_ulong_min( cursor-oldest_seq+1UL, circq->cnt );
 
+  /* Pop oldest-first, gathering the dropped payloads into batches
+     delivered to the eviction callback (if registered).  As in evict(),
+     a batch is flushed when it fills (FD_CIRCQ_EVICT_BATCH_MAX) and at
+     each buffer wrap, so a batch never straddles the wrap. */
+
   uchar * buf = (uchar *)(circq+1);
+
+  fd_circq_evict_entry_t pending[ FD_CIRCQ_EVICT_BATCH_MAX ];
+  ulong                  pending_cnt = 0UL;
+  int                    have_cb     = !!circq->batch_evict_cb;
+
   for( ulong i=0UL; i<to_pop; i++ ) {
     fd_circq_message_t * message = (fd_circq_message_t *)(buf+circq->head);
+    ulong next  = message->next;
+    int   wraps = next<circq->head; /* head about to wrap to a lower offset */
+
+    if( FD_UNLIKELY( have_cb ) ) {
+      if( FD_UNLIKELY( pending_cnt==FD_CIRCQ_EVICT_BATCH_MAX ) ) {
+        circq->batch_evict_cb( circq->batch_evict_ctx, pending, pending_cnt );
+        pending_cnt = 0UL;
+      }
+      pending[ pending_cnt ].payload = msg_payload( circq, circq->head, message );
+      pending[ pending_cnt ].sz      = message->footprint;
+      pending_cnt++;
+    }
+
     circq->cnt--;
 
     if( FD_UNLIKELY( !circq->cnt ) ) {
       circq->head = circq->tail = 0UL;
     } else {
-      circq->head = message->next;
+      circq->head = next;
       FD_TEST( circq->head<circq->size );
     }
+
+    /* Flush before crossing the wrap so a batch stays contiguous. */
+    if( FD_UNLIKELY( have_cb && wraps && pending_cnt ) ) {
+      circq->batch_evict_cb( circq->batch_evict_ctx, pending, pending_cnt );
+      pending_cnt = 0UL;
+    }
+  }
+
+  if( FD_UNLIKELY( have_cb && pending_cnt ) ) {
+    circq->batch_evict_cb( circq->batch_evict_ctx, pending, pending_cnt );
   }
 
   if( FD_UNLIKELY( !circq->cnt ) ) circq->cursor = ULONG_MAX;
@@ -238,6 +316,11 @@ fd_circq_pop_until( fd_circq_t * circq,
 void
 fd_circq_reset_cursor( fd_circq_t * circq ) {
   circq->cursor = ULONG_MAX;
+}
+
+ulong
+fd_circq_cursor( fd_circq_t const * circq ) {
+  return circq->cursor_seq;
 }
 
 ulong
@@ -257,4 +340,12 @@ ulong
 fd_circq_unsent_cnt( fd_circq_t const * circq ) {
   if( FD_UNLIKELY( circq->cursor==ULONG_MAX ) ) return circq->cnt;
   return fd_ulong_min( circq->cursor_push_seq - circq->cursor_seq, circq->cnt );
+}
+
+void
+fd_circq_set_batch_evict_cb( fd_circq_t *              circq,
+                             fd_circq_batch_evict_cb_t cb,
+                             void *                    ctx ) {
+  circq->batch_evict_cb  = cb;
+  circq->batch_evict_ctx = ctx;
 }

--- a/src/util/circq/fd_circq.c
+++ b/src/util/circq/fd_circq.c
@@ -1,6 +1,6 @@
 #include "fd_circq.h"
 
-#include "../../util/log/fd_log.h"
+#include "../log/fd_log.h"
 
 struct __attribute__((aligned(8UL))) fd_circq_message_private {
   ulong align;

--- a/src/util/circq/fd_circq.h
+++ b/src/util/circq/fd_circq.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_fd_src_disco_events_fd_circq_h
-#define HEADER_fd_src_disco_events_fd_circq_h
+#ifndef HEADER_fd_src_util_circq_fd_circq_h
+#define HEADER_fd_src_util_circq_fd_circq_h
 
 /* The circular buffer is a structure, which stores a queue of messages,
    supporting two operations: push_back and pop_front.  Unlike a regular
@@ -26,7 +26,7 @@
    the next message in the queue, and head, tail are the head and tail
    of the queue respectively. */
 
-#include "../../util/fd_util_base.h"
+#include "../fd_util_base.h"
 
 #define FD_CIRCQ_ALIGN (4096UL)
 
@@ -136,4 +136,4 @@ fd_circq_unsent_cnt( fd_circq_t const * circq );
 
 FD_PROTOTYPES_END
 
-#endif /* HEADER_fd_src_disco_events_fd_circq_h */
+#endif /* HEADER_fd_src_util_circq_fd_circq_h */

--- a/src/util/circq/fd_circq.h
+++ b/src/util/circq/fd_circq.h
@@ -30,6 +30,40 @@
 
 #define FD_CIRCQ_ALIGN (4096UL)
 
+/* FD_CIRCQ_EVICT_BATCH_MAX is the maximum number of entries delivered to
+   the batch eviction callback in a single invocation. */
+
+#define FD_CIRCQ_EVICT_BATCH_MAX (256UL)
+
+/* fd_circq_evict_entry_t describes one message about to be evicted:
+   payload points at the message's payload bytes within the circq data
+   region (NOT including the internal circq message header) and sz is the
+   payload footprint. */
+
+struct fd_circq_evict_entry {
+  uchar const * payload;
+  ulong         sz;
+};
+
+typedef struct fd_circq_evict_entry fd_circq_evict_entry_t;
+
+/* fd_circq_batch_evict_cb_t is invoked immediately before a contiguous
+   run of messages is dropped from the front of the buffer.  batch points
+   at cnt entries (payload+sz), in oldest-first order, each describing one
+   message's payload.  ctx is the value registered via
+   fd_circq_set_batch_evict_cb.  The callback MUST NOT push to, evict
+   from, or otherwise mutate the circq.
+
+   A single eviction may invoke the callback more than once: the run is
+   delivered in batches of at most FD_CIRCQ_EVICT_BATCH_MAX entries, and a
+   wrapping eviction is delivered as separate invocations per contiguous
+   run (a batch never straddles the buffer wrap). */
+
+typedef void
+(*fd_circq_batch_evict_cb_t)( void *                         ctx,
+                              fd_circq_evict_entry_t const * batch,
+                              ulong                          cnt );
+
 struct __attribute__((aligned(FD_CIRCQ_ALIGN))) fd_circq_private {
   /* Current count of elements in the queue. */
   ulong cnt;
@@ -45,6 +79,9 @@ struct __attribute__((aligned(FD_CIRCQ_ALIGN))) fd_circq_private {
   ulong cursor;          /* Current offset in buffer for iteration, or ULONG_MAX if at end */
   ulong cursor_seq;      /* Monotonic counter - cursor value for current position */
   ulong cursor_push_seq; /* Monotonic counter - incremented on each push */
+
+  fd_circq_batch_evict_cb_t batch_evict_cb;
+  void *                    batch_evict_ctx;
 
   struct {
     ulong drop_cnt;
@@ -107,7 +144,10 @@ fd_circq_cursor_advance( fd_circq_t * circq,
 /* fd_circq_pop_until removes messages from the front of the circular
    buffer up to and including the message with the given cursor value.
    Returns 0 on success, or -1 if the given cursor value is invalid
-   (i.e., larger than highest cursor value returned by cursor_advance). */
+   (i.e., larger than highest cursor value returned by cursor_advance).
+
+   The popped messages are also delivered oldest-first to the batch
+   eviction callback. */
 
 int
 fd_circq_pop_until( fd_circq_t * circq,
@@ -119,6 +159,13 @@ fd_circq_pop_until( fd_circq_t * circq,
 
 void
 fd_circq_reset_cursor( fd_circq_t * circq );
+
+/* fd_circq_cursor returns the current cursor.  The message returned by
+   fd_circq_cursor_advance will have a cursor of fd_circq_cursor()-1
+   until the cursor is advanced again. */
+
+FD_FN_PURE ulong
+fd_circq_cursor( fd_circq_t const * circq );
 
 /* fd_circq_bytes_used returns the total number of bytes currently used
    in the circular buffer, including message metadata and padding. */
@@ -133,6 +180,16 @@ fd_circq_bytes_used( fd_circq_t const * circq );
 
 ulong
 fd_circq_unsent_cnt( fd_circq_t const * circq );
+
+/* fd_circq_set_batch_evict_cb registers (or clears, when cb is NULL) the
+   batch eviction callback and its context (see
+   fd_circq_batch_evict_cb_t).  The callback is reset to none by
+   fd_circq_new. */
+
+void
+fd_circq_set_batch_evict_cb( fd_circq_t *              circq,
+                             fd_circq_batch_evict_cb_t cb,
+                             void *                    ctx );
 
 FD_PROTOTYPES_END
 

--- a/src/util/circq/test_circq.c
+++ b/src/util/circq/test_circq.c
@@ -1,4 +1,4 @@
-#include "../../util/fd_util.h"
+#include "../fd_util.h"
 #include "fd_circq.h"
 
 static void

--- a/src/util/circq/test_circq.c
+++ b/src/util/circq/test_circq.c
@@ -3,15 +3,18 @@
 
 static void
 test_fuzz( void ) {
-  uchar buf[ 128UL+4096UL ];
+  uchar buf[ 128UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 128 ) );
 
   fd_rng_t _rng[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
   for( ulong i=0UL; i<4UL*1024UL*1024UL; i++ ) {
-    uchar * msg = fd_circq_push_back( circq, fd_ulong_pow2( (int)fd_rng_ulong_roll( rng, 5 ) ), 1UL+fd_rng_ulong_roll( rng, 64 ) );
+    ulong   align = fd_ulong_pow2( (int)fd_rng_ulong_roll( rng, 5 ) );
+    uchar * msg   = fd_circq_push_back( circq, align, 1UL+fd_rng_ulong_roll( rng, 64 ) );
     FD_TEST( msg );
+    /* The returned payload must honor the requested alignment. */
+    FD_TEST( fd_ulong_is_aligned( (ulong)msg, align ) );
   }
 }
 
@@ -316,6 +319,205 @@ test_edge_cases( void ) {
   FD_TEST( out );
 }
 
+/* record the first byte and size of each evicted message in
+   oldest-first order, plus the number of callback invocations */
+
+struct evict_record {
+  ulong cnt;
+  ulong invocations;
+  uchar tag[ 256UL ];
+  ulong sz [ 256UL ];
+};
+
+typedef struct evict_record evict_record_t;
+
+static void
+record_evict_cb( void *                         ctx,
+                 fd_circq_evict_entry_t const * batch,
+                 ulong                          cnt ) {
+  evict_record_t * rec = (evict_record_t *)ctx;
+  FD_TEST( cnt>0UL );
+  rec->invocations++;
+  for( ulong i=0UL; i<cnt; i++ ) {
+    FD_TEST( rec->cnt<256UL );
+    rec->tag[ rec->cnt ] = batch[ i ].payload[ 0 ];
+    rec->sz [ rec->cnt ] = batch[ i ].sz;
+    rec->cnt++;
+  }
+}
+
+static void
+test_evict_callback_reactive( void ) {
+  uchar buf[ 192UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 192UL ) );
+
+  evict_record_t rec[1] = {0};
+  fd_circq_set_batch_evict_cb( circq, record_evict_cb, rec );
+
+  uchar * a = fd_circq_push_back( circq, 1UL, 8UL );
+  uchar * b = fd_circq_push_back( circq, 1UL, 8UL );
+  FD_TEST( a && b );
+  a[0] = 'A';
+  b[0] = 'B';
+
+  FD_TEST( rec->cnt==0UL );
+
+  /* This large push forces eviction of the front message(s). */
+  uchar * c = fd_circq_push_back( circq, 1UL, 112UL );
+  FD_TEST( c );
+  c[0] = 'C';
+
+  FD_TEST( circq->cnt==1UL );
+
+  /* Both A and B were evicted, oldest-first, with their original
+     first-byte tags and sizes; C itself is not evicted. */
+  FD_TEST( rec->cnt==2UL );
+  FD_TEST( rec->tag[0]=='A' && rec->sz[0]==8UL );
+  FD_TEST( rec->tag[1]=='B' && rec->sz[1]==8UL );
+
+  ulong msg_sz = 0UL;
+  uchar const * survivor = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( survivor );
+  FD_TEST( survivor[0]=='C' );
+  FD_TEST( msg_sz==112UL );
+}
+
+/* fd_circq_pop_until delivers the popped messages to the batch eviction
+   callback, oldest-first, and leaves the un-popped tail intact. */
+
+static void
+test_pop_until_callback( void ) {
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
+
+  evict_record_t rec[1] = {0};
+  fd_circq_set_batch_evict_cb( circq, record_evict_cb, rec );
+
+  for( ulong i=0UL; i<5UL; i++ ) {
+    uchar * m = fd_circq_push_back( circq, 1UL, 8UL );
+    FD_TEST( m );
+    m[0] = (uchar)('A' + i);
+  }
+  FD_TEST( rec->cnt==0UL ); /* no wrap yet -> no evictions during push */
+
+  /* Advance the cursor over the three oldest messages, then pop_until
+     the last of them.  The callback must observe exactly A,B,C in order. */
+  ulong msg_sz   = 0UL;
+  ulong last_seq = 0UL;
+  for( ulong i=0UL; i<3UL; i++ ) {
+    uchar const * m = fd_circq_cursor_advance( circq, &msg_sz );
+    FD_TEST( m );
+    last_seq = circq->cursor_seq-1UL; /* this message's own seq */
+  }
+  FD_TEST( !fd_circq_pop_until( circq, last_seq ) );
+
+  FD_TEST( rec->cnt==3UL );
+  FD_TEST( rec->tag[0]=='A' && rec->tag[1]=='B' && rec->tag[2]=='C' );
+  FD_TEST( rec->sz[0]==8UL && rec->sz[1]==8UL && rec->sz[2]==8UL );
+
+  /* The remaining two (D,E) are still present and in order. */
+  fd_circq_reset_cursor( circq );
+  uchar const * d = fd_circq_cursor_advance( circq, &msg_sz ); FD_TEST( d && d[0]=='D' );
+  uchar const * e = fd_circq_cursor_advance( circq, &msg_sz ); FD_TEST( e && e[0]=='E' );
+  FD_TEST( !fd_circq_cursor_advance( circq, &msg_sz ) );
+}
+
+/* A single push that evicts a contiguous run of multiple messages
+   delivers them in one oldest-first batch (one callback invocation), and
+   a wrapping eviction that drops messages on both sides of the wrap
+   arrives as separate invocations per contiguous run. */
+
+static void
+test_batch_evict_wrap( void ) {
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
+  ulong msg_sz = 0UL;
+
+  evict_record_t rec[1] = {0};
+  fd_circq_set_batch_evict_cb( circq, record_evict_cb, rec );
+
+  /* Each fp=1 message takes 24 (header) + 1 (payload), padded to a
+     32-byte stride, so seven of them fill [0,224) of the 256-byte buffer
+     without wrapping (head=0, tail=192). */
+  for( ulong i=0UL; i<7UL; i++ ) {
+    uchar * m = fd_circq_push_back( circq, 1UL, 1UL );
+    FD_TEST( m );
+    m[0] = (uchar)('a' + i);
+  }
+  FD_TEST( circq->cnt==7UL );
+  FD_TEST( rec->cnt==0UL );
+
+  /* This larger push evicts a contiguous run of more than one message in
+     a single eviction: the callback fires exactly once with the dropped
+     payloads in oldest-first order. */
+  ulong before_cnt = rec->cnt;
+  ulong before_inv = rec->invocations;
+  uchar * big = fd_circq_push_back( circq, 1UL, 24UL );
+  FD_TEST( big );
+  big[0] = 'Z';
+
+  FD_TEST( rec->invocations-before_inv==1UL );
+  FD_TEST( rec->cnt-before_cnt>1UL );
+  for( ulong i=before_cnt; i<rec->cnt; i++ ) {
+    FD_TEST( rec->tag[ i ]==(uchar)('a' + (i-before_cnt)) );
+    FD_TEST( rec->sz [ i ]==1UL );
+  }
+
+  /* Keep pushing alternating sizes until a single push yields >=2 cb
+     invocations. */
+  ulong baseline_invocations = rec->invocations;
+  ulong push_invocations     = 0UL;
+  for( ulong i=0UL; i<128UL; i++ ) {
+    ulong before = rec->invocations;
+    ulong fp = (i&1UL) ? 1UL : 48UL;
+    uchar * m = fd_circq_push_back( circq, 1UL, fp );
+    FD_TEST( m );
+    m[0] = (uchar)('0' + (i%10UL));
+    push_invocations = rec->invocations - before;
+    if( push_invocations>=2UL ) break;
+  }
+  FD_TEST( push_invocations>=2UL );
+  FD_TEST( rec->invocations>baseline_invocations );
+
+  /* Sanity: the most recently pushed message is still retrievable. */
+  fd_circq_reset_cursor( circq );
+  uchar const * last = NULL;
+  for(;;) {
+    uchar const * m = fd_circq_cursor_advance( circq, &msg_sz );
+    if( !m ) break;
+    last = m;
+  }
+  FD_TEST( last );
+}
+
+static void
+test_no_callback_regression( void ) {
+  uchar buf[ 192UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 192UL ) );
+  ulong msg_sz = 0UL;
+
+  /* Explicitly clear (already none after new) to assert NULL is a safe
+     no-op on the eviction path. */
+  fd_circq_set_batch_evict_cb( circq, NULL, NULL );
+
+  uchar * a = fd_circq_push_back( circq, 1UL, 8UL );
+  uchar * b = fd_circq_push_back( circq, 1UL, 8UL );
+  FD_TEST( a && b );
+  a[0] = 'A';
+  b[0] = 'B';
+
+  uchar * c = fd_circq_push_back( circq, 1UL, 112UL );
+  FD_TEST( c );
+  c[0] = 'C';
+
+  FD_TEST( circq->cnt==1UL );
+
+  uchar const * survivor = fd_circq_cursor_advance( circq, &msg_sz );
+  FD_TEST( survivor );
+  FD_TEST( survivor[0]=='C' );
+  FD_TEST( msg_sz==112UL );
+}
+
 static void
 test_bounds( void ) {
   uchar buf[ 128UL+4096UL ];
@@ -325,6 +527,38 @@ test_bounds( void ) {
   FD_TEST( fd_circq_push_back( circq, 1UL, 1024UL-24UL ) );
   FD_TEST( fd_circq_push_back( circq, 8UL, 1024UL-24UL ) );
   FD_TEST( !fd_circq_push_back( circq, 1UL, 1024UL-23UL ) );
+}
+
+static void
+test_misaligned_payload_span( void ) {
+  uchar buf[ 762UL+4096UL ] __attribute__((aligned(4096UL)));
+  ulong size = 762UL;
+  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, size ) );
+
+  /* Fill, wrap and drain to leave the tail ending at a 8-aligned but
+     not 64-aligned offset, then push a 64-aligned message that must
+     evict the head to fit. */
+  ulong const seq[][2] = {
+    {8,24},{8,24},{8,92},{32,45},{8,32},{8,25},{16,32},{8,163},{16,182},
+    {8,32},{16,33},{8,38},{8,25},{8,24},{8,27},{8,168},{8,32},{32,122},
+    {8,24},{8,178},{8,32},{64,216}
+  };
+  ulong n = sizeof(seq)/sizeof(seq[0]);
+
+  for( ulong i=0UL; i<n; i++ ) {
+    ulong align = seq[i][0];
+    ulong fp    = seq[i][1];
+    uchar * m = fd_circq_push_back( circq, align, fp );
+    FD_TEST( m );
+    FD_TEST( fd_ulong_is_aligned( (ulong)m, align ) ); /* honors requested align */
+    memset( m, (int)(i&0xff), fp );             /* touch the whole payload */
+    FD_TEST( fd_circq_bytes_used( circq )<=size ); /* never overruns */
+  }
+
+  /* Every live message must still iterate within bounds. */
+  fd_circq_reset_cursor( circq );
+  ulong msg_sz;
+  while( fd_circq_cursor_advance( circq, &msg_sz ) ) FD_TEST( msg_sz<=size );
 }
 
 int
@@ -344,7 +578,12 @@ main( int     argc,
   test_pop_recover();                  FD_LOG_NOTICE(( "pass: pop_recover" ));
   test_cursor_sequence_monotonicity(); FD_LOG_NOTICE(( "pass: cursor_sequence_monotonicity" ));
   test_edge_cases();                   FD_LOG_NOTICE(( "pass: edge_cases" ));
+  test_evict_callback_reactive();      FD_LOG_NOTICE(( "pass: evict_callback_reactive" ));
+  test_pop_until_callback();           FD_LOG_NOTICE(( "pass: pop_until_callback" ));
+  test_batch_evict_wrap();             FD_LOG_NOTICE(( "pass: batch_evict_wrap" ));
+  test_no_callback_regression();       FD_LOG_NOTICE(( "pass: no_callback_regression" ));
   test_bounds();                       FD_LOG_NOTICE(( "pass: bounds" ));
+  test_misaligned_payload_span();      FD_LOG_NOTICE(( "pass: misaligned_payload_span" ));
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
The plan is to eventually migrate to the following variable-size element storages (backed by disk)

per-slot data
per-epoch data
per-min/hour/day data (maybe?)