### PR TITLE
restore: snapwr in.pos reset on recovery

### DIFF
--- a/src/discof/restore/fd_snapwr_tile.c
+++ b/src/discof/restore/fd_snapwr_tile.c
@@ -275,6 +275,7 @@ handle_control_frag( fd_snapwr_tile_t *  ctx,
       FD_TEST( ctx->state==FD_SNAPSHOT_STATE_IDLE );
       ctx->state = FD_SNAPSHOT_STATE_PROCESSING;
       ctx->full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
+      ctx->in.pos = 0UL;
       fd_ssparse_init( ctx->ssparse );
       fd_ssmanifest_parser_init( ctx->manifest_parser, ctx->manifest );
 


### PR DESCRIPTION
Position tracker should be reset on INIT (this now matches the behavior in `snapdc` and `snapin`).