### PR TITLE
bank: fix 2x under allocation in test

### DIFF
--- a/src/flamenco/runtime/test_bank.c
+++ b/src/flamenco/runtime/test_bank.c
@@ -851,10 +851,10 @@ main( int argc, char ** argv ) {
   fd_wksp_t * wksp          = fd_wksp_new( wksp_mem, "snapin", 1U, wksp_part_max, wksp_data_max ); FD_TEST( wksp );
   fd_shmem_join_anonymous( "snapin", FD_SHMEM_JOIN_MODE_READ_WRITE, wksp, wksp_mem, FD_SHMEM_NORMAL_PAGE_SZ, mem_req>>FD_SHMEM_NORMAL_LG_PAGE_SZ );
 
-  uchar * mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( 16UL, 4UL, 2048UL, 2048UL ), 1UL );
+  ulong const fp = fd_banks_footprint( 16UL, 8UL, 2048UL, 2048UL );
+  uchar * mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fp, 1UL );
   FD_TEST( mem );
 # if !FD_HAS_MSAN
-  ulong fp = fd_banks_footprint( 16UL, 4UL, 2048UL, 2048UL );
   for( ulong i=0UL; i<fp; i+=8 ) FD_STORE( ulong, mem+i, fd_ulong_hash( i ) );
 # endif
 


### PR DESCRIPTION
we later call new on a bank with double the max fork width