### PR TITLE
vm: fix trace info truncation check

### DIFF
--- a/src/flamenco/vm/fd_vm_trace.c
+++ b/src/flamenco/vm/fd_vm_trace.c
@@ -203,7 +203,7 @@ fd_vm_trace_printf( fd_vm_trace_t const *      trace,
 
     /* Read the event info */
 
-    if( FD_UNLIKELY( rem<7UL ) ) {
+    if( FD_UNLIKELY( rem<sizeof(ulong) ) ) {
       FD_LOG_WARNING(( "truncated event (info)" ));
       return FD_VM_ERR_IO;
     }

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -294,7 +294,17 @@ vm_trace_done:
 
   FD_LOG_NOTICE(( "Synthetic trace"));
   FD_TEST( !fd_vm_trace_printf( trace, NULL ) );
-  /* FIXME: More fd_vm_trace coverage */
+
+  FD_LOG_NOTICE(( "Testing malformed trace records" ));
+  uchar malformed_shmem[ 256 ] __attribute__((aligned(8)));
+  fd_vm_trace_t * malformed_trace = fd_vm_trace_join( fd_vm_trace_new( malformed_shmem, sizeof(ulong), 0UL ) );
+  FD_TEST( malformed_trace );
+  FD_TEST( !fd_vm_trace_printf( malformed_trace, NULL ) );
+  for( ulong rem=1UL; rem<sizeof(ulong); rem++ ) {
+    malformed_trace->event_sz = rem;
+    FD_TEST( fd_vm_trace_printf( malformed_trace, NULL )==FD_VM_ERR_IO );
+  }
+  FD_TEST( fd_vm_trace_delete( fd_vm_trace_leave( malformed_trace ) )==(void *)malformed_shmem );
 
   /* Test destructors */
 


### PR DESCRIPTION
## Summary

- Fix the VM trace pretty-printer's truncated-info guard to require a full `ulong` before reading the event info word.
- Add malformed trace coverage for empty trace data and truncated info records with 1 through 7 remaining bytes.

## Root cause

`fd_vm_trace_printf` checked `rem < 7UL`, but then immediately loaded `*(ulong *)ptr`. A 7-byte remainder could pass the guard even though the next read requires 8 bytes.

## Validation

- `git diff --check`
- `clang -std=c17 -fsyntax-only -I. -D_XOPEN_SOURCE=700 -DFD_HAS_HOSTED=1 -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 src/flamenco/vm/fd_vm_trace.c`
- `clang -std=c17 -fsyntax-only -I. -D_XOPEN_SOURCE=700 -DFD_HAS_HOSTED=1 -DFD_HAS_INT128=1 -DFD_HAS_DOUBLE=1 -DFD_HAS_ALLOCA=1 src/flamenco/vm/test_vm_base.c`

I could not run `test_vm_base` locally because this checkout is on Darwin and the native make config does not generate the hosted VM unit-test target.
