### PR TITLE
restore: download http redirect

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -501,17 +501,19 @@ init_load( fd_snapct_tile_t *  ctx,
     else       fd_memcpy( out->snapshot_hash, ctx->peer.incr_hash, FD_HASH_FOOTPRINT );
   }
 
+  out->is_redirect = !file; /* always use redirect for HTTP downloads */
+
+  if( file ) out->file_sz = full ? ctx->local_in.full_snapshot_size : ctx->local_in.incremental_snapshot_size;
+  else       out->file_sz = 0UL;
+
   if( !file ) {
     out->addr = ctx->peer.addr;
-    char encoded_hash[ FD_BASE58_ENCODED_32_SZ ];
     if( full ) {
-      fd_base58_encode_32( ctx->peer.full_hash, NULL, encoded_hash );
-      FD_TEST( fd_cstr_printf_check( out->path, PATH_MAX, &out->path_len, "/snapshot-%lu-%s.tar.zst", ctx->peer.full_slot, encoded_hash ) );
-      FD_TEST( fd_cstr_printf_check( ctx->http_full_snapshot_name, PATH_MAX, NULL, "snapshot-%lu-%s.tar.zst", ctx->peer.full_slot, encoded_hash ) );
+      FD_TEST( fd_cstr_printf_check( out->path, PATH_MAX, &out->path_len, "/snapshot.tar.bz2" ) );
+      FD_TEST( fd_cstr_printf_check( ctx->http_full_snapshot_name, PATH_MAX, NULL, "snapshot.tar.bz2" ) );
     } else {
-      fd_base58_encode_32( ctx->peer.incr_hash, NULL, encoded_hash );
-      FD_TEST( fd_cstr_printf_check( out->path, PATH_MAX, &out->path_len, "/incremental-snapshot-%lu-%lu-%s.tar.zst", ctx->peer.full_slot, ctx->peer.incr_slot, encoded_hash ) );
-      FD_TEST( fd_cstr_printf_check( ctx->http_incr_snapshot_name, PATH_MAX, NULL, "incremental-snapshot-%lu-%lu-%s.tar.zst", ctx->peer.full_slot, ctx->peer.incr_slot, encoded_hash ) );
+      FD_TEST( fd_cstr_printf_check( out->path, PATH_MAX, &out->path_len, "/incremental-snapshot.tar.bz2" ) );
+      FD_TEST( fd_cstr_printf_check( ctx->http_incr_snapshot_name, PATH_MAX, NULL, "incremental-snapshot.tar.bz2" ) );
     }
 
     out->is_https = 0; /* if not found in the config list, it's not https */
@@ -528,13 +530,6 @@ init_load( fd_snapct_tile_t *  ctx,
   ctx->out_ld.chunk = fd_dcache_compact_next( ctx->out_ld.chunk, sizeof(fd_ssctrl_init_t), ctx->out_ld.chunk0, ctx->out_ld.wmark );
   ctx->flush_ack = 0;
   ctx->load_complete = 0;
-
-  /* If we are downloading the snapshot, we will get the snapshot size
-     in bytes from a metadata message sent from snapld. */
-  if( file ) {
-    if( full ) ctx->metrics.full.bytes_total = ctx->local_in.full_snapshot_size;
-    else       ctx->metrics.incremental.bytes_total = ctx->local_in.incremental_snapshot_size;
-  }
 
   if( !file ) {
     if( full ) {
@@ -557,32 +552,11 @@ init_load( fd_snapct_tile_t *  ctx,
     }
   }
 
-  /* Regardless of whether we load the snapshot from a file or download
-     it, we know the name of the snapshot and can publish it to the gui
-     here. */
-  if( full ) {
-    if( FD_LIKELY( !!ctx->out_gui.mem ) ) {
-      if( file ) {
-        fd_cstr_fini( ctx->http_full_snapshot_name );
-        snapshot_path_gui_publish( ctx, stem, ctx->local_in.full_snapshot_path, 1 );
-      }
-      else {
-        char snapshot_path[ PATH_MAX+30UL ]; /* 30 is fd_cstr_nlen( "https://255.255.255.255:65536/", ULONG_MAX ) */
-        FD_TEST( fd_cstr_printf_check( snapshot_path, sizeof(snapshot_path), NULL, "http://" FD_IP4_ADDR_FMT ":%hu/%s", FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_full_snapshot_name ) );
-        snapshot_path_gui_publish( ctx, stem, snapshot_path, 1 );
-      }
-    }
-  } else {
-    if( FD_LIKELY( !!ctx->out_gui.mem ) ) {
-      if( file ) {
-        fd_cstr_fini( ctx->http_incr_snapshot_name );
-        snapshot_path_gui_publish( ctx, stem, ctx->local_in.incremental_snapshot_path, 0 );
-      } else {
-        char snapshot_path[ PATH_MAX+30UL ]; /* 30 is fd_cstr_nlen( "https://255.255.255.255:65536/", ULONG_MAX ) */
-        FD_TEST( fd_cstr_printf_check( snapshot_path, sizeof(snapshot_path), NULL, "http://" FD_IP4_ADDR_FMT ":%hu/%s", FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ), ctx->http_incr_snapshot_name ) );
-        snapshot_path_gui_publish( ctx, stem, snapshot_path, 0 );
-      }
-    }
+  /* Clear stale http_*_snapshot_name for file loads before rename
+     functions run.  GUI publish is deferred to the META handler. */
+  if( file ) {
+    if( full ) fd_cstr_fini( ctx->http_full_snapshot_name );
+    else       fd_cstr_fini( ctx->http_incr_snapshot_name );
   }
 }
 
@@ -598,10 +572,9 @@ log_download( fd_snapct_tile_t * ctx,
     if( ci_entry->rpc_addr.l==addr.l ) {
       FD_TEST( ci_entry->allowed );
       FD_BASE58_ENCODE_32_BYTES( ci_entry->pubkey.uc, pubkey_b58 );
-      FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from allowed gossip peer %s at http://" FD_IP4_ADDR_FMT ":%hu/%s",
+      FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from allowed gossip peer %s at " FD_IP4_ADDR_FMT ":%hu",
                       full ? "full" : "incremental", slot, pubkey_b58,
-                      FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ),
-                      full ? ctx->http_full_snapshot_name : ctx->http_incr_snapshot_name ));
+                      FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
       return;
     }
   }
@@ -609,15 +582,13 @@ log_download( fd_snapct_tile_t * ctx,
   for( ulong i=0UL; i<ctx->config.sources.servers_cnt; i++ ) {
     if( addr.l==ctx->config.sources.servers[ i ].addr.l ) {
       if( ctx->config.sources.servers[ i ].is_https ) {
-        FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from configured server with index %lu at https://%s:%hu/%s",
+        FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from configured server with index %lu at %s:%hu",
                         full ? "full" : "incremental", slot, i,
-                        ctx->config.sources.servers[ i ].hostname, fd_ushort_bswap( addr.port ),
-                        full ? ctx->http_full_snapshot_name : ctx->http_incr_snapshot_name ));
+                        ctx->config.sources.servers[ i ].hostname, fd_ushort_bswap( addr.port ) ));
       } else {
-        FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from configured server with index %lu at http://" FD_IP4_ADDR_FMT ":%hu/%s",
+        FD_LOG_NOTICE(( "downloading %s snapshot at slot %lu from configured server with index %lu at " FD_IP4_ADDR_FMT ":%hu",
                         full ? "full" : "incremental", slot, i,
-                        FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ),
-                        full ? ctx->http_full_snapshot_name : ctx->http_incr_snapshot_name ));
+                        FD_IP4_ADDR_FMT_ARGS( addr.addr ), fd_ushort_bswap( addr.port ) ));
       }
       return;
     }
@@ -1462,13 +1433,17 @@ snapld_frag( fd_snapct_tile_t *  ctx,
              fd_stem_context_t * stem ) {
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) {
     /* Before snapld starts sending down data fragments, it first sends
-       a metadata message containing the total size of the snapshot as
-       well as the filename.  This is only done for HTTP loading. */
-    int full;
+       a metadata message containing the total size of the snapshot.
+       Both file and HTTP paths send this message. */
+    int full, file;
     switch( ctx->state ) {
-      case FD_SNAPCT_STATE_READING_FULL_HTTP:        full = 1; break;
-      case FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP: full = 0; break;
+      case FD_SNAPCT_STATE_READING_FULL_FILE:        full = 1; file = 1; break;
+      case FD_SNAPCT_STATE_READING_INCREMENTAL_FILE: full = 0; file = 1; break;
+      case FD_SNAPCT_STATE_READING_FULL_HTTP:        full = 1; file = 0; break;
+      case FD_SNAPCT_STATE_READING_INCREMENTAL_HTTP: full = 0; file = 0; break;
 
+      case FD_SNAPCT_STATE_FLUSHING_FULL_FILE_RESET:
+      case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_FILE_RESET:
       case FD_SNAPCT_STATE_FLUSHING_FULL_HTTP_RESET:
       case FD_SNAPCT_STATE_FLUSHING_INCREMENTAL_HTTP_RESET:
         return; /* Ignore */
@@ -1480,7 +1455,7 @@ snapld_frag( fd_snapct_tile_t *  ctx,
 
     if( FD_UNLIKELY( meta->total_sz==0UL ) ) {
       if( FD_UNLIKELY( !ctx->malformed ) ) {
-        FD_LOG_WARNING(( "received zero Content-Length metadata for %s snapshot, marking malformed", full ? "full" : "incremental" ));
+        FD_LOG_WARNING(( "received zero-length metadata for %s snapshot, marking malformed", full ? "full" : "incremental" ));
         ctx->malformed = 1;
         fd_stem_publish( stem, ctx->out_ld.idx, FD_SNAPSHOT_MSG_CTRL_ERROR, 0UL, 0UL, 0UL, 0UL, 0UL );
       }
@@ -1489,6 +1464,26 @@ snapld_frag( fd_snapct_tile_t *  ctx,
 
     if( full ) ctx->metrics.full.bytes_total        = meta->total_sz;
     else       ctx->metrics.incremental.bytes_total = meta->total_sz;
+
+    /* Publish snapshot path to GUI.  For file loads, use the local
+       path directly.  For HTTP downloads, construct the full URL from
+       the resolved snapshot name. */
+    if( file ) {
+      if( FD_LIKELY( !!ctx->out_gui.mem ) ) {
+        snapshot_path_gui_publish( ctx, stem, full ? ctx->local_in.full_snapshot_path : ctx->local_in.incremental_snapshot_path, full );
+      }
+    } else {
+      if( full ) fd_cstr_ncpy( ctx->http_full_snapshot_name, meta->resolved_name, PATH_MAX );
+      else       fd_cstr_ncpy( ctx->http_incr_snapshot_name, meta->resolved_name, PATH_MAX );
+
+      if( FD_LIKELY( !!ctx->out_gui.mem ) ) {
+        char snapshot_path[ PATH_MAX+30UL ]; /* 30 is fd_cstr_nlen( "https://255.255.255.255:65536/", ULONG_MAX ) */
+        FD_TEST( fd_cstr_printf_check( snapshot_path, sizeof(snapshot_path), NULL, "http://" FD_IP4_ADDR_FMT ":%hu/%s",
+                 FD_IP4_ADDR_FMT_ARGS( ctx->peer.addr.addr ), fd_ushort_bswap( ctx->peer.addr.port ),
+                 full ? ctx->http_full_snapshot_name : ctx->http_incr_snapshot_name ) );
+        snapshot_path_gui_publish( ctx, stem, snapshot_path, full );
+      }
+    }
 
     return;
   }

--- a/src/discof/restore/fd_snapdc_tile.c
+++ b/src/discof/restore/fd_snapdc_tile.c
@@ -99,12 +99,13 @@ handle_control_frag( fd_snapdc_tile_t *  ctx,
                      ulong               sig,
                      ulong               chunk,
                      ulong               sz ) {
-  if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) return;
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_LOAD_COMPLETE ) ) return;
 
-  /* All control messages cause us to want to reset the decompression stream */
-  ulong error = ZSTD_DCtx_reset( ctx->zstd, ZSTD_reset_session_only );
-  if( FD_UNLIKELY( ZSTD_isError( error ) ) ) FD_LOG_ERR(( "ZSTD_DCtx_reset failed (%lu-%s)", error, ZSTD_getErrorName( error ) ));
+  /* All control messages except META reset the decompression stream */
+  if( FD_UNLIKELY( sig!=FD_SNAPSHOT_MSG_META ) ) {
+    ulong error = ZSTD_DCtx_reset( ctx->zstd, ZSTD_reset_session_only );
+    if( FD_UNLIKELY( ZSTD_isError( error ) ) ) FD_LOG_ERR(( "ZSTD_DCtx_reset failed (%lu-%s)", error, ZSTD_getErrorName( error ) ));
+  }
 
   if( ctx->state==FD_SNAPSHOT_STATE_ERROR && sig!=FD_SNAPSHOT_MSG_CTRL_FAIL ) {
     /* Control messages move along the snapshot load pipeline.  Since
@@ -113,6 +114,17 @@ handle_control_frag( fd_snapdc_tile_t *  ctx,
        valid messages.  Only a fail message can revert this. */
     return;
   };
+
+  if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) {
+    /* Forward META to snapin so it can update the advertised
+       slot/hash for redirect-based downloads. */
+    FD_TEST( sz<=ctx->out.mtu );
+    void * dst = fd_chunk_to_laddr( ctx->out.mem, ctx->out.chunk );
+    fd_memcpy( dst, fd_chunk_to_laddr_const( ctx->in.mem, chunk ), sz );
+    fd_stem_publish( stem, 0UL, sig, ctx->out.chunk, sz, 0UL, 0UL, 0UL );
+    ctx->out.chunk = fd_dcache_compact_next( ctx->out.chunk, ctx->out.mtu, ctx->out.chunk0, ctx->out.wmark );
+    return;
+  }
 
   int forward_msg = 1;
 

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -1136,7 +1136,8 @@ static void
 handle_control_frag( fd_snapin_tile_t *  ctx,
                      fd_stem_context_t * stem,
                      ulong               sig,
-                     ulong               chunk ) {
+                     ulong               chunk,
+                     ulong               sz ) {
   if( ctx->state==FD_SNAPSHOT_STATE_ERROR && sig!=FD_SNAPSHOT_MSG_CTRL_FAIL ) {
     /* Control messages move along the snapshot load pipeline.  Since
        error conditions can be triggered by any tile in the pipeline,
@@ -1208,13 +1209,28 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       }
 
       /* Save the slot advertised by the snapshot peer and verify it
-         against the slot in the snapshot manifest.  For downloaded
-         snapshots, this is simply a best estimate.  The actual
-         advertised slot for downloaded snapshots is received in a
-         separate fd_ssctrl_meta_t message below. */
+         against the slot in the snapshot manifest.  For redirect-based
+         HTTP downloads, these are initial estimates from gossip and
+         will be updated by the META message below once the redirect
+         resolves to a concrete snapshot filename. */
       fd_ssctrl_init_t const * msg = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
       ctx->advertised_slot = msg->slot;
       fd_memcpy( ctx->advertised_hash, msg->snapshot_hash, FD_HASH_FOOTPRINT );
+      break;
+    }
+
+    case FD_SNAPSHOT_MSG_META: {
+      /* For redirect-based HTTP downloads, the META message carries
+         the resolved slot and hash from the actual snapshot filename
+         the server redirected to.  Update the advertised values so
+         that process_manifest can verify the manifest against them. */
+      FD_TEST( sz==sizeof(fd_ssctrl_meta_t) );
+      fd_ssctrl_meta_t const * meta = fd_chunk_to_laddr_const( ctx->in.wksp, chunk );
+      if( meta->resolved_slot!=ULONG_MAX ) {
+        ctx->advertised_slot = meta->resolved_slot;
+        fd_memcpy( ctx->advertised_hash, meta->resolved_hash, FD_HASH_FOOTPRINT );
+      }
+      forward_msg = 0; /* snapct already receives META directly from snapld */
       break;
     }
 
@@ -1352,7 +1368,7 @@ returnable_frag( fd_snapin_tile_t *  ctx,
   FD_TEST( ctx->state!=FD_SNAPSHOT_STATE_SHUTDOWN );
 
   if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_DATA ) ) return handle_data_frag( ctx, chunk, sz, stem );
-  else                                           handle_control_frag( ctx, stem, sig, chunk );
+  else                                           handle_control_frag( ctx, stem, sig, chunk, sz );
 
   return 0;
 }

--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -2,6 +2,7 @@
 #include "utils/fd_ssarchive.h"
 #include "utils/fd_ssctrl.h"
 #include "utils/fd_sshttp.h"
+#include "utils/fd_sspeer_selector.h"
 
 #include "../../disco/topo/fd_topo.h"
 #include "../../disco/metrics/fd_metrics.h"
@@ -38,6 +39,9 @@ typedef struct fd_snapld_tile {
   int   load_full;
   int   load_file;
   int   sent_meta;
+  int   is_redirect;
+  ulong gossip_slot;
+  ulong file_sz;
 
   ulong  bytes_in_batch;
   double download_speed_mibs;
@@ -218,6 +222,8 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->out_dc.chunk  = ctx->out_dc.chunk0;
   ctx->out_dc.mtu    = out_link->mtu;
 
+  FD_TEST( sizeof(fd_ssctrl_meta_t)<=ctx->out_dc.mtu );
+
   /* We can only close the temporary socket file descriptor after
      entering the sandbox because the sandbox checks all file
      descriptors are existent. */
@@ -291,6 +297,18 @@ after_credit( fd_snapld_tile_t *  ctx,
   uchar * out = fd_chunk_to_laddr( ctx->out_dc.mem, ctx->out_dc.chunk );
 
   if( ctx->load_file ) {
+    if( FD_UNLIKELY( !ctx->sent_meta ) ) {
+      FD_TEST( sizeof(fd_ssctrl_meta_t)<=ctx->out_dc.mtu );
+      fd_ssctrl_meta_t * meta = (fd_ssctrl_meta_t *)out;
+      meta->total_sz         = ctx->file_sz;
+      meta->resolved_slot    = ULONG_MAX;
+      fd_memset( meta->resolved_hash, 0, FD_HASH_FOOTPRINT );
+      meta->resolved_name[0] = '\0';
+      ctx->sent_meta = 1;
+      fd_stem_publish( stem, 0UL, FD_SNAPSHOT_MSG_META, ctx->out_dc.chunk, sizeof(fd_ssctrl_meta_t), 0UL, 0UL, 0UL );
+      ctx->out_dc.chunk = fd_dcache_compact_next( ctx->out_dc.chunk, sizeof(fd_ssctrl_meta_t), ctx->out_dc.chunk0, ctx->out_dc.wmark );
+      return;
+    }
     long result = read( ctx->load_full ? ctx->local_full_fd : ctx->local_incr_fd, out, ctx->out_dc.mtu );
     if( FD_UNLIKELY( result<=0L ) ) {
       if( result==0L ) {
@@ -329,6 +347,7 @@ after_credit( fd_snapld_tile_t *  ctx,
              we received with the headers (if any) to the next dcache
              chunk and then publish both in order. */
           ctx->start_batch = fd_log_wallclock();
+          FD_TEST( sizeof(fd_ssctrl_meta_t)<=ctx->out_dc.mtu );
           fd_ssctrl_meta_t * meta = (fd_ssctrl_meta_t *)out;
           ulong next_chunk = fd_dcache_compact_next( ctx->out_dc.chunk, sizeof(fd_ssctrl_meta_t), ctx->out_dc.chunk0, ctx->out_dc.wmark );
           memmove( fd_chunk_to_laddr( ctx->out_dc.mem, next_chunk ), out, data_len );
@@ -339,6 +358,51 @@ after_credit( fd_snapld_tile_t *  ctx,
             fd_sshttp_cancel( ctx->sshttp );
             break;
           }
+
+          /* Populate resolved redirect fields in META */
+          meta->resolved_slot    = ULONG_MAX;
+          meta->resolved_name[0] = '\0';
+          fd_memset( meta->resolved_hash, 0, FD_HASH_FOOTPRINT );
+
+          if( ctx->is_redirect ) {
+            char const * resolved_name = fd_sshttp_snapshot_name( ctx->sshttp );
+            if( FD_UNLIKELY( !resolved_name || resolved_name[0]=='\0' ) ) {
+              FD_LOG_WARNING(( "redirect-based download did not resolve to a snapshot filename for %s snapshot",
+                               ctx->load_full ? "full" : "incremental" ));
+              transition_malformed( ctx, stem );
+              fd_sshttp_cancel( ctx->sshttp );
+              break;
+            }
+            int is_full_filename = !strncmp( resolved_name, "snapshot-", 9 );
+            if( FD_UNLIKELY( is_full_filename!=ctx->load_full ) ) {
+              FD_LOG_WARNING(( "resolved snapshot type mismatch: expected %s but got %s filename `%s`",
+                               ctx->load_full ? "full" : "incremental", is_full_filename ? "full" : "incremental", resolved_name ));
+              transition_malformed( ctx, stem );
+              fd_sshttp_cancel( ctx->sshttp );
+              break;
+            }
+            ulong resolved_slot = fd_sshttp_resolved_slot( ctx->sshttp );
+            if( FD_UNLIKELY( resolved_slot<ctx->gossip_slot ) ) {
+              FD_LOG_WARNING(( "resolved snapshot slot %lu is older than gossip slot %lu for %s snapshot, rejecting",
+                               resolved_slot, ctx->gossip_slot, ctx->load_full ? "full" : "incremental" ));
+              transition_malformed( ctx, stem );
+              fd_sshttp_cancel( ctx->sshttp );
+              break;
+            }
+            if( FD_UNLIKELY( resolved_slot>=FD_SSPEER_PLAUSIBLE_MAX_SLOT ) ) {
+              FD_LOG_WARNING(( "resolved snapshot slot %lu exceeds plausibility bound for %s snapshot, rejecting",
+                               resolved_slot, ctx->load_full ? "full" : "incremental" ));
+              transition_malformed( ctx, stem );
+              fd_sshttp_cancel( ctx->sshttp );
+              break;
+            }
+            meta->resolved_slot = resolved_slot;
+            fd_memcpy( meta->resolved_hash, fd_sshttp_resolved_hash( ctx->sshttp ), FD_HASH_FOOTPRINT );
+            fd_cstr_ncpy( meta->resolved_name, resolved_name, PATH_MAX );
+            FD_LOG_NOTICE(( "redirect resolved to `%s` (slot %lu) for %s snapshot",
+                            resolved_name, resolved_slot, ctx->load_full ? "full" : "incremental" ));
+          }
+
           ctx->sent_meta = 1;
           fd_stem_publish( stem, 0UL, FD_SNAPSHOT_MSG_META, ctx->out_dc.chunk, sizeof(fd_ssctrl_meta_t), 0UL, 0UL, 0UL );
           ctx->out_dc.chunk = next_chunk;
@@ -426,9 +490,12 @@ returnable_frag( fd_snapld_tile_t *  ctx,
       ctx->state = FD_SNAPSHOT_STATE_PROCESSING;
       FD_TEST( sz==sizeof(fd_ssctrl_init_t) && sz<=ctx->out_dc.mtu );
       fd_ssctrl_init_t const * msg_in = fd_chunk_to_laddr_const( ctx->in_rd.base, chunk );
-      ctx->load_full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
-      ctx->load_file = msg_in->file;
-      ctx->sent_meta = 0;
+      ctx->load_full   = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
+      ctx->load_file   = msg_in->file;
+      ctx->sent_meta   = 0;
+      ctx->gossip_slot = msg_in->slot;
+      ctx->is_redirect = msg_in->is_redirect;
+      ctx->file_sz     = msg_in->file_sz;
 
       ctx->window_deadline = LONG_MAX;
       ctx->bytes_in_window = 0UL;

--- a/src/discof/restore/fd_snapwr_tile.c
+++ b/src/discof/restore/fd_snapwr_tile.c
@@ -259,6 +259,8 @@ static void
 handle_control_frag( fd_snapwr_tile_t *  ctx,
                      fd_stem_context_t * stem,
                      ulong               sig ) {
+  if( FD_UNLIKELY( sig==FD_SNAPSHOT_MSG_META ) ) return;
+
   if( ctx->state==FD_SNAPSHOT_STATE_ERROR && sig!=FD_SNAPSHOT_MSG_CTRL_FAIL ) {
     /* Control messages move along the snapshot load pipeline.  Since
        error conditions can be triggered by any tile in the pipeline,

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -124,11 +124,16 @@ typedef struct fd_ssctrl_init {
   char          path[ PATH_MAX ];
   ulong         path_len;
   int           is_https;
+  int           is_redirect; /* 1 if using well-known redirect path */
+  ulong         file_sz;     /* file size in bytes (file loads only, 0 for HTTP) */
 } fd_ssctrl_init_t;
 
 /* Sent by snapld to tell snapct metadata about a downloaded snapshot. */
 typedef struct fd_ssctrl_meta {
   ulong total_sz;
+  ulong resolved_slot;
+  uchar resolved_hash[ FD_HASH_FOOTPRINT ];
+  char  resolved_name[ PATH_MAX ];
 } fd_ssctrl_meta_t;
 
 struct fd_snapshot_account_hdr {

--- a/src/discof/restore/utils/fd_sshttp.c
+++ b/src/discof/restore/utils/fd_sshttp.c
@@ -8,6 +8,8 @@
 #include "../../../util/log/fd_log.h"
 #include "../../../waltz/http/fd_http.h"
 
+FD_STATIC_ASSERT( FD_HASH_FOOTPRINT==32UL, resolved_hash_sz );
+
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
@@ -50,6 +52,8 @@ fd_sshttp_new( void * shmem ) {
   sshttp->sockfd = -1;
   sshttp->content_len = 0UL;
   fd_cstr_fini( sshttp->snapshot_name );
+  sshttp->resolved_slot = 0UL;
+  fd_memset( sshttp->resolved_hash, 0, FD_HASH_FOOTPRINT );
 
 #if FD_HAS_OPENSSL
   sshttp->ssl     = NULL;
@@ -160,7 +164,12 @@ fd_sshttp_init( fd_sshttp_t * http,
 #endif
   }
 
-  if( hops!=ULONG_MAX ) http->hops = hops;
+  if( hops!=ULONG_MAX ) {
+    http->hops = hops;
+    fd_cstr_fini( http->snapshot_name );
+    http->resolved_slot = 0UL;
+    fd_memset( http->resolved_hash, 0, FD_HASH_FOOTPRINT );
+  }
   http->request_sent = 0UL;
   int fmt_ok;
   if( FD_LIKELY( is_https ) ) {
@@ -508,6 +517,10 @@ follow_redirect( fd_sshttp_t *        http,
         return FD_SSHTTP_ADVANCE_ERROR;
       }
 
+      http->resolved_slot = (incremental_entry_slot!=ULONG_MAX)
+                            ? incremental_entry_slot : full_entry_slot;
+      fd_memcpy( http->resolved_hash, decoded_hash, FD_HASH_FOOTPRINT );
+
       char encoded_hash[ FD_BASE58_ENCODED_32_SZ ];
       fd_base58_encode_32( decoded_hash, NULL, encoded_hash );
 
@@ -713,6 +726,16 @@ fd_sshttp_snapshot_name( fd_sshttp_t const * http ) {
 ulong
 fd_sshttp_content_len( fd_sshttp_t const * http ) {
   return http->content_len;
+}
+
+ulong
+fd_sshttp_resolved_slot( fd_sshttp_t const * http ) {
+  return http->resolved_slot;
+}
+
+uchar const *
+fd_sshttp_resolved_hash( fd_sshttp_t const * http ) {
+  return http->resolved_hash;
 }
 
 int

--- a/src/discof/restore/utils/fd_sshttp.h
+++ b/src/discof/restore/utils/fd_sshttp.h
@@ -26,6 +26,12 @@ fd_sshttp_snapshot_name( fd_sshttp_t const * http );
 ulong
 fd_sshttp_content_len( fd_sshttp_t const * http );
 
+ulong
+fd_sshttp_resolved_slot( fd_sshttp_t const * http );
+
+uchar const *
+fd_sshttp_resolved_hash( fd_sshttp_t const * http );
+
 /* fd_sshttp_init initializes an sshttp connection to the given server.
    addr is the resolved IP address and port.  hostname is a
    null-terminated string used for the Host header and TLS SNI.

--- a/src/discof/restore/utils/fd_sshttp_private.h
+++ b/src/discof/restore/utils/fd_sshttp_private.h
@@ -44,6 +44,8 @@ struct fd_sshttp_private {
   char  response[ USHORT_MAX ];
 
   char  snapshot_name[ PATH_MAX ];
+  ulong resolved_slot;       /* effective slot from redirect filename */
+  uchar resolved_hash[ 32 ]; /* binary hash from redirect filename */
 
 #if FD_HAS_OPENSSL
   SSL_CTX * ssl_ctx;


### PR DESCRIPTION
Switch HTTP snapshot downloads from direct filenames to redirect paths (`/snapshot.tar.bz2`, `/incremental-snapshot.tar.bz2`). This corrects the issue of HTTP 400 responses for outdated gossip slot info.
Propagate resolved slot/hash through the pipeline (snapld -> snapdc -> snapin) so snapin can verify the manifest against the actual redirect target
Validate redirect responses.
Adjust logs accordingly.

Closes https://github.com/firedancer-io/firedancer/issues/8956.
Closes https://github.com/firedancer-io/firedancer/issues/9091.