### PR TITLE
firedancer: add remove-all-authorized-voters command

### DIFF
--- a/book/api/firedancer-cli.md
+++ b/book/api/firedancer-cli.md
@@ -75,3 +75,50 @@ than 16).
 | `--config <path>` | Path to a configuration TOML file of the validator to add an authorized voter for. This must be the same configuration file the validator was started with |
 
 <<< @/snippets/commands/add-authorized-voter.ansi
+
+## `remove-all-authorized-voters`
+Removes all authorized voters from the running validator, including any
+seeded from `[paths.authorized_voter_paths]` at startup as well as any
+added at runtime with `add-authorized-voter`. After removal the validator
+can only sign votes for vote accounts whose authorized voter is the
+identity key. The command takes no arguments.
+
+::: warning WARNING
+
+`remove-all-authorized-voters` is only supported with `firedancer` and
+not `fdctl`. In other words, the command is only supported while running
+the full client validator and not Frankendancer.
+
+:::
+
+::: warning WARNING
+
+`remove-all-authorized-voters` must be called with the configuration file
+you started the validator with, like
+`firedancer remove-all-authorized-voters --config <config.toml>`, if the
+`config` argument is not provided, the command may not clear the
+authorized voter keys on all tiles and your validator may produce invalid
+votes.
+
+:::
+
+It is safe to call the command while the validator is running and voting.
+The validator clears the tower tile before the sign tiles, so a vote is
+never produced referencing an authorized voter after its key has been
+removed; in between, the validator simply falls back to signing with the
+identity key.
+
+The command is idempotent: removing when there are no authorized voters
+also succeeds. It exits successfully (with an exit code of 0) and prints
+`All authorized voters removed`.
+
+The change is live only: it is not written back to the configuration
+file, so any voters listed in `[paths.authorized_voter_paths]` return on
+the validator's next restart. To drop them across restarts, also remove
+them from the configuration file.
+
+| Arguments         | Description |
+|-------------------|-------------|
+| `--config <path>` | Path to a configuration TOML file of the validator to remove authorized voters from. This must be the same configuration file the validator was started with |
+
+<<< @/snippets/commands/remove-all-authorized-voters.ansi

--- a/book/snippets/commands/remove-all-authorized-voters.ansi
+++ b/book/snippets/commands/remove-all-authorized-voters.ansi
@@ -1,0 +1,2 @@
+$ sudo firedancer remove-all-authorized-voters --config ~/config.toml
+[32mNOTICE [0m All authorized voters removed

--- a/src/app/firedancer-dev/main.h
+++ b/src/app/firedancer-dev/main.h
@@ -208,6 +208,7 @@ extern action_t fd_action_gossip_dump;
 extern action_t fd_action_monitor_gossip;
 extern action_t fd_action_watch;
 extern action_t fd_action_add_authorized_voter;
+extern action_t fd_action_remove_all_authorized_voters;
 #if FD_HAS_ROCKSDB
 extern action_t fd_action_forktest;
 #endif
@@ -250,6 +251,7 @@ action_t * ACTIONS[] = {
   &fd_action_monitor_gossip,
   &fd_action_watch,
   &fd_action_add_authorized_voter,
+  &fd_action_remove_all_authorized_voters,
 #if FD_HAS_ROCKSDB
   &fd_action_forktest,
 #endif

--- a/src/app/firedancer/Local.mk
+++ b/src/app/firedancer/Local.mk
@@ -20,6 +20,7 @@ $(call add-objs,callbacks,fd_firedancer)
 
 # commands
 $(call add-objs,commands/add_authorized_voter,fd_firedancer)
+$(call add-objs,commands/remove_all_authorized_voters,fd_firedancer)
 $(call add-objs,commands/shred_version,fd_firedancer)
 $(call add-objs,commands/set_identity,fd_firedancer)
 $(call add-objs,commands/monitor_gossip/monitor_gossip commands/monitor_gossip/gossip_diag,fd_firedancer)

--- a/src/app/firedancer/commands/remove_all_authorized_voters.c
+++ b/src/app/firedancer/commands/remove_all_authorized_voters.c
@@ -1,0 +1,87 @@
+#include "../../shared/fd_config.h"
+#include "../../shared/fd_action.h"
+
+#include "../../../disco/topo/fd_topo.h"
+#include "../../../discof/admin/fd_adminctl.h"
+#include "../../../util/pod/fd_pod.h"
+
+void
+remove_all_authorized_voters_cmd_fn( args_t *   args FD_PARAM_UNUSED,
+                                     config_t * config ) {
+
+  /* Join the adminctl object.  Once joined, we can publish a request to
+     the admin tile. */
+  ulong admin_ctl_obj_id = fd_pod_query_ulong( config->topo.props, "adminctl", ULONG_MAX );
+  if( FD_UNLIKELY( admin_ctl_obj_id==ULONG_MAX ) ) FD_LOG_ERR(( "Failed to remove authorized voters as the command could not communicate with the "
+                                                                "running Firedancer process.  It is possible you are running the command from an "
+                                                                "older or newer version of Firedancer that is no longer compatible." ));
+  fd_topo_obj_t const * admin_ctl_obj = &config->topo.objs[ admin_ctl_obj_id ];
+
+  fd_topo_join_workspace( &config->topo, &config->topo.workspaces[ admin_ctl_obj->wksp_id ], FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );
+
+  fd_adminctl_t * adminctl = fd_adminctl_join( fd_topo_obj_laddr( &config->topo, admin_ctl_obj->id ) );
+  if( FD_UNLIKELY( !adminctl ) ) FD_LOG_ERR(( "Failed to remove authorized voters as the command could not communicate with the "
+                                              "running Firedancer process.  It is possible you are running the command from an "
+                                              "older or newer version of Firedancer that is no longer compatible." ));
+
+  void * payload     = NULL;
+  ulong  payload_max = 0UL;
+  ulong  slot_idx    = fd_adminctl_reserve( adminctl, &payload, &payload_max );
+  if( FD_UNLIKELY( slot_idx==ULONG_MAX ) ) {
+    FD_LOG_ERR(( "Failed to process `remove-all-authorized-voters` command as there are other pending "
+                 "commands that are being processed.  Please wait for other commands to complete "
+                 "or forcefully terminate the other processes and retry the command." ));
+  }
+
+  fd_adminctl_remove_all_auth_voters_t * req = (fd_adminctl_remove_all_auth_voters_t *)payload;
+  req->version = FD_ADMINCTL_REMOVE_ALL_AUTH_VOTERS_PAYLOAD_VERSION;
+
+  fd_adminctl_publish( adminctl, slot_idx, FD_ADMINCTL_CMD_REMOVE_ALL_AUTH_VOTERS, sizeof(fd_adminctl_remove_all_auth_voters_t) );
+
+  ulong result = fd_adminctl_wait( adminctl, slot_idx );
+  switch( result ) {
+    case FD_ADMINCTL_RESULT_SUCCESS:
+      FD_LOG_NOTICE(( "All authorized voters removed" ));
+      break;
+    case FD_REMOVE_ALL_AUTH_VOTERS_RESULT_PAYLOAD_TOO_SMALL:
+    case FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNSUPPORTED_PAYLOAD_VERSION:
+    case FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNEXPECTED_PAYLOAD_SIZE:
+      FD_LOG_ERR(( "Failed to remove authorized voter keys: the command was not able to "
+                   "successfully communicate with the running Firedancer process. It "
+                   "is possible that you are running the command from an older or "
+                   "newer version of Firedancer that is no longer compatible." ));
+    default:
+      FD_LOG_ERR(( "Unexpected remove-all-authorized-voters result %lu.  This can be a result "
+                   "of a version mismatch between the command and the running Firedancer "
+                   "process. Please report this to the Firedancer team for investigation.", result ));
+  }
+}
+
+action_t fd_action_remove_all_authorized_voters = {
+  .name           = "remove-all-authorized-voters",
+  .args           = NULL,
+  .fn             = remove_all_authorized_voters_cmd_fn,
+  .require_config = 1,
+  .perm           = NULL,
+  .description    = "Remove all authorized voters from the validator",
+  .detail         = "Removes every authorized voter key from an already running validator,\n"
+                    "including any seeded from [paths.authorized_voter_paths] at startup as\n"
+                    "well as any added at runtime with add-authorized-voter.  After this the\n"
+                    "validator can only sign votes for vote accounts whose authorized voter is\n"
+                    "the identity key.  On success it prints `All authorized voters removed` and\n"
+                    "exits 0.  It is idempotent: removing when there are no authorized voters\n"
+                    "also succeeds.\n"
+                    "\n"
+                    "This command does not start a validator; it attaches to one that is already\n"
+                    "running.  It finds the running validator from the shared memory described by\n"
+                    "the configuration file, so you must point --config at the SAME config file the\n"
+                    "validator was started with, and run it from a binary built from the SAME git\n"
+                    "commit (compare this binary's `--version` against the running validator's).  If\n"
+                    "the config or binary differ, the layout will not match and the command fails\n"
+                    "without changing anything.\n"
+                    "\n"
+                    "The change is live only: it is not written back to the config file, so any\n"
+                    "voters in [paths.authorized_voter_paths] return on the validator's next\n"
+                    "restart.  To drop them across restarts, also remove them from the config.",
+  .usage          = "remove-all-authorized-voters",
+};

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -162,6 +162,7 @@ extern action_t fd_action_version;
 extern action_t fd_action_shred_version;
 extern action_t fd_action_watch;
 extern action_t fd_action_add_authorized_voter;
+extern action_t fd_action_remove_all_authorized_voters;
 extern action_t fd_action_set_identity;
 extern action_t fd_action_monitor_gossip;
 
@@ -179,6 +180,7 @@ action_t * ACTIONS[] = {
   &fd_action_version,
   &fd_action_shred_version,
   &fd_action_add_authorized_voter,
+  &fd_action_remove_all_authorized_voters,
   &fd_action_watch,
   &fd_action_monitor_gossip,
   &fd_action_set_identity,

--- a/src/disco/keyguard/fd_keyswitch.h
+++ b/src/disco/keyguard/fd_keyswitch.h
@@ -17,6 +17,7 @@
 #define FD_KEYSWITCH_STATE_UNHALT_PENDING (3UL)
 #define FD_KEYSWITCH_STATE_FAILED         (4UL)
 #define FD_KEYSWITCH_STATE_COMPLETED      (5UL)
+#define FD_KEYSWITCH_STATE_CLEAR_PENDING  (6UL)
 
 struct __attribute__((aligned(FD_KEYSWITCH_ALIGN))) fd_keyswitch_private {
   ulong magic;     /* ==FD_KEYSWITCH_MAGIC */

--- a/src/disco/keyguard/fd_sign_tile.c
+++ b/src/disco/keyguard/fd_sign_tile.c
@@ -128,6 +128,13 @@ during_housekeeping_sensitive( fd_sign_ctx_t * ctx ) {
     ctx->authorized_voters_cnt++;
     fd_keyswitch_state( ctx->av_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }
+
+  if( FD_UNLIKELY( ctx->av_keyswitch && fd_keyswitch_state_query( ctx->av_keyswitch )==FD_KEYSWITCH_STATE_CLEAR_PENDING ) ) {
+    fd_memzero_explicit( ctx->authorized_voter_private_keys, sizeof( ctx->authorized_voter_private_keys ) );
+    fd_memzero_explicit( ctx->authorized_voter_pubkeys,      sizeof( ctx->authorized_voter_pubkeys      ) );
+    ctx->authorized_voters_cnt = 0UL;
+    fd_keyswitch_state( ctx->av_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
+  }
 }
 
 static inline void

--- a/src/discof/admin/fd_admin_tile.c
+++ b/src/discof/admin/fd_admin_tile.c
@@ -735,6 +735,180 @@ add_authorized_voter( fd_admin_tile_ctx_t *     ctx,
   fd_adminctl_complete( adminctl, slot_idx, result );
 }
 
+/* Removing all authorized voters from the validator is the inverse of
+   add-authorized-voter, and must be done in the opposite order.  When
+   adding, the sign tile is updated before the tower tile so that the
+   tower never asks the sign tile to sign a vote with an authority index
+   the sign tile does not yet know about.  When removing, the tower tile
+   must be cleared before the sign tiles, so that the tower stops
+   referencing an authorized voter index before the sign tile drops the
+   corresponding key.
+
+   Vote signing is synchronous (the tower busy-waits for the sign tile
+   reply) and keyswitch processing runs during housekeeping, between
+   frags, so there are never in-flight vote signing requests outstanding
+   while keys change.  Once the tower clears its authorized voter map it
+   can no longer emit a signing request referencing a removed voter, so
+   clearing the sign tiles afterwards is safe.  All transitions are
+   linear and in forward order.
+
+   Unlike add-authorized-voter, removal cannot fail on the tile side: it
+   is unconditional and idempotent (clearing an empty set succeeds). */
+
+/* State 0: UNLOCKED
+   The validator is not currently in the process of switching keys. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCKED             (0UL)
+
+/* State 1: LOCKED
+   Some client to the validator has requested to remove all authorized
+   voters.  To do so, it acquired an exclusive lock on the validator to
+   prevent the removal potentially being interleaved with another
+   client. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_LOCKED               (1UL)
+
+/* State 2: TOWER_TILE_REQUESTED
+   The tower tile has been notified to clear its authorized voter set.
+   It is cleared first so it stops preparing vote transactions with any
+   authorized voter before the sign tiles drop the keys. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_REQUESTED (2UL)
+
+/* State 3: TOWER_TILE_CLEARED
+   The tower tile confirmed it cleared its authorized voter map.  At
+   this point the validator will only prepare vote transactions signed
+   by the identity key. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_CLEARED   (3UL)
+
+/* State 4: SIGN_TILE_REQUESTED
+   All sign tiles have been notified to clear their authorized voter
+   keys. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_REQUESTED  (4UL)
+
+/* State 5: SIGN_TILE_CLEARED
+   All sign tiles confirmed they cleared (and securely zeroed) their
+   authorized voter keys. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_CLEARED    (5UL)
+
+/* State 6: UNLOCK_REQUESTED
+   The client requests that the tower tile release the lock. */
+#define FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCK_REQUESTED     (6UL)
+
+static void
+poll_remove_all_authorized_voters( fd_admin_tile_ctx_t * ctx,
+                                   ulong *               state ) {
+  fd_keyswitch_t * tower = ctx->tower_av_keyswitch;
+
+  switch( *state ) {
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCKED: {
+      if( FD_LIKELY( FD_KEYSWITCH_STATE_UNLOCKED==FD_ATOMIC_CAS( &tower->state, FD_KEYSWITCH_STATE_UNLOCKED, FD_KEYSWITCH_STATE_LOCKED ) ) ) {
+        *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_LOCKED;
+        FD_LOG_INFO(( "Locking authorized voter set for authorized voter update..." ));
+      } else {
+        /* keyswitch changes should be guarded and ordered by adminctl.
+           If the keyswitch is in a locked state means there is
+           unexpected process state and the validator should crash. */
+        FD_LOG_CRIT(( "keyswitch is in a locked state but should be unlocked" ));
+      }
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_LOCKED: {
+      FD_COMPILER_MFENCE();
+      tower->state = FD_KEYSWITCH_STATE_CLEAR_PENDING;
+      FD_COMPILER_MFENCE();
+      *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_REQUESTED;
+      FD_LOG_INFO(( "Requesting tower tile to clear authorized voter key set..." ));
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_REQUESTED: {
+      if( FD_LIKELY( tower->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
+        *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_CLEARED;
+        FD_LOG_INFO(( "Tower tile authorized voter key set cleared..." ));
+      } else {
+        FD_SPIN_PAUSE();
+      }
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_TOWER_TILE_CLEARED: {
+      for( ulong i=0UL; i<ctx->sign_av_keyswitch_cnt; i++ ) {
+        fd_keyswitch_t * sign = ctx->sign_av_keyswitch[ i ];
+        FD_COMPILER_MFENCE();
+        sign->state = FD_KEYSWITCH_STATE_CLEAR_PENDING;
+        FD_COMPILER_MFENCE();
+      }
+      *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_REQUESTED;
+      FD_LOG_INFO(( "Requesting all sign tiles to clear authorized voter key set..." ));
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_REQUESTED: {
+      int all_cleared = 1;
+      for( ulong i=0UL; i<ctx->sign_av_keyswitch_cnt; i++ ) {
+        fd_keyswitch_t * sign = ctx->sign_av_keyswitch[ i ];
+        if( FD_UNLIKELY( sign->state!=FD_KEYSWITCH_STATE_COMPLETED ) ) {
+          all_cleared = 0;
+          break;
+        }
+      }
+
+      if( FD_LIKELY( all_cleared ) ) *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_CLEARED;
+      else                           FD_SPIN_PAUSE();
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_SIGN_TILE_CLEARED: {
+      tower->state = FD_KEYSWITCH_STATE_UNHALT_PENDING;
+      *state       = FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCK_REQUESTED;
+      FD_LOG_INFO(( "Requesting an unlock of the authorized voter key set..." ));
+      break;
+    }
+    case FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCK_REQUESTED: {
+      if( FD_LIKELY( tower->state==FD_KEYSWITCH_STATE_UNLOCKED ) ) {
+        *state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCKED;
+        FD_LOG_INFO(( "Authorized voter key set unlocked..." ));
+      } else {
+        FD_SPIN_PAUSE();
+      }
+      break;
+    }
+    default: {
+      FD_LOG_CRIT(( "Unexpected remove-all-authorized-voters state %lu", *state ));
+    }
+  }
+}
+
+static void
+remove_all_authorized_voters( fd_admin_tile_ctx_t * ctx,
+                              ulong                 slot_idx,
+                              void *                data,
+                              ulong                 data_sz ) {
+
+  fd_adminctl_t * adminctl = ctx->adminctl;
+
+  if( FD_UNLIKELY( data_sz<sizeof(ulong) ) ) {
+    FD_LOG_WARNING(( "adminctl remove-all-authorized-voters payload too small: %lu", data_sz ));
+    fd_adminctl_complete( adminctl, slot_idx, FD_REMOVE_ALL_AUTH_VOTERS_RESULT_PAYLOAD_TOO_SMALL );
+    return;
+  }
+
+  ulong version = FD_LOAD( ulong, data );
+  if( FD_UNLIKELY( version!=FD_ADMINCTL_REMOVE_ALL_AUTH_VOTERS_PAYLOAD_VERSION ) ) {
+    FD_LOG_WARNING(( "unsupported adminctl remove-all-authorized-voters payload version %lu", version ));
+    fd_adminctl_complete( adminctl, slot_idx, FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNSUPPORTED_PAYLOAD_VERSION );
+    return;
+  }
+
+  if( FD_UNLIKELY( data_sz!=sizeof(fd_adminctl_remove_all_auth_voters_t) ) ) {
+    FD_LOG_WARNING(( "unexpected adminctl remove-all-authorized-voters payload_sz %lu", data_sz ));
+    fd_adminctl_complete( adminctl, slot_idx, FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNEXPECTED_PAYLOAD_SIZE );
+    return;
+  }
+
+  ulong state = FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCKED;
+  for(;;) {
+    poll_remove_all_authorized_voters( ctx, &state );
+    if( FD_UNLIKELY( state==FD_REMOVE_ALL_AUTH_VOTERS_STATE_UNLOCKED ) ) break;
+  }
+
+  fd_adminctl_complete( adminctl, slot_idx, FD_ADMINCTL_RESULT_SUCCESS );
+}
+
 static inline void FD_FN_SENSITIVE
 after_credit( fd_admin_tile_ctx_t * ctx,
               fd_stem_context_t *   stem FD_PARAM_UNUSED,
@@ -756,6 +930,10 @@ after_credit( fd_admin_tile_ctx_t * ctx,
       break;
     case FD_ADMINCTL_CMD_SET_IDENTITY:
       set_identity( ctx, slot_idx, payload, payload_sz );
+      *charge_busy = 1;
+      break;
+    case FD_ADMINCTL_CMD_REMOVE_ALL_AUTH_VOTERS:
+      remove_all_authorized_voters( ctx, slot_idx, payload, payload_sz );
       *charge_busy = 1;
       break;
     default:

--- a/src/discof/admin/fd_adminctl.h
+++ b/src/discof/admin/fd_adminctl.h
@@ -31,9 +31,10 @@
    All input into fd_adminctl_t must be trusted.  If the adminctl memory
    layout changes, adminctl magic must be updated. */
 
-#define FD_ADMINCTL_CMD_IDLE           (0UL)
-#define FD_ADMINCTL_CMD_ADD_AUTH_VOTER (1UL)
-#define FD_ADMINCTL_CMD_SET_IDENTITY   (2UL)
+#define FD_ADMINCTL_CMD_IDLE                   (0UL)
+#define FD_ADMINCTL_CMD_ADD_AUTH_VOTER         (1UL)
+#define FD_ADMINCTL_CMD_SET_IDENTITY           (2UL)
+#define FD_ADMINCTL_CMD_REMOVE_ALL_AUTH_VOTERS (3UL)
 
 #define FD_ADMINCTL_ALIGN       (8UL)
 #define FD_ADMINCTL_PAYLOAD_MAX (256UL)
@@ -71,6 +72,16 @@ typedef struct fd_adminctl_set_identity_v1 fd_adminctl_set_identity_t;
 #define FD_SET_IDENTITY_RESULT_UNSUPPORTED_PAYLOAD_VERSION (3UL)
 #define FD_SET_IDENTITY_RESULT_UNEXPECTED_PAYLOAD_SIZE     (4UL)
 #define FD_SET_IDENTITY_RESULT_KEYPAIR_MISMATCH            (5UL)
+
+struct fd_adminctl_remove_all_auth_voters_v1 {
+  ulong version; /* ==FD_ADMINCTL_REMOVE_ALL_AUTH_VOTERS_PAYLOAD_VERSION */
+};
+typedef struct fd_adminctl_remove_all_auth_voters_v1 fd_adminctl_remove_all_auth_voters_t;
+#define FD_ADMINCTL_REMOVE_ALL_AUTH_VOTERS_PAYLOAD_VERSION (1UL)
+
+#define FD_REMOVE_ALL_AUTH_VOTERS_RESULT_PAYLOAD_TOO_SMALL           (2UL)
+#define FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNSUPPORTED_PAYLOAD_VERSION (3UL)
+#define FD_REMOVE_ALL_AUTH_VOTERS_RESULT_UNEXPECTED_PAYLOAD_SIZE     (4UL)
 
 typedef struct fd_adminctl_private fd_adminctl_t;
 

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -1675,6 +1675,12 @@ during_housekeeping( fd_tower_tile_t * ctx ) {
     fd_keyswitch_state( ctx->auth_vtr_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }
 
+  if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->auth_vtr_keyswitch )==FD_KEYSWITCH_STATE_CLEAR_PENDING ) ) {
+    auth_vtr_clear( ctx->auth_vtr );
+    ctx->auth_vtr_path_cnt = 0UL;
+    fd_keyswitch_state( ctx->auth_vtr_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
+  }
+
   /* FIXME: Currently, the tower tile doesn't support set-identity with
      a tower file.  When support for a tower file is added, we need to
      swap the file that is running and sync it to the local state of


### PR DESCRIPTION
Adds the inverse of add-authorized-voter, matching agave-validator's `authorized-voter remove-all` (removeAllAuthorizedVoters admin RPC). Removes every authorized voter from a running validator, including config-seeded and runtime-added ones, leaving only the identity key.

Mechanism mirrors add-authorized-voter but in reverse order: a new FD_KEYSWITCH_STATE_CLEAR_PENDING keyswitch signal clears the tower tile first (so it stops referencing any authorized voter index), then the sign tiles (which securely zero key material). Vote signing is synchronous and keyswitch handling runs between frags, so no in-flight vote-sign request can reference a key after the tower stops emitting them. Removal is unconditional and idempotent.