### PR TITLE
rdisp: do not mutate keys currently in map

### DIFF
--- a/src/discof/replay/fd_rdisp.c
+++ b/src/discof/replay/fd_rdisp.c
@@ -882,6 +882,7 @@ fd_rdisp_rekey_block( fd_rdisp_t *           disp,
   fd_rdisp_blockinfo_t * block = block_map_ele_query      ( disp->blockmap, &old_tag, NULL, block_pool );
   if( FD_UNLIKELY(        NULL== block ) )                                                                   return -1;
 
+  block_map_idx_remove( disp->blockmap, &old_tag, ULONG_MAX, block_pool );
   block->block = new_tag;
   block_map_ele_insert( disp->blockmap, block, block_pool );
   return 0;

--- a/src/discof/replay/fd_rdisp.h
+++ b/src/discof/replay/fd_rdisp.h
@@ -289,9 +289,9 @@ fd_rdisp_demote_block( fd_rdisp_t *          disp,
 
 
 /* fd_rdisp_rekey_block renames the block with tag old_tag so that it
-   has tag new_tag instead.  The block retains all transactions, it's
+   has tag new_tag instead.  The block retains all transactions, its
    STAGED/UNSTAGED state, etc.  On successful return, tag old_tag will
-   know longer be a known tag, and new_tag must be used in any future
+   no longer be a known tag, and new_tag must be used in any future
    calls to refer to the block previously known as old_tag.
 
    disp must be a valid local join.  new_tag must not be a known tag,

--- a/src/discof/replay/fd_rdisp_simple.c
+++ b/src/discof/replay/fd_rdisp_simple.c
@@ -329,6 +329,7 @@ fd_rdisp_rekey_block( fd_rdisp_t *           disp,
   fd_rdisp_blockinfo_t * block = block_map_ele_query      ( disp->blockmap, &old_tag, NULL, block_pool );
   if( FD_UNLIKELY(        NULL== block ) )                                                                   return -1;
 
+  block_map_idx_remove( disp->blockmap, &old_tag, ULONG_MAX, block_pool );
   block->block = new_tag;
   block_map_ele_insert( disp->blockmap, block, block_pool );
   return 0;

--- a/src/discof/replay/test_rdisp.c
+++ b/src/discof/replay/test_rdisp.c
@@ -478,10 +478,30 @@ main( int     argc,
   FD_TEST(  0==fd_rdisp_add_block( disp, tag( 1UL ), FD_RDISP_UNSTAGED ) );
   FD_TEST( 0x1UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
 
+  FD_TEST(  0==fd_rdisp_add_block( disp, tag( 8UL ), FD_RDISP_UNSTAGED ) );
+  FD_TEST(  0==fd_rdisp_rekey_block( disp, tag( 9UL ), tag( 8UL ) ) );
+  fd_rdisp_verify( disp, verify_scratch );
+  FD_TEST( -1==fd_rdisp_remove_block( disp, tag( 8UL ) ) );
+  FD_TEST(  0==fd_rdisp_add_block( disp, tag( 8UL ), FD_RDISP_UNSTAGED ) );
+  FD_TEST(  0==fd_rdisp_remove_block( disp, tag( 8UL ) ) );
+  FD_TEST(  0==fd_rdisp_remove_block( disp, tag( 9UL ) ) );
+  fd_rdisp_verify( disp, verify_scratch );
+
   FD_TEST(  0==fd_rdisp_add_block( disp, tag( 2UL ), 2 ) );
   FD_TEST( 0x5UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
   FD_TEST(  0==fd_rdisp_remove_block( disp, tag( 2UL ) ) );
   FD_TEST( 0x1UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
+
+  FD_TEST(  0==fd_rdisp_add_block( disp, tag( 10UL ), 3 ) );
+  FD_TEST( 0x9UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
+  FD_TEST(  0==fd_rdisp_rekey_block( disp, tag( 11UL ), tag( 10UL ) ) );
+  fd_rdisp_verify( disp, verify_scratch );
+  FD_TEST( 0x9UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
+  FD_TEST( tag_eq( lane_info[ 3 ].schedule_ready_block, 11UL ) );
+  FD_TEST( -1==fd_rdisp_remove_block( disp, tag( 10UL ) ) );
+  FD_TEST(  0==fd_rdisp_remove_block( disp, tag( 11UL ) ) );
+  FD_TEST( 0x1UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
+
   FD_TEST(  0==fd_rdisp_add_block( disp, tag( 6UL ), 2 ) );
   FD_TEST( 0x5UL==fd_rdisp_staging_lane_info( disp, lane_info ) );
   FD_TEST(  0==fd_rdisp_add_block( disp, tag( 2UL ), 2 ) );


### PR DESCRIPTION
We should not mutate keys that are currently in the map as the map verify function will fail and it's against the map contract as well:
https://github.com/firedancer-io/firedancer/blob/d72abfb99bc933844bbb7a885f5f7dc4b18b0c8f/src/util/tmpl/fd_map_chain.c#L22

I think I'll have an idea for a CodeQL query as well to catch similar issues.