### PR TITLE
quic: missing conn_final callback in fd_quic_tls_hs_cache_evict

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -1370,6 +1370,7 @@ fd_quic_tls_hs_cache_evict( fd_quic_t       * quic,
     return 0;
   }
 
+  fd_quic_cb_conn_final(quic, hs_to_free->context);
   fd_quic_conn_free( quic, hs_to_free->context );
   quic->metrics.hs_evicted_cnt++;
   return 1;


### PR DESCRIPTION
It is stated (for example at fd_txsend_tile.h:40) that the conn_final callback should be called before freeing a conn object, which is what this commit adds.

This might be reachable in the quic_tile, but doesn't cause any harm, since it's just a metrics update, and should not be reachable in the txsend_tile, given the low number of maximum open connection versus the pool size.