### PR TITLE
Revert "tls: remove client cert auth"

### DIFF
--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -285,8 +285,10 @@ fd_tls_send_cert_verify( fd_tls_t const *       this,
   return 0L;
 }
 
-static long fd_tls_server_hs_start        ( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
-static long fd_tls_server_hs_wait_finished( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
+static long fd_tls_server_hs_start           ( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
+static long fd_tls_server_hs_wait_cert       ( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
+static long fd_tls_server_hs_wait_cert_verify( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
+static long fd_tls_server_hs_wait_finished   ( fd_tls_t const *, fd_tls_estate_srv_t *, uchar const *, ulong, uint );
 
 long
 fd_tls_server_handshake( fd_tls_t const *      server,
@@ -296,9 +298,13 @@ fd_tls_server_handshake( fd_tls_t const *      server,
                          uint                  encryption_level ) {
   switch( handshake->base.state ) {
   case FD_TLS_HS_START:
-    return fd_tls_server_hs_start        ( server, handshake, msg, msg_sz, encryption_level );
+    return fd_tls_server_hs_start           ( server, handshake, msg, msg_sz, encryption_level );
+  case FD_TLS_HS_WAIT_CERT:
+    return fd_tls_server_hs_wait_cert       ( server, handshake, msg, msg_sz, encryption_level );
+  case FD_TLS_HS_WAIT_CV:
+    return fd_tls_server_hs_wait_cert_verify( server, handshake, msg, msg_sz, encryption_level );
   case FD_TLS_HS_WAIT_FINISHED:
-    return fd_tls_server_hs_wait_finished( server, handshake, msg, msg_sz, encryption_level );
+    return fd_tls_server_hs_wait_finished   ( server, handshake, msg, msg_sz, encryption_level );
   default:
     return fd_tls_alert( &handshake->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_ILLEGAL_STATE );
   }
@@ -695,6 +701,31 @@ fd_tls_server_hs_start( fd_tls_t const *      const server,
 
   fd_sha256_append( &transcript, msg_buf, server_ee_sz );
 
+  /* Send CertificateRequest ******************************************/
+
+  static uchar const cert_req[] = {
+    FD_TLS_MSG_CERT_REQ,     /* msg_type */
+    0x00, 0x00, 0x0b,        /* msg_sz */
+    0x00,                    /* certificate_request_context */
+    0x00, 0x08,              /* extensions length prefix */
+    0x00, FD_TLS_EXT_SIGNATURE_ALGORITHMS,
+                             /* ext type */
+    0x00, 0x04,              /* ext sz */
+    0x00, 0x02,              /* sigalg sz */
+    0x08, 0x07,              /* Ed25519 */
+  };
+
+  if( FD_UNLIKELY( !server->sendmsg_fn(
+        handshake,
+        cert_req, sizeof(cert_req),
+        FD_TLS_LEVEL_HANDSHAKE,
+        /* flush */ 0 ) ) )
+    return fd_tls_alert( &handshake->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_SENDMSG_FAIL );
+
+  /* Record CertificateRequest in transcript hash */
+
+  fd_sha256_append( &transcript, cert_req, sizeof(cert_req) );
+
   /* Send Certificate *************************************************/
 
   ulong cert_msg_sz;
@@ -810,7 +841,7 @@ fd_tls_server_hs_start( fd_tls_t const *      const server,
 
   /* Done */
 
-  handshake->base.state = FD_TLS_HS_WAIT_FINISHED;
+  handshake->base.state = FD_TLS_HS_WAIT_CERT;
 
 # undef MSG_BUFSZ
   return (long)read_sz;
@@ -910,6 +941,91 @@ fd_tls_handle_cert_verify( fd_tls_estate_base_t * hs,
     return fd_tls_alert( hs, FD_TLS_ALERT_DECRYPT_ERROR, FD_TLS_REASON_ED25519_FAIL );
 
   return (long)read_sz;
+}
+
+static long
+fd_tls_server_hs_wait_cert( fd_tls_t const *      server,
+                            fd_tls_estate_srv_t * handshake,
+                            uchar const *   const record,
+                            ulong           const record_sz,
+                            uint                  encryption_level ) {
+
+  (void)server;
+
+  if( FD_UNLIKELY( encryption_level != FD_TLS_LEVEL_HANDSHAKE ) )
+    return fd_tls_alert( &handshake->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_WRONG_ENC_LVL );
+
+  /* Read Certificate *************************************************/
+
+  ulong read_sz;
+  do {
+    uchar const *       wire     = record;
+    uchar const * const wire_end = record + record_sz;
+
+    /* Decode message header */
+
+    fd_tls_msg_hdr_t msg_hdr = {0};
+    long decode_res = fd_tls_decode_msg_hdr( &msg_hdr, wire, (ulong)(wire_end-wire) );
+    if( FD_UNLIKELY( decode_res<0L ) )
+      return fd_tls_alert( &handshake->base, FD_TLS_ALERT_DECODE_ERROR, FD_TLS_REASON_CERT_PARSE );
+    wire += (ulong)decode_res;
+
+    if( FD_UNLIKELY( msg_hdr.type != FD_TLS_MSG_CERT ) )
+      return fd_tls_alert( &handshake->base, FD_TLS_ALERT_UNEXPECTED_MESSAGE, FD_TLS_REASON_CERT_EXPECTED );
+
+    ulong msg_sz = fd_tls_u24_to_uint( msg_hdr.sz );
+    if( FD_UNLIKELY( msg_sz > (ulong)(wire_end-wire) ) )
+      return fd_tls_alert( &handshake->base, FD_TLS_ALERT_DECODE_ERROR, FD_TLS_REASON_CERT_CR_PARSE );
+
+    /* Decode Certificate */
+
+    decode_res = fd_tls_handle_cert_chain( &handshake->base, wire, msg_sz, NULL, handshake->client_pubkey, handshake->client_cert_rpk );
+    if( FD_UNLIKELY( decode_res<0L ) )
+      return fd_tls_alert( &handshake->base, (uint)(-decode_res), FD_TLS_REASON_CERT_PARSE );
+    wire += (ulong)decode_res;
+
+    read_sz = (ulong)(wire - record);
+  } while(0);
+
+  fd_sha256_t transcript;
+  fd_tls_transcript_load( &handshake->transcript, &transcript );
+  fd_sha256_append( &transcript, record, read_sz );
+  fd_tls_transcript_store( &handshake->transcript, &transcript );
+
+  /* Finish up ********************************************************/
+
+  handshake->base.state = FD_TLS_HS_WAIT_CV;
+  return (long)read_sz;
+}
+
+static long
+fd_tls_server_hs_wait_cert_verify( fd_tls_t const *      server,
+                                   fd_tls_estate_srv_t * hs,
+                                   uchar const *   const record,
+                                   ulong           const record_sz,
+                                   uint                  encryption_level ) {
+
+  (void)server;
+
+  if( FD_UNLIKELY( encryption_level != FD_TLS_LEVEL_HANDSHAKE ) )
+    return fd_tls_alert( &hs->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_WRONG_ENC_LVL );
+
+  fd_sha256_t transcript;
+  fd_tls_transcript_load( &hs->transcript, &transcript );
+  fd_sha256_t transcript_clone = transcript;
+
+  /* Decode incoming client CertificateVerify *************************/
+
+  long res = fd_tls_handle_cert_verify( &hs->base, &transcript_clone, record, record_sz, hs->client_pubkey, 1 );
+  if( FD_UNLIKELY( res<0L ) ) return res;
+
+  fd_sha256_append( &transcript, record, (ulong)res );
+  fd_tls_transcript_store( &hs->transcript, &transcript );
+
+  /* Finish up ********************************************************/
+
+  hs->base.state = FD_TLS_HS_WAIT_FINISHED;
+  return res;
 }
 
 static long


### PR DESCRIPTION
This reverts commit 648a5e899c6b862646c644a5092feeac40584fe0.

Required for Alpenglow