### PR TITLE
backup: add bank and txncache serializers

### DIFF
--- a/src/discof/backup/Local.mk
+++ b/src/discof/backup/Local.mk
@@ -1,0 +1,6 @@
+$(call add-objs,fd_ssmanifest_writer fd_txncache_writer,fd_discof)
+ifdef FD_HAS_HOSTED
+ifdef FD_HAS_INT128
+$(call make-unit-test,test_snap_roundtrip,test_snap_roundtrip,fd_discof fd_flamenco_test fd_flamenco fd_funk fd_tango fd_ballet fd_util fd_disco)
+endif
+endif

--- a/src/discof/backup/fd_ssmanifest_encoder.c
+++ b/src/discof/backup/fd_ssmanifest_encoder.c
@@ -1,0 +1,311 @@
+/* Serialize a chunk of values.
+   Each call may only produce up to FD_SSMANIFEST_BUF_MIN bytes worth of
+   serialized data.  Therefore, we split the serializer into multiple
+   states. */
+
+ENCODE_FN {
+  fd_bank_t const * bank = enc->bank;
+
+  PREP
+
+  switch( enc->state ) {
+  case STATE_BLOCKHASH_QUEUE: {
+    fd_blockhashes_t const *    bhq = &bank->f.block_hash_queue;
+    fd_blockhash_info_t const * deq = bhq->d.deque;
+    ulong total    = fd_blockhash_deq_cnt( deq );
+    ulong to_write = fd_ulong_min( total, FD_BLOCKHASHES_MAX );
+    ulong to_skip  = total - to_write;
+    PUSH_VAL( ulong, to_write-1UL ); /* last hash index */
+    fd_hash_t const * last_hash = fd_blockhashes_peek_last_hash( bhq );
+    PUSH_VAL( uchar, !!last_hash );
+    if( last_hash ) PUSH_VAL( fd_hash_t, *last_hash );
+
+    PUSH_VAL( ulong, to_write );
+    for( ulong i=0UL; i<to_write; i++ ) {
+      fd_blockhash_info_t const * ele = fd_blockhash_deq_peek_index_const( deq, to_skip+i );
+      PUSH_VAL( fd_hash_t, ele->hash );
+      PUSH_VAL( ulong,     ele->lamports_per_signature );
+      PUSH_VAL( ulong,     i );
+      PUSH_VAL( ulong,     0UL ); /* timestamp, ignored */
+    }
+    PUSH_VAL( ulong, FD_BLOCKHASHES_MAX-1UL ); /* max_age */
+    enc->state = STATE_HASHES;
+    break;
+  }
+  case STATE_HASHES: {
+    PUSH_VAL( ulong,     0UL ); /* ancestors */
+    PUSH_VAL( fd_hash_t, bank->f.bank_hash      );
+    PUSH_VAL( fd_hash_t, bank->f.prev_bank_hash );
+    PUSH_VAL( ulong,     bank->f.parent_slot    );
+    enc->state = STATE_HARD_FORKS;
+    break;
+  }
+  case STATE_HARD_FORKS: {
+    PUSH_VAL( ulong, bank->f.hard_fork_cnt );
+    for( ulong i=0UL; i<bank->f.hard_fork_cnt; i++ ) {
+      PUSH_VAL( ulong, bank->f.hard_forks[ i ].slot );
+      PUSH_VAL( ulong, bank->f.hard_forks[ i ].cnt  );
+    }
+    enc->state = STATE_COUNTERS;
+    break;
+  }
+  case STATE_COUNTERS: {
+    PUSH_VAL( ulong,  bank->f.txn_count             );
+    PUSH_VAL( ulong,  bank->f.tick_height           );
+    PUSH_VAL( ulong,  bank->f.signature_count       );
+    PUSH_VAL( ulong,  bank->f.capitalization        );
+    PUSH_VAL( ulong,  bank->f.max_tick_height       );
+    PUSH_VAL( uchar,  1                             );
+    PUSH_VAL( ulong,  bank->f.hashes_per_tick       );
+    PUSH_VAL( ulong,  bank->f.ticks_per_slot        );
+    PUSH_VAL( fd_w_u128_t, bank->f.ns_per_slot      );
+    PUSH_VAL( ulong,  bank->f.genesis_creation_time );
+    PUSH_VAL( double, bank->f.slots_per_year        );
+    PUSH_VAL( ulong,  0UL ); /* accounts_data_len, unused */
+    PUSH_VAL( ulong,  bank->f.slot                  );
+    PUSH_VAL( ulong,  bank->f.epoch                 );
+    PUSH_VAL( ulong,  bank->f.block_height          );
+    PUSH_VAL( fd_pubkey_t, (fd_pubkey_t){0} ); /* leader_id, unused */
+    PUSH_VAL( ulong, 0UL ); /* unused_collector_fees */
+    PUSH_VAL( ulong, 0UL ); /* unused_fee_calculator */
+
+    fd_fee_rate_governor_t const * frg = &bank->f.fee_rate_governor;
+    PUSH_VAL( ulong, frg->target_lamports_per_signature );
+    PUSH_VAL( ulong, frg->target_signatures_per_slot    );
+    PUSH_VAL( ulong, frg->min_lamports_per_signature    );
+    PUSH_VAL( ulong, frg->max_lamports_per_signature    );
+    PUSH_VAL( uchar, frg->burn_percent                  );
+    PUSH_VAL( ulong, 0UL );
+    PUSH_VAL( ulong, bank->f.epoch );
+
+    fd_epoch_schedule_t const * es = &bank->f.epoch_schedule;
+    fd_rent_t const * rent = &bank->f.rent;
+    PUSH_VAL( ulong,  es->slots_per_epoch             );
+    PUSH_VAL( ulong,  es->leader_schedule_slot_offset );
+    PUSH_VAL( uchar,  es->warmup                      );
+    PUSH_VAL( ulong,  es->first_normal_epoch          );
+    PUSH_VAL( ulong,  es->first_normal_slot           );
+    PUSH_VAL( double, bank->f.slots_per_year          );
+    PUSH_VAL( ulong,  rent->lamports_per_uint8_year   );
+    PUSH_VAL( double, rent->exemption_threshold       );
+    PUSH_VAL( uchar,  rent->burn_percent              );
+    PUSH_VAL( ulong,  es->slots_per_epoch             );
+    PUSH_VAL( ulong,  es->leader_schedule_slot_offset );
+    PUSH_VAL( uchar,  es->warmup                      );
+    PUSH_VAL( ulong,  es->first_normal_epoch          );
+    PUSH_VAL( ulong,  es->first_normal_slot           );
+
+    fd_inflation_t const * inf = &bank->f.inflation;
+    PUSH_VAL( double, inf->initial        );
+    PUSH_VAL( double, inf->terminal       );
+    PUSH_VAL( double, inf->taper          );
+    PUSH_VAL( double, inf->foundation     );
+    PUSH_VAL( double, inf->foundation_term );
+    PUSH_VAL( double, inf->unused          );
+
+    enc->state = STATE_VOTE_ACCOUNTS;
+    break;
+  }
+  case STATE_VOTE_ACCOUNTS: {
+    PUSH_VAL( ulong, 0UL ); /* zero vote_accounts */
+    PUSH_VAL( ulong, 0UL ); /* zero stake delegations */
+    PUSH_VAL( ulong, 0UL ); /* unused */
+    PUSH_VAL( ulong, bank->f.epoch );
+    enc->state = STATE_STAKE_HISTORY;
+    break;
+  }
+  case STATE_STAKE_DELEGATION: { FD_LOG_ERR(( "TODO")); }
+  case STATE_STAKE_EPOCH: { FD_LOG_ERR(( "TODO")); }
+  case STATE_STAKE_HISTORY: {
+    PUSH_VAL( ulong, 0UL ); /* zero stake history entries */
+    enc->state = STATE_BANK_TRAILER;
+    break;
+  }
+  case STATE_BANK_TRAILER: {
+    PUSH_VAL( ulong, 0UL ); /* unused_accounts.unused1 */
+    PUSH_VAL( ulong, 0UL ); /* unused_accounts.unused2 */
+    PUSH_VAL( ulong, 0UL ); /* unused_accounts.unused3 */
+    PUSH_VAL( ulong, 0UL ); /* unused_epoch_stakes */
+    PUSH_VAL( uchar, 0   ); /* is_delta */
+    PUSH_VAL( ulong, 0UL ); /* zero account_storage_entries */
+    enc->state = STATE_BANK_HASH_INFO;
+    break;
+  }
+  case STATE_ACCOUNT_STORAGE_ENTRY: { FD_LOG_ERR(( "TODO")); }
+  case STATE_BANK_HASH_INFO: {
+    /* AccountsDbFields */
+    PUSH_VAL( ulong, 0UL          ); /* write_version, unused */
+    PUSH_VAL( ulong, bank->f.slot ); /* slot */
+    PUSH_VAL( fd_hash_t, (fd_hash_t){0} ); /* unused_accounts_delta_hash */
+    PUSH_VAL( fd_hash_t, (fd_hash_t){0} ); /* unused_accounts_hash */
+    PUSH_VAL( ulong, 0UL ); /* num_updated_accounts, unused */
+    PUSH_VAL( ulong, 0UL ); /* num_removed_accounts, unused */
+    PUSH_VAL( ulong, 0UL ); /* num_lamports_stored, unused */
+    PUSH_VAL( ulong, 0UL ); /* total_data_len, unused */
+    PUSH_VAL( ulong, 0UL ); /* num_executable_accounts, unused */
+    PUSH_VAL( ulong, 0UL ); /* historical_roots, unused */
+    PUSH_VAL( ulong, 0UL ); /* historical_roots_with_hash, unused */
+    /* ExtraFieldsToSerialize */
+    PUSH_VAL( ulong, bank->f.rbh_lamports_per_sig );
+    PUSH_VAL( uchar, 0 ); /* unused_incremental_snapshot_persistence */
+    PUSH_VAL( uchar, 0 ); /* unused_epoch_accounts_hash */
+
+    ulong epoch = bank->f.epoch;
+    ulong epoch_cnt = (epoch > 0UL) ? 3UL : 2UL;
+    PUSH_VAL( ulong, epoch_cnt );
+    enc->epoch_cnt = (uchar)epoch_cnt;
+    enc->epoch_idx = 0;
+    enc->state = STATE_EPOCH_STAKES;
+    break;
+  }
+  case STATE_EPOCH_STAKES: {
+    ulong epoch = bank->f.epoch;
+    ulong epoch_stakes_base = (epoch > 0UL) ? (epoch - 1UL) : 0UL;
+    ulong epoch_key = epoch_stakes_base + (ulong)enc->epoch_idx;
+
+    /* entry_type: 0=T-3 commission, 1=T-2 stakes, 2=T-1 stakes+credits */
+    uint entry_type = (epoch > 0UL) ? enc->epoch_idx : (uint)(enc->epoch_idx + 1U);
+
+    uint vote_cnt;
+    if( entry_type==2U ) {
+      vote_cnt = (uint)*fd_bank_epoch_credits_len( enc->bank );
+    } else if( entry_type==1U ) {
+      vote_cnt = (uint)*fd_bank_epoch_credits_len( enc->bank );
+    } else {
+      vote_cnt = (uint)*fd_bank_snapshot_commission_t_3_len( enc->bank );
+    }
+    enc->vote_cnt    = vote_cnt;
+    enc->vote_idx    = 0;
+    enc->total_stake = 0UL;
+
+    PUSH_VAL( ulong, epoch_key );
+    PUSH_VAL( uint,  0U ); /* variant = 0 (VersionedEpochStakes::Current) */
+    PUSH_VAL( ulong, (ulong)vote_cnt );
+
+    enc->state = (vote_cnt > 0U) ? STATE_EPOCH_STAKES_STAKES : STATE_EPOCH_STAKES_EPOCH;
+    break;
+  }
+  case STATE_EPOCH_STAKES_STAKES: {
+    ulong epoch = bank->f.epoch;
+    uint entry_type = (epoch > 0UL) ? enc->epoch_idx : (uint)(enc->epoch_idx + 1U);
+
+    fd_pubkey_t pubkey       = {0};
+    ulong       stake        = 0UL;
+    fd_pubkey_t node_account = {0};
+    ushort      commission   = 0;
+    ulong       ec_cnt       = 0UL;
+    fd_epoch_credits_t const * ec = NULL;
+
+    fd_vote_stakes_t * vs       = fd_bank_vote_stakes( bank );
+    ushort             fork_idx = fd_vote_stakes_get_root_idx( vs );
+
+    if( entry_type==2U ) {
+      ec     = &fd_bank_epoch_credits( enc->bank )[ enc->vote_idx ];
+      ec_cnt = ec->cnt;
+      fd_memcpy( &pubkey, ec->pubkey, 32UL );
+      fd_vote_stakes_query_t_1( vs, fork_idx, &pubkey, &stake, &node_account, &commission );
+    } else if( entry_type==1U ) {
+      fd_epoch_credits_t const * ec_src = &fd_bank_epoch_credits( enc->bank )[ enc->vote_idx ];
+      fd_memcpy( &pubkey, ec_src->pubkey, 32UL );
+      fd_vote_stakes_query_t_2( vs, fork_idx, &pubkey, &stake, &node_account, &commission );
+    } else {
+      fd_stashed_commission_t const * sc = &fd_bank_snapshot_commission_t_3( enc->bank )[ enc->vote_idx ];
+      fd_memcpy( &pubkey, sc->pubkey, 32UL );
+      commission = sc->commission;
+    }
+
+    enc->total_stake += stake;
+    ulong data_length = 186UL + 24UL * ec_cnt;
+
+    /* Vote account key + stake */
+    PUSH_VAL( fd_pubkey_t, pubkey );
+    PUSH_VAL( ulong,       stake  );
+
+    /* AccountSharedData: lamports, data_length */
+    PUSH_VAL( ulong, 0UL         );
+    PUSH_VAL( ulong, data_length );
+
+    /* VoteStateV4 */
+    PUSH_VAL( uint,       3U           ); /* variant = V4 */
+    PUSH_VAL( fd_pubkey_t, node_account ); /* node_pubkey */
+    PUSH_VAL( fd_pubkey_t, (fd_pubkey_t){0} ); /* authorized_withdrawer */
+    PUSH_VAL( fd_pubkey_t, (fd_pubkey_t){0} ); /* inflation_rewards_collector */
+    PUSH_VAL( fd_pubkey_t, (fd_pubkey_t){0} ); /* block_revenue_collector */
+    PUSH_VAL( ushort, (ushort)((uint)commission * 100U) ); /* inflation_rewards_commission_bps */
+    PUSH_VAL( ushort, (ushort)0 ); /* block_revenue_commission_bps */
+    PUSH_VAL( ulong,  0UL      ); /* pending_delegator_rewards */
+    PUSH_VAL( uchar,  0        ); /* bls_pubkey_compressed = None */
+    PUSH_VAL( ulong,  0UL      ); /* votes_length = 0 */
+    PUSH_VAL( uchar,  0        ); /* root_slot = None */
+    PUSH_VAL( ulong,  0UL      ); /* authorized_voters_length = 0 */
+
+    /* Epoch credits */
+    PUSH_VAL( ulong, ec_cnt );
+    for( ulong j=0UL; j<ec_cnt; j++ ) {
+      PUSH_VAL( ulong, (ulong)ec->epoch[j] );
+      PUSH_VAL( ulong, ec->base_credits + (ulong)ec->credits_delta[j] );
+      PUSH_VAL( ulong, ec->base_credits + (ulong)ec->prev_credits_delta[j] );
+    }
+
+    PUSH_VAL( ulong, 0UL ); /* last_timestamp_slot */
+    PUSH_VAL( ulong, 0UL ); /* last_timestamp_timestamp */
+
+    /* AccountSharedData trailer */
+    PUSH_VAL( fd_pubkey_t, fd_solana_vote_program_id ); /* owner */
+    PUSH_VAL( uchar,       1                         ); /* executable */
+    PUSH_VAL( ulong,       0UL                       ); /* rent_epoch */
+
+    enc->vote_idx++;
+    if( enc->vote_idx >= enc->vote_cnt ) enc->state = STATE_EPOCH_STAKES_EPOCH;
+    break;
+  }
+  case STATE_EPOCH_STAKES_EPOCH: {
+    ulong epoch = bank->f.epoch;
+    ulong epoch_stakes_base = (epoch > 0UL) ? (epoch - 1UL) : 0UL;
+    ulong epoch_key = epoch_stakes_base + (ulong)enc->epoch_idx;
+
+    PUSH_VAL( ulong, 0UL       ); /* stake_delegations_length = 0 */
+    PUSH_VAL( ulong, 0UL       ); /* unused */
+    PUSH_VAL( ulong, epoch_key ); /* epoch */
+    PUSH_VAL( ulong, 0UL       ); /* stake_history_length = 0 */
+    enc->state = STATE_EPOCH_TOTAL_STAKE;
+    break;
+  }
+  case STATE_EPOCH_STAKE_HISTORY: { __builtin_unreachable(); }
+  case STATE_EPOCH_TOTAL_STAKE: {
+    uint entry_type = (bank->f.epoch > 0UL) ? enc->epoch_idx : (uint)(enc->epoch_idx + 1U);
+    ulong total_stake = (entry_type==2U) ? bank->f.total_epoch_stake : enc->total_stake;
+    PUSH_VAL( ulong, total_stake );
+    enc->state = STATE_NODE_VOTE_ACCOUNTS;
+    break;
+  }
+  case STATE_NODE_VOTE_ACCOUNTS: {
+    PUSH_VAL( ulong, 0UL ); /* node_id_to_vote_accounts_length = 0 */
+    enc->state = STATE_AUTH_VOTER;
+    break;
+  }
+  case STATE_AUTH_VOTER: {
+    PUSH_VAL( ulong, 0UL ); /* epoch_authorized_voters_length = 0 */
+    enc->epoch_idx++;
+    enc->state = (enc->epoch_idx < enc->epoch_cnt) ? STATE_EPOCH_STAKES : STATE_LTHASH;
+    break;
+  }
+  case STATE_LTHASH: {
+    PUSH_VAL( uchar, 1 );
+    PUSH_VAL( fd_lthash_value_t, bank->f.lthash );
+    enc->state = STATE_DONE;
+    break;
+  }
+  case STATE_DONE:
+    return 0UL;
+  default:
+    FD_LOG_CRIT(( "invalid state reached (%u)", enc->state ));
+  }
+
+  return RET_EXPR;
+}
+
+#undef PREP
+#undef ENCODE_FN
+#undef PUSH_VAL
+#undef RET_EXPR

--- a/src/discof/backup/fd_ssmanifest_writer.c
+++ b/src/discof/backup/fd_ssmanifest_writer.c
@@ -1,0 +1,87 @@
+#include "fd_ssmanifest_writer.h"
+#include "../../flamenco/stakes/fd_vote_stakes.h"
+#include "../../flamenco/runtime/fd_system_ids.h"
+
+#define STATE_BLOCKHASH_QUEUE        1
+#define STATE_HASHES                 2
+#define STATE_HARD_FORKS             3
+#define STATE_COUNTERS               4
+#define STATE_VOTE_ACCOUNTS          5
+#define STATE_STAKE_DELEGATION       6
+#define STATE_STAKE_EPOCH            7
+#define STATE_STAKE_HISTORY          8
+#define STATE_BANK_TRAILER           9
+#define STATE_ACCOUNT_STORAGE_ENTRY 10
+#define STATE_BANK_HASH_INFO        11
+#define STATE_EPOCH_STAKES          12
+#define STATE_EPOCH_STAKES_STAKES   13
+#define STATE_EPOCH_STAKES_EPOCH    14
+#define STATE_EPOCH_STAKE_HISTORY   15
+#define STATE_EPOCH_TOTAL_STAKE     16
+#define STATE_NODE_VOTE_ACCOUNTS    17
+#define STATE_AUTH_VOTER            18
+#define STATE_LTHASH                19
+#define STATE_DONE                  20
+#define STATE_INIT STATE_BLOCKHASH_QUEUE
+
+fd_ssmanifest_writer_t *
+fd_ssmanifest_writer_init( fd_ssmanifest_writer_t * enc,
+                           fd_bank_t *              bank ) {
+  enc->state       = STATE_BLOCKHASH_QUEUE;
+  enc->bank        = bank;
+  enc->epoch_idx   = 0;
+  enc->epoch_cnt   = 0;
+  enc->vote_cnt    = 0;
+  enc->vote_idx    = 0;
+  enc->total_stake = 0UL;
+  return enc;
+}
+
+/* Size estimate */
+
+#define ENCODE_FN     static ulong manifest_estimate( fd_ssmanifest_writer_t * enc )
+#define PREP          ulong sz = 0UL;
+#define PUSH_VAL(t,n) do { sz += sizeof(t); (void)(n); } while(0)
+#define RET_EXPR      sz
+#include "fd_ssmanifest_encoder.c"
+
+ulong
+fd_snap_manifest_serialized_sz( fd_bank_t * bank ) {
+  fd_ssmanifest_writer_t writer[1];
+  fd_ssmanifest_writer_init( writer, bank );
+  ulong sz = 0UL;
+  for(;;) {
+    ulong chunk = manifest_estimate( writer );
+    if( FD_UNLIKELY( !chunk ) ) break;
+    sz += chunk;
+  }
+  return sz;
+}
+
+/* Actual encoder */
+
+__attribute__((cold,noreturn))
+static void fail( fd_ssmanifest_writer_t const * enc,
+                  ulong buf_sz,
+                  ulong line_nr ) {
+  FD_LOG_ERR(( "buffer overflow (state=%u, buf_sz=%lu, line_nr=%lu)", enc->state, buf_sz, line_nr ));
+}
+
+#define ENCODE_FN                                                         \
+  ulong                                                                   \
+  fd_snap_manifest_serialize( fd_ssmanifest_writer_t * enc,               \
+                              uchar out_buf[ FD_SSMANIFEST_BUF_MIN ],     \
+                              ulong buf_sz )
+#define PREP                                                              \
+  uchar * p  = out_buf;                                                   \
+  uchar * p1 = out_buf+buf_sz;
+#define PUSH_VAL( t, n )                                                  \
+  FD_STORE( t, __extension__({                                            \
+    /* compile time bounds check elide */                                 \
+    if( FD_UNLIKELY( p+sizeof(t) > p1 ) ) fail( enc, buf_sz, __LINE__ );  \
+    uchar * ret = p;                                                      \
+    p += sizeof(t);                                                       \
+    ret;                                                                  \
+  }), (n) )
+#define RET_EXPR (ulong)( p - out_buf )
+#include "fd_ssmanifest_encoder.c"

--- a/src/discof/backup/fd_ssmanifest_writer.h
+++ b/src/discof/backup/fd_ssmanifest_writer.h
@@ -1,0 +1,57 @@
+#ifndef HEADER_fd_src_discof_backup_fd_ssmanifest_writer_h
+#define HEADER_fd_src_discof_backup_fd_ssmanifest_writer_h
+
+/* fd_ssmanifest_writer.h provides streaming serialization of a Solana
+   snapshot manifest. */
+
+#include "../../flamenco/runtime/fd_bank.h"
+
+struct fd_ssmanifest_writer {
+  uint        state;
+  fd_bank_t * bank;
+  uchar       epoch_idx;
+  uchar       epoch_cnt;
+  uint        vote_cnt;
+  uint        vote_idx;
+  ulong       total_stake;
+};
+
+typedef struct fd_ssmanifest_writer fd_ssmanifest_writer_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_ssmanifest_writer_init creates a new snapshot manifest writer.
+   Guaranteed to succeed for a valid bank. */
+
+fd_ssmanifest_writer_t *
+fd_ssmanifest_writer_init( fd_ssmanifest_writer_t * writer,
+                           fd_bank_t *              bank );
+
+/* fd_snap_manifest_serialize serializes up to buf_sz worth of snapshot
+   manifest data into out_buf.  Returns the number of bytes written.
+   Returns 0UL if the manifest was fully serialized out.  Typical usage:
+
+     uchar out_buf[ FD_SSMANIFEST_BUF_MIN ];
+     for(;;) {
+       ulong sz = fd_snap_manifest_serialize( enc, out_buf, sizeof(out_buf) );
+       if( !sz ) break;
+       fd_io_write( ... ); // write out chunk
+     }
+
+   Produces 1 GiB-ish data for a mainnet snapshot. */
+
+#define FD_SSMANIFEST_BUF_MIN (32UL<<20)
+ulong
+fd_snap_manifest_serialize( fd_ssmanifest_writer_t * enc,
+                            uchar out_buf[ FD_SSMANIFEST_BUF_MIN ],
+                            ulong buf_sz );
+
+/* fd_snapshot_manifest_serialized_sz returns the total amount of data
+   that fd_snap_manifest_serialize would produce for the given bank. */
+
+ulong
+fd_snap_manifest_serialized_sz( fd_bank_t * bank );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_backup_fd_ssmanifest_writer_h */

--- a/src/discof/backup/fd_txncache_encoder.c
+++ b/src/discof/backup/fd_txncache_encoder.c
@@ -1,0 +1,106 @@
+/* Serialize status_cache (Vec<SlotDelta>) for a Solana snapshot.
+   Included twice: once for size estimation, once for actual encoding.
+   See fd_ssmanifest_encoder.c for the pattern. */
+
+ENCODE_FN {
+
+  PREP
+
+  fd_txncache_writer_tc_t const * tc = (fd_txncache_writer_tc_t const *)enc->tc;
+
+  switch( enc->state ) {
+
+  case STATE_HEADER: {
+    ulong root_cnt = 0UL;
+    for( ulong it = root_slist_iter_init( tc->shmem->root_ll, tc->blockcache_shmem_pool );
+         !root_slist_iter_done( it, tc->shmem->root_ll, tc->blockcache_shmem_pool );
+         it = root_slist_iter_next( it, tc->shmem->root_ll, tc->blockcache_shmem_pool ) ) {
+      root_cnt++;
+    }
+    PUSH_VAL( ulong, 1UL                ); /* slot_deltas_len = 1 */
+    PUSH_VAL( ulong, enc->slot          ); /* slot                */
+    PUSH_VAL( uchar, 1                  ); /* is_root = true      */
+    PUSH_VAL( ulong, root_cnt           ); /* status_len         */
+    enc->root_iter = root_slist_iter_init( tc->shmem->root_ll, tc->blockcache_shmem_pool );
+    if( root_slist_iter_done( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool ) ) {
+      enc->state = STATE_DONE;
+    } else {
+      enc->state = STATE_BLOCKHASH;
+    }
+    break;
+  }
+
+  case STATE_BLOCKHASH: {
+    ulong bc_idx = root_slist_iter_idx( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool );
+    fd_txncache_blockcache_shmem_t const * bc_shmem = &tc->blockcache_shmem_pool[ bc_idx ];
+
+    PUSH_VAL( fd_hash_t, bc_shmem->blockhash      );
+    PUSH_VAL( ulong,     bc_shmem->txnhash_offset  );
+
+    ulong txn_cnt = txncache_count_txns( tc, enc->snapshot_root_idx, bc_idx );
+    PUSH_VAL( ulong, txn_cnt );
+
+    if( txn_cnt ) {
+      fd_txncache_writer_blockcache_t const * bc = &tc->blockcache_pool[ bc_idx ];
+      enc->page_idx    = 0UL;
+      enc->txn_idx     = 0UL;
+      enc->txns_in_page = FD_TXNCACHE_TXNS_PER_PAGE - (ulong)tc->txnpages[ bc->pages[ 0 ] ].free;
+      enc->state = STATE_TXNS;
+    } else {
+      enc->root_iter = root_slist_iter_next( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool );
+      if( root_slist_iter_done( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool ) ) {
+        enc->state = STATE_DONE;
+      }
+    }
+    break;
+  }
+
+  case STATE_TXNS: {
+    ulong bc_idx = root_slist_iter_idx( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool );
+    fd_txncache_blockcache_shmem_t const * bc_shmem = &tc->blockcache_shmem_pool[ bc_idx ];
+    fd_txncache_writer_blockcache_t const * bc      = &tc->blockcache_pool[ bc_idx ];
+
+    while( enc->page_idx < (ulong)bc_shmem->pages_cnt ) {
+      fd_txncache_txnpage_t const * page = &tc->txnpages[ bc->pages[ enc->page_idx ] ];
+      while( enc->txn_idx < enc->txns_in_page ) {
+        fd_txncache_single_txn_t const * txn = page->txns[ enc->txn_idx ];
+        if( FD_UNLIKELY( !txncache_txn_on_snapshot_root( tc, enc->snapshot_root_idx, txn ) ) ) {
+          enc->txn_idx++;
+          continue;
+        }
+        fd_txnhash_20_t h;
+        __builtin_memcpy( h.b, txn->txnhash, 20UL );
+        PUSH_VAL( fd_txnhash_20_t, h  );
+        PUSH_VAL( uint,            0U ); /* result = Ok */
+        enc->txn_idx++;
+      }
+      enc->page_idx++;
+      enc->txn_idx = 0UL;
+      if( enc->page_idx < (ulong)bc_shmem->pages_cnt ) {
+        enc->txns_in_page = FD_TXNCACHE_TXNS_PER_PAGE - (ulong)tc->txnpages[ bc->pages[ enc->page_idx ] ].free;
+      }
+    }
+
+    enc->root_iter = root_slist_iter_next( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool );
+    if( root_slist_iter_done( enc->root_iter, tc->shmem->root_ll, tc->blockcache_shmem_pool ) ) {
+      enc->state = STATE_DONE;
+    } else {
+      enc->state = STATE_BLOCKHASH;
+    }
+    break;
+  }
+
+  case STATE_DONE:
+    return 0UL;
+
+  default:
+    FD_LOG_CRIT(( "invalid state reached (%u)", enc->state ));
+  }
+
+  return RET_EXPR;
+}
+
+#undef PREP
+#undef ENCODE_FN
+#undef PUSH_VAL
+#undef RET_EXPR

--- a/src/discof/backup/fd_txncache_writer.c
+++ b/src/discof/backup/fd_txncache_writer.c
@@ -1,0 +1,131 @@
+#include "fd_txncache_writer.h"
+#include "../../flamenco/runtime/fd_txncache_private.h"
+#include "../../util/fd_util.h"
+
+/* Mirror of blockcache_t and fd_txncache_private from fd_txncache.c.
+   Needed to access the page index array and txnpages. */
+
+struct fd_txncache_writer_blockcache {
+  fd_txncache_blockcache_shmem_t * shmem;
+  uint *           heads;
+  ushort *         pages;
+  descends_set_t * descends;
+};
+
+typedef struct fd_txncache_writer_blockcache fd_txncache_writer_blockcache_t;
+
+struct fd_txncache_writer_tc {
+  fd_txncache_shmem_t *                 shmem;
+  fd_txncache_blockcache_shmem_t *      blockcache_shmem_pool;
+  fd_txncache_writer_blockcache_t *     blockcache_pool;
+  blockhash_map_t *                     blockhash_map;
+  ushort *                              txnpages_free;
+  fd_txncache_txnpage_t *               txnpages;
+};
+
+typedef struct fd_txncache_writer_tc fd_txncache_writer_tc_t;
+
+#define STATE_HEADER    1
+#define STATE_BLOCKHASH 2
+#define STATE_TXNS      3
+#define STATE_DONE      4
+#define STATE_INIT STATE_HEADER
+
+static int
+txncache_txn_on_snapshot_root( fd_txncache_writer_tc_t const * tc,
+                               ulong                           snapshot_root_idx,
+                               fd_txncache_single_txn_t const * txn ) {
+  if( FD_UNLIKELY( snapshot_root_idx>=tc->shmem->active_slots_max ) ) return 0;
+  if( FD_UNLIKELY( txn->fork_id.val>=tc->shmem->active_slots_max ) ) return 0;
+
+  fd_txncache_blockcache_shmem_t const * txn_fork = &tc->blockcache_shmem_pool[ txn->fork_id.val ];
+  if( FD_UNLIKELY( txn_fork->frozen<0 || txn_fork->generation!=txn->generation ) ) return 0;
+
+  return txn->fork_id.val==snapshot_root_idx ||
+         descends_set_test( tc->blockcache_pool[ snapshot_root_idx ].descends, txn->fork_id.val );
+}
+
+static ulong
+txncache_count_txns( fd_txncache_writer_tc_t const * tc,
+                     ulong                           snapshot_root_idx,
+                     ulong                           bc_idx ) {
+  fd_txncache_blockcache_shmem_t const * bc_shmem = &tc->blockcache_shmem_pool[ bc_idx ];
+  fd_txncache_writer_blockcache_t const * bc      = &tc->blockcache_pool[ bc_idx ];
+  ulong cnt = 0UL;
+  for( ushort p=0; p<bc_shmem->pages_cnt; p++ ) {
+    fd_txncache_txnpage_t const * page = &tc->txnpages[ bc->pages[ p ] ];
+    ulong txns_in_page = FD_TXNCACHE_TXNS_PER_PAGE - (ulong)page->free;
+    for( ulong t=0UL; t<txns_in_page; t++ ) {
+      fd_txncache_single_txn_t const * txn = page->txns[ t ];
+      if( FD_LIKELY( txncache_txn_on_snapshot_root( tc, snapshot_root_idx, txn ) ) ) cnt++;
+    }
+  }
+  return cnt;
+}
+
+fd_txncache_writer_t *
+fd_txncache_writer_init( fd_txncache_writer_t * writer,
+                         fd_txncache_t *        tc,
+                         ulong                  slot ) {
+  fd_txncache_writer_tc_t const * ltc = (fd_txncache_writer_tc_t const *)tc;
+  writer->state      = STATE_INIT;
+  writer->tc         = tc;
+  writer->slot       = slot;
+  writer->snapshot_root_idx = root_slist_is_empty( ltc->shmem->root_ll, ltc->blockcache_shmem_pool ) ?
+                              ULONG_MAX :
+                              root_slist_idx_peek_tail( ltc->shmem->root_ll, ltc->blockcache_shmem_pool );
+  writer->root_iter  = root_slist_iter_init( ltc->shmem->root_ll, ltc->blockcache_shmem_pool );
+  writer->page_idx   = 0UL;
+  writer->txn_idx    = 0UL;
+  writer->txns_in_page = 0UL;
+  return writer;
+}
+
+/* Size estimate */
+
+#define ENCODE_FN     static ulong txncache_estimate( fd_txncache_writer_t * enc )
+#define PREP          ulong sz = 0UL;
+#define PUSH_VAL(t,n) do { sz += sizeof(t); (void)(n); } while(0)
+#define RET_EXPR      sz
+#include "fd_txncache_encoder.c"
+
+ulong
+fd_txncache_writer_serialized_sz( fd_txncache_t * tc,
+                                  ulong           slot ) {
+  fd_txncache_writer_t writer[1];
+  fd_txncache_writer_init( writer, tc, slot );
+  ulong sz = 0UL;
+  for(;;) {
+    ulong chunk = txncache_estimate( writer );
+    if( FD_UNLIKELY( !chunk ) ) break;
+    sz += chunk;
+  }
+  return sz;
+}
+
+/* Actual encoder */
+
+__attribute__((cold,noreturn,unused))
+static void fail( fd_txncache_writer_t const * enc,
+                  ulong buf_sz,
+                  ulong line_nr ) {
+  FD_LOG_ERR(( "buffer overflow (state=%u, buf_sz=%lu, line_nr=%lu)", enc->state, buf_sz, line_nr ));
+}
+
+#define ENCODE_FN                                                         \
+  ulong                                                                   \
+  fd_txncache_writer_serialize( fd_txncache_writer_t * enc,               \
+                                uchar out_buf[ FD_TXNCACHE_WRITER_BUF_MIN ], \
+                                ulong buf_sz )
+#define PREP                                                              \
+  uchar * p  = out_buf;                                                   \
+  uchar * p1 __attribute__((unused)) = out_buf+buf_sz;
+#define PUSH_VAL( t, n )                                                  \
+  FD_STORE( t, __extension__({                                            \
+    if( FD_UNLIKELY( p+sizeof(t) > p1 ) ) fail( enc, buf_sz, __LINE__ ); \
+    uchar * ret = p;                                                      \
+    p += sizeof(t);                                                       \
+    ret;                                                                  \
+  }), (n) )
+#define RET_EXPR (ulong)( p - out_buf )
+#include "fd_txncache_encoder.c"

--- a/src/discof/backup/fd_txncache_writer.h
+++ b/src/discof/backup/fd_txncache_writer.h
@@ -1,0 +1,43 @@
+#ifndef HEADER_fd_src_discof_backup_fd_txncache_writer_h
+#define HEADER_fd_src_discof_backup_fd_txncache_writer_h
+
+#include "../../flamenco/runtime/fd_txncache.h"
+
+struct fd_txnhash_20 { uchar b[20]; };
+typedef struct fd_txnhash_20 fd_txnhash_20_t;
+
+struct fd_txncache_writer {
+  uint              state;
+  fd_txncache_t *   tc;
+  ulong             slot;
+  ulong             snapshot_root_idx;
+
+  ulong             root_iter;
+  ulong             page_idx;
+  ulong             txn_idx;
+  ulong             txns_in_page;
+};
+
+typedef struct fd_txncache_writer fd_txncache_writer_t;
+
+FD_PROTOTYPES_BEGIN
+
+fd_txncache_writer_t *
+fd_txncache_writer_init( fd_txncache_writer_t * writer,
+                         fd_txncache_t *        tc,
+                         ulong                  slot );
+
+#define FD_TXNCACHE_WRITER_BUF_MIN (32UL<<20)
+
+ulong
+fd_txncache_writer_serialize( fd_txncache_writer_t * enc,
+                              uchar                  out_buf[ FD_TXNCACHE_WRITER_BUF_MIN ],
+                              ulong                  buf_sz );
+
+ulong
+fd_txncache_writer_serialized_sz( fd_txncache_t * tc,
+                                  ulong           slot );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_backup_fd_txncache_writer_h */

--- a/src/discof/backup/test_snap_roundtrip.c
+++ b/src/discof/backup/test_snap_roundtrip.c
@@ -1,0 +1,268 @@
+#include "fd_ssmanifest_writer.h"
+#include "fd_txncache_writer.h"
+#include "../restore/utils/fd_ssmanifest_parser.h"
+#include "../restore/utils/fd_slot_delta_parser.h"
+#include "../../flamenco/runtime/tests/fd_svm_mini.h"
+#include "../../flamenco/runtime/fd_txncache.h"
+#include "../../flamenco/runtime/fd_txncache_shmem.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_LIVE_SLOTS   16UL
+#define MAX_TXN_PER_SLOT 4096UL
+#define VALIDATOR_CNT    3UL
+#define ROOT_SLOT        42UL
+
+static fd_txncache_t *
+create_txncache( void ) {
+  ulong shmem_fp = fd_txncache_shmem_footprint( MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT );
+  void * shmem_raw = aligned_alloc( fd_txncache_shmem_align(), shmem_fp );
+  FD_TEST( shmem_raw );
+  fd_txncache_shmem_t * shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem_raw, MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT, 1UL ) );
+  FD_TEST( shmem );
+
+  ulong ljoin_fp = fd_txncache_footprint( MAX_LIVE_SLOTS );
+  void * ljoin_raw = aligned_alloc( fd_txncache_align(), ljoin_fp );
+  FD_TEST( ljoin_raw );
+  fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( ljoin_raw, shmem ) );
+  FD_TEST( tc );
+  return tc;
+}
+
+#define NULL_FORK ((fd_txncache_fork_id_t){ .val = USHORT_MAX })
+
+static void
+populate_txncache( fd_txncache_t * tc,
+                   uchar           blockhashes[ 4 ][ 32 ],
+                   uchar           txnhashes[ 6 ][ 20 ] ) {
+  for( ulong bh=0UL; bh<3UL; bh++ ) {
+    memset( blockhashes[bh], 0, 32UL );
+    blockhashes[bh][0] = (uchar)(bh+1U);
+    blockhashes[bh][1] = 0xAB;
+  }
+  memset( blockhashes[3], 0xFF, 32UL );
+
+  /* Build a chain where each slot finalizes with a blockhash,
+     making it available for txn inserts in the next slot.
+     root  -> finalize(bh0)
+     s1    -> insert(bh0, txn0..1) -> finalize(bh1)
+     s2    -> insert(bh1, txn2..3) -> finalize(bh2)
+     s3    -> insert(bh2, txn4..5) -> finalize(final_bh)
+     advance root to s3 */
+
+  fd_txncache_fork_id_t root = fd_txncache_attach_child( tc, NULL_FORK );
+  fd_txncache_finalize_fork( tc, root, 0UL, blockhashes[0] );
+
+  fd_txncache_fork_id_t s1 = fd_txncache_attach_child( tc, root );
+  for( ulong tx=0UL; tx<2UL; tx++ ) {
+    memset( txnhashes[tx], 0, 20UL );
+    txnhashes[tx][0] = (uchar)(tx+1U);
+    txnhashes[tx][1] = 0xCD;
+    fd_txncache_insert( tc, s1, blockhashes[0], txnhashes[tx] );
+  }
+  fd_txncache_finalize_fork( tc, s1, 0UL, blockhashes[1] );
+  fd_txncache_advance_root( tc, s1 );
+
+  fd_txncache_fork_id_t s2 = fd_txncache_attach_child( tc, s1 );
+  for( ulong tx=0UL; tx<2UL; tx++ ) {
+    ulong idx = 2UL + tx;
+    memset( txnhashes[idx], 0, 20UL );
+    txnhashes[idx][0] = (uchar)(idx+1U);
+    txnhashes[idx][1] = 0xCD;
+    fd_txncache_insert( tc, s2, blockhashes[1], txnhashes[idx] );
+  }
+  fd_txncache_finalize_fork( tc, s2, 0UL, blockhashes[2] );
+  fd_txncache_advance_root( tc, s2 );
+
+  fd_txncache_fork_id_t s3 = fd_txncache_attach_child( tc, s2 );
+  for( ulong tx=0UL; tx<2UL; tx++ ) {
+    ulong idx = 4UL + tx;
+    memset( txnhashes[idx], 0, 20UL );
+    txnhashes[idx][0] = (uchar)(idx+1U);
+    txnhashes[idx][1] = 0xCD;
+    fd_txncache_insert( tc, s3, blockhashes[2], txnhashes[idx] );
+  }
+  fd_txncache_finalize_fork( tc, s3, 0UL, blockhashes[3] );
+  fd_txncache_advance_root( tc, s3 );
+
+  fd_txncache_fork_id_t future = fd_txncache_attach_child( tc, s3 );
+  for( ulong tx=0UL; tx<2UL; tx++ ) {
+    uchar future_txnhash[ 20UL ];
+    memset( future_txnhash, 0, 20UL );
+    future_txnhash[0] = (uchar)(0x80U+tx);
+    future_txnhash[1] = 0xCD;
+    fd_txncache_insert( tc, future, tx ? blockhashes[2] : blockhashes[3], future_txnhash );
+  }
+}
+
+static void
+test_manifest_roundtrip( fd_bank_t * bank ) {
+  FD_LOG_NOTICE(( "test_manifest_roundtrip" ));
+
+  ulong manifest_sz = fd_snap_manifest_serialized_sz( bank );
+  FD_TEST( manifest_sz>0UL );
+  FD_LOG_NOTICE(( "manifest serialized size: %lu", manifest_sz ));
+
+  uchar * buf = aligned_alloc( 1UL, manifest_sz );
+  FD_TEST( buf );
+
+  uchar * chunk_buf = aligned_alloc( 1UL, FD_SSMANIFEST_BUF_MIN );
+  FD_TEST( chunk_buf );
+
+  fd_ssmanifest_writer_t writer[1];
+  fd_ssmanifest_writer_init( writer, bank );
+  ulong total_written = 0UL;
+  for(;;) {
+    ulong sz = fd_snap_manifest_serialize( writer, chunk_buf, FD_SSMANIFEST_BUF_MIN );
+    if( !sz ) break;
+    FD_TEST( total_written + sz <= manifest_sz );
+    memcpy( buf + total_written, chunk_buf, sz );
+    total_written += sz;
+  }
+  FD_TEST( total_written==manifest_sz );
+
+  fd_snapshot_manifest_t * manifest = aligned_alloc( alignof(fd_snapshot_manifest_t), sizeof(fd_snapshot_manifest_t) );
+  FD_TEST( manifest );
+  memset( manifest, 0, sizeof(fd_snapshot_manifest_t) );
+
+  void * parser_mem = aligned_alloc( fd_ssmanifest_parser_align(), fd_ssmanifest_parser_footprint() );
+  FD_TEST( parser_mem );
+  fd_ssmanifest_parser_t * parser = fd_ssmanifest_parser_join( fd_ssmanifest_parser_new( parser_mem ) );
+  FD_TEST( parser );
+  fd_ssmanifest_parser_init( parser, manifest );
+
+  int result = fd_ssmanifest_parser_consume( parser, buf, total_written );
+  FD_TEST( result==FD_SSMANIFEST_PARSER_ADVANCE_DONE );
+
+  FD_TEST( manifest->slot==bank->f.slot );
+  FD_TEST( manifest->block_height==bank->f.block_height );
+  FD_TEST( manifest->capitalization==bank->f.capitalization );
+  FD_TEST( manifest->ticks_per_slot==bank->f.ticks_per_slot );
+  FD_TEST( manifest->epoch_schedule_params.slots_per_epoch==bank->f.epoch_schedule.slots_per_epoch );
+  FD_TEST( manifest->rent_params.lamports_per_uint8_year==bank->f.rent.lamports_per_uint8_year );
+  FD_TEST( manifest->rent_params.burn_percent==bank->f.rent.burn_percent );
+
+  ulong expected_epoch_cnt = (bank->f.epoch > 0UL) ? 3UL : 2UL;
+  for( ulong i=0UL; i<expected_epoch_cnt; i++ ) {
+    FD_LOG_NOTICE(( "epoch_stakes[%lu]: epoch=%lu total_stake=%lu vote_stakes_len=%lu",
+                    i,
+                    manifest->epoch_stakes[i].epoch,
+                    manifest->epoch_stakes[i].total_stake,
+                    manifest->epoch_stakes[i].vote_stakes_len ));
+  }
+
+  free( parser_mem );
+  free( manifest );
+  free( chunk_buf );
+  free( buf );
+}
+
+static void
+test_txncache_roundtrip( void ) {
+  FD_LOG_NOTICE(( "test_txncache_roundtrip" ));
+
+  fd_txncache_t * tc = create_txncache();
+
+  uchar blockhashes[4][32];
+  uchar txnhashes[6][20];
+  populate_txncache( tc, blockhashes, txnhashes );
+
+  ulong tc_sz = fd_txncache_writer_serialized_sz( tc, ROOT_SLOT );
+  FD_TEST( tc_sz>0UL );
+  FD_LOG_NOTICE(( "txncache serialized size: %lu", tc_sz ));
+
+  uchar * buf = aligned_alloc( 1UL, tc_sz );
+  FD_TEST( buf );
+
+  uchar * chunk_buf = aligned_alloc( 1UL, FD_TXNCACHE_WRITER_BUF_MIN );
+  FD_TEST( chunk_buf );
+
+  fd_txncache_writer_t writer[1];
+  fd_txncache_writer_init( writer, tc, ROOT_SLOT );
+  ulong total_written = 0UL;
+  for(;;) {
+    ulong sz = fd_txncache_writer_serialize( writer, chunk_buf, FD_TXNCACHE_WRITER_BUF_MIN );
+    if( !sz ) break;
+    FD_TEST( total_written + sz <= tc_sz );
+    memcpy( buf + total_written, chunk_buf, sz );
+    total_written += sz;
+  }
+  FD_TEST( total_written==tc_sz );
+
+  void * parser_mem = aligned_alloc( fd_slot_delta_parser_align(), fd_slot_delta_parser_footprint() );
+  FD_TEST( parser_mem );
+  fd_slot_delta_parser_t * parser = fd_slot_delta_parser_join( fd_slot_delta_parser_new( parser_mem ) );
+  FD_TEST( parser );
+  fd_slot_delta_parser_init( parser );
+
+  ulong entries_parsed = 0UL;
+  ulong groups_parsed  = 0UL;
+  uchar const * p = buf;
+  ulong remaining = total_written;
+  for(;;) {
+    fd_slot_delta_parser_advance_result_t result[1];
+    int res = fd_slot_delta_parser_consume( parser, p, remaining, result );
+    FD_TEST( res>=0 );
+
+    if( res==FD_SLOT_DELTA_PARSER_ADVANCE_DONE ) break;
+
+    if( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) {
+      fd_sstxncache_entry_t const * entry = result->entry;
+      FD_TEST( entry->slot==ROOT_SLOT );
+      FD_TEST( entry->result==0U );
+
+      int found = 0;
+      for( ulong i=0UL; i<6UL; i++ ) {
+        if( 0==memcmp( entry->txnhash, txnhashes[i], 20UL ) ) { found = 1; break; }
+      }
+      FD_TEST( found );
+      entries_parsed++;
+    }
+
+    if( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) {
+      int found = 0;
+      for( ulong i=0UL; i<4UL; i++ ) {
+        if( 0==memcmp( result->group.blockhash, blockhashes[i], 32UL ) ) { found = 1; break; }
+      }
+      FD_TEST( found );
+      groups_parsed++;
+    }
+
+    p         += result->bytes_consumed;
+    remaining -= result->bytes_consumed;
+  }
+
+  FD_TEST( entries_parsed==6UL );
+  FD_TEST( groups_parsed==4UL );
+  FD_LOG_NOTICE(( "parsed %lu entries across %lu groups", entries_parsed, groups_parsed ));
+
+  free( fd_slot_delta_parser_delete( fd_slot_delta_parser_leave( parser ) ) );
+  free( chunk_buf );
+  free( buf );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_svm_mini_limits_t limits[1];
+  fd_svm_mini_limits_default( limits );
+  fd_svm_mini_t * mini = fd_svm_test_boot( &argc, &argv, limits );
+  FD_TEST( mini );
+
+  fd_svm_mini_params_t params[1];
+  fd_svm_mini_params_default( params );
+  params->mock_validator_cnt = VALIDATOR_CNT;
+  params->root_slot          = ROOT_SLOT;
+  params->slots_per_epoch    = 432UL;
+  ulong bank_idx = fd_svm_mini_reset( mini, params );
+  fd_bank_t * bank = fd_svm_mini_bank( mini, bank_idx );
+  FD_TEST( bank );
+
+  test_manifest_roundtrip( bank );
+  test_txncache_roundtrip();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_svm_test_halt( mini );
+  return 0;
+}


### PR DESCRIPTION
Add serialization logic for a Solana snapshot manifest

Submitting this as a separate PR to ease reviews:
This is the first part of Firedancer's snapshot producer