### PR TITLE
quic: reduce default ACK delay

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1151,7 +1151,7 @@ dynamic_port_range = "8900-9000"
         idle_timeout_millis = 10000
 
         # Max delay for outgoing ACKs.
-        ack_delay_millis = 50
+        ack_delay_millis = 10
 
         # QUIC retry is a feature to combat new connection request
         # spamming.  See rfc9000 8.1.2 for more details.  This flag

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1241,7 +1241,7 @@ telemetry = true
         idle_timeout_millis = 10000
 
         # Max delay for outgoing ACKs.
-        ack_delay_millis = 50
+        ack_delay_millis = 10
 
         # QUIC retry is a feature to combat new connection request
         # spamming.  See rfc9000 8.1.2 for more details.  This flag

--- a/src/waltz/quic/fd_quic.h
+++ b/src/waltz/quic/fd_quic.h
@@ -188,7 +188,7 @@ struct __attribute__((aligned(16UL))) fd_quic_config {
   /* ack_delay: median delay on outgoing ACKs.  Greater delays allow
      fd_quic to coalesce packet ACKs. */
   long ack_delay;
-# define FD_QUIC_DEFAULT_ACK_DELAY (long)(50e6) /* 50ms */
+# define FD_QUIC_DEFAULT_ACK_DELAY (long)(10e6) /* 10ms */
 
   /* ack_threshold: immediately send an ACK when the number of
      unacknowledged stream bytes exceeds this value. */


### PR DESCRIPTION
Power users on Solana (PropAMMs etc) have become more latency sensitive and have started to monitor QUIC ACKs for faster recovery from tail drop events. Additionally, validators can now pack and execute entire blocks in less than 50ms. Reduce max ACK delay from 50ms to 10ms to help them.