### PR TITLE
topo: allow manual affinity str to overlap snap tiles

### DIFF
--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -8,7 +8,6 @@
 #include "../../disco/bundle/fd_bundle_tile.h"
 #include "../../util/pod/fd_pod_format.h"
 #include "../../util/net/fd_ip4.h"
-#include "../../util/tile/fd_tile_private.h"
 
 extern fd_topo_obj_callbacks_t * CALLBACKS[];
 
@@ -127,7 +126,7 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
@@ -338,7 +337,7 @@ fd_topo_initialize( config_t * config ) {
 
     if( FD_LIKELY( strcmp( "", config->frankendancer.layout.agave_affinity ) ) ) {
       ushort agave_cpu[ FD_TILE_MAX ];
-      ulong agave_cpu_cnt = fd_tile_private_cpus_parse( config->frankendancer.layout.agave_affinity, agave_cpu );
+      ulong agave_cpu_cnt = fd_topob_parse_affinity_cstr( config->frankendancer.layout.agave_affinity, agave_cpu, 0 );
 
       for( ulong i=0UL; i<agave_cpu_cnt; i++ ) {
         if( FD_UNLIKELY( agave_cpu[ i ]>=cpus->cpu_cnt ) )
@@ -362,14 +361,14 @@ fd_topo_initialize( config_t * config ) {
     }
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_tile_private_cpus_parse( config->layout.blocklist_cores, blocklist_cores );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));
     }
 
     for( ulong i=0UL; i<topo->blocklist_cores_cnt; i++ ) {
-      /* Since we use fd_tile_private_cpus_parse() like for affinity, the user
+      /* Since we use fd_topob_parse_affinity_cstr() like for affinity, the user
          may input a string containing `f`. That's parsed correctly, but it's
          meaningless for blocklisted cores, so we reject it here.  */
       if( FD_UNLIKELY( blocklist_cores[ i ]==USHORT_MAX ) ) {

--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -17,7 +17,6 @@ Constructed using a full topology which is pruned down. */
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_cpu_topo.h"
 #include "../../../../util/pod/fd_pod_format.h"
-#include "../../../../util/tile/fd_tile_private.h"
 #include "../../../../discof/restore/utils/fd_slot_delta_parser.h"
 #include "../../../../discof/restore/utils/fd_ssctrl.h"
 #include "../../../../discof/restore/utils/fd_ssmsg.h"
@@ -203,7 +202,7 @@ forktest_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->firedancer.development.forktest.affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->firedancer.development.forktest.affinity, parsed_tile_to_cpu, 0 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
@@ -347,7 +346,7 @@ forktest_topo( config_t * config ) {
                        topo->tile_cnt, affinity_tile_cnt ));
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_tile_private_cpus_parse( config->layout.blocklist_cores, blocklist_cores );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -7,7 +7,6 @@
 #include "../../../disco/topo/fd_topob.h"
 #include "../../../disco/topo/fd_cpu_topo.h"
 #include "../../../util/pod/fd_pod_format.h"
-#include "../../../util/tile/fd_tile_private.h"
 
 #include "../../firedancer/topology.h"
 #include "../../shared/commands/configure/configure.h"
@@ -289,7 +288,7 @@ repair_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
 
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
     if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -22,7 +22,6 @@ up the entire gossip subtopo.
 #include "../../../shared/fd_config.h" /* config_t */
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_cpu_topo.h" /* fd_topo_cpus_t */
-#include "../../../../util/tile/fd_tile_private.h"
 #include "../../../../disco/net/fd_net_tile.h" /* fd_topos_net_tiles */
 #include "../../../../discof/tower/fd_tower_tile.h"
 #include "../../../../flamenco/leaders/fd_leaders_base.h" /* FD_STAKE_OUT_MTU */
@@ -64,7 +63,7 @@ send_test_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( strcmp( config->layout.affinity, "auto" ) ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( strcmp( config->layout.affinity, "auto" ) ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
 
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
     if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -19,7 +19,6 @@
 #include "../../disco/topo/fd_cpu_topo.h"
 #include "../../disco/bundle/fd_bundle_tile.h"
 #include "../../util/pod/fd_pod_format.h"
-#include "../../util/tile/fd_tile_private.h"
 #include "../../discof/restore/utils/fd_ssctrl.h"
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../flamenco/capture/fd_solcap_writer.h"
@@ -625,7 +624,7 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( config->layout.affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
@@ -999,14 +998,14 @@ fd_topo_initialize( config_t * config ) {
                        topo->tile_cnt, affinity_tile_cnt ));
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_tile_private_cpus_parse( config->layout.blocklist_cores, blocklist_cores );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));
     }
 
     for( ulong i=0UL; i<topo->blocklist_cores_cnt; i++ ) {
-      /* Since we use fd_tile_private_cpus_parse() like for affinity, the user
+      /* Since we use fd_topob_parse_affinity_cstr() like for affinity, the user
          may input a string containing `f`. That's parsed correctly, but it's
          meaningless for blocklisted cores, so we reject it here.  */
       if( FD_UNLIKELY( blocklist_cores[ i ]==USHORT_MAX ) ) {

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -7,7 +7,6 @@
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_cpu_topo.h"
 #include "../../../../disco/net/fd_net_tile.h"
-#include "../../../../util/tile/fd_tile_private.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -66,7 +65,7 @@ add_bench_topo( fd_topo_t  * topo,
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_bench_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_bench_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -6,7 +6,6 @@
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_cpu_topo.h"
 #include "../../../../util/net/fd_ip4.h"
-#include "../../../../util/tile/fd_tile_private.h" /* fd_tile_private_cpus_parse */
 
 #include <stdio.h> /* printf */
 #include <unistd.h> /* isatty */
@@ -30,7 +29,7 @@ pktgen_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -5,7 +5,6 @@
 #include "../../../../disco/topo/fd_topob.h"
 #include "../../../../disco/topo/fd_cpu_topo.h"
 #include "../../../../util/net/fd_ip4.h"
-#include "../../../../util/tile/fd_tile_private.h" /* fd_tile_private_cpus_parse */
 
 #include <unistd.h> /* pause */
 
@@ -26,7 +25,7 @@ udpecho_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_tile_private_cpus_parse( affinity, parsed_tile_to_cpu );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -1,11 +1,14 @@
 #include "fd_topob.h"
 
 #include "../../util/pod/fd_pod_format.h"
+#include "../../util/tile/fd_tile_private.h" /* fd_tile_private_sibling_idx */
 #include "fd_cpu_topo.h"
 
 #define SET_NAME cpu_bv
 #define SET_MAX  FD_TILE_MAX
 #include "../../util/tmpl/fd_set.c"
+
+#include <ctype.h>
 
 fd_topo_t *
 fd_topob_new( void * mem,
@@ -468,6 +471,144 @@ fd_topob_tile_priority_type( char const * name ) {
   return FD_TOPOB_PRIORITY_FLOATING;
 }
 
+FD_STATIC_ASSERT( FD_TILE_MAX<65535, update_tile_to_cpu_type );
+
+ulong
+fd_topob_parse_affinity_cstr( char const * cstr,
+                              ushort *     tile_to_cpu,
+                              int          allow_repeats ) {
+  if( !cstr ) return 0UL;
+  ulong cnt = 0UL;
+
+  cpu_bv_t cpu_assigned[ cpu_bv_word_cnt ];
+  cpu_bv_new( cpu_assigned );
+
+  char const * p = cstr;
+  for(;;) {
+
+    while( fd_isspace( (int)p[0] ) ) p++;
+
+    if( p[0]=='f' ) {
+      p++;
+
+      ulong float_cnt;
+
+      while( fd_isspace( (int)p[0] ) ) p++;
+      if     ( p[0]==','             ) float_cnt = 1UL, p++;
+      else if( p[0]=='\0'            ) float_cnt = 1UL;
+      else if( !fd_isdigit( (int)p[0] ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (malformed float count)" ));
+      else {
+        float_cnt = fd_cstr_to_ulong( p );
+        if( FD_UNLIKELY( !float_cnt ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (bad float count)" ));
+        p++; while( fd_isdigit( (int)p[0] ) ) p++;
+        while( fd_isspace( (int)p[0] ) ) p++;
+        if( FD_UNLIKELY( !( p[0]==',' || p[0]=='\0' ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (bad float count delimiter)" ));
+        if( p[0]==',' ) p++;
+      }
+
+      do {
+        if( FD_UNLIKELY( cnt>=FD_TILE_MAX ) ) FD_LOG_ERR(( "fd_topob: too many affinity entries" ));
+        tile_to_cpu[ cnt++ ] = (ushort)65535;
+      } while( --float_cnt );
+
+      continue;
+    }
+
+    if( !fd_isdigit( (int)p[0] ) ) {
+      if( FD_UNLIKELY( p[0]!='\0' ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (range lo not a cpu)" ));
+      break;
+    }
+    ulong cpu0   = fd_cstr_to_ulong( p );
+    ulong cpu1   = cpu0;
+    ulong stride = 1UL;
+    p++; while( fd_isdigit( (int)p[0] ) ) p++;
+    while( fd_isspace( (int)p[0] ) ) p++;
+    if( p[0]=='-' ) {
+      p++;
+      while( fd_isspace( (int)p[0] ) ) p++;
+      if( FD_UNLIKELY( !fd_isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (range hi not a cpu)" ));
+      cpu1 = fd_cstr_to_ulong( p );
+      p++; while( fd_isdigit( (int)p[0] ) ) p++;
+      while( fd_isspace( (int)p[0] ) ) p++;
+      if( p[0]=='/' || p[0]==':' ) {
+        p++;
+        while( fd_isspace( (int)p[0] ) ) p++;
+        if( FD_UNLIKELY( !fd_isdigit( (int)p[0] ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (stride not an int)" ));
+        stride = fd_cstr_to_ulong( p );
+        p++; while( fd_isdigit( (int)p[0] ) ) p++;
+      }
+    }
+    else if( p[0]=='h' ) {
+      p++;
+      ulong sibling = fd_tile_private_sibling_idx( cpu0 );
+      cpu1 =   fd_ulong_if( sibling==ULONG_MAX, cpu0, sibling );
+      stride = fd_ulong_if( sibling==ULONG_MAX, 1,    sibling-cpu0 );
+    }
+    while( fd_isspace( (int)p[0] ) ) p++;
+    if( FD_UNLIKELY( !( p[0]==',' || p[0]=='\0' ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (bad range delimiter)" ));
+    if( p[0]==',' ) p++;
+    cpu1++;
+    if( FD_UNLIKELY( cpu1<=cpu0 ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (invalid range)"  ));
+    if( FD_UNLIKELY( !stride    ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (invalid stride)" ));
+
+    for( ulong cpu=cpu0; cpu<cpu1; cpu+=stride ) {
+      if( FD_UNLIKELY( cnt>=FD_TILE_MAX ) ) FD_LOG_ERR(( "fd_topob: too many affinity entries" ));
+      if( FD_UNLIKELY( !allow_repeats && cpu_bv_test( cpu_assigned, cpu ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (repeated cpu)" ));
+      tile_to_cpu[ cnt++ ] = (ushort)cpu;
+      cpu_bv_insert( cpu_assigned, cpu );
+    }
+  }
+
+  return cnt;
+}
+
+static int
+tile_name_in( char const *         name,
+              char const * const * names ) {
+  for( char const * const * p = names; *p; p++ ) {
+    if( !strcmp( name, *p ) ) return 1;
+  }
+  return 0;
+}
+
+#define FD_TOPOB_LIVE_ALWAYS    (1)
+#define FD_TOPOB_LIVE_STARTUP   (2)
+#define FD_TOPOB_LIVE_POSTSTART (3)
+
+static int
+fd_topob_tile_live_phase( char const * name ) {
+  if( tile_name_in( name, STARTUP    ) ) return FD_TOPOB_LIVE_STARTUP;
+  if( tile_name_in( name, POST_START ) ) return FD_TOPOB_LIVE_POSTSTART;
+  return FD_TOPOB_LIVE_ALWAYS;
+}
+
+static int
+fd_topob_cpu_overlap_allowed( fd_topo_tile_t const * a,
+                              fd_topo_tile_t const * b ) {
+  int a_phase = fd_topob_tile_live_phase( a->name );
+  int b_phase = fd_topob_tile_live_phase( b->name );
+
+  return ( a_phase==FD_TOPOB_LIVE_STARTUP   && b_phase==FD_TOPOB_LIVE_POSTSTART ) ||
+         ( a_phase==FD_TOPOB_LIVE_POSTSTART && b_phase==FD_TOPOB_LIVE_STARTUP   );
+}
+
+void
+fd_topob_validate_cpu_overlaps( fd_topo_t const * topo ) {
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    fd_topo_tile_t const * a = &topo->tiles[ i ];
+    if( a->cpu_idx>=FD_TILE_MAX ) continue;
+
+    for( ulong j=i+1UL; j<topo->tile_cnt; j++ ) {
+      fd_topo_tile_t const * b = &topo->tiles[ j ];
+      if( b->cpu_idx!=a->cpu_idx ) continue;
+      if( FD_LIKELY( fd_topob_cpu_overlap_allowed( a, b ) ) ) continue;
+
+      FD_LOG_ERR(( "tile `%s:%lu` and tile `%s:%lu` are both assigned to CPU %lu and may try to run at the same time",
+                   a->name, a->kind_id, b->name, b->kind_id, a->cpu_idx ));
+    }
+  }
+}
+
 static void
 auto_tile_cpu( fd_topo_tile_t * tile,
                fd_topo_cpus_t * cpus,
@@ -844,5 +985,6 @@ fd_topob_finish( fd_topo_t *                topo,
 
   initialize_numa_assignments( topo );
 
+  fd_topob_validate_cpu_overlaps( topo );
   validate( topo );
 }

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -172,6 +172,15 @@ fd_topob_finish( fd_topo_t *                topo,
 /* Classify a tile name into one of the FD_TOPOB_PRIORITY_* categories. */
 int
 fd_topob_tile_priority_type( char const * name );
+
+void
+fd_topob_validate_cpu_overlaps( fd_topo_t const * topo );
+
+ulong
+fd_topob_parse_affinity_cstr( char const * cstr,
+                              ushort *     tile_to_cpu,
+                              int          allow_repeats );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_disco_topo_fd_topob_h */

--- a/src/disco/topo/test_topob.c
+++ b/src/disco/topo/test_topob.c
@@ -15,6 +15,11 @@
 
 #include "fd_topob.h"
 #include "fd_cpu_topo.h"
+#include "../../util/tmpl/fd_unit_test.c"
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 /* ---- Tile specification ------------------------------------------------ */
 
@@ -121,16 +126,12 @@ print_layout( fd_topo_t const * topo,
    expected[i] = NULL       →  cpu unassigned (blocked / unused)
    Entries beyond expected_len must also be unassigned. */
 static void
-run_test( char const *          test_name,
-          ulong                 physical_cores,
+run_test( ulong                 physical_cores,
           tile_spec_t const *   tiles,
           ulong const *         blocklist,      /* ULONG_MAX terminated */
           int                   reserve_agave,
           ulong                 expected_len,
           char const * const *  expected ) {
-
-  FD_LOG_NOTICE(( "=== %s (%lu phys × 2) ===", test_name, physical_cores ));
-
   /* Build CPU topology */
   fd_topo_cpus_t cpus[1];
   make_cpus( cpus, physical_cores );
@@ -171,7 +172,6 @@ run_test( char const *          test_name,
     print_layout( topo, cpu_cnt );
   }
   FD_TEST( ok );
-  FD_LOG_NOTICE(( "  PASS" ));
 }
 
 /* ======================================================================== */
@@ -217,7 +217,7 @@ static tile_spec_t const FRANKENDANCER_TILES[] = {
 /* Default "0h" blocklist for N physical cores:
    cores 0 and N are blocked.  Built per-test as a local array. */
 
-#define BLOCKLIST_0H( N ) { 0, (N), ULONG_MAX }
+#define BLOCKLIST_0H( N ) (ulong const[]){ 0, (N), ULONG_MAX }
 
 /* ======================================================================== */
 /*  Expected results                                                        */
@@ -448,42 +448,35 @@ static char const * const FD_32X2_EXTRA_BL[] = {
 
 /* --- Firedancer (no agave) ---------------------------------------------- */
 
-static void test_firedancer_24x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 24 );
-  run_test( "firedancer_24x2", 24, FIREDANCER_TILES, bl, 0, FD_24X2_LEN, FD_24X2 );
+FD_UNIT_TEST( test_firedancer_24x2 ) {
+  run_test( 24, FIREDANCER_TILES, BLOCKLIST_0H( 24 ), 0, FD_24X2_LEN, FD_24X2 );
 }
 
-static void test_firedancer_32x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 32 );
-  run_test( "firedancer_32x2", 32, FIREDANCER_TILES, bl, 0, FD_32X2_LEN, FD_32X2 );
+FD_UNIT_TEST( test_firedancer_32x2 ) {
+  run_test( 32, FIREDANCER_TILES, BLOCKLIST_0H( 32 ), 0, FD_32X2_LEN, FD_32X2 );
 }
 
-static void test_firedancer_48x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 48 );
-  run_test( "firedancer_48x2", 48, FIREDANCER_TILES, bl, 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
+FD_UNIT_TEST( test_firedancer_48x2 ) {
+  run_test( 48, FIREDANCER_TILES, BLOCKLIST_0H( 48 ), 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
 }
 
-static void test_firedancer_64x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 64 );
-  run_test( "firedancer_64x2", 64, FIREDANCER_TILES, bl, 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
+FD_UNIT_TEST( test_firedancer_64x2 ) {
+  run_test( 64, FIREDANCER_TILES, BLOCKLIST_0H( 64 ), 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
 }
 
-static void test_firedancer_128x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 128 );
-  run_test( "firedancer_128x2", 128, FIREDANCER_TILES, bl, 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
+FD_UNIT_TEST( test_firedancer_128x2 ) {
+  run_test( 128, FIREDANCER_TILES, BLOCKLIST_0H( 128 ), 0, FD_SKIP_HT_LEN, FD_SKIP_HT );
 }
 
 /* --- Frankendancer (with agave visible in expected arrays) -------------- */
 
-static void test_frankendancer_24x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 24 );
-  run_test( "frankendancer_24x2", 24, FRANKENDANCER_TILES, bl, 1,
+FD_UNIT_TEST( test_frankendancer_24x2 ) {
+  run_test( 24, FRANKENDANCER_TILES, BLOCKLIST_0H( 24 ), 1,
             FRANK_24X2_LEN, FRANK_24X2 );
 }
 
-static void test_frankendancer_32x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 32 );
-  run_test( "frankendancer_32x2", 32, FRANKENDANCER_TILES, bl, 1,
+FD_UNIT_TEST( test_frankendancer_32x2 ) {
+  run_test( 32, FRANKENDANCER_TILES, BLOCKLIST_0H( 32 ), 1,
             FRANK_32X2_LEN, FRANK_32X2 );
 }
 
@@ -491,51 +484,92 @@ static void test_frankendancer_32x2( void ) {
    from the shared tile prefix, then mark agave regions with AGAVE.
    Tiles on physical 1-21, agave on physical 22..N-1 and HT N+22..2N-1. */
 
-static void test_frankendancer_48x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 48 );
+FD_UNIT_TEST( test_frankendancer_48x2 ) {
   char const * expected[96] = {0};
   for( ulong i=0UL; i<FRANK_SKIP_HT_PREFIX_LEN; i++ ) expected[i] = FRANK_SKIP_HT_PREFIX[i];
   for( ulong i=22; i<48;  i++ ) expected[i] = "AGAVE";  /* phys agave  */
   for( ulong i=70; i<96;  i++ ) expected[i] = "AGAVE";  /* HT agave    */
-  run_test( "frankendancer_48x2", 48, FRANKENDANCER_TILES, bl, 1, 96, expected );
+  run_test( 48, FRANKENDANCER_TILES, BLOCKLIST_0H( 48 ), 1, 96, expected );
 }
 
-static void test_frankendancer_64x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 64 );
+FD_UNIT_TEST( test_frankendancer_64x2 ) {
   char const * expected[128] = {0};
   for( ulong i=0UL; i<FRANK_SKIP_HT_PREFIX_LEN; i++ ) expected[i] = FRANK_SKIP_HT_PREFIX[i];
   for( ulong i=22; i<64;   i++ ) expected[i] = "AGAVE";  /* phys agave */
   for( ulong i=86; i<128;  i++ ) expected[i] = "AGAVE";  /* HT agave   */
-  run_test( "frankendancer_64x2", 64, FRANKENDANCER_TILES, bl, 1, 128, expected );
+  run_test( 64, FRANKENDANCER_TILES, BLOCKLIST_0H( 64 ), 1, 128, expected );
 }
 
-static void test_frankendancer_128x2( void ) {
-  ulong bl[] = BLOCKLIST_0H( 128 );
+FD_UNIT_TEST( test_frankendancer_128x2 ) {
   char const * expected[256] = {0};
   for( ulong i=0UL; i<FRANK_SKIP_HT_PREFIX_LEN; i++ ) expected[i] = FRANK_SKIP_HT_PREFIX[i];
   for( ulong i=22;  i<128; i++ ) expected[i] = "AGAVE";  /* phys agave */
   for( ulong i=150; i<256; i++ ) expected[i] = "AGAVE";  /* HT agave   */
-  run_test( "frankendancer_128x2", 128, FRANKENDANCER_TILES, bl, 1, 256, expected );
+  run_test( 128, FRANKENDANCER_TILES, BLOCKLIST_0H( 128 ), 1, 256, expected );
 }
 
 /* --- Variations on 32×2 ------------------------------------------------ */
 
-static void test_firedancer_32x2_fewer_tiles( void ) {
-  ulong bl[] = BLOCKLIST_0H( 32 );
-  run_test( "firedancer_32x2_fewer_tiles", 32, FD_FEWER_TILES, bl, 0,
+FD_UNIT_TEST( test_firedancer_32x2_fewer_tiles ) {
+  run_test( 32, FD_FEWER_TILES, BLOCKLIST_0H( 32 ), 0,
             FD_32X2_FEWER_LEN, FD_32X2_FEWER );
 }
 
-static void test_frankendancer_32x2_more_bank( void ) {
-  ulong bl[] = BLOCKLIST_0H( 32 );
-  run_test( "frankendancer_32x2_more_bank", 32, FRANK_MORE_BANK, bl, 1,
+FD_UNIT_TEST( test_frankendancer_32x2_more_bank ) {
+  run_test( 32, FRANK_MORE_BANK, BLOCKLIST_0H( 32 ), 1,
             FRANK_32X2_MORE_BANK_LEN, FRANK_32X2_MORE_BANK );
 }
 
-static void test_firedancer_32x2_extra_blocklist( void ) {
-  ulong bl[] = { 0, 32, 5, 37, ULONG_MAX };
-  run_test( "firedancer_32x2_extra_blocklist", 32, FIREDANCER_TILES, bl, 0,
-            FD_32X2_EXTRA_BL_LEN, FD_32X2_EXTRA_BL );
+FD_UNIT_TEST( test_firedancer_32x2_extra_blocklist ) {
+  run_test( 32, FIREDANCER_TILES, (ulong[]){ 0, 32, 5, 37, ULONG_MAX },
+            0, FD_32X2_EXTRA_BL_LEN, FD_32X2_EXTRA_BL );
+}
+
+static fd_topo_tile_t *
+add_test_tile( fd_topo_t *  topo,
+               char const * name,
+               ulong        kind_id,
+               ulong        cpu_idx ) {
+  fd_topo_tile_t * tile = &topo->tiles[ topo->tile_cnt++ ];
+  strncpy( tile->name, name, sizeof(tile->name) );
+  tile->kind_id = kind_id;
+  tile->cpu_idx = cpu_idx;
+  return tile;
+}
+
+FD_UNIT_TEST( test_cpu_overlap_permitted ) {
+  static fd_topo_t _topo[1];
+  fd_topo_t * topo = _topo;
+  fd_memset( topo, 0, sizeof(*topo) );
+
+  add_test_tile( topo, "snapct", 0UL, 7UL );
+  add_test_tile( topo, "execle", 0UL, 7UL );
+
+  fd_topob_validate_cpu_overlaps( topo );
+}
+
+FD_UNIT_TEST( test_cpu_overlap_banned ) {
+  pid_t pid = fork();
+  FD_TEST( pid>=0 );
+
+  if( pid==0 ) {
+    fd_log_level_logfile_set( 6 );
+
+    static fd_topo_t _topo[1];
+    fd_topo_t * topo = _topo;
+    fd_memset( topo, 0, sizeof(*topo) );
+
+    add_test_tile( topo, "pack",  0UL, 9UL );
+    add_test_tile( topo, "shred", 0UL, 9UL );
+
+    fd_topob_validate_cpu_overlaps( topo );
+    _exit( 0 );
+  }
+
+  int status = 0;
+  FD_TEST( waitpid( pid, &status, 0 )==pid );
+  FD_TEST( ( WIFEXITED( status ) && WEXITSTATUS( status )==1 ) ||
+           ( WIFSIGNALED( status ) && WTERMSIG( status )==SIGABRT ) );
 }
 
 /* ======================================================================== */
@@ -544,26 +578,7 @@ int
 main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
-
-  /* Firedancer */
-  test_firedancer_24x2();
-  test_firedancer_32x2();
-  test_firedancer_48x2();
-  test_firedancer_64x2();
-  test_firedancer_128x2();
-
-  /* Frankendancer */
-  test_frankendancer_24x2();
-  test_frankendancer_32x2();
-  test_frankendancer_48x2();
-  test_frankendancer_64x2();
-  test_frankendancer_128x2();
-
-  /* Variations on 32×2 */
-  test_firedancer_32x2_fewer_tiles();
-  test_frankendancer_32x2_more_bank();
-  test_firedancer_32x2_extra_blocklist();
-
+  fd_unit_tests( argc, argv );
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;


### PR DESCRIPTION
Fixes a bug where overly strict tile overlap checks don't allow
STARTUP and POST_START tiles to overlap (which is permitted in
default affinity)

Needed a refactor of the affinity string parser.  The parser is
now copied to fd_topob so we don't have to depend on util internals.

Closes https://github.com/firedancer-io/firedancer/issues/10328
