### PR TITLE
net: preferred busy polling

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -978,36 +978,31 @@ dynamic_port_range = "8900-9000"
         xdp_zero_copy = false
 
         # The poll_mode option determines how Firedancer polls NAPI (Linux's
-        # high perf networking mechanisms). Its possible values are:
+        # high perf networking mechanisms).  Its possible values are:
         #
         #  "softirq" (default)
         #   Relies significantly more on Linux to manage NAPI through wakeups,
         #   softirqs, and under higher network load, a separate ksoftirqd
-        #   thread which Linux schedules onto a separate core. If a ksoftirqd
-        #   is scheduled by Linux onto a core corresponding to a different
-        #   tile, the performance of that tile is significantly degraded. softirq
-        #   poll mode is the default since it is more well tested.
+        #   thread which Linux schedules onto a separate core.
         #
         #  "prefbusy"
         #   Experimental option which gives Firedancer significantly more
-        #   control over how and when NAPI is polled, leading to much fewer
-        #   IRQs and ksoftirqds.
-        #
-        #   Its main benefit is significantly increased IRQ/ksoftirqd livelock
-        #   protection, which is important during DoS attacks and high net load.
+        #   control over how and when NAPI is polled.  Reduces networking
+        #   related IRQs and ksoftirqds to near zero on well supported NIC
+        #   drivers, increasing determinism and stability during DoS attacks
+        #   and high net load.
         #
         #   Hardware Support: Currently best supported on mlx5 (Mellanox).
-        #   Depending on the driver, XDP Copy Mode (SKB) can see massive
-        #   throughput gains (up to 2x on mlx5, 1.5x on i40e). Zero-copy (AF_XDP)
-        #   throughput generally remains the same across both poll modes.
+        #   Depending on the driver, XDP Copy Mode can see noticeable throughput
+        #   gains (up to 2.4x on mlx5, 1.5x on i40e).  Zero-copy RX throughput
+        #   generally remains the same across both poll modes.
         #
         # Extra info
         #
-        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
-        #  automatically fall back to "softirq" mode and emit a warning.
+        #  Requires a kernel version of at least v5.11 (Feb 2021).
         #
-        #  SSH minor latency: You may notice a small-medium increase in SSH
-        #  latency if using the same interface(s) as Firedancer for SSH.
+        #  Prefbusy mode increases tail latency for other applications on
+        #  the system sharing the same network interface.
         poll_mode = "softirq"
 
         # XDP uses metadata queues shared across the kernel and
@@ -1015,7 +1010,7 @@ dynamic_port_range = "8900-9000"
         # This setting defines the number of entries in these metadata
         # queues, which has to be a power of two.
         #
-        # Smaller values use less memory. Larger values reduce packet
+        # Smaller values use less memory.  Larger values reduce packet
         # loss caused by excessive scheduling or inter-CPU latency.
         xdp_rx_queue_size = 32768
         xdp_tx_queue_size = 32768

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -977,12 +977,45 @@ dynamic_port_range = "8900-9000"
         # "operation not supported".
         xdp_zero_copy = false
 
+        # The poll_mode option determines how Firedancer polls NAPI (Linux's
+        # high perf networking mechanisms). Its possible values are:
+        #
+        #  "softirq" (default)
+        #   Relies significantly more on Linux to manage NAPI through wakeups,
+        #   softirqs, and under higher network load, a separate ksoftirqd
+        #   thread which Linux schedules onto a separate core. If a ksoftirqd
+        #   is scheduled by Linux onto a core corresponding to a different
+        #   tile, the performance of that tile is significantly degraded. softirq
+        #   poll mode is the default since it is more well tested.
+        #
+        #  "prefbusy"
+        #   Experimental option which gives Firedancer significantly more
+        #   control over how and when NAPI is polled, leading to much fewer
+        #   IRQs and ksoftirqds.
+        #
+        #   Its main benefit is significantly increased IRQ/ksoftirqd livelock
+        #   protection, which is important during DoS attacks and high net load.
+        #
+        #   Hardware Support: Currently best supported on mlx5 (Mellanox).
+        #   Depending on the driver, XDP Copy Mode (SKB) can see massive
+        #   throughput gains (up to 2x on mlx5, 1.5x on i40e). Zero-copy (AF_XDP)
+        #   throughput generally remains the same across both poll modes.
+        #
+        # Extra info
+        #
+        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
+        #  automatically fall back to "softirq" mode and emit a warning.
+        #
+        #  SSH minor latency: You may notice a small-medium increase in SSH
+        #  latency if using the same interface(s) as Firedancer for SSH.
+        poll_mode = "softirq"
+
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
         # This setting defines the number of entries in these metadata
         # queues, which has to be a power of two.
         #
-        # Smaller values use less memory.  Larger values reduce packet
+        # Smaller values use less memory. Larger values reduce packet
         # loss caused by excessive scheduling or inter-CPU latency.
         xdp_rx_queue_size = 32768
         xdp_tx_queue_size = 32768

--- a/src/app/fdctl/main.c
+++ b/src/app/fdctl/main.c
@@ -39,6 +39,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_ethtool_channels,
   &fd_cfg_stage_ethtool_offloads,
   &fd_cfg_stage_ethtool_loopback,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/fddev/main.h
+++ b/src/app/fddev/main.h
@@ -34,6 +34,7 @@ extern configure_stage_t fd_cfg_stage_kill;
 extern configure_stage_t fd_cfg_stage_genesis;
 extern configure_stage_t fd_cfg_stage_keys;
 extern configure_stage_t fd_cfg_stage_blockstore;
+extern configure_stage_t fd_cfg_stage_sysfs_poll;
 
 configure_stage_t * STAGES[] = {
   &fd_cfg_stage_kill,
@@ -47,6 +48,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_keys,
   &fd_cfg_stage_genesis,
   &fd_cfg_stage_blockstore,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1059,36 +1059,31 @@ telemetry = true
         xdp_zero_copy = false
 
         # The poll_mode option determines how Firedancer polls NAPI (Linux's
-        # high perf networking mechanisms). Its possible values are:
+        # high perf networking mechanisms).  Its possible values are:
         #
         #  "softirq" (default)
         #   Relies significantly more on Linux to manage NAPI through wakeups,
         #   softirqs, and under higher network load, a separate ksoftirqd
-        #   thread which Linux schedules onto a separate core. If a ksoftirqd
-        #   is scheduled by Linux onto a core corresponding to a different
-        #   tile, the performance of that tile is significantly degraded. softirq
-        #   poll mode is the default since it is more well tested.
+        #   thread which Linux schedules onto a separate core.
         #
         #  "prefbusy"
         #   Experimental option which gives Firedancer significantly more
-        #   control over how and when NAPI is polled, leading to much fewer
-        #   IRQs and ksoftirqds.
-        #
-        #   Its main benefit is significantly increased IRQ/ksoftirqd livelock
-        #   protection, which is important during DoS attacks and high net load.
+        #   control over how and when NAPI is polled.  Reduces networking
+        #   related IRQs and ksoftirqds to near zero on well supported NIC
+        #   drivers, increasing determinism and stability during DoS attacks
+        #   and high net load.
         #
         #   Hardware Support: Currently best supported on mlx5 (Mellanox).
-        #   Depending on the driver, XDP Copy Mode (SKB) can see massive
-        #   throughput gains (up to 2x on mlx5, 1.5x on i40e). Zero-copy (AF_XDP)
-        #   throughput generally remains the same across both poll modes.
+        #   Depending on the driver, XDP Copy Mode can see noticeable throughput
+        #   gains (up to 2.4x on mlx5, 1.5x on i40e).  Zero-copy RX throughput
+        #   generally remains the same across both poll modes.
         #
         # Extra info
         #
-        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
-        #  automatically fall back to "softirq" mode and emit a warning.
+        #  Requires a kernel version of at least v5.11 (Feb 2021).
         #
-        #  SSH minor latency: You may notice a small-medium increase in SSH
-        #  latency if using the same interface(s) as Firedancer for SSH.
+        #  Prefbusy mode increases tail latency for other applications on
+        #  the system sharing the same network interface.
         poll_mode = "softirq"
 
         # XDP uses metadata queues shared across the kernel and

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1058,6 +1058,39 @@ telemetry = true
         # "operation not supported".
         xdp_zero_copy = false
 
+        # The poll_mode option determines how Firedancer polls NAPI (Linux's
+        # high perf networking mechanisms). Its possible values are:
+        #
+        #  "softirq" (default)
+        #   Relies significantly more on Linux to manage NAPI through wakeups,
+        #   softirqs, and under higher network load, a separate ksoftirqd
+        #   thread which Linux schedules onto a separate core. If a ksoftirqd
+        #   is scheduled by Linux onto a core corresponding to a different
+        #   tile, the performance of that tile is significantly degraded. softirq
+        #   poll mode is the default since it is more well tested.
+        #
+        #  "prefbusy"
+        #   Experimental option which gives Firedancer significantly more
+        #   control over how and when NAPI is polled, leading to much fewer
+        #   IRQs and ksoftirqds.
+        #
+        #   Its main benefit is significantly increased IRQ/ksoftirqd livelock
+        #   protection, which is important during DoS attacks and high net load.
+        #
+        #   Hardware Support: Currently best supported on mlx5 (Mellanox).
+        #   Depending on the driver, XDP Copy Mode (SKB) can see massive
+        #   throughput gains (up to 2x on mlx5, 1.5x on i40e). Zero-copy (AF_XDP)
+        #   throughput generally remains the same across both poll modes.
+        #
+        # Extra info
+        #
+        #  Older kernels: If your kernel is too old (< v5.11), Firedancer will
+        #  automatically fall back to "softirq" mode and emit a warning.
+        #
+        #  SSH minor latency: You may notice a small-medium increase in SSH
+        #  latency if using the same interface(s) as Firedancer for SSH.
+        poll_mode = "softirq"
+
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
         # This setting defines the number of entries in these metadata

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -56,6 +56,7 @@ configure_stage_t * STAGES[] = {
   &fd_cfg_stage_irq_balance,
   &fd_cfg_stage_irq_affinity,
   &fd_cfg_stage_snapshots,
+  &fd_cfg_stage_sysfs_poll,
   NULL,
 };
 

--- a/src/app/shared/Local.mk
+++ b/src/app/shared/Local.mk
@@ -31,6 +31,7 @@ $(call add-objs,commands/configure/fd_irqbalance_client,fdctl_shared)
 $(call add-objs,commands/configure/hugetlbfs,fdctl_shared)
 $(call add-objs,commands/configure/hyperthreads,fdctl_shared)
 $(call add-objs,commands/configure/sysctl,fdctl_shared)
+$(call add-objs,commands/configure/sysfs-poll,fdctl_shared)
 $(call add-objs,commands/configure/snapshots,fdctl_shared)
 ifdef FD_HAS_ALLOCA
 $(call add-objs,commands/monitor/monitor commands/monitor/helper,fdctl_shared)

--- a/src/app/shared/commands/configure/configure.h
+++ b/src/app/shared/commands/configure/configure.h
@@ -86,6 +86,7 @@ extern configure_stage_t fd_cfg_stage_ethtool_offloads;
 extern configure_stage_t fd_cfg_stage_ethtool_loopback;
 extern configure_stage_t fd_cfg_stage_irq_affinity;
 extern configure_stage_t fd_cfg_stage_irq_balance;
+extern configure_stage_t fd_cfg_stage_sysfs_poll;
 extern configure_stage_t fd_cfg_stage_snapshots;
 
 extern configure_stage_t * STAGES[];

--- a/src/app/shared/commands/configure/sysfs-poll.c
+++ b/src/app/shared/commands/configure/sysfs-poll.c
@@ -1,0 +1,94 @@
+/* This stage configures the OS to support effective preferred busy
+   polling, allowing for significantly improved network stack (XDP)
+   reliability under high load if enabled on a well supported driver. */
+
+#include "configure.h"
+
+#define NAME "sysfs-poll"
+
+#include "../../../platform/fd_file_util.h"
+
+#include <string.h> /* strcmp */
+#include <unistd.h> /* access */
+#include <linux/capability.h>
+
+/* Values for NAPI_DEFER_HARD_IRQS and GRO_FLUSH_TIMEOUT
+   chosen based on napibusy configuration tested and shown
+   in https://lwn.net/Articles/997491/ Linux patch cover letter.
+   Chosen over fullbusy since for Firedancer the values of
+   fullbusy are unnecessarily high and cause significant SSH
+   latency. */
+#define NAPI_DEFER_HARD_IRQS 100U
+#define GRO_FLUSH_TIMEOUT    200000U
+
+static char const setting_napi_defer_hard_irqs[] = "napi_defer_hard_irqs";
+static char const setting_gro_flush_timeout[]    = "gro_flush_timeout";
+
+static int
+enabled( config_t const * config ) {
+  return !strcmp( config->net.provider, "xdp")
+      && !strcmp( config->net.xdp.poll_mode, "prefbusy");
+}
+
+static void
+init_perm( fd_cap_chk_t   * chk,
+           config_t const * config FD_PARAM_UNUSED ) {
+  fd_cap_chk_cap( chk, NAME, CAP_NET_ADMIN, "configure preferred busy polling via `/sys/class/net/*/{napi_defer_hard_irqs, gro_flush_timeout}`" );
+}
+
+static void
+sysfs_net_set( char const * device,
+               char const * setting,
+               ulong        value ) {
+  char path[ PATH_MAX ];
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", device, setting );
+  FD_LOG_NOTICE(( "RUN: `echo \"%lu\" > %s`", value, path ));
+  if( FD_UNLIKELY( -1==fd_file_util_write_uint( path, (uint)value ) ) ) {
+    FD_LOG_ERR(( "could not write to `%s`, 'prefbusy' poll mode may not be supported for this network configuration, consider switching back 'poll_mode' within your config to 'softirq' mode.", path));
+  }
+}
+
+static void
+init( config_t const * config ) {
+  sysfs_net_set( config->net.interface, setting_napi_defer_hard_irqs, NAPI_DEFER_HARD_IRQS );
+
+  sysfs_net_set( config->net.interface, setting_gro_flush_timeout, GRO_FLUSH_TIMEOUT );
+}
+
+static int
+fini( config_t const * config,
+      int              pre_init FD_PARAM_UNUSED ) {
+  sysfs_net_set( config->net.interface, setting_napi_defer_hard_irqs, 0U );
+  sysfs_net_set( config->net.interface, setting_gro_flush_timeout,    0U );
+  return 1;
+}
+
+static configure_result_t
+check( config_t const * config,
+       int              check_type FD_PARAM_UNUSED ) {
+  char path[ PATH_MAX ];
+  uint value;
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_napi_defer_hard_irqs );
+  if( fd_file_util_read_uint( path, &value )
+      || value != ( NAPI_DEFER_HARD_IRQS ) ) {
+    NOT_CONFIGURED("Setting napi_defer_hard_irqs failed.");
+  }
+
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_gro_flush_timeout );
+  if( fd_file_util_read_uint( path, &value )
+      || value != ( GRO_FLUSH_TIMEOUT ) ) {
+    NOT_CONFIGURED("Setting gro_flush_timeout failed.");
+  }
+
+  CONFIGURE_OK();
+}
+
+configure_stage_t fd_cfg_stage_sysfs_poll = {
+  .name      = NAME,
+  .enabled   = enabled,
+  .init_perm = init_perm,
+  .fini_perm = init_perm,
+  .init      = init,
+  .fini      = fini,
+  .check     = check,
+};

--- a/src/app/shared/commands/configure/sysfs-poll.c
+++ b/src/app/shared/commands/configure/sysfs-poll.c
@@ -10,14 +10,15 @@
 
 #include <string.h> /* strcmp */
 #include <unistd.h> /* access */
+#include <errno.h>
 #include <linux/capability.h>
 
 /* Values for NAPI_DEFER_HARD_IRQS and GRO_FLUSH_TIMEOUT
    chosen based on napibusy configuration tested and shown
    in https://lwn.net/Articles/997491/ Linux patch cover letter.
    Chosen over fullbusy since for Firedancer the values of
-   fullbusy are unnecessarily high and cause significant SSH
-   latency. */
+   fullbusy are unnecessarily high and could cause some extra
+   latency to regular non-Firedancer traffic. */
 #define NAPI_DEFER_HARD_IRQS 100U
 #define GRO_FLUSH_TIMEOUT    200000U
 
@@ -44,7 +45,7 @@ sysfs_net_set( char const * device,
   fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", device, setting );
   FD_LOG_NOTICE(( "RUN: `echo \"%lu\" > %s`", value, path ));
   if( FD_UNLIKELY( -1==fd_file_util_write_uint( path, (uint)value ) ) ) {
-    FD_LOG_ERR(( "could not write to `%s`, 'prefbusy' poll mode may not be supported for this network configuration, consider switching back 'poll_mode' within your config to 'softirq' mode.", path));
+    FD_LOG_ERR(( "could not write to `%s` (%i-%s), 'prefbusy' poll mode may not be supported for this network configuration, consider switching back 'poll_mode' within your config to 'softirq' mode.", path, errno, fd_io_strerror( errno ) ));
   }
 }
 
@@ -70,14 +71,14 @@ check( config_t const * config,
   uint value;
   fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_napi_defer_hard_irqs );
   if( fd_file_util_read_uint( path, &value )
-      || value != ( NAPI_DEFER_HARD_IRQS ) ) {
-    NOT_CONFIGURED("Setting napi_defer_hard_irqs failed.");
+      || value != NAPI_DEFER_HARD_IRQS ) {
+    NOT_CONFIGURED( "Setting napi_defer_hard_irqs failed." );
   }
 
   fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/%s", config->net.interface, setting_gro_flush_timeout );
   if( fd_file_util_read_uint( path, &value )
-      || value != ( GRO_FLUSH_TIMEOUT ) ) {
-    NOT_CONFIGURED("Setting gro_flush_timeout failed.");
+      || value != GRO_FLUSH_TIMEOUT ) {
+    NOT_CONFIGURED( "Setting gro_flush_timeout failed." );
   }
 
   CONFIGURE_OK();

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -531,6 +531,11 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_ZERO( net.ingress_buffer_size );
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     CFG_HAS_NON_EMPTY( net.xdp.xdp_mode );
+
+    if( 0!=strcmp( config->net.xdp.poll_mode, "prefbusy" ) && 0!=strcmp( config->net.xdp.poll_mode, "softirq" ) ) {
+      FD_LOG_ERR(( "invalid `net.xdp.poll_mode`: must be \"prefbusy\" or \"softirq\"" ));
+    }
+
     CFG_HAS_POW2     ( net.xdp.xdp_rx_queue_size );
     CFG_HAS_POW2     ( net.xdp.xdp_tx_queue_size );
     if( 0!=strcmp( config->net.xdp.rss_queue_mode, "dedicated" ) &&

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -206,6 +206,7 @@ struct fd_config_net {
   struct {
     char xdp_mode[ 8 ];
     int  xdp_zero_copy;
+    char poll_mode[ 16 ]; /* "prefbusy" or "softirq" */
 
     uint xdp_rx_queue_size;
     uint xdp_tx_queue_size;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -186,6 +186,7 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( uint,   net.ingress_buffer_size                          );
   CFG_POP      ( cstr,   net.xdp.xdp_mode                                 );
   CFG_POP      ( bool,   net.xdp.xdp_zero_copy                            );
+  CFG_POP      ( cstr,   net.xdp.poll_mode                                );
   CFG_POP      ( uint,   net.xdp.xdp_rx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.xdp_tx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.flush_timeout_micros                     );

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -208,6 +208,7 @@ pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   configure_stage( &fd_cfg_stage_bonding,          CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_channels, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_offloads, CONFIGURE_CMD_INIT, config );
+  configure_stage( &fd_cfg_stage_sysfs_poll,       CONFIGURE_CMD_INIT, config );
 
   fdctl_check_configure( config );
   /* FIXME this allocates lots of memory unnecessarily */

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -100,6 +100,7 @@ udpecho_cmd_fn( args_t *   args,
   configure_stage( &fd_cfg_stage_ethtool_channels, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_offloads, CONFIGURE_CMD_INIT, config );
   configure_stage( &fd_cfg_stage_ethtool_loopback, CONFIGURE_CMD_INIT, config );
+  configure_stage( &fd_cfg_stage_sysfs_poll,       CONFIGURE_CMD_INIT, config );
 
   fdctl_check_configure( config );
   /* FIXME this allocates lots of memory unnecessarily */

--- a/src/disco/net/fd_net_tile_topo.c
+++ b/src/disco/net/fd_net_tile_topo.c
@@ -45,6 +45,8 @@ setup_xdp_tile( fd_topo_t *             topo,
   tile->xdp.zero_copy           = net_cfg->xdp.xdp_zero_copy;
   fd_cstr_ncpy( tile->xdp.xdp_mode, net_cfg->xdp.xdp_mode, sizeof(tile->xdp.xdp_mode) );
 
+  fd_cstr_ncpy( tile->xdp.poll_mode, net_cfg->xdp.poll_mode, sizeof(tile->xdp.poll_mode) );
+
   tile->xdp.net.umem_dcache_obj_id = umem_obj->id;
   tile->xdp.netdev_tbl_obj_id      = netlink_tile->netlink.netdev_tbl_obj_id;
   tile->xdp.fib4_main_obj_id       = netlink_tile->netlink.fib4_main_obj_id;

--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -51,6 +51,45 @@
 #define XSK_IDX_MAIN 0
 #define XSK_IDX_LO   1
 
+/* XSK 'busy_poll_usecs' value (max amount of time
+   spent spinning in a NAPI poll before returning back to
+   userspace if the processing budget hasn't already ran out).
+
+   64us chosen based on napibusy configuration tested and
+   shown in https://lwn.net/Articles/997491/ Linux patch
+   cover letter. Chosen over fullbusy since for Firedancer
+   the values of fullbusy are unnecessarily high and cause
+   significant SSH latency.*/
+#define PREFBUSY_TIME_BUDGET_MICROS (64L)
+
+/* PREFBUSY_RX_BUDGET is the NAPI RX processing budget (max num RX
+   packets that the NIC driver can move from the hw rings into the
+   XSK rings per poll).
+
+   Default RX budget used by NIC drivers is 64, therefore
+   it is safest to use 64 in prefbusy polling. Also reduces
+   TX starvation risks as the TX budget set by the NIC driver
+   is also generally 64. */
+#define PREFBUSY_RX_BUDGET (64L)
+
+/* Min time between each prefbusy poll (further protects against livelocks).
+
+   Value chosen based on experimentation on ixgbe, mlx5 and i40e as well
+   as on varying CPUs and clock speeds. Too low -> lower max TX
+   throughput when RX is low. Too high -> lower max RX and TX throughput. */
+#define PREFBUSY_MIN_INTERVAL_NS (5e3) /* 5us */
+
+/* Max time since last prefbusy poll before a prefbusy poll is
+   forced (has been read that polling can sometimes resolve a stall).
+
+   Exact value again not particularly important as this is just extra
+   protection against stalls which have not been observed in testing but
+   are still good to protect against since there is no cost to doing so.
+
+   Value of 150us chosen since it is easily large enough to not interfere
+   with standard prefbusy runtime unless there is a serious problem. */
+#define PREFBUSY_STALL_TIMEOUT_NS (150e3) /* 150us */
+
 /* fd_net_in_ctx_t contains consumer information for an incoming tango
    link.  It is used as part of the TX path. */
 
@@ -94,10 +133,17 @@ struct fd_net_flusher {
      wakeup.  This can result in the tail of a burst getting delayed or
      overrun.  If more than tail_flush_backoff ticks pass since the last
      sendto() wakeup and there are still unacknowledged packets in the
-     TX ring, issues another wakeup. */
+     TX ring, issues another wakeup. Only used by "softirq" poll mode. */
   long next_tail_flush_ticks;
   long tail_flush_backoff;
 
+  /* When the most recent prefbusy poll was. */
+  long prefbusy_last_poll_ticks;
+  /* Min time between each prefbusy poll (further protects against livelocks). */
+  long prefbusy_min_interval_ticks;
+  /* Max time since last prefbusy poll before a prefbusy poll is
+     forced (has been read that polling can sometimes resolve a stall). */
+  long prefbusy_stall_timeout_ticks;
 };
 
 typedef struct fd_net_flusher fd_net_flusher_t;
@@ -1122,6 +1168,99 @@ net_rx_event( fd_net_ctx_t * ctx,
   fill_ring->cached_prod = fill_prod+1U;
 }
 
+/* before_credit_softirq is called every loop iteration if net tile
+   is in softirq polling mode (fallback if prefbusy polling mode
+   is not enabled). */
+
+static void
+before_credit_softirq( fd_net_ctx_t *      ctx,
+                       int *               charge_busy,
+                       uint                rr_idx,
+                       fd_xsk_t *          rr_xsk ) {
+
+  net_tx_periodic_wakeup( ctx, rr_idx, fd_tickcount(), charge_busy );
+
+  /* Fire RX event if we have RX desc avail */
+  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
+    *charge_busy = 1;
+    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  } else {
+    net_rx_wakeup( ctx, rr_xsk, charge_busy );
+
+    /* Iterate onto the next NAPI queue. */
+    ctx->rr_idx++;
+    ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+  }
+}
+
+static int
+net_prefbusy_poll_ready( fd_xsk_t *         rr_xsk,
+                         fd_net_flusher_t * flusher,
+                         long               now ) {
+
+  if( FD_LIKELY( now < ( flusher->prefbusy_last_poll_ticks + flusher->prefbusy_min_interval_ticks ) ) ) return 0;
+  if( FD_UNLIKELY( now > ( flusher->prefbusy_last_poll_ticks + flusher->prefbusy_stall_timeout_ticks ) ) ) return 1;
+
+  int rx_empty = fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS );
+
+  return rx_empty;
+}
+
+static void
+net_prefbusy_poll_flush( fd_net_flusher_t * flusher,
+                         long               now ) {
+  flusher->prefbusy_last_poll_ticks = now;
+}
+
+/* before_credit_prefbusy is called every loop iteration if net
+   tile is in preferred busy (often referred to as "prefbusy" in
+   Firedancer) polling mode. */
+
+static void
+before_credit_prefbusy( fd_net_ctx_t *      ctx,
+                        int *               charge_busy,
+                        uint                rr_idx,
+                        fd_xsk_t *          rr_xsk ) {
+
+  fd_net_flusher_t * flusher = ctx->tx_flusher+rr_idx;
+  if( FD_UNLIKELY( net_prefbusy_poll_ready( rr_xsk, flusher, fd_tickcount() ) ) ) {
+    /* NAPI needs to be polled to process new TX from
+       Firedancer's net tile and process new RX from the NIC. */
+
+    FD_VOLATILE( *rr_xsk->ring_tx.prod ) = rr_xsk->ring_tx.cached_prod; /* write-back local copies to fseqs */
+    FD_VOLATILE( *rr_xsk->ring_cr.cons ) = rr_xsk->ring_cr.cached_cons;
+    FD_VOLATILE( *rr_xsk->ring_rx.cons ) = rr_xsk->ring_rx.cached_cons;
+    FD_VOLATILE( *rr_xsk->ring_fr.prod ) = rr_xsk->ring_fr.cached_prod;
+
+    if( FD_UNLIKELY( -1==sendto( rr_xsk->xsk_fd, NULL, 0, MSG_DONTWAIT, NULL, 0 ) ) ) {
+      if( FD_UNLIKELY( net_is_fatal_xdp_error( errno ) ) ) {
+        FD_LOG_ERR(( "xsk sendto failed xsk_fd=%d (%i-%s)", rr_xsk->xsk_fd, errno, fd_io_strerror( errno ) ));
+      }
+      if( FD_UNLIKELY( errno!=EAGAIN ) ) {
+        long ts = fd_log_wallclock();
+        if( ts > rr_xsk->log_suppress_until_ns ) {
+          FD_LOG_WARNING(( "xsk sendto failed xsk_fd=%d (%i-%s)", rr_xsk->xsk_fd, errno, fd_io_strerror( errno ) ));
+          rr_xsk->log_suppress_until_ns = ts + (long)1e9;
+        }
+      }
+    }
+    /* Since xsk sendmsg in prefbusy mode drives both rx and tx, both are incremented */
+    ctx->metrics.xsk_tx_wakeup_cnt++;
+    ctx->metrics.xsk_rx_wakeup_cnt++;
+
+    net_prefbusy_poll_flush( flusher, fd_tickcount() );
+  }
+
+  /* Process new RX from xsk ring if there is any. */
+  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
+    *charge_busy = 1;
+    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  }
+  /* Iterate onto the next NAPI queue. */
+  ctx->rr_idx++;
+  ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+}
+
 /* before_credit is called every loop iteration. */
 
 static void
@@ -1148,16 +1287,11 @@ before_credit( fd_net_ctx_t *      ctx,
   uint       rr_idx = ctx->rr_idx;
   fd_xsk_t * rr_xsk = &ctx->xsk[ rr_idx ];
 
-  net_tx_periodic_wakeup( ctx, rr_idx, fd_tickcount(), charge_busy );
-
-  /* Fire RX event if we have RX desc avail */
-  if( !fd_xdp_ring_empty( &rr_xsk->ring_rx, FD_XDP_RING_ROLE_CONS ) ) {
-    *charge_busy = 1;
-    net_rx_event( ctx, rr_xsk, rr_xsk->ring_rx.cached_cons );
+  if( FD_LIKELY( !rr_xsk->prefbusy_poll_enabled ) ) {
+    /* Default poll mode which relies on irqs and wakeups */
+    before_credit_softirq( ctx, charge_busy, rr_idx, rr_xsk );
   } else {
-    net_rx_wakeup( ctx, rr_xsk, charge_busy );
-    ctx->rr_idx++;
-    ctx->rr_idx = fd_uint_if( ctx->rr_idx>=ctx->xsk_cnt, 0, ctx->rr_idx );
+    before_credit_prefbusy( ctx, charge_busy, rr_idx, rr_xsk );
   }
 
   /* Fire comp event if we have comp desc avail */
@@ -1288,6 +1422,10 @@ privileged_init( fd_topo_t const *      topo,
        (e.g. 5.14.0-503.23.1.el9_5 with i40e) */
     .bind_flags  = tile->xdp.zero_copy ? XDP_ZEROCOPY : XDP_COPY,
 
+    .prefbusy_time_budget_micros = PREFBUSY_TIME_BUDGET_MICROS,
+
+    .prefbusy_rx_budget = PREFBUSY_RX_BUDGET,
+
     .fr_depth  = tile->xdp.xdp_rx_queue_size*2,
     .rx_depth  = tile->xdp.xdp_rx_queue_size,
     .cr_depth  = tile->xdp.xdp_tx_queue_size,
@@ -1299,6 +1437,8 @@ privileged_init( fd_topo_t const *      topo,
 
     .core_dump = tile->xdp.xsk_core_dump,
   };
+
+  fd_cstr_ncpy( params0.poll_mode, tile->xdp.poll_mode, sizeof(params0.poll_mode) );
 
   /* Re-derive XDP file descriptors */
 
@@ -1496,6 +1636,10 @@ unprivileged_init( fd_topo_t const *      topo,
     ctx->tx_flusher[ j ].pending_wmark         = (ulong)( (double)tile->xdp.xdp_tx_queue_size * 0.7 );
     ctx->tx_flusher[ j ].tail_flush_backoff    = (long)( (double)tile->xdp.tx_flush_timeout_ns * fd_tempo_tick_per_ns( NULL ) );
     ctx->tx_flusher[ j ].next_tail_flush_ticks = LONG_MAX;
+
+    ctx->tx_flusher[ j ].prefbusy_last_poll_ticks     = 0L;
+    ctx->tx_flusher[ j ].prefbusy_min_interval_ticks  = (long)( PREFBUSY_MIN_INTERVAL_NS * fd_tempo_tick_per_ns( NULL ) );
+    ctx->tx_flusher[ j ].prefbusy_stall_timeout_ticks = (long)( PREFBUSY_STALL_TIMEOUT_NS * fd_tempo_tick_per_ns( NULL ) );
   }
 
   /* Join netbase objects */

--- a/src/disco/net/xdp/fd_xdp_tile.c
+++ b/src/disco/net/xdp/fd_xdp_tile.c
@@ -57,9 +57,9 @@
 
    64us chosen based on napibusy configuration tested and
    shown in https://lwn.net/Articles/997491/ Linux patch
-   cover letter. Chosen over fullbusy since for Firedancer
-   the values of fullbusy are unnecessarily high and cause
-   significant SSH latency.*/
+   cover letter.  Chosen over fullbusy since for Firedancer
+   the values of fullbusy are unnecessarily high and could
+   cause some extra latency to regular non-Firedancer traffic.*/
 #define PREFBUSY_TIME_BUDGET_MICROS (64L)
 
 /* PREFBUSY_RX_BUDGET is the NAPI RX processing budget (max num RX
@@ -67,16 +67,18 @@
    XSK rings per poll).
 
    Default RX budget used by NIC drivers is 64, therefore
-   it is safest to use 64 in prefbusy polling. Also reduces
+   it is safest to use 64 in prefbusy polling.  Also reduces
    TX starvation risks as the TX budget set by the NIC driver
    is also generally 64. */
 #define PREFBUSY_RX_BUDGET (64L)
 
-/* Min time between each prefbusy poll (further protects against livelocks).
+/* Min time between each prefbusy poll.  Necessary to avoid a no RX
+   scenario livelocking TX with overly frequent sendto calls, given
+   prefbusy polls whenever the RX queue is empty.
 
    Value chosen based on experimentation on ixgbe, mlx5 and i40e as well
-   as on varying CPUs and clock speeds. Too low -> lower max TX
-   throughput when RX is low. Too high -> lower max RX and TX throughput. */
+   as on varying CPUs and clock speeds.  Too low -> lower max TX
+   throughput when RX is very low.  Too high -> lower max RX and TX throughput. */
 #define PREFBUSY_MIN_INTERVAL_NS (5e3) /* 5us */
 
 /* Max time since last prefbusy poll before a prefbusy poll is
@@ -139,7 +141,7 @@ struct fd_net_flusher {
 
   /* When the most recent prefbusy poll was. */
   long prefbusy_last_poll_ticks;
-  /* Min time between each prefbusy poll (further protects against livelocks). */
+  /* Min time between each prefbusy poll. */
   long prefbusy_min_interval_ticks;
   /* Max time since last prefbusy poll before a prefbusy poll is
      forced (has been read that polling can sometimes resolve a stall). */
@@ -1168,10 +1170,6 @@ net_rx_event( fd_net_ctx_t * ctx,
   fill_ring->cached_prod = fill_prod+1U;
 }
 
-/* before_credit_softirq is called every loop iteration if net tile
-   is in softirq polling mode (fallback if prefbusy polling mode
-   is not enabled). */
-
 static void
 before_credit_softirq( fd_net_ctx_t *      ctx,
                        int *               charge_busy,
@@ -1211,10 +1209,6 @@ net_prefbusy_poll_flush( fd_net_flusher_t * flusher,
                          long               now ) {
   flusher->prefbusy_last_poll_ticks = now;
 }
-
-/* before_credit_prefbusy is called every loop iteration if net
-   tile is in preferred busy (often referred to as "prefbusy" in
-   Firedancer) polling mode. */
 
 static void
 before_credit_prefbusy( fd_net_ctx_t *      ctx,

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -189,7 +189,10 @@ struct fd_topo_tile {
       char   xdp_mode[8];
       int    zero_copy;
 
+      char poll_mode[ 16 ]; /* "softirq" or "prefbusy" */
+
       ulong netdev_tbl_obj_id;
+
       ulong fib4_main_obj_id;      /* fib4 containing main route table */
       ulong fib4_local_obj_id;     /* fib4 containing local route table */
       ulong neigh4_obj_id;         /* neigh4 hash map */

--- a/src/waltz/xdp/fd_xsk.c
+++ b/src/waltz/xdp/fd_xsk.c
@@ -6,7 +6,9 @@
 
 #include <errno.h>
 #include <stdio.h> /* snprintf */
+#include <string.h> /* strcmp */
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/mman.h> /* mmap */
 #include <sys/types.h>
 #include <sys/socket.h> /* sendto */
@@ -14,6 +16,20 @@
 
 #include "../../util/log/fd_log.h"
 #include "fd_xsk.h"
+
+/* Support for older kernels */
+
+#ifndef SO_BUSY_POLL
+#define SO_BUSY_POLL 46
+#endif
+
+#ifndef SO_PREFER_BUSY_POLL
+#define SO_PREFER_BUSY_POLL	69
+#endif
+
+#ifndef SO_BUSY_POLL_BUDGET
+#define SO_BUSY_POLL_BUDGET	70
+#endif
 
 /* Join/leave *********************************************************/
 
@@ -187,6 +203,57 @@ fd_xsk_setup_umem( fd_xsk_t *              xsk,
   return 0;
 }
 
+/* fd_xsk_setup_poll: Setup preferred busy polling if the user has
+   set that to be their preferred polling method */
+
+static void
+fd_xsk_setup_poll( fd_xsk_t *              xsk,
+                   fd_xsk_params_t const * params ) {
+  xsk->prefbusy_poll_enabled = 0;
+  if( 0!=strcmp( params->poll_mode, "prefbusy" ) ) return;
+
+  /* Configure socket options for preferred busy polling */
+
+  int prefbusy_poll = 1;
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_PREFER_BUSY_POLL, &prefbusy_poll, sizeof(int) ) ) ) {
+    int err = errno;
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_PREFER_BUSY_POLL,1) failed (%i-%s)", err, fd_io_strerror( err ) ));
+    if( err==EINVAL ) {
+      FD_LOG_WARNING(( "Hint: Does your kernel support preferred busy polling? SO_PREFER_BUSY_POLL is available from Linux 5.11 onwards" ));
+    }
+    return;
+  }
+
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_BUSY_POLL, &params->prefbusy_time_budget_micros, sizeof(int) ) ) ) {
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL,%i) failed (%i-%s)",
+                     params->prefbusy_time_budget_micros, errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_BUSY_POLL_BUDGET, &params->prefbusy_rx_budget, sizeof(int) ) ) ) {
+    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL_BUDGET,%i) failed (%i-%s)",
+                     params->prefbusy_rx_budget , errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  /* Set socket non blocking */
+
+  int sk_flags = fcntl( xsk->xsk_fd, F_GETFL, 0 );
+  if( FD_UNLIKELY( -1==sk_flags ) ) {
+    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_GETFL, 0) failed (%i-%s)",
+                     errno, fd_io_strerror( errno ) ));
+    return;
+  }
+  if( FD_UNLIKELY( -1==fcntl( xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK ) ) ) {
+    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK) failed (%i-%s)",
+                     errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  /* Successfully finished setting up prefbusy polling */
+  xsk->prefbusy_poll_enabled = 1U;
+}
+
 /* fd_xsk_init: Creates and configures an XSK socket object, and
    attaches to a preinstalled XDP program.  The various steps are
    implemented in fd_xsk_setup_{...}. */
@@ -288,6 +355,10 @@ fd_xsk_init( fd_xsk_t *              xsk,
 
   FD_LOG_INFO(( "AF_XDP socket initialized: bind( PF_XDP, ifindex=%u (%s), queue_id=%u, flags=%x ) success",
                 xsk->if_idx, if_indextoname( xsk->if_idx, if_name ), xsk->if_queue_id, flags ));
+
+  /* If requested, enable preferred busy polling */
+
+  fd_xsk_setup_poll( xsk, params );
 
   return xsk;
 

--- a/src/waltz/xdp/fd_xsk.c
+++ b/src/waltz/xdp/fd_xsk.c
@@ -203,8 +203,7 @@ fd_xsk_setup_umem( fd_xsk_t *              xsk,
   return 0;
 }
 
-/* fd_xsk_setup_poll: Setup preferred busy polling if the user has
-   set that to be their preferred polling method */
+/* fd_xsk_setup_poll: Setup preferred busy polling */
 
 static void
 fd_xsk_setup_poll( fd_xsk_t *              xsk,
@@ -217,15 +216,15 @@ fd_xsk_setup_poll( fd_xsk_t *              xsk,
   int prefbusy_poll = 1;
   if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_PREFER_BUSY_POLL, &prefbusy_poll, sizeof(int) ) ) ) {
     int err = errno;
-    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_PREFER_BUSY_POLL,1) failed (%i-%s)", err, fd_io_strerror( err ) ));
+    FD_LOG_WARNING(( "failed to enable XDP prefbusy polling: setsockopt(xsk_fd,SOL_SOCKET,SO_PREFER_BUSY_POLL,1) failed (%i-%s)", err, fd_io_strerror( err ) ));
     if( err==EINVAL ) {
-      FD_LOG_WARNING(( "Hint: Does your kernel support preferred busy polling? SO_PREFER_BUSY_POLL is available from Linux 5.11 onwards" ));
+      FD_LOG_NOTICE(( "Hint: Does your kernel support preferred busy polling? SO_PREFER_BUSY_POLL is available from Linux 5.11 onwards" ));
     }
     return;
   }
 
   if( FD_UNLIKELY( 0!=setsockopt( xsk->xsk_fd, SOL_SOCKET, SO_BUSY_POLL, &params->prefbusy_time_budget_micros, sizeof(int) ) ) ) {
-    FD_LOG_WARNING(( "setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL,%i) failed (%i-%s)",
+    FD_LOG_WARNING(( "failed to enable XDP prefbusy polling: setsockopt(xsk_fd,SOL_SOCKET,SO_BUSY_POLL,%i) failed (%i-%s)",
                      params->prefbusy_time_budget_micros, errno, fd_io_strerror( errno ) ));
     return;
   }
@@ -240,12 +239,12 @@ fd_xsk_setup_poll( fd_xsk_t *              xsk,
 
   int sk_flags = fcntl( xsk->xsk_fd, F_GETFL, 0 );
   if( FD_UNLIKELY( -1==sk_flags ) ) {
-    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_GETFL, 0) failed (%i-%s)",
+    FD_LOG_WARNING(( "failed to enable XDP prefbusy polling: fcntl(xsk->xsk_fd, F_GETFL, 0) failed (%i-%s)",
                      errno, fd_io_strerror( errno ) ));
     return;
   }
   if( FD_UNLIKELY( -1==fcntl( xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK ) ) ) {
-    FD_LOG_WARNING(( "fcntl(xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK) failed (%i-%s)",
+    FD_LOG_WARNING(( "failed to enable XDP prefbusy polling: fcntl(xsk->xsk_fd, F_SETFL, sk_flags | O_NONBLOCK) failed (%i-%s)",
                      errno, fd_io_strerror( errno ) ));
     return;
   }

--- a/src/waltz/xdp/fd_xsk.h
+++ b/src/waltz/xdp/fd_xsk.h
@@ -187,8 +187,8 @@ fd_xdp_ring_full( fd_xdp_ring_t * ring ) {
   return ring->cached_prod - ring->cached_cons >= ring->depth;
 }
 
-/* fd_xsk_params_t: Memory layout parameters of XSK.
-   Can be retrieved using fd_xsk_get_params() */
+/* fd_xsk_params_t: XSK poll configuration and memory layout
+   parameters. Can be retrieved using fd_xsk_get_params() */
 
 struct fd_xsk_params {
   /* {fr,rx,tx,cr}_depth: Number of frames allocated for the Fill, RX,
@@ -217,6 +217,17 @@ struct fd_xsk_params {
   /* sockaddr_xdp.sxdp_flags additional params, e.g. XDP_ZEROCOPY */
   uint bind_flags;
 
+  /* Whether to use softirqs to poll napi or prefbusy poll */
+  char poll_mode[ 16 ];
+
+  /* Max time during prefbusy napi poll. Referred to as
+     'busy_poll_usecs' within Linux. */
+  int prefbusy_time_budget_micros;
+
+  /* Max RX processing budget during prefbusy napi poll.
+     Referred to as 'busy_poll_budget' within Linux. */
+  int prefbusy_rx_budget;
+
   /* whether the xsk memory should be included in core dumps */
   int core_dump;
 };
@@ -235,6 +246,10 @@ struct fd_xsk {
 
   /* AF_XDP socket file descriptor */
   int xsk_fd;
+
+  /* Whether preferred busy polling was successfully enabled
+     during XSK socket setup. */
+  int prefbusy_poll_enabled;
 
   /* ring_{rx,tx,fr,cr}: XSK ring descriptors */
 


### PR DESCRIPTION
## Cover letter
Relates to https://github.com/firedancer-io/firedancer/issues/3618

Softirq poll mode is identical to what Firedancer currently uses and is set to be the default poll mode in this PR since it is more well tested. Prefbusy is the new poll mode this PR adds.

Prefbusy poll mode gives Firedancer significantly more control over how and when NAPI is polled, with no networking related IRQs or ksoftirqds during main runtime when used on a well supported driver.

Even when used on a less well supported driver inwhich ksoftirqds still occur like bnxt_en (Broadcom), the poll scheduling code used with prefbusy in this PR have been shown to be beneficial to RX throughput robustness as demonstrated in the test results below.
(bnxt_en Copy Mode)
<img width="526" height="371" alt="image" src="https://github.com/user-attachments/assets/9a333036-0aa1-43f0-869b-8346dad9e011" />
(note TX still degraded towards 0Mpps like in softirq mode)

Prefbusy when well supported, removes Firedancer’s reliance on softirqs and ksoftirqds to poll NAPI. ksoftirqds are separate threads which softirqs execute inside of instead of the net tile's thread once network load is medium-high.

ksoftirqds are bad for a few reasons:
1. They (generally but not always) run on a different core to the net tile so each net tile in softirq poll mode effectively occupies two cores (when under medium-high network load) or if multiple ksoftirqd threads are running on the same core (polling for separate net tiles), only one of those net tiles can poll NAPI at a time.
2. If Linux schedules a ksoftirqd onto a core corresponding to a Firedancer tile, the performance of that tile will significantly degrade as network load increases, this situation is analyzed and tested in the mlx5 testing pdf with the net tile being the example choked Firedancer tile.
3. Linux decides how much the ksoftirqd thread runs vs other irq/house keeping threads, creating unwanted dependence on scheduling algorithms designed to prioritize fairness over performance.

## Test results
Update: IRQs/softirqs should no longer land on Firedancer tiles with the new IRQ affinity config stage implemented.

[ixgbe PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358809/ixgbe.PrefBusy.Tests.pdf)
[mlx5 PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358810/mlx5.PrefBusy.Tests.pdf)
[i40e PrefBusy Tests.pdf](https://github.com/user-attachments/files/29358811/i40e.PrefBusy.Tests.pdf)