### PR TITLE
ci: stricter timeouts for book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    timeout-minutes: 30
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,7 +49,7 @@ jobs:
 
   # Deployment job
   deploy:
-    timeout-minutes: 30
+    timeout-minutes: 2
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
GitHub Pages has some sort of outage leading CI jobs to time out and burn credits. Defend against this in the future