### PR TITLE
build: cut clean firedancer-dev build from ~10.6s to ~4.6s

### DIFF
--- a/config/base.mk
+++ b/config/base.mk
@@ -14,7 +14,9 @@ LDFLAGS:=-lm -ldl -L./$(OPT)/lib
 LDFLAGS_EXE:=
 LDFLAGS_SO:=-shared
 AR:=ar
-ARFLAGS:=rc
+# 's' writes the symbol index during archive creation, replacing the
+# separate ranlib pass (supported by GNU ar and llvm-ar alike).
+ARFLAGS:=rcs
 RANLIB:=ranlib
 CP:=cp -p
 RM:=rm -f
@@ -60,6 +62,20 @@ CC_MAJOR_VERSION:=$(shell $(CC) -dumpversion | cut -f1 -d.)
 
 # Default _FORTIFY_SOURCE level
 FORTIFY_SOURCE?=2
+
+# Link with LLD when it is installed and the compiler driver supports
+# -fuse-ld=lld (gcc>=9, any modern clang).  BFD ld is single threaded
+# and roughly 10x slower linking the large -g3 executables produced by
+# this build (measured 2.7s -> 0.27s for firedancer-dev).  Cross builds
+# that need a specific linker can override LDFLAGS after including this
+# file.
+ifeq ($(CROSS),)
+ifneq ($(shell command -v ld.lld 2>/dev/null),)
+ifeq ($(shell test $(CC_MAJOR_VERSION) -ge 9 2>/dev/null && echo ok),ok)
+LDFLAGS+=-fuse-ld=lld
+endif
+endif
+endif
 
 ifneq ($(CROSS),)
 include config/cross/$(CROSS).mk

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -182,6 +182,19 @@ add-test-scripts = $(foreach script,$(1),$(eval $(call _add-script,unit-test,$(s
 
 # Note: The library arguments require customization of each target
 
+# Libraries whose objects dominate the parallel build's critical path
+# (biggest compile times in the tree: generated reedsol SIMD kernels and
+# bn254/ed25519/zksdk in ballet).  A parallel make spawns jobs in
+# prerequisite order, and these libs sit late in every exe's library
+# list (they must: static link order requires providers after
+# consumers).  Prepending them to the *prerequisite* list only (link
+# order is generated separately from $(3) below) makes their long
+# compiles start first instead of ~2s into the build, pulling several
+# seconds off the clean-build tail.  Only libs already present in an
+# exe's own library list are prepended, so no target builds anything it
+# would not have built anyway.
+SCHED_HOT_LIBS?=fd_reedsol fd_ballet
+
 # _make-exe usage:
 #
 #   $(1): Filename of exe
@@ -197,7 +210,7 @@ DEPFILES+=$(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR
 .PHONY: $(1)
 $(1): $(OBJDIR)/$(5)/$(1)
 
-$(OBJDIR)/$(5)/$(1): $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),$(OBJDIR)/lib/lib$(lib).a)
+$(OBJDIR)/$(5)/$(1): $(foreach lib,$(filter $(SCHED_HOT_LIBS),$(3)),$(OBJDIR)/lib/lib$(lib).a) $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),$(OBJDIR)/lib/lib$(lib).a)
 	@echo -e "LD\t$$(notdir $$@) ($(5))"
 	$(Q)$(MKDIR) $$(dir $$@) && \
 $$(LD) -L$(OBJDIR)/lib $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),-l$(lib)) $(6) $$(LDFLAGS) -o $$@
@@ -338,12 +351,14 @@ $(OBJDIR)/obj/%.check : src/%.c
 $(OBJDIR)/obj/%.check : src/%.cxx
 	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fsyntax-only $<
 
+# ARFLAGS includes 's' (write the symbol index at creation), so no
+# separate $(RANLIB) pass is needed; archive creation sits on the
+# serial pre-link tail of the build.
 $(OBJDIR)/lib/%.a :
 	@echo -e "AR\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(RM) $@ && \
-$(AR) $(ARFLAGS) $@ $^ && \
-$(RANLIB)  $@
+$(AR) $(ARFLAGS) $@ $^
 
 $(OBJDIR)/include/firedancer/% : src/%
 	$(Q)$(MKDIR) $(dir $@) && \

--- a/config/extra/with-debug.mk
+++ b/config/extra/with-debug.mk
@@ -1,3 +1,17 @@
 CPPFLAGS+=-g3
 CPPFLAGS+=-fno-omit-frame-pointer
 LDFLAGS+=-rdynamic
+
+# At -O3, GCC's variable location tracking (the pass that records which
+# register/stack slot holds each source variable at each PC range) is by
+# far the most expensive part of debug info generation: up to ~50% of
+# compile time on large vectorized TUs (reedsol, bn254) and ~18% of the
+# .debug_* bytes (.debug_loclists).  Disable it: line tables, types,
+# frames, unwind info and macro info are all unaffected, so backtraces,
+# breakpoints, perf/flamegraphs and core triage still work; only
+# "print <var>" fidelity inside optimized frames degrades (which is
+# already unreliable at -O3).  Clang has no such flag (var tracking is
+# cheap there), so keep this GCC only.
+ifdef FD_USING_GCC
+CPPFLAGS+=-fno-var-tracking
+endif


### PR DESCRIPTION
## Summary

Profiled a clean `make -j firedancer-dev` end-to-end (per-invocation exec-shim timeline, gcc `-ftime-report`, per-TU `-E`/`-fsyntax-only` sweeps, linker A/B) and applied the four highest-impact levers found. **Wall clock: 10.5–10.7s → 4.54–4.59s (2.3×)** on a 96-thread EPYC 9474F; compile CPU total drops 319s → 276s (−13%), so smaller-core machines/CI benefit too.

### Baseline findings (what the 10.6s was made of)

| Window | What |
|---|---|
| 0–3.1s | ~101 concurrent compiles, CPU saturated |
| 3.1–7.7s | Straggler tail: reedsol `recover_256/128`, `fft_impl_256_0`, `bn254` (5–5.6s TUs, spawned late as jobs #398+) |
| 7.7–8.0s | Serial ar+ranlib waiting on stragglers |
| 8.0–10.7s | Single-threaded bfd link, 2.70s (29% of wall at <4 jobs active) |

### Changes

1. **`-fuse-ld=lld` when available** (`config/base.mk`, native builds, gcc≥9, gated on `ld.lld` in PATH): link 2.70s → 0.27s. Output byte-comparable (LLD 20.1.8, `.comment` confirms), binary boots, `-pie`/relro/shstk flags all honored.
2. **`-fno-var-tracking`** (`config/extra/with-debug.mk`, GCC only): at `-O3`, variable location tracking is up to 54% of compile time on the big vectorized TUs (measured via `-ftime-report` + flag A/B). Keeps line tables, types, unwind, macro info — backtraces/breakpoints/perf/flamegraphs unaffected; only `print <var>` fidelity in optimized frames degrades. Longest TU 5.65s → 3.7s.
3. **Hot-lib scheduling** (`config/everything.mk`): prepend `libfd_reedsol`/`libfd_ballet` to exe *prerequisite* lists only (link argument order untouched — verified identical). Their long compiles now spawn at t≈0.1s instead of t≈2s, so the tail overlaps the saturated wave. Only libs already in the exe's own lib list are prepended, so nothing new gets built.
4. **`ar rcs`, drop separate ranlib** (`config/base.mk`, `config/everything.mk`): symbol index written during creation; halves the serial pre-link archive step, −16 forks. (`ARFLAGS` verbose suffix in everything.mk still composes: `rcsv`.)

### Verification

- 2× clean timed builds after: 4.589s / 4.544s (before: 10.52s / 10.68s, same machine, distclean between all runs)
- `firedancer-dev version` runs: `0.1.1 (061abe1504...)`
- `readelf --debug-dump=decodedline` + `addr2line -f` resolve correctly; `.debug_line`/`.debug_info`/`.symtab` present
- Binary 91.7MB (was 112.5MB — `.debug_loclists` mostly gone)
- Link line flags and library order byte-identical apart from `-fuse-ld=lld`

### New timeline after this PR

583 compiles finish by ~4.2s (reedsol/bn254 now start at t≈0.12s and overlap the wave), ar 16×~0.1s interleaved, link 0.27s. Remaining wall ≈ CPU-bound compile floor (276 CPU·s ÷ 96 threads ≈ 2.9s) + longest TU overlap.

Not included (follow-up candidates from the profile): moving `<x86intrin.h>` out of the `fd_tango_base.h` include chain (13M preprocessed lines fleet-wide, 57% of TUs), ccache for CI (separate plan exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)