### PR TITLE
codeql: find places where we mutate keys currently in map

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,8 +56,6 @@ jobs:
           queries: ./contrib/codeql/src/nightly
           config: |
               disable-default-queries: true
-              paths-ignore:
-                - src/third_party
       - if: matrix.build-mode == 'manual'
         shell: bash
         run: |

--- a/contrib/codeql/lib/filter.qll
+++ b/contrib/codeql/lib/filter.qll
@@ -2,6 +2,11 @@
  * Exclude agave code and whatever else we don't want to analyze.
  */
 import cpp
+
+private predicate codeqlTestMode() {
+  exists(Macro m | m.hasName("__CODEQL_TEST__"))
+}
+
 predicate included(Location loc) {
-  loc.getFile().getRelativePath().prefix(4) = "src/"
+  codeqlTestMode() or loc.getFile().getRelativePath().prefix(4) = "src/"
 }

--- a/contrib/codeql/lib/filter.qll
+++ b/contrib/codeql/lib/filter.qll
@@ -1,12 +1,14 @@
 /**
  * Exclude agave code and whatever else we don't want to analyze.
  */
+
 import cpp
 
-private predicate codeqlTestMode() {
-  exists(Macro m | m.hasName("__CODEQL_TEST__"))
-}
+private predicate codeqlTestMode() { exists(Macro m | m.hasName("__CODEQL_TEST__")) }
 
 predicate included(Location loc) {
-  codeqlTestMode() or loc.getFile().getRelativePath().prefix(4) = "src/"
+  codeqlTestMode()
+  or
+  loc.getFile().getRelativePath().prefix(4) = "src/" and
+  not loc.getFile().getRelativePath().matches("src/third_party/%")
 }

--- a/contrib/codeql/src/nightly/MapKeyMutation.ql
+++ b/contrib/codeql/src/nightly/MapKeyMutation.ql
@@ -1,0 +1,145 @@
+/**
+ * @name Do not mutate keys that are currently used in a map.
+ * @description Mutating a key that is currently used in a map corrupts it.
+ * @kind problem
+ * @id asymmetric-research/map-key-mutation
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ */
+
+import cpp
+import semmle.code.cpp.valuenumbering.HashCons
+import filter
+
+bindingset[a, b]
+private predicate sameExpr(Expr a, Expr b) {
+  hashCons(a.getFullyConverted()) = hashCons(b.getFullyConverted())
+}
+
+bindingset[mapName]
+private string mapKey(string mapName) {
+  exists(Macro name, Macro key |
+    name.hasName("MAP_NAME") and
+    key.hasName("MAP_KEY") and
+    name.getFile() = key.getFile() and
+    name.getLocation().getStartLine() <= key.getLocation().getStartLine() and
+    result = key.getBody() and
+    mapName = name.getBody() and
+    not exists(Macro other |
+      other.hasName("MAP_NAME") and
+      other.getFile() = key.getFile() and
+      name.getLocation().getStartLine() < other.getLocation().getStartLine() and
+      other.getLocation().getStartLine() < key.getLocation().getStartLine()
+    )
+  )
+}
+
+bindingset[e]
+private predicate denotesVariable(Expr e, Variable v) {
+  e = v.getAnAccess() or
+  exists(PointerDereferenceExpr deref |
+    e = deref and
+    deref.getOperand() = v.getAnAccess()
+  ) or
+  exists(Cast cast |
+    e = cast and
+    cast.getExpr() = v.getAnAccess()
+  )
+}
+
+bindingset[access]
+private predicate accessesKey(Variable ele, string key, FieldAccess access) {
+  key = access.getTarget().getName() and
+  denotesVariable(access.getQualifier(), ele)
+  or
+  exists(FieldAccess parent |
+    parent = access.getQualifier() and
+    key = parent.getTarget().getName() + "." + access.getTarget().getName() and
+    denotesVariable(parent.getQualifier(), ele)
+  )
+}
+
+private class MapQueryCall extends FunctionCall {
+  MapQueryCall() { this.getTarget().getName().matches("%_ele_query") }
+
+  string getMapName() { result = this.getTarget().getName().regexpCapture("(.*)_ele_query", 1) }
+
+  Expr getMapArg() { result = this.getArgument(0) }
+
+  Expr getKeyArg() { result = this.getArgument(1) }
+}
+
+private class MapRemoveCall extends FunctionCall {
+  MapRemoveCall() {
+    this.getTarget().getName().matches("%_ele_remove") or
+    this.getTarget().getName().matches("%_idx_remove") or
+    this.getTarget().getName().matches("%_ele_remove_fast")
+  }
+
+  string getMapName() {
+    result = this.getTarget().getName().regexpCapture("(.*)_ele_remove", 1) or
+    result = this.getTarget().getName().regexpCapture("(.*)_idx_remove", 1) or
+    result = this.getTarget().getName().regexpCapture("(.*)_ele_remove_fast", 1)
+  }
+
+  predicate removes(MapQueryCall query, Variable ele) {
+    this.getMapName() = query.getMapName() and
+    this.getBasicBlock().getEnclosingFunction() = query.getBasicBlock().getEnclosingFunction() and
+    sameExpr(this.getArgument(0), query.getMapArg()) and
+    (
+      (
+        this.getTarget().getName().matches("%_ele_remove") or
+        this.getTarget().getName().matches("%_idx_remove")
+      ) and
+      sameExpr(this.getArgument(1), query.getKeyArg())
+      or
+      this.getTarget().getName().matches("%_ele_remove_fast") and
+      denotesVariable(this.getArgument(1), ele)
+    )
+  }
+}
+
+private predicate queryStoredIn(MapQueryCall query, Variable ele) {
+  ele.getInitializer().getExpr() = query or
+  exists(AssignExpr assign |
+    assign.getRValue() = query and
+    assign.getLValue().(VariableAccess).getTarget() = ele
+  )
+}
+
+private predicate overwrittenBeforeUse(MapQueryCall query, Variable ele, ControlFlowNode use) {
+  exists(AssignExpr assign |
+    assign.getLValue().(VariableAccess).getTarget() = ele and
+    assign.getRValue() != query and
+    assign.getBasicBlock().getEnclosingFunction() = query.getBasicBlock().getEnclosingFunction() and
+    dominates(query, assign) and
+    dominates(assign, use)
+  )
+}
+
+private predicate keyMutation(Variable ele, string key, FieldAccess access, ControlFlowNode mutation) {
+  accessesKey(ele, key, access) and
+  (
+    exists(Assignment assign | assign.getLValue() = access and mutation = assign) or
+    exists(CrementOperation crement | crement.getOperand() = access and mutation = crement)
+  )
+}
+
+from MapQueryCall query, Variable ele, FieldAccess access, ControlFlowNode mutation, string key
+where
+  included(access.getLocation()) and
+  included(query.getLocation()) and
+  queryStoredIn(query, ele) and
+  query.getBasicBlock().getEnclosingFunction() = mutation.getBasicBlock().getEnclosingFunction() and
+  key = mapKey(query.getMapName()) and
+  keyMutation(ele, key, access, mutation) and
+  dominates(query, mutation) and
+  not overwrittenBeforeUse(query, ele, mutation) and
+  not exists(MapRemoveCall remove |
+    remove.removes(query, ele) and
+    dominates(remove, mutation)
+  )
+select access,
+  "Map key '" + key + "' is mutated while the element may still be in " +
+    query.getMapName() + "; remove it from the map first."

--- a/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.c
+++ b/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.c
@@ -1,0 +1,142 @@
+#define __CODEQL_TEST__ 1
+
+typedef unsigned long ulong;
+
+#define NULL ((void *)0)
+#define ULONG_MAX (~0UL)
+
+typedef struct block_map block_map_t;
+typedef struct other_map other_map_t;
+typedef struct nested_map nested_map_t;
+
+typedef struct block_info {
+  ulong block;
+  ulong height;
+} block_info_t;
+
+typedef struct nested_info {
+  struct {
+    ulong key;
+  } hdr;
+  ulong value;
+} nested_info_t;
+
+#define MAP_NAME block_map
+#define MAP_KEY  block
+
+block_info_t *       block_map_ele_query      ( block_map_t * map, ulong const * key, block_info_t * sentinel, block_info_t * pool );
+block_info_t const * block_map_ele_query_const( block_map_t * map, ulong const * key, block_info_t const * sentinel, block_info_t * pool );
+block_info_t *       block_map_ele_remove     ( block_map_t * map, ulong const * key, block_info_t * sentinel, block_info_t * pool );
+ulong                block_map_idx_remove     ( block_map_t * map, ulong const * key, ulong sentinel, block_info_t * pool );
+void                 block_map_ele_remove_fast( block_map_t * map, block_info_t * ele, block_info_t * pool );
+void                 block_map_ele_insert     ( block_map_t * map, block_info_t * ele, block_info_t * pool );
+ulong                other_map_idx_remove     ( other_map_t * map, ulong const * key, ulong sentinel, block_info_t * pool );
+
+#undef MAP_NAME
+#undef MAP_KEY
+#define MAP_NAME nested_map
+#define MAP_KEY  hdr.key
+
+nested_info_t * nested_map_ele_query ( nested_map_t * map, ulong const * key, nested_info_t * sentinel, nested_info_t * pool );
+ulong           nested_map_idx_remove( nested_map_t * map, ulong const * key, ulong sentinel, nested_info_t * pool );
+
+void
+unsafe_initializer_query( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele->block = new_key; // $ Alert
+}
+
+void
+unsafe_assignment_query( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele;
+  ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele->block += new_key; // $ Alert
+}
+
+void
+unsafe_increment( block_map_t * map, block_info_t * pool, ulong old_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele->block++; // $ Alert
+}
+
+void
+unsafe_remove_after_mutation( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele->block = new_key; // $ Alert
+  block_map_idx_remove( map, &old_key, ULONG_MAX, pool );
+}
+
+void
+unsafe_wrong_key_removed( block_map_t * map, block_info_t * pool, ulong old_key, ulong other_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  block_map_idx_remove( map, &other_key, ULONG_MAX, pool );
+  ele->block = new_key; // $ Alert
+}
+
+void
+unsafe_wrong_map_removed( block_map_t * map, block_map_t * other_map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  block_map_idx_remove( other_map, &old_key, ULONG_MAX, pool );
+  ele->block = new_key; // $ Alert
+}
+
+void
+unsafe_wrong_map_family_removed( block_map_t * map, other_map_t * other_map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  other_map_idx_remove( other_map, &old_key, ULONG_MAX, pool );
+  ele->block = new_key; // $ Alert
+}
+
+void
+unsafe_branch_only_remove( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key, int remove_it ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  if( remove_it ) block_map_idx_remove( map, &old_key, ULONG_MAX, pool );
+  ele->block = new_key; // $ Alert
+}
+
+void
+unsafe_nested_key( nested_map_t * map, nested_info_t * pool, ulong old_key, ulong new_key ) {
+  nested_info_t * ele = nested_map_ele_query( map, &old_key, NULL, pool );
+  ele->hdr.key = new_key; // $ Alert
+}
+
+void
+safe_remove_by_idx( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  block_map_idx_remove( map, &old_key, ULONG_MAX, pool );
+  ele->block = new_key;
+  block_map_ele_insert( map, ele, pool );
+}
+
+void
+safe_remove_by_ele( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  block_map_ele_remove( map, &old_key, NULL, pool );
+  ele->block = new_key;
+}
+
+void
+safe_remove_fast_by_element( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  block_map_ele_remove_fast( map, ele, pool );
+  ele->block = new_key;
+}
+
+void
+safe_mutate_non_key( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_height ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele->height = new_height;
+}
+
+void
+safe_const_query( block_map_t * map, block_info_t * pool, ulong old_key, ulong new_key ) {
+  block_info_t const * ele = block_map_ele_query_const( map, &old_key, NULL, pool );
+  ((block_info_t *)ele)->block = new_key;
+}
+
+void
+safe_overwritten_pointer( block_map_t * map, block_info_t * pool, ulong old_key, block_info_t * other, ulong new_key ) {
+  block_info_t * ele = block_map_ele_query( map, &old_key, NULL, pool );
+  ele = other;
+  ele->block = new_key;
+}

--- a/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.expected
+++ b/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.expected
@@ -1,0 +1,9 @@
+| MapKeyMutation.c:46:8:46:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:53:8:53:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:59:8:59:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:65:8:65:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:73:8:73:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:80:8:80:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:87:8:87:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:94:8:94:12 | block | Map key 'block' is mutated while the element may still be in block_map; remove it from the map first. |
+| MapKeyMutation.c:100:12:100:14 | key | Map key 'hdr.key' is mutated while the element may still be in nested_map; remove it from the map first. |

--- a/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.qlref
+++ b/contrib/codeql/test/query-tests/MapKeyMutation/MapKeyMutation.qlref
@@ -1,0 +1,2 @@
+query: MapKeyMutation.ql
+postprocess: InlineExpectationsTestQuery.ql


### PR DESCRIPTION
1. Would have found https://github.com/firedancer-io/firedancer/pull/10339
2. path-ignore doesn't work for compiled languages except when
they are built with build-mode:none. Moved to our "included" predicate instead.
