### PR TITLE
Fix offline cpu handling

### DIFF
--- a/src/app/shared/commands/configure/fd_ethtool_ioctl.c
+++ b/src/app/shared/commands/configure/fd_ethtool_ioctl.c
@@ -86,7 +86,7 @@ fd_ethtool_ioctl_channels_set_num( fd_ethtool_ioctl_t * ioc,
   ech.cmd = ETHTOOL_SCHANNELS;
   if( num == 0 ) {
     uint max_queue_count = ech.max_combined ? ech.max_combined : ech.max_rx;
-    num = fd_uint_min( max_queue_count, (uint)fd_shmem_cpu_cnt() );
+    num = fd_uint_min( max_queue_count, (uint)fd_shmem_available_cpu_cnt() );
   }
   if( ech.max_combined ) {
     ech.combined_count = num;
@@ -123,7 +123,7 @@ fd_ethtool_ioctl_channels_get_num( fd_ethtool_ioctl_t * ioc,
 
   if( FD_LIKELY( ech.combined_count ) ) {
     channels->current = ech.combined_count;
-    channels->max = fd_uint_min( ech.max_combined, (uint)fd_shmem_cpu_cnt() );
+    channels->max = fd_uint_min( ech.max_combined, (uint)fd_shmem_available_cpu_cnt() );
     return 0;
   }
   if( ech.rx_count || ech.tx_count ) {
@@ -131,7 +131,7 @@ fd_ethtool_ioctl_channels_get_num( fd_ethtool_ioctl_t * ioc,
       FD_LOG_WARNING(( "device `%s` has unbalanced channel count: (got %u rx, %u tx)",
                        ioc->ifr.ifr_name, ech.rx_count, ech.tx_count ));
     channels->current = ech.rx_count;
-    channels->max = fd_uint_min( ech.max_rx, (uint)fd_shmem_cpu_cnt() );
+    channels->max = fd_uint_min( ech.max_rx, (uint)fd_shmem_available_cpu_cnt() );
     return 0;
   }
   return EINVAL;

--- a/src/disco/topo/fd_cpu_topo.c
+++ b/src/disco/topo/fd_cpu_topo.c
@@ -24,30 +24,6 @@ read_uint_file( char const * path,
   return value;
 }
 
-static ulong
-fd_topo_cpu_cnt( void ) {
-  char path[ PATH_MAX ];
-  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/devices/system/cpu/present" );
-
-  char line[ 128 ];
-  int fd = open( path, O_RDONLY );
-  if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "open( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-
-  long bytes_read = read( fd, line, sizeof( line ) );
-  if( FD_UNLIKELY( -1==bytes_read ) ) FD_LOG_ERR(( "read( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-  else if ( FD_UNLIKELY( (ulong)bytes_read>=sizeof( line ) ) ) FD_LOG_ERR(( "read( \"%s\" ) failed: buffer too small", path ));
-
-  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_ERR(( "close( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-
-  line[ bytes_read ] = '\0';
-  char * saveptr;
-  char * token = strtok_r( line, "-", &saveptr );
-  token = strtok_r( NULL, "-", &saveptr );
-  ulong end = fd_cstr_to_ulong( token );
-
-  return end+1UL;
-}
-
 static int
 fd_topo_cpus_online( ulong cpu_idx ) {
   if( FD_UNLIKELY( cpu_idx==0UL ) ) return 1; /* Cannot set cpu0 to offline */
@@ -60,18 +36,24 @@ fd_topo_cpus_online( ulong cpu_idx ) {
 void
 fd_topo_cpus_init( fd_topo_cpus_t * cpus ) {
   cpus->numa_node_cnt = fd_numa_node_cnt();
-  cpus->cpu_cnt = fd_topo_cpu_cnt();
+  cpus->cpu_cnt = fd_numa_cpu_cnt();
   if( FD_UNLIKELY( cpus->cpu_cnt > FD_TILE_MAX ) ) {
     FD_LOG_ERR(( "unsupported system: Firedancer supports up to %lu CPUs", FD_TILE_MAX ));
   }
 
+  ulong online_cnt = 0;
   for( ulong i=0UL; i<cpus->cpu_cnt; i++ ) {
     cpus->cpu[ i ].idx = i;
     cpus->cpu[ i ].online = fd_topo_cpus_online( i );
     cpus->cpu[ i ].numa_node = fd_numa_node_idx( i );
-    if( FD_LIKELY( cpus->cpu[ i ].online ) ) cpus->cpu[ i ].sibling = fd_tile_private_sibling_idx( i );
-    else                                     cpus->cpu[ i ].sibling = ULONG_MAX;
+    if( FD_LIKELY( cpus->cpu[ i ].online ) ) {
+      cpus->cpu[ i ].sibling = fd_tile_private_sibling_idx( i );
+      online_cnt++;
+    } else {
+      cpus->cpu[ i ].sibling = ULONG_MAX;
+    }
   }
+  cpus->cpu_online_cnt = online_cnt;
 }
 
 void

--- a/src/disco/topo/fd_cpu_topo.h
+++ b/src/disco/topo/fd_cpu_topo.h
@@ -17,6 +17,7 @@ struct fd_topo_cpus {
   ulong         numa_node_cnt;
 
   ulong         cpu_cnt;
+  ulong         cpu_online_cnt;
   fd_topo_cpu_t cpu[ FD_TILE_MAX ];
 };
 

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -619,7 +619,7 @@ auto_tile_cpu( fd_topo_tile_t * tile,
               _Bool             skip_ht_pairs ) {
   ulong cpu_idx = *cpu_idx_p;
 
-  ulong cpu_cnt = cpus->cpu_cnt;
+  ulong cpu_cnt = cpus->cpu_online_cnt;
   while( cpu_idx<cpu_cnt && cpu_bv_test( cpu_assigned, cpu_ordering[ cpu_idx ] ) ) cpu_idx++;
   if( FD_UNLIKELY( cpu_idx>=cpu_cnt ) ) {
     FD_LOG_ERR(( "auto layout cannot set affinity for tile `%s:%lu` because all the CPUs are already assigned", tile->name, tile->kind_id ));
@@ -645,7 +645,7 @@ auto_tile_cpu( fd_topo_tile_t * tile,
            ( cpus->cpu[ cpu_ordering[ try_assign ] ].sibling!=ULONG_MAX &&
              cpu_bv_test( cpu_assigned, cpus->cpu[ cpu_ordering[ try_assign ] ].sibling ) ) ) {
       try_assign++;
-      if( FD_UNLIKELY( try_assign>=cpus->cpu_cnt ) ) FD_LOG_ERR(( "auto layout cannot set affinity for tile `%s:%lu` because all the CPUs are already assigned or have a HT pair assigned", tile->name, tile->kind_id ));
+      if( FD_UNLIKELY( try_assign>=cpus->cpu_online_cnt ) ) FD_LOG_ERR(( "auto layout cannot set affinity for tile `%s:%lu` because all the CPUs are already assigned or have a HT pair assigned", tile->name, tile->kind_id ));
     }
 
     ulong sibling = cpus->cpu[ cpu_ordering[ try_assign ] ].sibling;
@@ -684,14 +684,17 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
     for( ulong j=0UL; j<cpus->cpu_cnt; j++ ) {
       fd_topo_cpu_t * cpu = &cpus->cpu[ j ];
 
-      if( FD_UNLIKELY( cpu_bv_test( pairs_assigned, j ) || cpu->numa_node!=i ) ) continue;
+      if( FD_UNLIKELY( cpu_bv_test( pairs_assigned, j ) || cpu->numa_node!=i || !cpu->online ) ) continue;
 
       FD_TEST( next_cpu_idx<FD_TILE_MAX );
       cpu_ordering[ next_cpu_idx++ ] = (ushort)j;
 
-      if( FD_UNLIKELY( cpu->sibling!=ULONG_MAX ) ) {
-        /* If the CPU has a HT pair, place it immediately after so they
-           are sequentially assigned. */
+      if( FD_UNLIKELY( cpu->sibling<cpus->cpu_cnt && cpus->cpu[ cpu->sibling ].online ) ) {
+        /* If the CPU has an online HT pair, place it immediately after
+           so they are sequentially assigned.
+           When a sibling is offline, cpu->sibling should be ULONG_MAX,
+           so the online check is useless in real life cases. Keep it
+           for correctness.*/
         FD_TEST( next_cpu_idx<FD_TILE_MAX );
         cpu_ordering[ next_cpu_idx++ ] = (ushort)cpu->sibling;
         cpu_bv_insert( pairs_assigned, cpu->sibling );
@@ -699,7 +702,7 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
     }
   }
 
-  FD_TEST( next_cpu_idx==cpus->cpu_cnt );
+  FD_TEST( next_cpu_idx==cpus->cpu_online_cnt );
 
   /* excluded cpus are simply considered already assigned */
   cpu_bv_t cpu_assigned[ cpu_bv_word_cnt ];
@@ -714,6 +717,7 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
   for( ulong i=0UL; i<cpus->cpu_cnt; i++ ) {
     if( !cpu_bv_test( cpu_assigned, i   ) &&
         !cpu_bv_test( pairs_assigned, i ) &&
+        cpus->cpu[ i ].online               &&
         ( cpus->cpu[ i ].sibling==ULONG_MAX ||
           !cpu_bv_test( cpu_assigned, cpus->cpu[ i ].sibling ) ) ) {
       available_physical++;
@@ -805,8 +809,7 @@ fd_topob_auto_layout_cpus( fd_topo_t *      topo,
 
   topo->agave_affinity_cnt = 0UL;
   if( FD_UNLIKELY( reserve_agave_cores ) ) {
-    for( ulong i=cpu_idx; i<cpus->cpu_cnt; i++ ) {
-      if( FD_UNLIKELY( !cpus->cpu[ cpu_ordering[ i ] ].online ) ) continue;
+    for( ulong i=cpu_idx; i<cpus->cpu_online_cnt; i++ ) {
       if( FD_UNLIKELY( cpu_bv_test( cpu_assigned, cpu_ordering[ i ] ) ) ) continue;
 
       if( FD_LIKELY( topo->agave_affinity_cnt<sizeof(topo->agave_affinity_cpu_idx)/sizeof(topo->agave_affinity_cpu_idx[0]) ) ) {

--- a/src/disco/topo/test_topob.c
+++ b/src/disco/topo/test_topob.c
@@ -35,8 +35,9 @@ static void
 make_cpus( fd_topo_cpus_t * cpus,
            ulong            physical_cores ) {
   fd_memset( cpus, 0, sizeof(*cpus) );
-  cpus->numa_node_cnt = 1UL;
-  cpus->cpu_cnt       = 2UL * physical_cores;
+  cpus->numa_node_cnt  = 1UL;
+  cpus->cpu_cnt        = 2UL * physical_cores;
+  cpus->cpu_online_cnt = cpus->cpu_cnt;
   for( ulong i=0UL; i<physical_cores; i++ ) {
     cpus->cpu[ i ].idx       = i;
     cpus->cpu[ i ].online    = 1;

--- a/src/util/shmem/fd_numa_linux.c
+++ b/src/util/shmem/fd_numa_linux.c
@@ -4,7 +4,10 @@
 #include "../sanitize/fd_msan.h"
 #include <errno.h>
 #include <dirent.h>
+#include <fcntl.h>
 #include <sys/sysinfo.h>
+#include <unistd.h>
+
 
 /* The below uses the sysfs API added ~2009-Dec.  See
    https://github.com/torvalds/linux/commit/1830794ae6392ce12d36dbcc5ff52f11298ddab6 */
@@ -76,10 +79,7 @@ fd_numa_node_cnt( void ) {
 }
 
 ulong
-fd_numa_cpu_cnt( void ) {
-
-  /* FIXME: Consider using get_nprocs_conf, syscall or sysfs director
-     scan. */
+fd_numa_available_cpu_cnt( void ) {
 
   int cpu_cnt = get_nprocs();
   if( FD_UNLIKELY( cpu_cnt<=0 ) ) {
@@ -88,6 +88,34 @@ fd_numa_cpu_cnt( void ) {
   }
 
   return (ulong)cpu_cnt;
+}
+
+ulong
+fd_numa_cpu_cnt( void ) {
+  /* Don't use get_nprocs_conf() because it returns
+     /sys/devices/system/cpu/possible.
+     Parse /sys/devices/system/cpu/present instead. */
+
+  char path[ PATH_MAX ];
+  fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/devices/system/cpu/present" );
+
+  char line[ 128 ];
+  int fd = open( path, O_RDONLY );
+  if( FD_UNLIKELY( -1==fd ) ) FD_LOG_ERR(( "open( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  long bytes_read = read( fd, line, sizeof( line ) );
+  if( FD_UNLIKELY( -1==bytes_read ) ) FD_LOG_ERR(( "read( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+  else if ( FD_UNLIKELY( (ulong)bytes_read>=sizeof( line ) ) ) FD_LOG_ERR(( "read( \"%s\" ) failed: buffer too small", path ));
+
+  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_ERR(( "close( \"%s\" ) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
+
+  line[ bytes_read ] = '\0';
+  char * saveptr;
+  char * first = strtok_r( line, "-", &saveptr );
+  char * last  = strtok_r( NULL, "-", &saveptr );
+  ulong end    = fd_cstr_to_ulong( last ? last : first );
+
+  return end+1UL;
 }
 
 ulong

--- a/src/util/shmem/fd_shmem.h
+++ b/src/util/shmem/fd_shmem.h
@@ -281,8 +281,9 @@ fd_shmem_leave_anonymous( void *                 join,
    [1,FD_SHMEM_NUMA_MAX] and similarly for logical cpus.  This value is
    determined at thread group boot.  cpu_cnt>=numa_cnt. */
 
-FD_FN_PURE ulong fd_shmem_numa_cnt( void );
-FD_FN_PURE ulong fd_shmem_cpu_cnt ( void );
+FD_FN_PURE ulong fd_shmem_numa_cnt         ( void );
+FD_FN_PURE ulong fd_shmem_cpu_cnt          ( void );
+FD_FN_PURE ulong fd_shmem_available_cpu_cnt( void );
 
 /* fd_shmem_numa_idx returns the closest numa node to the given logical
    cpu_idx.  Given a cpu_idx in [0,fd_shmem_cpu_cnt()), returns a value
@@ -294,7 +295,8 @@ FD_FN_PURE ulong fd_shmem_numa_idx( ulong cpu_idx );
 /* fd_shmem_cpu_idx returns the smallest cpu_idx of a cpu close to
    numa_idx.  Given a numa_idx in [0,fd_shmem_numa_cnt()), returns a
    value in [0,fd_shmem_cpu_cnt()).  Returns ULONG_MAX otherwise.  The
-   numa -> cpu mapping is determined at thread group boot. */
+   numa -> cpu mapping is determined at thread group boot.
+   The returned cpu may be offline. */
 
 FD_FN_PURE ulong fd_shmem_cpu_idx( ulong numa_idx );
 

--- a/src/util/shmem/fd_shmem_admin.c
+++ b/src/util/shmem/fd_shmem_admin.c
@@ -82,11 +82,13 @@ ulong fd_shmem_private_base_len;                          /* 0UL at ",          
 
 static ulong  fd_shmem_private_numa_cnt;                      /* 0UL at thread group start, initialized at boot */
 static ulong  fd_shmem_private_cpu_cnt;                       /* " */
+static ulong  fd_shmem_private_available_cpu_cnt;             /* " */
 static ushort fd_shmem_private_numa_idx[ FD_SHMEM_CPU_MAX  ]; /* " */
 static ushort fd_shmem_private_cpu_idx [ FD_SHMEM_NUMA_MAX ]; /* " */
 
-ulong fd_shmem_numa_cnt( void ) { return fd_shmem_private_numa_cnt; }
-ulong fd_shmem_cpu_cnt ( void ) { return fd_shmem_private_cpu_cnt;  }
+ulong fd_shmem_numa_cnt         ( void ) { return fd_shmem_private_numa_cnt; }
+ulong fd_shmem_cpu_cnt          ( void ) { return fd_shmem_private_cpu_cnt;  }
+ulong fd_shmem_available_cpu_cnt( void ) { return fd_shmem_private_available_cpu_cnt;  }
 
 ulong
 fd_shmem_numa_idx( ulong cpu_idx ) {
@@ -713,6 +715,11 @@ fd_shmem_private_boot( int *    pargc,
     FD_LOG_ERR(( "fd_shmem: unexpected cpu_cnt %lu (expected in [1,%lu])", cpu_cnt, FD_SHMEM_CPU_MAX ));
   fd_shmem_private_cpu_cnt = cpu_cnt;
 
+  ulong available_cpu_cnt = fd_numa_available_cpu_cnt();
+  if( FD_UNLIKELY( !((1UL<=available_cpu_cnt) & (available_cpu_cnt<=FD_SHMEM_CPU_MAX)) ) )
+    FD_LOG_ERR(( "fd_shmem: unexpected available_cpu_cnt %lu (expected in [1,%lu])", available_cpu_cnt, FD_SHMEM_CPU_MAX ));
+  fd_shmem_private_available_cpu_cnt = available_cpu_cnt;
+
   for( ulong cpu_rem=cpu_cnt; cpu_rem; cpu_rem-- ) {
     ulong cpu_idx  = cpu_rem-1UL;
     ulong numa_idx = fd_numa_node_idx( cpu_idx );
@@ -746,8 +753,9 @@ fd_shmem_private_halt( void ) {
 
   /* At this point, shared memory is offline */
 
-  fd_shmem_private_numa_cnt = 0;
-  fd_shmem_private_cpu_cnt  = 0;
+  fd_shmem_private_numa_cnt           = 0;
+  fd_shmem_private_cpu_cnt            = 0;
+  fd_shmem_private_available_cpu_cnt  = 0;
   fd_memset( fd_shmem_private_numa_idx, 0, FD_SHMEM_CPU_MAX );
 
   fd_shmem_private_base[0] = '\0';

--- a/src/util/shmem/fd_shmem_private.h
+++ b/src/util/shmem/fd_shmem_private.h
@@ -39,6 +39,9 @@ fd_numa_node_cnt( void );
 ulong
 fd_numa_cpu_cnt( void );
 
+ulong
+fd_numa_available_cpu_cnt( void );
+
 /* fd_numa_node_idx determines the numa node closest to the given
    cpu_idx (roughly equivalent to libnuma's numa_node_of_cpu).  Returns
    ULONG_MAX if this could not be determined (logs details on failure).


### PR DESCRIPTION
This is a replacement for PR #8065 that was incomplete and created an additional unneeded dependency to disco library.

Problems fixed:
* Automatic tile layout can pin tiles to offline CPUs, and cause `sched_setaffinity` to fail later on.
* `fd_shmem`'s CPU topology sizes the cpu<>numa mapping using a call to `get_nprocs()` which returns the number of online CPUs, while the cpu indices are from `/sys/devices/system/cpu/cpuXX` and can be up to the total number of CPU -1.  This results in workspaces assigned to wrong numa nodes, or errors when trying to set an affinity for cpu 63, for instance, on a machine with 64 logical cpu with 2 cpu offline.
* In `irq-affinity.c `, `topo_banned_cpus` only considers cpu with an index < available count, so IRQs on high index CPUs are possibly not moved off.
* In `fd_topob.c`, `available_physical` includes offline CPUs, possibly  enabling wrongly  the 1-tile-per-physical-cpu setup.