### PR TITLE
Fix non-temporal copy in shred tile

### DIFF
--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -911,7 +911,7 @@ send_shred( fd_shred_ctx_t                 * ctx,
 
   ulong end_offset = shred_sz + sizeof(fd_ip4_udp_hdrs_t);
   ulong i;
-  for( i=64UL; end_offset-i<64UL; i+=64UL ) {
+  for( i=64UL; end_offset-i>=64UL; i+=64UL ) {
 #  if FD_HAS_AVX512
     _mm512_stream_si512( (void *)(packet+i     ), _mm512_loadu_si512( (void const *)(src+i     ) ) );
 #  else


### PR DESCRIPTION
The end condition of this loop is obviously wrong.
It does not affect functionality since the memcpy afterwards copies what is not copied in the loop (trashing the cache).
Since this loop probably never run in production, it could be worthy to now check how it affects latency or throughput.
Simple tests pass.