### PR TITLE
bundle: guard authentication during identity keyswitch

### DIFF
--- a/src/disco/bundle/fd_bundle_auth.c
+++ b/src/disco/bundle/fd_bundle_auth.c
@@ -1,6 +1,7 @@
 #include "fd_bundle_auth.h"
 #include "proto/auth.pb.h"
 #include "../../ballet/base58/fd_base58.h"
+#include "../../ballet/ed25519/fd_ed25519.h"
 #include "../../third_party/nanopb/pb_decode.h"
 #include "../../disco/keyguard/fd_keyguard.h"
 #include "../../disco/keyguard/fd_keyguard_client.h"
@@ -122,6 +123,19 @@ fd_bundle_auther_req_tokens( fd_bundle_auther_t *   auther,
   fd_keyguard_client_sign( keyguard, req.signed_challenge.bytes, (uchar const *)auther->challenge, 9UL, FD_KEYGUARD_SIGN_TYPE_PUBKEY_CONCAT_ED25519 );
   req.signed_challenge.size = 64UL;
 
+  fd_sha512_t sha[1];
+  int verify_res = fd_ed25519_verify( req.challenge.bytes,
+                                      req.challenge.size,
+                                      req.signed_challenge.bytes,
+                                      auther->pubkey,
+                                      fd_sha512_join( fd_sha512_new( sha ) ) );
+  if( FD_UNLIKELY( verify_res!=FD_ED25519_SUCCESS ) ) {
+    FD_LOG_WARNING(( "Bundle auth signature does not verify against cached identity (%s)",
+                     fd_ed25519_strerror( verify_res ) ));
+    fd_bundle_auther_reset( auther );
+    return;
+  }
+
   static char const path[] = "/auth.AuthService/GenerateAuthTokens";
   fd_grpc_h2_stream_t * request = fd_grpc_client_request_start(
       client,
@@ -197,4 +211,7 @@ void
 fd_bundle_auther_reset( fd_bundle_auther_t * auther ) {
   auther->state      = FD_BUNDLE_AUTH_STATE_REQ_CHALLENGE;
   auther->needs_poll = 1;
+  fd_memset( auther->challenge, 0, sizeof(auther->challenge) );
+  fd_memset( auther->access_token, 0, sizeof(auther->access_token) );
+  auther->access_token_sz = 0;
 }

--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -135,6 +135,18 @@ metrics_write( fd_bundle_tile_t * ctx ) {
   ctx->bundle_status_recent = (uchar)state;
 }
 
+static _Bool
+fd_bundle_tile_apply_pending_keyswitch( fd_bundle_tile_t * ctx ) {
+  if( FD_LIKELY( !ctx->keyswitch ||
+                 fd_keyswitch_state_query( ctx->keyswitch )!=FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) return 0;
+
+  fd_memcpy( ctx->auther.pubkey, ctx->keyswitch->bytes, 32UL );
+  fd_keyswitch_state( ctx->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
+  ctx->defer_reset = 1;
+  ctx->sleep_check_ns = 0;
+  return 1;
+}
+
 void
 fd_bundle_tile_housekeeping( fd_bundle_tile_t * ctx ) {
   long log_interval_ns = (long)30e9;
@@ -147,12 +159,7 @@ fd_bundle_tile_housekeeping( fd_bundle_tile_t * ctx ) {
     ctx->last_bundle_status_log_nanos = now_ns;
   }
 
-  if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
-    fd_memcpy( ctx->auther.pubkey, ctx->keyswitch->bytes, 32UL );
-    fd_keyswitch_state( ctx->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
-    ctx->defer_reset = 1;
-    ctx->sleep_check_ns = 0;
-  }
+  fd_bundle_tile_apply_pending_keyswitch( ctx );
 
   fd_bundle_tile_maybe_sleep( ctx, now_ns );
 }
@@ -238,6 +245,8 @@ before_credit( fd_bundle_tile_t *  ctx,
   if( FD_UNLIKELY( !ctx->stem ) ) {
     ctx->stem = stem;
   }
+
+  if( FD_UNLIKELY( fd_bundle_tile_apply_pending_keyswitch( ctx ) ) ) return;
 
   if( FD_UNLIKELY( ctx->sleep_mode ) ) {
     if( ctx->tcp_sock>=0 ) {

--- a/src/disco/bundle/test_bundle_client.c
+++ b/src/disco/bundle/test_bundle_client.c
@@ -1,6 +1,7 @@
 #include "test_bundle_common.c"
 #include "proto/block_engine.pb.h"
 #include "../../ballet/base58/fd_base58.h"
+#include "../../ballet/ed25519/fd_ed25519.h"
 #include "../../third_party/nanopb/pb_encode.h"
 #include "../../util/tmpl/fd_unit_test.c"
 
@@ -372,6 +373,83 @@ FD_UNIT_TEST( bundle_msg_oversized ) {
   FD_TEST( !state->bundle_subscription_live );
   FD_TEST( state->defer_reset );
 
+  test_bundle_env_destroy( env );
+}
+
+FD_UNIT_TEST( bundle_auth_signature_verifies_cached_identity ) {
+  test_bundle_env_t env[1];
+  test_bundle_env_create( env, wksp );
+  test_bundle_env_mock_conn_empty( env );
+  test_bundle_env_mock_h2_hs( env->state );
+  fd_bundle_tile_t * state = env->state;
+
+  ulong const depth = 8UL;
+  void * request_mcache_mem = fd_wksp_alloc_laddr( wksp, fd_mcache_align(), fd_mcache_footprint( depth, 0UL ), 1UL );
+  void * response_mcache_mem = fd_wksp_alloc_laddr( wksp, fd_mcache_align(), fd_mcache_footprint( depth, 0UL ), 1UL );
+  fd_frag_meta_t * request_mcache = fd_mcache_join( fd_mcache_new( request_mcache_mem, depth, 0UL, 0UL ) );
+  fd_frag_meta_t * response_mcache = fd_mcache_join( fd_mcache_new( response_mcache_mem, depth, 0UL, 0UL ) );
+  FD_TEST( request_mcache && response_mcache );
+
+  ulong request_data_sz = fd_dcache_req_data_sz( 64UL, depth, 1UL, 1 );
+  ulong response_data_sz = fd_dcache_req_data_sz( 64UL, depth, 1UL, 1 );
+  void * request_dcache_mem = fd_wksp_alloc_laddr( wksp, fd_dcache_align(), fd_dcache_footprint( request_data_sz, 0UL ), 1UL );
+  void * response_dcache_mem = fd_wksp_alloc_laddr( wksp, fd_dcache_align(), fd_dcache_footprint( response_data_sz, 0UL ), 1UL );
+  uchar * request_data = fd_dcache_join( fd_dcache_new( request_dcache_mem, request_data_sz, 0UL ) );
+  uchar * response_data = fd_dcache_join( fd_dcache_new( response_dcache_mem, response_data_sz, 0UL ) );
+  FD_TEST( request_data && response_data );
+  FD_TEST( fd_keyguard_client_new( state->keyguard_client,
+                                   request_mcache, request_data,
+                                   response_mcache, response_data, 64UL ) );
+
+  uchar public_key[2][32];
+  uchar private_key[2][32];
+  fd_sha512_t sha[1];
+  FD_TEST( fd_sha512_join( fd_sha512_new( sha ) ) );
+  for( ulong key_idx=0UL; key_idx<2UL; key_idx++ ) {
+    for( ulong i=0UL; i<32UL; i++ ) private_key[key_idx][i] = (uchar)( i+1UL+key_idx );
+    fd_ed25519_public_from_private( public_key[key_idx], private_key[key_idx], sha );
+  }
+
+  char const challenge[9] = { '1','2','3','4','5','6','7','8','9' };
+  fd_memcpy( state->auther.pubkey, public_key[0], 32UL );
+  state->auther.access_token_sz = 1U;
+  state->auther.access_token[0] = 'x';
+  uchar payload[55];
+  uchar signature[64];
+  for( ulong attempt=0UL; attempt<2UL; attempt++ ) {
+    ulong signer_idx = !attempt;
+    fd_memcpy( state->auther.challenge, challenge, 9UL );
+    state->auther.state = FD_BUNDLE_AUTH_STATE_REQ_TOKENS;
+    state->auther.needs_poll = 1U;
+
+    ulong payload_sz;
+    fd_base58_encode_32( public_key[signer_idx], &payload_sz, (char *)payload );
+    payload[payload_sz++] = '-';
+    fd_memcpy( payload+payload_sz, challenge, 9UL );
+    payload_sz += 9UL;
+    fd_ed25519_sign( signature, payload, payload_sz, public_key[signer_idx], private_key[signer_idx], sha );
+    fd_memcpy( fd_chunk_to_laddr( state->keyguard_client->response_mem,
+                                  state->keyguard_client->response_chunk0 ), signature, 64UL );
+    fd_mcache_publish( response_mcache, depth, state->keyguard_client->response_seq,
+                       0UL, state->keyguard_client->response_chunk0, 64UL, 0UL, 0UL, 0UL );
+
+    FD_TEST( fd_bundle_client_step_reconnect( state, g_clock ) );
+    if( FD_UNLIKELY( !attempt ) ) {
+      FD_TEST( state->grpc_client->stream_cnt==0UL );
+      FD_TEST( state->auther.state==FD_BUNDLE_AUTH_STATE_REQ_CHALLENGE );
+      FD_TEST( state->auther.needs_poll && !state->auther.access_token_sz );
+      FD_TEST( !state->auther.access_token[0] && !memcmp( state->auther.challenge, "\0\0\0\0\0\0\0\0\0", 9UL ) );
+    } else {
+      FD_TEST( state->auther.state==FD_BUNDLE_AUTH_STATE_WAIT_TOKENS );
+      FD_TEST( !state->auther.needs_poll && state->grpc_client->stream_cnt==1UL );
+      FD_TEST( state->grpc_client->stream_pool[0].request_ctx==FD_BUNDLE_CLIENT_REQ_Auth_GenerateAuthTokens );
+    }
+  }
+
+  fd_wksp_free_laddr( fd_dcache_delete( fd_dcache_leave( request_data ) ) );
+  fd_wksp_free_laddr( fd_dcache_delete( fd_dcache_leave( response_data ) ) );
+  fd_wksp_free_laddr( fd_mcache_delete( fd_mcache_leave( request_mcache ) ) );
+  fd_wksp_free_laddr( fd_mcache_delete( fd_mcache_leave( response_mcache ) ) );
   test_bundle_env_destroy( env );
 }
 

--- a/src/disco/bundle/test_bundle_tile.c
+++ b/src/disco/bundle/test_bundle_tile.c
@@ -383,6 +383,28 @@ test_saturating_sub( void ) {
   free( wksp );
 }
 
+static void
+test_pending_keyswitch_before_credit( void ) {
+  FD_LOG_NOTICE(( "TEST pending keyswitch before credit" ));
+
+  fd_bundle_tile_t ctx[1] = {0};
+  fd_keyswitch_t keyswitch = { .state = FD_KEYSWITCH_STATE_SWITCH_PENDING };
+  keyswitch.bytes[0] = 1U;
+  ctx->keyswitch = &keyswitch;
+  ctx->auther.state = FD_BUNDLE_AUTH_STATE_WAIT_TOKENS;
+  ctx->sleep_check_ns = 123L;
+
+  int charge_busy = 0;
+  before_credit( ctx, NULL, &charge_busy );
+
+  FD_TEST( fd_keyswitch_state_query( ctx->keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+  FD_TEST( ctx->auther.pubkey[0]==1U );
+  FD_TEST( ctx->defer_reset );
+  FD_TEST( ctx->sleep_check_ns==0L );
+  FD_TEST( !charge_busy );
+  FD_TEST( ctx->auther.state==FD_BUNDLE_AUTH_STATE_WAIT_TOKENS );
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -404,6 +426,7 @@ main( int     argc,
   test_replay_triggers_sleep_transition();
   test_boundary_thresholds();
   test_saturating_sub();
+  test_pending_keyswitch_before_credit();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
Purpose: avoid authing with old cached keypair during hotswap

## Summary

- process pending validator identity switches before the bundle client advances authentication
- verify keyguard challenge signatures locally against the cached validator identity before sending `GenerateAuthTokens`
- clear cached challenges and access tokens when bundle authentication resets

## Root cause

The sign tile can begin using a new validator identity before the bundle tile's lazy housekeeping callback updates its cached public key. During that window, the bundle client could pair a new-key signature with its old cached identity and send an authentication request that the Block Engine rejects.

The bundle client now observes a pending keyswitch at the credit boundary and retains local signature verification as a second guard for switches that become visible while keyguard signing is in flight.

## Exposure window

| | Before | After |
|---|---|---|
| Window | Until the next lazy housekeeping pass | Only after the early check or during keyguard signing |
| Guard | None; mismatched auth reached the Block Engine | Pre-step keyswitch handling plus local signature verification |
| Outcome | Remote rejection and reconnect | Auth resets locally; no mismatched `GenerateAuthTokens` request |
