### PR TITLE
eqvoc: detect same-index equivocation across FEC sets

### DIFF
--- a/src/choreo/eqvoc/fd_eqvoc.c
+++ b/src/choreo/eqvoc/fd_eqvoc.c
@@ -683,6 +683,24 @@ verify_proof( fd_eqvoc_t *               eqvoc,
     }
   }
 
+  /* Two same-type shreds with the same index (shred->idx) but conflicting
+     merkle roots are an equivocation regardless of FEC set.  Mirrors Agave
+     check_shreds; index() is the common-header index (shred->idx), not the
+     per-FEC-set position shred->code.idx:
+       https://github.com/anza-xyz/agave/blob/v4.2/gossip/src/duplicate_shred.rs#L212-L220
+       https://github.com/anza-xyz/agave/blob/v4.2/ledger/src/shred.rs#L470-L471 */
+
+  int both_data = fd_shred_is_data( fd_shred_type( shred1->variant ) ) &&
+                  fd_shred_is_data( fd_shred_type( shred2->variant ) );
+  int both_code = fd_shred_is_code( fd_shred_type( shred1->variant ) ) &&
+                  fd_shred_is_code( fd_shred_type( shred2->variant ) );
+
+  if( FD_LIKELY( both_data || both_code ) ) {
+    if( FD_UNLIKELY( shred1->idx==shred2->idx && 0!=memcmp( mr1.hash, mr2.hash, sizeof(mr1.hash) ) ) ) {
+      return FD_EQVOC_SUCCESS;
+    }
+  }
+
   /* If both are data shreds, then check for last shred conflicts. */
 
   if( FD_LIKELY( fd_shred_is_data( fd_shred_type( shred1->variant ) ) && fd_shred_is_data( fd_shred_type( shred2->variant ) ) ) ) {

--- a/src/choreo/eqvoc/test_eqvoc.c
+++ b/src/choreo/eqvoc/test_eqvoc.c
@@ -411,11 +411,54 @@ test_update_voters( void ) {
   teardown( eqvoc );
 }
 
+/* Coding-shred equivocation: two coding shreds for one slot with the same
+   index (shred->idx=5) in different FEC sets (fec_set_idx 0 vs 100) and
+   conflicting merkle roots.  verify_proof must flag it (see its same-index
+   check).  Synthetic 32:32-block shreds (variant 0x66, proof_size 6);
+   leader_schedule=NULL skips sigverify. */
+
+static void
+setup_code_shred( uchar buf[ FD_SHRED_MAX_SZ ], uint fec_set_idx ) {
+  fd_memset( buf, 0, FD_SHRED_MAX_SZ );
+  fd_shred_t * s   = (fd_shred_t *)fd_type_pun( buf );
+  s->variant       = (uchar)0x66;  /* MERKLE_CODE_CHAINED, proof_size 6 */
+  s->slot          = 100;
+  s->version       = SHRED_VERSION;
+  s->idx           = 5;            /* common-header index */
+  s->fec_set_idx   = fec_set_idx;
+  s->code.data_cnt = 32;
+  s->code.code_cnt = 32;
+  s->code.idx      = 0;            /* per-FEC-set position (not the compared field) */
+}
+
+void
+test_same_coding_index_different_fec_sets( void ) {
+  fd_eqvoc_t * eqvoc = setup();
+
+  uchar buf1[ FD_SHRED_MAX_SZ ];
+  uchar buf2[ FD_SHRED_MAX_SZ ];
+  setup_code_shred( buf1, 0   );   /* FEC set 0                          */
+  setup_code_shred( buf2, 100 );   /* FEC set 100 -> same idx, diff root */
+
+  fd_shred_t const * s1 = fd_shred_parse( buf1, FD_SHRED_MAX_SZ, FD_SHRED_BLK_MAX );
+  fd_shred_t const * s2 = fd_shred_parse( buf2, FD_SHRED_MAX_SZ, FD_SHRED_BLK_MAX );
+  FD_TEST( s1 );
+  FD_TEST( s2 );
+  FD_TEST( s1->idx == s2->idx );                /* same common-header index */
+  FD_TEST( s1->fec_set_idx != s2->fec_set_idx );
+
+  /* Must flag equivocation; == SUCCESS since a negative ERR_ code is truthy. */
+  FD_TEST( verify_proof( eqvoc, SHRED_VERSION, NULL, s1, s2 ) == FD_EQVOC_SUCCESS );
+
+  teardown( eqvoc );
+}
+
 int
 main( void ) {
   test_shred_insert();
   test_chunk_insert();
   test_proof_verified();
   test_update_voters();
+  test_same_coding_index_different_fec_sets();
   return 0;
 }


### PR DESCRIPTION
   ## eqvoc: detect same-index equivocation across FEC sets

   ### Problem
   `verify_proof` (`src/choreo/eqvoc/fd_eqvoc.c`) has no general same-index check. Its only index comparison
 is gated to data shreds (last-shred conflict), and its other content check requires equal `fec_set_idx`
 (same-FEC merkle conflict). So two coding shreds for one slot with the same coding index but
 different `fec_set_idx` and different payloads — both leader-signed — match neither path and fall through
 to `FD_EQVOC_IGNORED`.

   ### Fix
   Add a general same-index check to `verify_proof`, before the FEC-set-scoped checks: two same-type
 shreds at the same type-appropriate index (coding index for coding shreds, data index for data shreds) with
 differing merkle roots are an equivocation regardless of `fec_set_idx`, returning `FD_EQVOC_SUCCESS`.
 Additive — the existing last-shred and same-FEC-set merkle paths are unchanged.

   Merkle-root inequality is the differing-content proxy (equivalent to Agave's payload compare modulo hash
 collision, and reuses the same idiom as the same-FEC-set check just below).

   ### Commits (red → green)
   1. `eqvoc: add test for same-index equivocation across FEC sets` — adds
 `test_same_coding_index_different_fec_sets`, asserting `verify_proof` detects the pair (`FD_EQVOC_SUCCESS`).
 Fails on current code, documenting the bug test-first.
   2. `eqvoc: detect same-index equivocation across FEC sets` — adds the check; turns the test green.

   ### Verification
   `build/native/gcc/unit-test/test_eqvoc`:
   - With fix: RC=0 — `test_same_coding_index_different_fec_sets` passes; `test_slot_zero_proof_rejected`
 / `test_version_max_rejected` unaffected.
   - Commit 1 alone (test without fix): RC=134 — `FAIL: verify_proof(...)` (SIGABRT), confirming the test
 catches the regression.