### PR TITLE
Fix false-positive equivocation on same-merkle-root FEC set

### DIFF
--- a/src/disco/shred/Local.mk
+++ b/src/disco/shred/Local.mk
@@ -6,6 +6,8 @@ $(call add-objs,fd_fec_resolver,fd_disco)
 $(call add-objs,fd_shred_tile,fd_disco)
 $(call make-unit-test,test_fec_resolver,test_fec_resolver,fd_flamenco fd_disco fd_ballet fd_util fd_tango fd_reedsol)
 $(call run-unit-test,test_fec_resolver)
+$(call make-unit-test,test_fec_resolver_bp627,test_fec_resolver_bp627,fd_flamenco fd_disco fd_ballet fd_util fd_tango fd_reedsol)
+$(call run-unit-test,test_fec_resolver_bp627)
 endif
 $(call make-unit-test,test_shred_dest,test_shred_dest,fd_disco fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_shred_dest_conformance,test_shred_dest_conformance,fd_disco fd_flamenco fd_ballet fd_util)

--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -117,21 +117,27 @@ struct done_ele {
   uint            heap_right;
   uint            map_next;
   uint            map_prev;
-  /* In order to save space in the done_map and make this struct 32
-     bytes, we store a 32 bit validator-specific hash of the shred
-     signature.  If a malicious leader equivocates and produces two FEC
-     sets which have the same hash for us, a task which takes a decent
-     but doable amount of effort, the only impact is that we would
-     reject the shreds with SHRED_IGNORED instead of SHRED_EQUIVOC,
-     which is not a big deal.  It's documented that SHRED_EQUIVOC
-     detection is on a best-effort basis.  If we detect an equivocation
-     for this (slot, FEC set idx), sig_hash gets set to
-     SIG_HASH_EQUIVOC, and we start returning SHRED_IGNORED for any
-     non-repair shred for that (slot, FEC set idx). */
+  /* We store a 32 bit validator-specific hash of the shred signature.
+     If a malicious leader equivocates and produces two FEC sets which
+     have the same hash for us, a task which takes a decent but doable
+     amount of effort, the only impact is that we would reject the
+     shreds with SHRED_IGNORED instead of SHRED_EQUIVOC, which is not a
+     big deal.  It's documented that SHRED_EQUIVOC detection is on a
+     best-effort basis.  If we detect an equivocation for this (slot,
+     FEC set idx), sig_hash gets set to SIG_HASH_EQUIVOC, and we start
+     returning SHRED_IGNORED for any non-repair shred for that
+     (slot, FEC set idx). */
   uint           sig_hash;
+  /* Merkle root of the completed FEC set.  Used to distinguish a
+     signature-only mismatch (BP627: two valid signatures over the same
+     merkle root -- not equivocation, matches Agave semantics) from a
+     genuine equivocation (different merkle roots for the same
+     (slot, fec_set_idx)).  Populated on FEC set completion and on the
+     equivoc-detection path. */
+  uchar          merkle_root[32];
 };
 typedef struct done_ele done_ele_t;
-FD_STATIC_ASSERT( sizeof(done_ele_t)==32UL, done_ele_t );
+FD_STATIC_ASSERT( sizeof(done_ele_t)==64UL, done_ele_t );
 #define SIG_HASH_EQUIVOC UINT_MAX
 
 #define MAP_NAME              done_map
@@ -701,15 +707,47 @@ fd_fec_resolver_add_shred( fd_fec_resolver_t         * resolver,
     if( FD_LIKELY( out_merkle_root ) ) memcpy( out_merkle_root, _root, sizeof(fd_bmtree_node_t) );
 
     if( FD_UNLIKELY( equivoc_or_invalid ) ) {
-      /* It wasn't invalid, so it must be equivoc */
+      /* Signature-keyed ctx_map missed but (slot, fec_set_idx) was
+         already known.  Sigverify succeeded on the second signature, so
+         the shred is not invalid; it is either a genuine equivocation
+         (different merkle roots) or the BP627 case of two valid
+         signatures over the same merkle root.
+
+         Agave's check_merkle_root_consistency
+         (agave/ledger/src/blockstore.rs:3010) treats the same-merkle-
+         root case as "no conflict" and ingests both shreds.  We match
+         that semantics: if the reconstructed merkle root equals the
+         root recorded for the existing (slot, fec_set_idx), return
+         SHRED_IGNORED and do not stamp SIG_HASH_EQUIVOC.  Otherwise the
+         merkle roots genuinely differ and this is a real equivocation.
+
+         Look up the existing root: in-progress sets live in ctx_treap;
+         completed sets live in done_map. */
       ctx_list_ele_push_head( free_list, ctx, ctx_pool );
       resolver->free_list_cnt++;
-      /* We want to record that we've sigverified the shred somewhere so
-         that if an attacker sends it to us again, we don't have to
-         verify it again.  We do that by inserting it into the done_map
-         with SIG_HASH_EQUIVOC. */
+
       slot_fec_pair_t slot_fec_pair[1] = {{ .slot = shred->slot, .fec_idx = shred->fec_set_idx }};
+
+      uchar const * existing_root = NULL;
+      set_ctx_t const * existing_ctx = ctx_treap_ele_query_const( ctx_treap, slot_fec_pair, ctx_pool );
       done_ele_t * done = done_map_ele_query( done_map, slot_fec_pair, NULL, done_pool );
+      if( FD_LIKELY( existing_ctx ) )      existing_root = existing_ctx->root.hash;
+      else if( FD_LIKELY( done ) )         existing_root = done->merkle_root;
+
+      if( FD_LIKELY( existing_root && 0==memcmp( existing_root, _root->hash, 32UL ) ) ) {
+        /* Same merkle root under (slot, fec_set_idx) -- not
+           equivocation.  This is BP627's signer-side non-determinism
+           case; Agave ingests both.  Do not stamp SIG_HASH_EQUIVOC. */
+        return FD_FEC_RESOLVER_SHRED_IGNORED;
+      }
+
+      /* Genuine equivocation: merkle roots differ (or existing root not
+         available, e.g. because the completed done_ele was evicted from
+         done_map -- in which case we conservatively keep the existing
+         behavior). Record that we've sigverified the shred so that if
+         an attacker sends it again, we don't have to verify it again.
+         We do that by inserting it into the done_map with
+         SIG_HASH_EQUIVOC. */
       if( FD_LIKELY( done ) ) done->sig_hash = SIG_HASH_EQUIVOC;
       else {
         ensure_done_pool_free( done_pool, done_heap, done_map );
@@ -719,6 +757,7 @@ fd_fec_resolver_add_shred( fd_fec_resolver_t         * resolver,
         done->key.slot    = shred->slot;
         done->key.fec_idx = shred->fec_set_idx;
         done->sig_hash    = SIG_HASH_EQUIVOC;
+        memcpy( done->merkle_root, _root->hash, 32UL );
 
         done_heap_ele_insert( done_heap, done, done_pool );
         done_map_ele_insert ( done_map,  done, done_pool );
@@ -822,6 +861,7 @@ fd_fec_resolver_add_shred( fd_fec_resolver_t         * resolver,
     done->key.slot    = ctx->slot;
     done->key.fec_idx = ctx->fec_set_idx;
     done->sig_hash    = (uint)fd_hash( resolver->seed, w_sig, sizeof(wrapped_sig_t) );
+    memcpy( done->merkle_root, ctx->root.hash, 32UL );
 
     done_heap_ele_insert( done_heap, done, done_pool );
     done_map_ele_insert ( done_map,  done, done_pool );

--- a/src/disco/shred/test_fec_resolver_bp627.c
+++ b/src/disco/shred/test_fec_resolver_bp627.c
@@ -1,0 +1,408 @@
+/* test_fec_resolver_bp627.c
+
+   Boundary point BP627: divergence between Firedancer and Agave when a
+   FEC set contains two shreds carrying two distinct valid ed25519
+   signatures over the same reconstructed merkle root.
+
+   Original divergence: Firedancer's fd_fec_resolver_add_shred keyed
+   its in-progress FEC-set map (`ctx_map`) by the ed25519 signature
+   bytes; the pair (slot, fec_set_idx) is a secondary index in a treap.
+   When two shreds carried different valid signatures over the same
+   merkle root, the treap hit set `equivoc_or_invalid=1` and the
+   resolver returned FD_FEC_RESOLVER_SHRED_EQUIVOC -- a false positive
+   that propagated through the shred/tower tiles into fd_ghost_eqvoc
+   and caused FD to abstain from voting on blocks Agave votes on.
+
+   Fix (this branch): before returning EQUIVOC, compare the newly
+   reconstructed merkle root against the root recorded for the existing
+   (slot, fec_set_idx).  If they match, return SHRED_IGNORED (no
+   equivocation -- Agave semantics); if they differ, return EQUIVOC
+   (genuine equivocation).
+
+     src/disco/shred/fd_fec_resolver.c  (MAP_KEY = sig)
+     src/disco/shred/fd_fec_resolver.c  (equivoc-branch merkle-root compare)
+
+   Agave reference: keys FEC-set metadata by (slot, fec_set_index) in
+   `MerkleRootMeta` (agave/ledger/src/blockstore_meta.rs:376) and its
+   cross-shred consistency check `check_merkle_root_consistency`
+   (agave/ledger/src/blockstore.rs:3010) compares only the merkle root.
+   Two shreds with the same merkle root but different valid ed25519
+   signatures both land in the ShredData column with no
+   PossibleDuplicateShred pushed.
+
+   Ed25519 verify is stateless.  RFC 8032's deterministic-r rule for
+   nonce derivation is a signer-side convention -- verify only checks
+   that s is canonical, that R and A' decompress and are non-small
+   order, and that [8][S]B == [8]R + [8][k]A'.  A malfunctioning or
+   malicious leader can therefore produce two accepting signatures
+   Sig_A and Sig_B over the same message M by using two different
+   values of r.  fd_ed25519_verify (see the block comment at
+   src/ballet/ed25519/fd_ed25519_user.c:168 -- "verify_strict"
+   semantics) accepts both.
+
+   Tests:
+
+   test_bp627_two_valid_sigs (same-root, fix asserted):
+     1. Sig_A != Sig_B (byte-inequal signatures).
+     2. Both verify against pk_L over M under fd_ed25519_verify.
+     3. Feeding shred_A returns FD_FEC_RESOLVER_SHRED_OKAY.
+     4. Feeding shred_B returns FD_FEC_RESOLVER_SHRED_IGNORED (fix).
+     5. Resent shred_B still returns FD_FEC_RESOLVER_SHRED_IGNORED.
+
+   test_bp627_real_equivocation (different-root, regression guard):
+     Two shreds at the same (slot, fec_set_idx) but with different
+     merkle roots must still return FD_FEC_RESOLVER_SHRED_EQUIVOC. */
+
+#include <stdio.h>
+#include <string.h>
+#include "fd_shredder.h"
+#include "fd_fec_resolver.h"
+#include "fd_fec_set.h"
+#include "../../ballet/shred/fd_shred.h"
+#include "../../ballet/ed25519/fd_ed25519.h"
+#include "../../ballet/ed25519/fd_curve25519.h"
+#include "../../ballet/ed25519/fd_curve25519_scalar.h"
+#include "../../disco/metrics/fd_metrics.h"
+
+/* Reuse the same demo-shreds keypair the neighbor test_fec_resolver.c
+   uses -- 32 bytes private || 32 bytes public. */
+FD_IMPORT_BINARY( test_private_key, "src/disco/shred/fixtures/demo-shreds.key" );
+
+#define SHRED_VER (ushort)6051
+#define MAX       (32UL*1024UL)
+#define SEED      10388431120836828144UL
+
+static uchar entry_batch[ 32768UL ];
+
+static uchar res_mem[ 1024UL*1024UL ] __attribute__((aligned(FD_FEC_RESOLVER_ALIGN)));
+static fd_fec_set_t out_sets[ 4UL ];
+static fd_fec_set_t _set[ 1UL ];
+static fd_shredder_t _shredder[ 1 ];
+static uchar metrics_scratch[ FD_METRICS_FOOTPRINT( 0 ) ] __attribute__((aligned(FD_METRICS_ALIGN)));
+
+/* Signer context / callback identical in shape to test_fec_resolver.c.
+   The shredder calls this once per FEC set to produce Sig_A. */
+struct signer_ctx {
+  fd_sha512_t   sha512[ 1 ];
+  uchar const * public_key;
+  uchar const * private_key;
+};
+typedef struct signer_ctx signer_ctx_t;
+
+static void
+signer_ctx_init( signer_ctx_t * ctx,
+                 uchar const *  private_key ) {
+  FD_TEST( fd_sha512_init( fd_sha512_new( ctx->sha512 ) ) );
+  ctx->public_key  = private_key + 32UL;
+  ctx->private_key = private_key;
+}
+
+static void
+det_signer( void *        _ctx,
+            uchar *       signature,
+            uchar const * merkle_root ) {
+  signer_ctx_t * ctx = (signer_ctx_t *)_ctx;
+  fd_ed25519_sign( signature, merkle_root, 32UL, ctx->public_key, ctx->private_key, ctx->sha512 );
+}
+
+/* alt_ed25519_sign produces a valid ed25519 signature over msg using
+   the caller-supplied 32-byte nonce_seed to drive the choice of r.
+
+   This mirrors fd_ed25519_sign (fd_ed25519_user.c:60) exactly except
+   for the r-derivation step: RFC 8032 specifies
+   r = SHA-512(prefix || M) where prefix is the second half of
+   SHA-512(private_key); we substitute r = SHA-512(nonce_seed || M)
+   reduced mod L.  Everything after r is identical:
+
+     R  = [r] B                    (curve base point)
+     k  = SHA-512(R || A || M) mod L
+     S  = (r + k*s) mod L
+     sig = R || S
+
+   The resulting signature verifies under RFC 8032 verify (and thus
+   under fd_ed25519_verify) because the equations
+     [8][S]B == [8]R + [8][k]A'
+   depend only on the algebraic relation, not on how r was chosen.
+   The signer-side deterministic-r rule is a hygiene requirement to
+   avoid leaking s across signatures; it is NOT part of the verify
+   contract.  Using two different nonce_seed values with the same
+   (private_key, msg) yields two byte-distinct signatures, both of
+   which fd_ed25519_verify accepts. */
+static void
+alt_ed25519_sign( uchar         sig[ 64 ],
+                  uchar const   msg[ 32 ],
+                  uchar const   public_key[ 32 ],
+                  uchar const   private_key[ 32 ],
+                  uchar const   nonce_seed[ 32 ],
+                  fd_sha512_t * sha ) {
+
+  /* s (secret scalar) derived from private_key exactly as in RFC 8032. */
+  uchar s_h[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_init( sha ), private_key, 32UL ), s_h );
+  s_h[ 0] &= (uchar)0xF8;
+  s_h[31] &= (uchar)0x7F;
+  s_h[31] |= (uchar)0x40;
+  uchar * s = s_h; /* first 32 bytes */
+
+  /* r derived from (nonce_seed || msg) instead of (prefix || msg).
+     Note: fd_curve25519_scalar_reduce reduces a 64-byte little-endian
+     value mod L into the first 32 bytes of its output. */
+  uchar r[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_append( fd_sha512_init( sha ), nonce_seed, 32UL ), msg, 32UL ), r );
+  fd_curve25519_scalar_reduce( r, r );
+
+  /* R = [r] B, write encoded R into sig[0..32). */
+  fd_ed25519_point_t R[1];
+  fd_ed25519_scalar_mul_base_const_time( R, r );
+  fd_ed25519_point_tobytes( sig, R );
+
+  /* k = SHA-512(R || A || M) mod L. */
+  uchar k[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_append( fd_sha512_append( fd_sha512_init( sha ),
+                  sig, 32UL ), public_key, 32UL ), msg, 32UL ), k );
+  fd_curve25519_scalar_reduce( k, k );
+
+  /* S = (k*s + r) mod L, into sig[32..64). */
+  fd_curve25519_scalar_muladd( sig + 32UL, k, s, r );
+}
+
+static void
+test_bp627_two_valid_sigs( void ) {
+  signer_ctx_t signer_ctx[ 1 ];
+  signer_ctx_init( signer_ctx, test_private_key );
+
+  uchar const * private_key = test_private_key;
+  uchar const * pubkey      = test_private_key + 32UL;
+
+  /* Fill the entry batch with arbitrary bytes -- content does not
+     matter, only that the shredder produces a well-formed 32/32 FEC
+     set.  Using 28000 bytes matches test_chained_merkle_shreds and
+     produces exactly one FEC set with 32 data + 32 parity shreds. */
+  for( ulong i=0UL; i<sizeof(entry_batch); i++ ) entry_batch[ i ] = (uchar)(i*0x9EU + 0x37U);
+  ulong const data_sz = 28000UL;
+  FD_TEST( fd_shredder_count_fec_sets( data_sz, 1 ) == 1UL );
+  FD_TEST( fd_shredder_count_data_shreds( data_sz, 1 ) == FD_FEC_SHRED_CNT );
+
+  FD_TEST( _shredder==fd_shredder_new( _shredder, det_signer, signer_ctx ) );
+  fd_shredder_t * shredder = fd_shredder_join( _shredder ); FD_TEST( shredder );
+  fd_shredder_set_shred_version( shredder, SHRED_VER );
+
+  fd_entry_batch_meta_t meta[1];
+  fd_memset( meta, 0, sizeof(fd_entry_batch_meta_t) );
+  meta->block_complete = 1;
+  /* parent_offset must be non-zero for slots >0 (fd_shred_parse
+     rejects slot!=0 & parent_off==0, per fd_shred.c:96). */
+  meta->parent_offset  = 1UL;
+
+  /* Build the FEC set at slot 100.  All 32 data + 32 parity shreds
+     share the same signature Sig_A over the merkle root M of this set. */
+  ulong const slot     = 100UL;
+  FD_TEST( fd_shredder_init_batch( shredder, entry_batch, data_sz, slot, meta ) );
+  uchar chained_merkle_root[ 32 ] = { 0 };
+  fd_fec_set_t * set = fd_shredder_next_fec_set( shredder, _set, chained_merkle_root );
+  FD_TEST( set );
+  FD_TEST( fd_shredder_fini_batch( shredder ) );
+
+  /* Reconstruct M (the merkle root over the 32 data + 32 parity shreds)
+     from data_shreds[0]. */
+  uchar bmtree_mem[ fd_bmtree_commit_footprint( FD_SHRED_MERKLE_LAYER_CNT ) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
+  fd_bmtree_node_t M[1] = { 0 };
+  FD_TEST( fd_shred_merkle_root( set->data_shreds[ 0 ].s, bmtree_mem, M ) );
+
+  /* Sanity: idx=0 and idx=1 shreds carry the SAME signature Sig_A
+     (the shredder signs once over M and copies the signature into every
+     shred in the FEC set). */
+  uchar Sig_A[ 64 ];
+  fd_memcpy( Sig_A, set->data_shreds[ 0 ].s->signature, 64UL );
+  FD_TEST( 0==memcmp( set->data_shreds[ 1 ].s->signature, Sig_A, 64UL ) );
+
+  /* Sig_A must verify against pk_L over M. */
+  fd_sha512_t _sha[ 1 ];
+  fd_sha512_t * sha = fd_sha512_join( fd_sha512_new( _sha ) );
+  FD_TEST( FD_ED25519_SUCCESS == fd_ed25519_verify( M->hash, 32UL, Sig_A, pubkey, sha ) );
+
+  /* Compute an alternate valid signature Sig_B over the SAME message
+     M using a different nonce seed.  Any nonce_seed distinct from the
+     RFC 8032 prefix-derived r produces a distinct valid signature. */
+  uchar Sig_B[ 64 ];
+  static const uchar nonce_seed[ 32 ] = {
+    0xB6,0x27,0xBE,0xEF,0xF0,0x0D,0xDE,0xAD,
+    0xCA,0xFE,0xBA,0xBE,0xFA,0xCE,0xB0,0x0C,
+    0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,
+    0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF
+  };
+  alt_ed25519_sign( Sig_B, M->hash, pubkey, private_key, nonce_seed, sha );
+
+  /* Assertion 1: Sig_A and Sig_B are byte-distinct. */
+  FD_TEST( 0 != memcmp( Sig_A, Sig_B, 64UL ) );
+
+  /* Assertion 2: both signatures verify against pk_L over M. */
+  FD_TEST( FD_ED25519_SUCCESS == fd_ed25519_verify( M->hash, 32UL, Sig_A, pubkey, sha ) );
+  FD_TEST( FD_ED25519_SUCCESS == fd_ed25519_verify( M->hash, 32UL, Sig_B, pubkey, sha ) );
+
+  fd_sha512_delete( fd_sha512_leave( sha ) );
+
+  /* Assemble shred_A (a copy of data_shreds[0] with Sig_A -- unchanged)
+     and shred_B (a copy of data_shreds[1] with Sig_A overwritten by
+     Sig_B).  We work on stack copies so we don't perturb the FEC set. */
+  uchar shred_A_buf[ FD_SHRED_MIN_SZ ];
+  uchar shred_B_buf[ FD_SHRED_MIN_SZ ];
+  fd_memcpy( shred_A_buf, set->data_shreds[ 0 ].b, FD_SHRED_MIN_SZ );
+  fd_memcpy( shred_B_buf, set->data_shreds[ 1 ].b, FD_SHRED_MIN_SZ );
+  /* Overwrite signature on shred_B. */
+  fd_memcpy( shred_B_buf, Sig_B, 64UL );
+
+  /* Now drive the resolver. */
+  fd_fec_resolver_t * r =
+      fd_fec_resolver_join( fd_fec_resolver_new( res_mem, NULL, NULL, 2UL, 1UL, 1UL, 1UL, out_sets, SEED ) );
+  FD_TEST( r );
+  fd_fec_resolver_set_shred_version( r, SHRED_VER );
+
+  fd_fec_set_t const * out_fec[ 1 ];
+  fd_shred_t   const * out_shred[ 1 ];
+  fd_bmtree_node_t     out_merkle_root[ 1 ];
+
+  /* Assertion 3: shred_A is accepted. */
+  fd_shred_t const * parsed_A = fd_shred_parse( shred_A_buf, FD_SHRED_MIN_SZ, FD_SHRED_BLK_MAX );
+  FD_TEST( parsed_A );
+  int rv_A = fd_fec_resolver_add_shred( r, parsed_A, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BP627: add_shred(shred_A, Sig_A) returned %d (expected %d = OKAY)",
+                  rv_A, FD_FEC_RESOLVER_SHRED_OKAY ));
+  FD_TEST( rv_A == FD_FEC_RESOLVER_SHRED_OKAY );
+  /* Reconstructed root must equal M. */
+  FD_TEST( 0 == memcmp( out_merkle_root->hash, M->hash, 32UL ) );
+
+  /* Assertion 4 (post-fix): shred_B is IGNORED, not EQUIVOC.  The
+     ctx_map lookup by Sig_B misses (Sig_B != Sig_A), the ctx_treap
+     lookup on (slot=100, fec_set_idx=0) hits, equivoc_or_invalid is
+     set to 1, the merkle proof recomputes root M, sig-verify of Sig_B
+     over M succeeds -- and then the merkle-root compare against the
+     existing ctx finds M == M, so the resolver returns
+     SHRED_IGNORED without stamping SIG_HASH_EQUIVOC.  This matches
+     Agave's check_merkle_root_consistency semantics. */
+  fd_shred_t const * parsed_B = fd_shred_parse( shred_B_buf, FD_SHRED_MIN_SZ, FD_SHRED_BLK_MAX );
+  FD_TEST( parsed_B );
+  int rv_B = fd_fec_resolver_add_shred( r, parsed_B, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BP627: add_shred(shred_B, Sig_B) returned %d (expected %d = IGNORED)",
+                  rv_B, FD_FEC_RESOLVER_SHRED_IGNORED ));
+  FD_TEST( rv_B == FD_FEC_RESOLVER_SHRED_IGNORED );
+
+  /* Follow-up: resending shred_B must still be IGNORED.  Without a
+     SIG_HASH_EQUIVOC stamp in done_map, the done_map lookup at
+     fd_fec_resolver.c misses; ctx_map by Sig_B still misses;
+     ctx_treap on (100,0) still hits; equivoc_or_invalid=1; merkle-root
+     compare finds M == M; return SHRED_IGNORED. */
+  int rv_B2 = fd_fec_resolver_add_shred( r, parsed_B, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                         out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BP627: add_shred(shred_B, Sig_B) resent returned %d (expected %d = IGNORED)",
+                  rv_B2, FD_FEC_RESOLVER_SHRED_IGNORED ));
+  FD_TEST( rv_B2 == FD_FEC_RESOLVER_SHRED_IGNORED );
+
+  fd_fec_resolver_delete( fd_fec_resolver_leave( r ) );
+}
+
+/* Regression guard: genuine equivocation (same slot/fec_set_idx but
+   different merkle roots) MUST still return EQUIVOC.  Build two
+   distinct FEC sets (payloads chosen so their merkle roots differ) at
+   the same (slot, fec_set_idx=0), then feed one shred from each. */
+static void
+test_bp627_real_equivocation( void ) {
+  signer_ctx_t signer_ctx[ 1 ];
+  signer_ctx_init( signer_ctx, test_private_key );
+
+  uchar const * pubkey = test_private_key + 32UL;
+
+  ulong const slot = 200UL;
+
+  /* Build FEC set A (payload pattern 1). */
+  static uchar entry_batch_A[ 32768UL ];
+  for( ulong i=0UL; i<sizeof(entry_batch_A); i++ ) entry_batch_A[ i ] = (uchar)(i*0x9EU + 0x37U);
+
+  fd_shredder_t _shredder_A[ 1 ];
+  FD_TEST( _shredder_A==fd_shredder_new( _shredder_A, det_signer, signer_ctx ) );
+  fd_shredder_t * shredder_A = fd_shredder_join( _shredder_A ); FD_TEST( shredder_A );
+  fd_shredder_set_shred_version( shredder_A, SHRED_VER );
+
+  fd_entry_batch_meta_t meta[1];
+  fd_memset( meta, 0, sizeof(fd_entry_batch_meta_t) );
+  meta->block_complete = 1;
+  meta->parent_offset  = 1UL;
+
+  fd_fec_set_t _set_A[ 1 ];
+  FD_TEST( fd_shredder_init_batch( shredder_A, entry_batch_A, 28000UL, slot, meta ) );
+  uchar chained_A[ 32 ] = { 0 };
+  fd_fec_set_t * set_A = fd_shredder_next_fec_set( shredder_A, _set_A, chained_A );
+  FD_TEST( set_A );
+  FD_TEST( fd_shredder_fini_batch( shredder_A ) );
+
+  /* Build FEC set B (payload pattern 2) at the SAME slot/fec_set_idx. */
+  static uchar entry_batch_B[ 32768UL ];
+  for( ulong i=0UL; i<sizeof(entry_batch_B); i++ ) entry_batch_B[ i ] = (uchar)(i*0x5DU + 0x91U);
+
+  fd_shredder_t _shredder_B[ 1 ];
+  FD_TEST( _shredder_B==fd_shredder_new( _shredder_B, det_signer, signer_ctx ) );
+  fd_shredder_t * shredder_B = fd_shredder_join( _shredder_B ); FD_TEST( shredder_B );
+  fd_shredder_set_shred_version( shredder_B, SHRED_VER );
+
+  fd_fec_set_t _set_B[ 1 ];
+  FD_TEST( fd_shredder_init_batch( shredder_B, entry_batch_B, 28000UL, slot, meta ) );
+  uchar chained_B[ 32 ] = { 0 };
+  fd_fec_set_t * set_B = fd_shredder_next_fec_set( shredder_B, _set_B, chained_B );
+  FD_TEST( set_B );
+  FD_TEST( fd_shredder_fini_batch( shredder_B ) );
+
+  /* Sanity: the two FEC sets have different merkle roots (different
+     payloads under the same slot/fec_set_idx). */
+  uchar bmtree_mem_A[ fd_bmtree_commit_footprint( FD_SHRED_MERKLE_LAYER_CNT ) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
+  uchar bmtree_mem_B[ fd_bmtree_commit_footprint( FD_SHRED_MERKLE_LAYER_CNT ) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
+  fd_bmtree_node_t M_A[1] = { 0 };
+  fd_bmtree_node_t M_B[1] = { 0 };
+  FD_TEST( fd_shred_merkle_root( set_A->data_shreds[ 0 ].s, bmtree_mem_A, M_A ) );
+  FD_TEST( fd_shred_merkle_root( set_B->data_shreds[ 0 ].s, bmtree_mem_B, M_B ) );
+  FD_TEST( 0 != memcmp( M_A->hash, M_B->hash, 32UL ) );
+
+  /* And the signatures differ (each set signed over its own root). */
+  FD_TEST( 0 != memcmp( set_A->data_shreds[ 0 ].s->signature,
+                        set_B->data_shreds[ 0 ].s->signature, 64UL ) );
+
+  static uchar res_mem2[ 1024UL*1024UL ] __attribute__((aligned(FD_FEC_RESOLVER_ALIGN)));
+  static fd_fec_set_t out_sets2[ 4UL ];
+  fd_fec_resolver_t * r =
+      fd_fec_resolver_join( fd_fec_resolver_new( res_mem2, NULL, NULL, 2UL, 1UL, 1UL, 1UL, out_sets2, SEED ) );
+  FD_TEST( r );
+  fd_fec_resolver_set_shred_version( r, SHRED_VER );
+
+  fd_fec_set_t const * out_fec[ 1 ];
+  fd_shred_t   const * out_shred[ 1 ];
+  fd_bmtree_node_t     out_merkle_root[ 1 ];
+
+  int rv_A = fd_fec_resolver_add_shred( r, set_A->data_shreds[ 0 ].s, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BP627 regression: add_shred(set_A idx0) returned %d (expected %d = OKAY)",
+                  rv_A, FD_FEC_RESOLVER_SHRED_OKAY ));
+  FD_TEST( rv_A == FD_FEC_RESOLVER_SHRED_OKAY );
+
+  int rv_B = fd_fec_resolver_add_shred( r, set_B->data_shreds[ 0 ].s, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BP627 regression: add_shred(set_B idx0) returned %d (expected %d = EQUIVOC)",
+                  rv_B, FD_FEC_RESOLVER_SHRED_EQUIVOC ));
+  FD_TEST( rv_B == FD_FEC_RESOLVER_SHRED_EQUIVOC );
+
+  fd_fec_resolver_delete( fd_fec_resolver_leave( r ) );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_metrics_register( (ulong *)fd_metrics_new( metrics_scratch, 0UL ) );
+
+  test_bp627_two_valid_sigs();
+  test_bp627_real_equivocation();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/discof/tower/Local.mk
+++ b/src/discof/tower/Local.mk
@@ -1,4 +1,5 @@
 ifdef FD_HAS_HOSTED
 $(call add-objs,fd_tower_tile,fd_discof)
 $(call make-unit-test,test_tower_tile,test_tower_tile,fd_discof fd_choreo fd_disco fd_flamenco fd_tango fd_ballet fd_util)
+$(call make-unit-test,test_bhp_627_integration,test_bhp_627_integration/test_bhp_627_integration,fd_choreo fd_disco fd_flamenco fd_tango fd_ballet fd_util fd_reedsol)
 endif

--- a/src/discof/tower/test_bhp_627_integration/RUN.md
+++ b/src/discof/tower/test_bhp_627_integration/RUN.md
@@ -1,0 +1,96 @@
+# BHP-627 integration test — run notes
+
+This directory contains the integration test for the BHP-627 (= BP-627)
+divergence: FD's `fd_fec_resolver_add_shred` (`src/disco/shred/
+fd_fec_resolver.c`) returns `FD_FEC_RESOLVER_SHRED_EQUIVOC` when a
+second shred in the same FEC set carries a byte-different but
+individually-valid ed25519 signature over the same reconstructed
+merkle root; Agave's `check_merkle_root_consistency`
+(`ledger/src/blockstore.rs:3010`) short-circuits on equal merkle roots
+at line 3020 and inserts both shreds cleanly. The consensus-visible
+consequence of the buggy FD behavior is a *vote-abstain* divergence:
+FD refuses to vote on the slot; Agave votes normally.
+
+## What this test asserts
+
+`test_bhp_627_integration.c` drives the divergence end-to-end and
+asserts the vote path is preserved (i.e. the bug is not present):
+
+1. Builds a valid 32-data/32-parity chained-merkle FEC set with a
+   controlled leader keypair at slot=100, fec_set_idx=0.
+2. Crafts a second valid ed25519 signature `Sig_B` over the same
+   merkle root `M` via an RFC-8032-compatible signer with a distinct
+   nonce seed. Both `Sig_A != Sig_B` byte-wise and both verify against
+   the leader pubkey over `M`.
+3. Builds a minimal ghost tree: root → eqvoc_blk (slot 100) → child_blk.
+4. Feeds `shred_A` (with `Sig_A`) to `fd_fec_resolver_add_shred`.
+   Asserts return is `SHRED_OKAY`.
+5. Feeds `shred_B` (same shred body as `shred[1]`, signature rewritten
+   to `Sig_B`) to the resolver.
+6. Simulates the tower-tile propagation: if the resolver returns
+   `SHRED_EQUIVOC`, invokes `fd_ghost_eqvoc` on `eqvoc_id`. This
+   compresses the real tile chain (`fd_shred_tile.c:997` publishes
+   `SHRED_SIG_RESULT_EQVOC` → `fd_tower_tile.c:1732` calls
+   `fd_eqvoc_shred_insert` → `fd_eqvoc.c:717-728` inserts a proof →
+   `fd_tower_tile.c:1268-1275` fires `fd_ghost_eqvoc` on
+   `SLOT_COMPLETED`) into a single conditional.
+7. Load-bearing assertion: `eqvoc_blk->valid == 1`. If the resolver
+   returned `EQUIVOC`, the simulated propagation zeroed `valid` at
+   `fd_ghost.c:638` and this assertion fails.
+
+Behavior across the fix:
+
+- **Before BP-627 fix:** resolver returns `EQUIVOC` on step 5;
+  simulated propagation runs; `eqvoc_blk->valid` drops to 0; test
+  **FAILS** at the `valid == 1` assertion.
+- **After BP-627 fix:** resolver returns `IGNORED` on step 5; no
+  propagation; `eqvoc_blk->valid` stays 1; test **PASSES**.
+
+The test also asserts that `fd_ghost_best(root) == child_blk` and
+`fd_ghost_invalid_ancestor(child_blk) == NULL` after the fix,
+confirming that fork-choice can still select the eqvoc subtree and
+FD's vote for the affected slot is not gated off.
+
+## Building and running
+
+```bash
+make -j test_bhp_627_integration
+./build/native/gcc/unit-test/test_bhp_627_integration --page-sz normal --page-cnt 512
+```
+
+Expected output (on fixed code):
+
+```
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration test: resolver -> ghost vote-path preservation
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration: add_shred(shred_A, Sig_A) returned 0
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration: add_shred(shred_B, Sig_B) returned -2
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration: eqvoc_blk.valid=1 child_blk.valid=1 -- vote path preserved
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration: fd_ghost_best(root) == child (slot 101) -- fork-choice can still select the eqvoc subtree
+NOTICE  test_bhp_627_integration.c(...): BHP-627 integration test pass
+```
+
+On buggy code (pre-fix), `add_shred(shred_B, Sig_B)` returns `-4`
+(EQUIVOC) and the test fails at the `eqvoc_blk->valid == 1`
+assertion.
+
+## What is out of scope
+
+This test compresses the tile-layer propagation into a single
+conditional call to `fd_ghost_eqvoc`. It does not run the full FD
+tile stack (shred tile → FEC resolver → tower tile → vote emit) end
+to end, nor does it exercise the real vote-txn assembly path
+(`fd_tower_choose_next` at `fd_tower.c:851`, which requires a
+fully-provisioned tower + eqvoc + vote-account state).
+
+Empirically observing the divergence in production shape requires a
+two-validator co-run harness: both validators booted from the same
+genesis, fed the same shred stream including the crafted
+same-merkle-root two-signature pair, comparing per-slot vote
+emissions and bank_hash lineage. That harness is not in-tree.
+
+## References
+
+- Report: `boundary-mappings/divergences/BP627-report.md`
+- Unit reproducer: `src/disco/shred/test_fec_resolver_bp627.c`
+- Fix: `src/disco/shred/fd_fec_resolver.c` (equivoc-branch merkle-
+  root compare)

--- a/src/discof/tower/test_bhp_627_integration/test_bhp_627_integration.c
+++ b/src/discof/tower/test_bhp_627_integration/test_bhp_627_integration.c
@@ -1,0 +1,309 @@
+/* test_bhp_627_integration.c
+
+   Integration test for BHP-627 (= BP-627): consensus-layer projection
+   of the FEC-resolver divergence.  Given two shreds in the same FEC
+   set that reconstruct the same 32-byte merkle root but carry
+   byte-different, individually-valid ed25519 signatures under the
+   leader keypair, the correct behavior (matching Agave's
+   check_merkle_root_consistency at agave/ledger/src/blockstore.rs
+   :3010) is to ingest both shreds and continue toward completion.
+   The buggy behavior returned FD_FEC_RESOLVER_SHRED_EQUIVOC, which
+   propagated through fd_shred_tile -> fd_tower_tile -> fd_eqvoc ->
+   fd_ghost_eqvoc, marked the block invalid, and made FD abstain from
+   voting on a block Agave would vote on.
+
+   This test drives the resolver end-to-end AND simulates the
+   tower-tile propagation:
+
+     1. Build a valid 32-data/32-parity chained-merkle FEC set with a
+        controlled leader keypair (slot=100, fec_set_idx=0).
+     2. Craft a second valid ed25519 signature Sig_B over the same
+        merkle root M via an RFC-8032-compatible signer with a
+        distinct nonce seed.  Sig_A != Sig_B, but both verify.
+     3. Build a ghost tree: root -> eqvoc_blk -> child_blk.
+     4. Feed shred_A (Sig_A) into fd_fec_resolver_add_shred -- assert
+        SHRED_OKAY.
+     5. Feed shred_B (Sig_B) into fd_fec_resolver_add_shred.
+        - Simulate the tower-tile propagation: if the resolver returns
+          EQUIVOC, call fd_ghost_eqvoc on eqvoc_blk (this mirrors
+          fd_shred_tile.c publishing SHRED_SIG_RESULT_EQVOC -> the
+          tower tile calling fd_eqvoc_shred_insert -> the SLOT_COMPLETED
+          handler firing fd_ghost_eqvoc).
+     6. Assert eqvoc_blk->valid == 1.  This is the load-bearing
+        assertion: FD did not mark the block invalid, so fork-choice
+        can still select it and FD's vote is preserved.
+
+   Behavior across the fix:
+     - Before BP-627 fix: resolver returns EQUIVOC on step (5); the
+       simulated propagation calls fd_ghost_eqvoc; eqvoc_blk->valid
+       drops to 0; assertion FAILS.
+     - After BP-627 fix: resolver returns IGNORED on step (5); no
+       propagation; eqvoc_blk->valid stays 1; assertion PASSES.
+
+   This makes the test a real failure signal for the BP-627 bug and a
+   real passing signal for the fix -- not a documentation-only
+   scaffold.
+
+   Layout: this test lives under discof/tower/ because the
+   consensus-visible effect (vote-abstain) surfaces at the tower tile
+   through fd_ghost.  The sibling unit test at
+   src/disco/shred/test_fec_resolver_bp627.c asserts the resolver-only
+   behavior; this test asserts that behavior does not break the
+   downstream vote path. */
+
+#include "../../../disco/shred/fd_fec_resolver.h"
+#include "../../../disco/shred/fd_shredder.h"
+#include "../../../disco/shred/fd_fec_set.h"
+#include "../../../ballet/shred/fd_shred.h"
+#include "../../../ballet/ed25519/fd_ed25519.h"
+#include "../../../ballet/ed25519/fd_curve25519.h"
+#include "../../../ballet/ed25519/fd_curve25519_scalar.h"
+#include "../../../choreo/ghost/fd_ghost.h"
+#include "../../../disco/metrics/fd_metrics.h"
+
+#include <string.h>
+
+FD_IMPORT_BINARY( bhp627_private_key, "src/disco/shred/fixtures/demo-shreds.key" );
+
+#define SHRED_VER (ushort)6051
+#define MAX       (32UL*1024UL)
+#define SEED      10388431120836828144UL
+
+static uchar bhp627_entry_batch[ 32768UL ];
+static uchar bhp627_res_mem[ 1024UL*1024UL ] __attribute__((aligned(FD_FEC_RESOLVER_ALIGN)));
+static fd_fec_set_t bhp627_out_sets[ 4UL ];
+static fd_fec_set_t bhp627_set[ 1UL ];
+static fd_shredder_t bhp627_shredder[ 1 ];
+static uchar bhp627_metrics_scratch[ FD_METRICS_FOOTPRINT( 0 ) ] __attribute__((aligned(FD_METRICS_ALIGN)));
+
+struct bhp627_signer_ctx {
+  fd_sha512_t   sha512[ 1 ];
+  uchar const * public_key;
+  uchar const * private_key;
+};
+typedef struct bhp627_signer_ctx bhp627_signer_ctx_t;
+
+static void
+bhp627_signer_init( bhp627_signer_ctx_t * ctx,
+                    uchar const *         private_key ) {
+  FD_TEST( fd_sha512_init( fd_sha512_new( ctx->sha512 ) ) );
+  ctx->public_key  = private_key + 32UL;
+  ctx->private_key = private_key;
+}
+
+static void
+bhp627_det_signer( void *        _ctx,
+                   uchar *       signature,
+                   uchar const * merkle_root ) {
+  bhp627_signer_ctx_t * ctx = (bhp627_signer_ctx_t *)_ctx;
+  fd_ed25519_sign( signature, merkle_root, 32UL, ctx->public_key, ctx->private_key, ctx->sha512 );
+}
+
+/* Produces a valid ed25519 signature over msg using a caller-supplied
+   nonce_seed instead of the RFC-8032 prefix.  See the sibling test at
+   src/disco/shred/test_fec_resolver_bp627.c for the full derivation
+   commentary. */
+static void
+bhp627_alt_ed25519_sign( uchar         sig[ 64 ],
+                         uchar const   msg[ 32 ],
+                         uchar const   public_key[ 32 ],
+                         uchar const   private_key[ 32 ],
+                         uchar const   nonce_seed[ 32 ],
+                         fd_sha512_t * sha ) {
+  uchar s_h[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_init( sha ), private_key, 32UL ), s_h );
+  s_h[ 0] &= (uchar)0xF8;
+  s_h[31] &= (uchar)0x7F;
+  s_h[31] |= (uchar)0x40;
+  uchar * s = s_h;
+
+  uchar r[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_append( fd_sha512_init( sha ), nonce_seed, 32UL ), msg, 32UL ), r );
+  fd_curve25519_scalar_reduce( r, r );
+
+  fd_ed25519_point_t R[1];
+  fd_ed25519_scalar_mul_base_const_time( R, r );
+  fd_ed25519_point_tobytes( sig, R );
+
+  uchar k[ FD_SHA512_HASH_SZ ];
+  fd_sha512_fini( fd_sha512_append( fd_sha512_append( fd_sha512_append( fd_sha512_init( sha ),
+                  sig, 32UL ), public_key, 32UL ), msg, 32UL ), k );
+  fd_curve25519_scalar_reduce( k, k );
+
+  fd_curve25519_scalar_muladd( sig + 32UL, k, s, r );
+}
+
+static void
+test_bhp_627_end_to_end( fd_wksp_t * wksp ) {
+  bhp627_signer_ctx_t signer_ctx[ 1 ];
+  bhp627_signer_init( signer_ctx, bhp627_private_key );
+
+  uchar const * private_key = bhp627_private_key;
+  uchar const * pubkey      = bhp627_private_key + 32UL;
+
+  for( ulong i=0UL; i<sizeof(bhp627_entry_batch); i++ ) bhp627_entry_batch[ i ] = (uchar)(i*0x9EU + 0x37U);
+  ulong const data_sz = 28000UL;
+  FD_TEST( fd_shredder_count_fec_sets( data_sz, 1 ) == 1UL );
+  FD_TEST( fd_shredder_count_data_shreds( data_sz, 1 ) == FD_FEC_SHRED_CNT );
+
+  FD_TEST( bhp627_shredder==fd_shredder_new( bhp627_shredder, bhp627_det_signer, signer_ctx ) );
+  fd_shredder_t * shredder = fd_shredder_join( bhp627_shredder ); FD_TEST( shredder );
+  fd_shredder_set_shred_version( shredder, SHRED_VER );
+
+  fd_entry_batch_meta_t meta[1];
+  fd_memset( meta, 0, sizeof(fd_entry_batch_meta_t) );
+  meta->block_complete = 1;
+  meta->parent_offset  = 1UL;
+
+  ulong const slot = 100UL;
+  FD_TEST( fd_shredder_init_batch( shredder, bhp627_entry_batch, data_sz, slot, meta ) );
+  uchar chained_merkle_root[ 32 ] = { 0 };
+  fd_fec_set_t * set = fd_shredder_next_fec_set( shredder, bhp627_set, chained_merkle_root );
+  FD_TEST( set );
+  FD_TEST( fd_shredder_fini_batch( shredder ) );
+
+  uchar bmtree_mem[ fd_bmtree_commit_footprint( FD_SHRED_MERKLE_LAYER_CNT ) ] __attribute__((aligned(FD_BMTREE_COMMIT_ALIGN)));
+  fd_bmtree_node_t M[1] = { 0 };
+  FD_TEST( fd_shred_merkle_root( set->data_shreds[ 0 ].s, bmtree_mem, M ) );
+
+  uchar Sig_A[ 64 ];
+  fd_memcpy( Sig_A, set->data_shreds[ 0 ].s->signature, 64UL );
+
+  fd_sha512_t _sha[ 1 ];
+  fd_sha512_t * sha = fd_sha512_join( fd_sha512_new( _sha ) );
+  FD_TEST( FD_ED25519_SUCCESS == fd_ed25519_verify( M->hash, 32UL, Sig_A, pubkey, sha ) );
+
+  uchar Sig_B[ 64 ];
+  static const uchar nonce_seed[ 32 ] = {
+    0xB6,0x27,0xBE,0xEF,0xF0,0x0D,0xDE,0xAD,
+    0xCA,0xFE,0xBA,0xBE,0xFA,0xCE,0xB0,0x0C,
+    0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,
+    0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF
+  };
+  bhp627_alt_ed25519_sign( Sig_B, M->hash, pubkey, private_key, nonce_seed, sha );
+
+  FD_TEST( 0 != memcmp( Sig_A, Sig_B, 64UL ) );
+  FD_TEST( FD_ED25519_SUCCESS == fd_ed25519_verify( M->hash, 32UL, Sig_B, pubkey, sha ) );
+
+  fd_sha512_delete( fd_sha512_leave( sha ) );
+
+  uchar shred_A_buf[ FD_SHRED_MIN_SZ ];
+  uchar shred_B_buf[ FD_SHRED_MIN_SZ ];
+  fd_memcpy( shred_A_buf, set->data_shreds[ 0 ].b, FD_SHRED_MIN_SZ );
+  fd_memcpy( shred_B_buf, set->data_shreds[ 1 ].b, FD_SHRED_MIN_SZ );
+  fd_memcpy( shred_B_buf, Sig_B, 64UL );
+
+  /* Build a small ghost tree: root -> eqvoc_blk (slot 100) -> child.
+     block_ids are placeholders (ghost topology is what we care about;
+     any distinct 32-byte value works). */
+  ulong const blk_max = 8UL;
+  ulong const vtr_max = 8UL;
+  void       * ghost_mem = fd_wksp_alloc_laddr( wksp, fd_ghost_align(), fd_ghost_footprint( blk_max, vtr_max ), 42UL );
+  FD_TEST( ghost_mem );
+  fd_ghost_t * ghost = fd_ghost_join( fd_ghost_new( ghost_mem, blk_max, vtr_max, 42UL ) );
+  FD_TEST( ghost );
+
+  fd_hash_t const root_id  = { .ul = { 0xB6270000UL, 0UL, 0UL, 0UL } };
+  fd_hash_t const eqvoc_id = { .ul = { 0xB6270001UL, 0UL, 0UL, 0UL } };
+  fd_hash_t const child_id = { .ul = { 0xB6270002UL, 0UL, 0UL, 0UL } };
+
+  fd_ghost_blk_t * root_blk  = fd_ghost_init( ghost, 0UL, 99UL, &root_id );
+  FD_TEST( root_blk && root_blk->valid == 1 );
+
+  fd_ghost_blk_t * eqvoc_blk = fd_ghost_insert( ghost, 100UL, 100UL, &eqvoc_id, &root_id );
+  FD_TEST( eqvoc_blk && eqvoc_blk->valid == 1 );
+
+  fd_ghost_blk_t * child_blk = fd_ghost_insert( ghost, 101UL, 101UL, &child_id, &eqvoc_id );
+  FD_TEST( child_blk && child_blk->valid == 1 );
+
+  /* Drive the resolver. */
+  fd_fec_resolver_t * r =
+      fd_fec_resolver_join( fd_fec_resolver_new( bhp627_res_mem, NULL, NULL, 2UL, 1UL, 1UL, 1UL, bhp627_out_sets, SEED ) );
+  FD_TEST( r );
+  fd_fec_resolver_set_shred_version( r, SHRED_VER );
+
+  fd_fec_set_t const * out_fec[ 1 ];
+  fd_shred_t   const * out_shred[ 1 ];
+  fd_bmtree_node_t     out_merkle_root[ 1 ];
+
+  fd_shred_t const * parsed_A = fd_shred_parse( shred_A_buf, FD_SHRED_MIN_SZ, FD_SHRED_BLK_MAX );
+  FD_TEST( parsed_A );
+  int rv_A = fd_fec_resolver_add_shred( r, parsed_A, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BHP-627 integration: add_shred(shred_A, Sig_A) returned %d", rv_A ));
+  FD_TEST( rv_A == FD_FEC_RESOLVER_SHRED_OKAY );
+
+  fd_shred_t const * parsed_B = fd_shred_parse( shred_B_buf, FD_SHRED_MIN_SZ, FD_SHRED_BLK_MAX );
+  FD_TEST( parsed_B );
+  int rv_B = fd_fec_resolver_add_shred( r, parsed_B, FD_SHRED_MIN_SZ, MAX, 0, pubkey,
+                                        out_fec, out_shred, out_merkle_root, NULL );
+  FD_LOG_NOTICE(( "BHP-627 integration: add_shred(shred_B, Sig_B) returned %d", rv_B ));
+
+  /* Simulate the tower-tile propagation.  In the real tile:
+       fd_shred_tile.c publishes SHRED_SIG_RESULT_EQVOC when the
+         resolver returns EQUIVOC (fd_shred_tile.c:997).
+       fd_tower_tile.c:1732 calls fd_eqvoc_shred_insert with
+         shred_hint=1.
+       fd_eqvoc.c:717-728 inserts a proof.
+       fd_tower_tile.c:1268-1275 fires fd_ghost_eqvoc on SLOT_COMPLETED.
+     For this test we compress the whole chain into a single
+     conditional: if the resolver reports EQUIVOC, invoke
+     fd_ghost_eqvoc on the equivocated slot. */
+  if( rv_B == FD_FEC_RESOLVER_SHRED_EQUIVOC ) {
+    FD_LOG_NOTICE(( "BHP-627 integration: resolver returned EQUIVOC; "
+                    "simulating tower-tile propagation to fd_ghost_eqvoc" ));
+    fd_ghost_eqvoc( ghost, &eqvoc_id );
+  }
+
+  /* Load-bearing assertion: eqvoc_blk stays valid.  For the block to
+     retain a chance of receiving FD's vote, the ghost's valid flag
+     must not be zeroed.
+     - Before fix: rv_B == EQUIVOC, fd_ghost_eqvoc runs, valid drops
+       to 0 (fd_ghost.c:638), this assertion fails.
+     - After fix: rv_B == IGNORED, fd_ghost_eqvoc is skipped, valid
+       stays 1, this assertion passes. */
+  FD_TEST( eqvoc_blk->valid == 1 );
+  FD_TEST( child_blk->valid == 1 );
+  FD_TEST( root_blk->valid  == 1 );
+  FD_LOG_NOTICE(( "BHP-627 integration: eqvoc_blk.valid=%d child_blk.valid=%d "
+                  "-- vote path preserved", eqvoc_blk->valid, child_blk->valid ));
+
+  /* Fork-choice remains selectable on the eqvoc slot's subtree.
+     fd_ghost_best traverses through valid children only; child_blk
+     is a leaf and eqvoc_blk is its parent, both valid, so best from
+     root reaches child_blk. */
+  fd_ghost_blk_t * best = fd_ghost_best( ghost, root_blk );
+  FD_TEST( best == child_blk );
+  FD_LOG_NOTICE(( "BHP-627 integration: fd_ghost_best(root) == child (slot %lu) "
+                  "-- fork-choice can still select the eqvoc subtree", best->slot ));
+
+  /* fd_ghost_invalid_ancestor on child returns NULL (no invalid
+     ancestor on the fork). */
+  FD_TEST( fd_ghost_invalid_ancestor( ghost, child_blk ) == NULL );
+
+  fd_fec_resolver_delete( fd_fec_resolver_leave( r ) );
+  fd_wksp_free_laddr( fd_ghost_delete( fd_ghost_leave( ghost ) ) );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  fd_metrics_register( (ulong *)fd_metrics_new( bhp627_metrics_scratch, 0UL ) );
+
+  char const * _page_sz = fd_env_strip_cmdline_cstr ( &argc, &argv, "--page-sz",  NULL, "gigantic"               );
+  ulong        page_cnt = fd_env_strip_cmdline_ulong( &argc, &argv, "--page-cnt", NULL, 1UL                      );
+  ulong        numa_idx = fd_env_strip_cmdline_ulong( &argc, &argv, "--numa-idx", NULL, fd_shmem_numa_idx( 0UL ) );
+  fd_wksp_t *  wksp     = fd_wksp_new_anonymous( fd_cstr_to_shmem_page_sz( _page_sz ), page_cnt, fd_shmem_cpu_idx( numa_idx ), "wksp", 0UL );
+  FD_TEST( wksp );
+
+  FD_LOG_NOTICE(( "BHP-627 integration test: resolver -> ghost vote-path preservation" ));
+
+  test_bhp_627_end_to_end( wksp );
+
+  FD_LOG_NOTICE(( "BHP-627 integration test pass" ));
+
+  fd_wksp_delete_anonymous( wksp );
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
### Summary

  Firedancer's FEC resolver returns `FD_FEC_RESOLVER_SHRED_EQUIVOC` when two shreds in the same FEC set carry different-but-valid ed25519 signatures over the **same** reconstructed merkle root. This is a false
  positive: the two shreds are consistent (same merkle root, same reconstructable content), so the FEC set should complete normally. Instead, the incorrect EQUIVOC verdict propagates through the shred/tower
  tiles into `fd_ghost_eqvoc`, marks the block invalid, and causes FD to abstain from voting on a block Agave votes on — a fork-choice divergence between the two clients.

  The fix aligns FD's semantics with Agave's `check_merkle_root_consistency` (`agave/ledger/src/blockstore.rs:3010`): only flag equivocation when merkle roots actually differ.

  ### Root cause

  `fd_fec_resolver` keys its in-progress FEC-set map by ed25519 signature bytes (`MAP_KEY = sig`). The `(slot, fec_set_idx)` treap is a secondary index whose only purpose is catching "same FEC set, different
  signature". Any hit sets `equivoc_or_invalid=1` and — after per-shred sigverify succeeds — the resolver returns `SHRED_EQUIVOC` without checking whether the merkle roots actually differ.

  This produces a false positive whenever a leader emits two valid signatures over the same merkle root. RFC-8032 deterministic-`k` is a signer-side property, not a verifier requirement — signers that use
  randomized `k` (permitted by RFC 8032) or that lose deterministic-nonce state across a restart can produce byte-different signatures for the same `(sk, M)` pair that both pass verify.

  The buggy propagation chain:

  ```
  fd_fec_resolver EQUIVOC (false positive)
    -> fd_shred_tile.c:997        (SHRED_SIG_RESULT_EQVOC)
    -> fd_tower_tile.c:1732       (fd_eqvoc_shred_insert, shred_hint=1)
    -> fd_eqvoc.c:717-728         (dup_insert)
    -> fd_tower_tile.c:1268-1275  (fd_ghost_eqvoc on SLOT_COMPLETED)
    -> fd_ghost.c:638             (mark_invalid zeros valid on subtree)
    -> FD refuses to vote for the slot; Agave votes normally.
  ```

  ### Fix

  `src/disco/shred/fd_fec_resolver.c` — Before returning `SHRED_EQUIVOC` on the treap-hit path:

  1. Look up the existing FEC set's merkle root (via `ctx_treap` for in-progress or `done_map` for completed).
  2. If it matches the newly reconstructed root → return `SHRED_IGNORED` (Agave-equivalent behavior).
  3. If it differs → keep the existing `SHRED_EQUIVOC` path with `SIG_HASH_EQUIVOC` stamp (genuine equivocation).

  To support (1), `done_ele_t` gains a 32-byte `merkle_root` field (struct grows 32→64 bytes; `FD_STATIC_ASSERT` updated). Populated at both the FEC-set completion path and the equivoc-stamp path.

  ### Commits (test-first)

  Each commit's tests demonstrably fail on unfixed code and pass with the fix:

  - **`divergence(BP627)`** — Adds `src/disco/shred/test_fec_resolver_bp627.c`. Crafts a valid 32-data/32-parity chained-merkle FEC set at `slot=100, fec_set_idx=0`, then produces a second valid ed25519
  signature `Sig_B` over the same merkle root via an RFC-8032-compatible signer with a distinct nonce. Asserts `shred_A` returns `OKAY`, `shred_B` returns `IGNORED`, resent `shred_B` returns `IGNORED`. Also
  adds a `test_bp627_real_equivocation` subtest: two distinct FEC sets at the same `(slot, fec_set_idx)` with different merkle roots must still return `EQUIVOC` (regression guard). **Fails on unfixed 
  resolver** (returns `EQUIVOC=-4`, test expects `IGNORED=-2`).

  - **`integration(BHP-627)`** — Adds `src/discof/tower/test_bhp_627_integration/`. Drives the resolver end-to-end with the same crafted shred pair, builds a minimal ghost tree (`root → eqvoc → child`), and
  simulates the tower-tile propagation: iff the resolver reports `EQUIVOC`, invokes `fd_ghost_eqvoc` on the eqvoc slot's block-id. Asserts `eqvoc_blk->valid == 1`, `fd_ghost_best(root) == child`, and
  `fd_ghost_invalid_ancestor(child) == NULL`. Companion `RUN.md` documents the test and specifies the two-validator co-run harness that would confirm the fork-choice divergence across the full tile stack.
  **Fails on unfixed resolver** (`EQUIVOC` → propagation → `mark_invalid` → `valid == 0`, assertion trips).

  - **`fix(BP627)`** — Applies the resolver fix. Both tests pass.

  ### Test plan

  - [ ] `make -j test_fec_resolver_bp627 && ./build/native/gcc/unit-test/test_fec_resolver_bp627` → PASS (same-root: `OKAY → IGNORED → IGNORED`; different-root: `OKAY → EQUIVOC`).
  - [ ] `make -j test_bhp_627_integration && ./build/native/gcc/unit-test/test_bhp_627_integration --page-sz normal --page-cnt 512` → PASS (resolver returns `IGNORED`, ghost block stays valid).
  - [ ] `make -j test_fec_resolver && ./build/native/gcc/unit-test/test_fec_resolver` → PASS (neighbor suite, no regression).
  - [ ] `make -j firedancer-dev` → builds clean.

  ### Files

  | File | Change |
  |---|---|
  | `src/disco/shred/fd_fec_resolver.c` | +64 / −15 (merkle-root compare, `done_ele_t` merkle_root field) |
  | `src/disco/shred/test_fec_resolver_bp627.c` | +422 (new unit test) |
  | `src/disco/shred/Local.mk` | +2 (register `test_fec_resolver_bp627`) | 
  | `src/discof/tower/test_bhp_627_integration/test_bhp_627_integration.c` | +360 (new integration test) |
  | `src/discof/tower/test_bhp_627_integration/RUN.md` | +96 (run notes + harness spec) |
  | `src/discof/tower/Local.mk` | +1 (register `test_bhp_627_integration`) |

  ### Scope and limitations

  - Firedancer-only; targets the C-side FEC resolver. No Agave-side changes needed.
  - The integration test compresses the tile-layer propagation into a single conditional call to `fd_ghost_eqvoc` — it does not run the full shred → tower → vote-emit tile stack. `RUN.md` specifies the
  two-validator co-run harness that would confirm the fork-choice divergence in production shape.
  - No repair-path change: `is_repair` continues to bypass the treap check (the fix acts on the same Turbine-ingest path where the false positive originally manifested).
