### PR TITLE
Use constant-time comparison for GCM authentication tag verification

### DIFF
--- a/src/ballet/aes/fd_aes_gcm_ref.c
+++ b/src/ballet/aes/fd_aes_gcm_ref.c
@@ -7,6 +7,17 @@
 #define fd_gcm_gmult fd_gcm_gmult_4bit
 #define fd_gcm_ghash fd_gcm_ghash_4bit
 
+/* fd_aes_gcm_tag_eq compares two 16-byte GCM authentication tags in
+   constant time (independent of where the first differing byte is),
+   to avoid a timing side channel on tag verification. */
+static inline int
+fd_aes_gcm_tag_eq( uchar const * a,
+                    uchar const * b ) {
+  uchar diff = 0;
+  for( ulong i=0UL; i<16UL; i++ ) diff = (uchar)( diff | (uchar)( a[i] ^ b[i] ) );
+  return diff==0;
+}
+
 static void
 fd_aes_gcm_setiv( fd_aes_gcm_ref_t * gcm,
                   uchar const        iv[ 12 ] ) {
@@ -282,5 +293,5 @@ fd_aes_gcm_decrypt_ref( fd_aes_gcm_ref_t * aes_gcm,
 
   /* CRYPTO_gcm128_finish */
   fd_gcm128_finish( aes_gcm );
-  return 0==memcmp( aes_gcm->Xi.c, tag, 16 );  /* TODO USE CONSTANT TIME COMPARE */
+  return fd_aes_gcm_tag_eq( aes_gcm->Xi.c, tag );
 }


### PR DESCRIPTION
## Summary

\`fd_aes_gcm_ref.c\` verifies the computed GCM authentication tag against the received tag using \`memcmp\`, which the surrounding comment already flags: \`/* TODO USE CONSTANT TIME COMPARE */\`.

\`memcmp\` (and this codebase's own \`fd_memeq\` — checked, it also early-exits via \`repe cmpsb\` on x86 or falls back to plain \`memcmp\`) is not constant-time: it can return as soon as it finds a differing byte. For an authenticated decryption tag check, this opens a theoretical timing side channel: an attacker who can measure response timing precisely enough (same host, or very low-jitter local network) could in principle learn the tag byte-by-byte faster than brute force, since a comparison that fails earlier (first byte mismatch) is measurably faster than one that fails later.

This PR replaces the tag comparison with an explicit constant-time compare (XOR-accumulate over all 16 bytes, single branch at the end) so comparison time is independent of where the first mismatch occurs.

## Testing

Built and tested on native Linux x86-64 (Ubuntu 24.04, gcc 13.3):

\`\`\`
$ source activate && make test_aes
CC	fd_aes_gcm_ref.o
AR	libfd_ballet.a
LD	test_aes (unit-test)

$ ./build/native/gcc/unit-test/test_aes
NOTICE  test_aes.c(542): Using AES-ECB AESNI backend
NOTICE  test_aes.c(550): Using AES-GCM AVX2 AESNI backend
NOTICE  test_aes.c(563): pass
\`\`\`

\`test_aes\` passes with the same result as the unmodified baseline (confirmed both before and after the change), including the existing corrupted-tag test case (\`test_aes.c:460\`) — the new constant-time comparison correctly rejects invalid tags, same as before.

## Disclosure

Found via an independent, read-only source review exercise. No exploit was constructed or run — this addresses the TODO already present in the code.