### PR TITLE
Guard against FD_TCACHE_TAG_NULL collision in dedup tile

### DIFF
--- a/src/disco/dedup/fd_dedup_tile.c
+++ b/src/disco/dedup/fd_dedup_tile.c
@@ -117,6 +117,7 @@ during_frag( fd_dedup_ctx_t * ctx,
       fd_replay_txn_executed_t * txn_executed = fd_type_pun( src );
       if( FD_UNLIKELY( !txn_executed->is_committable ) ) return;
       ulong ha_dedup_tag = fd_hash( ctx->hashmap_seed, fd_txn_get_signatures( TXN(txn_executed->txn), txn_executed->txn->payload ), FD_TXN_SIGNATURE_SZ );
+      if( FD_UNLIKELY( fd_tcache_tag_is_null( ha_dedup_tag ) ) ) ha_dedup_tag = 1UL; /* avoid colliding with the tcache empty-slot sentinel (FD_TCACHE_INSERT/QUERY assume tag is never null) */
       int _is_dup;
       FD_TCACHE_INSERT( _is_dup, *ctx->tcache_sync, ctx->tcache_ring, ctx->tcache_depth, ctx->tcache_map, ctx->tcache_map_cnt, ha_dedup_tag );
       (void)_is_dup;
@@ -126,6 +127,7 @@ during_frag( fd_dedup_ctx_t * ctx,
     /* Executed txns just have their signature inserted into the tcache
        so we can dedup them easily. */
     ulong ha_dedup_tag = fd_hash( ctx->hashmap_seed, src, FD_TXN_SIGNATURE_SZ );
+    if( FD_UNLIKELY( fd_tcache_tag_is_null( ha_dedup_tag ) ) ) ha_dedup_tag = 1UL;
     int _is_dup;
     FD_TCACHE_INSERT( _is_dup, *ctx->tcache_sync, ctx->tcache_ring, ctx->tcache_depth, ctx->tcache_map, ctx->tcache_map_cnt, ha_dedup_tag );
     (void)_is_dup;
@@ -191,6 +193,7 @@ after_frag( fd_dedup_ctx_t *    ctx,
   if( FD_LIKELY( !txnm->block_engine.bundle_id ) ) {
     /* Compute fd_hash(signature) for dedup. */
     ulong ha_dedup_tag = fd_hash( ctx->hashmap_seed, fd_txn_m_payload( txnm )+txn->signature_off, 64UL );
+    if( FD_UNLIKELY( fd_tcache_tag_is_null( ha_dedup_tag ) ) ) ha_dedup_tag = 1UL;
 
     FD_TCACHE_INSERT( is_dup, *ctx->tcache_sync, ctx->tcache_ring, ctx->tcache_depth, ctx->tcache_map, ctx->tcache_map_cnt, ha_dedup_tag );
   } else {

--- a/src/tango/tcache/test_tcache.c
+++ b/src/tango/tcache/test_tcache.c
@@ -101,6 +101,31 @@ main( int     argc,
     FD_TEST( map[ map_idx ]==tag );
   }
 
+  FD_LOG_NOTICE(( "Testing null tag precondition (documents caller responsibility, not a tcache bug)" ));
+
+  /* FD_TCACHE_QUERY/INSERT explicitly assume tag is never
+     FD_TCACHE_TAG_NULL (0) -- that value is the "empty slot" sentinel.
+     If a caller passes tag==0 anyway (e.g. an unchecked hash output
+     that happens to collide with 0), it is treated as matching any
+     empty slot: found comes back true even though nothing was ever
+     inserted for that tag, and INSERT never actually stores it.  This
+     confirms callers computing tags from untrusted/hashed input (like
+     disco/dedup/fd_dedup_tile.c) must remap a null tag to a non-null
+     sentinel before calling QUERY/INSERT -- this is NOT something the
+     macro itself can safely detect for you, by design (documented
+     precondition, checked here for regression coverage). */
+  {
+    int   null_found;
+    ulong null_map_idx;
+    FD_TCACHE_QUERY( null_found, null_map_idx, map, map_cnt, FD_TCACHE_TAG_NULL );
+    FD_TEST( null_found ); /* matches the first empty slot probed, even though tag 0 was never inserted */
+    (void)null_map_idx;
+
+    int null_dup;
+    FD_TCACHE_INSERT( null_dup, oldest, ring, depth, map, map_cnt, FD_TCACHE_TAG_NULL );
+    FD_TEST( null_dup ); /* "duplicate" on the very first insert of tag 0 -- it is silently never stored */
+  }
+
   FD_LOG_NOTICE(( "Testing remove" ));
 
   for( ulong seq=0UL; seq<depth; seq++ ) {


### PR DESCRIPTION
## Summary

\`fd_tcache.h\` documents that \`FD_TCACHE_QUERY\`/\`FD_TCACHE_INSERT\` assume the tag is never \`FD_TCACHE_TAG_NULL\` (0) — that value is reserved as the empty-slot sentinel. None of the three call sites in \`fd_dedup_tile.c\` (in \`during_frag\`/\`after_frag\`) checked this precondition before calling \`FD_TCACHE_INSERT\` with a hash-derived tag.

If a transaction signature happens to hash to exactly \`0\` via \`fd_hash(hashmap_seed, sig, ...)\`, \`FD_TCACHE_INSERT\`/\`QUERY\` treat it as an empty slot and report \`is_dup=1\` unconditionally, silently dropping that transaction the first time it is seen (never actually inserted into the map). This is practically low-risk since \`hashmap_seed\` is a per-process CSPRNG value never exposed (finding a colliding signature requires an infeasible ~2^64 blind search), but it's a real, consistently-missing precondition check across all three call sites — and the codebase already has a helper for exactly this case (\`fd_tcache_tag_is_null\`, used elsewhere in \`fd_tcache.h\` itself).

This PR adds an explicit guard: if the computed tag is null, remap it to a fixed non-null sentinel (\`1UL\`) before calling \`FD_TCACHE_INSERT\`/\`QUERY\`, so the null-tag transaction gets deduped correctly like any other tag instead of silently colliding with the empty-slot marker.

## Testing

Adds a regression test to \`test_tcache.c\` (already an active unit test in the build) documenting the underlying macro behavior with \`tag==0\`: \`FD_TCACHE_QUERY\` reports \`found\` against an empty slot even though nothing was inserted, and \`FD_TCACHE_INSERT\` reports it as a duplicate on the very first insert — making the documented precondition explicit and catching any future regression in \`fd_tcache.h\` itself.

Built and tested on native Linux x86-64 (Ubuntu 24.04, gcc 13.3) at commit \`3d3e8007d4d8d9edd039691eba4dccc6c5230f93\`:

- Full project build (\`make -j\`) completes with no errors, including \`firedancer\`/\`firedancer-dev\` binaries.
- \`test_tcache\` passes (\`pass\`), including the new null-tag section.

\`test_dedup.c\` (the dedup tile's own unit test) is currently disabled in \`src/disco/dedup/Local.mk\` (commented out), so I validated the tcache-level behavior directly instead of trying to resurrect that test blind.

## Disclosure

Found via an independent, read-only source review exercise. No exploit was constructed or run.