### PR TITLE
events: fix misaligned circq test buffers

### DIFF
--- a/src/disco/events/test_circq.c
+++ b/src/disco/events/test_circq.c
@@ -3,7 +3,7 @@
 
 static void
 test_fuzz( void ) {
-  uchar buf[ 128UL+4096UL ];
+  uchar buf[ 128UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 128 ) );
 
   fd_rng_t _rng[1];
@@ -17,7 +17,7 @@ test_fuzz( void ) {
 
 static void
 test_cursor_lifecycle( void ) {
-  uchar buf[ 256UL+4096UL ];
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
   ulong msg_sz;
 
@@ -48,7 +48,7 @@ test_cursor_lifecycle( void ) {
 
 static void
 test_ack_protocol( void ) {
-  uchar buf[ 512UL+4096UL ];
+  uchar buf[ 512UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 512UL ) );
   ulong msg_sz;
 
@@ -81,7 +81,7 @@ test_ack_protocol( void ) {
 
 static void
 test_pop_until_rejects_unadvanced_cursor( void ) {
-  uchar buf[ 512UL+4096UL ];
+  uchar buf[ 512UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 512UL ) );
   ulong msg_sz;
 
@@ -114,7 +114,7 @@ test_pop_until_rejects_unadvanced_cursor( void ) {
 
 static void
 test_wraparound_iteration( void ) {
-  uchar buf[ 256UL+4096UL ];
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
   ulong msg_sz;
 
@@ -137,7 +137,7 @@ test_wraparound_iteration( void ) {
 
 static void
 test_interleaved_ops( void ) {
-  uchar buf[ 512UL+4096UL ];
+  uchar buf[ 512UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 512UL ) );
   ulong msg_sz;
 
@@ -170,7 +170,7 @@ test_interleaved_ops( void ) {
 
 static void
 test_stale_cursor_handling( void ) {
-  uchar buf[ 256UL+4096UL ];
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
   ulong msg_sz;
 
@@ -232,7 +232,7 @@ test_overrun_recover( void ) {
 
 static void
 test_pop_recover( void ) {
-  uchar buf[ 256UL+4096UL ];
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
   ulong msg_sz = 0UL;
 
@@ -257,7 +257,7 @@ test_pop_recover( void ) {
 
 static void
 test_cursor_sequence_monotonicity( void ) {
-  uchar buf[ 512UL+4096UL ];
+  uchar buf[ 512UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 512UL ) );
   ulong msg_sz;
 
@@ -285,7 +285,7 @@ test_cursor_sequence_monotonicity( void ) {
 
 static void
 test_edge_cases( void ) {
-  uchar buf[ 256UL+4096UL ];
+  uchar buf[ 256UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
   ulong msg_sz;
 
@@ -318,7 +318,7 @@ test_edge_cases( void ) {
 
 static void
 test_bounds( void ) {
-  uchar buf[ 128UL+4096UL ];
+  uchar buf[ 128UL+4096UL ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 1024UL ) );
 
   FD_TEST( fd_circq_push_back( circq, 1UL, 1024UL-25UL ) );


### PR DESCRIPTION
Calling tested functions with unaligned buf variables was causing segfaults. 
```assembly
(gdb) disas
Dump of assembler code for function fd_circq_new
   0x0000555555563d20 <+0>:	vpxor  xmm0,xmm0,xmm0
   0x0000555555563d24 <+4>:	mov    QWORD PTR [rdi+0x30],0x0
   0x0000555555563d2c <+12>:	mov    QWORD PTR [rdi+0x38],0x0
   0x0000555555563d34 <+20>:	mov    rax,rdi
   0x0000555555563d37 <+23>:	vmovdqa ymm1,ymm0
   0x0000555555563d3b <+27>:	vpinsrq xmm0,xmm0,rsi,0x1
   0x0000555555563d41 <+33>:	vinserti128 ymm1,ymm1,xmm0,0x1
   0x0000555555563d47 <+39>:	vmovdqa xmm0,XMMWORD PTR [rip+0xffffffffffff94a1]        # 0x55555555d1f0
=> 0x0000555555563d4f <+47>:	vmovdqa YMMWORD PTR [rdi],ymm1  
   0x0000555555563d53 <+51>:	vmovdqa XMMWORD PTR [rdi+0x20],xmm0
   0x0000555555563d58 <+56>:	vzeroupper
   0x0000555555563d5b <+59>:	ret
End of assembler dump.
(gdb)
```
vmovdqa requires 32 byte alignment for YMM registers. rdi register is the buf variable, which causes the segfault;
```assembly
0x0000555555563d4f in fd_circq_new (shmem=0x7fffffffc570, sz=256) at src/disco/events/fd_circq.c:32
32	  circq->cnt  = 0UL;
(gdb) up
#1  0x00005555555621ac in test_cursor_lifecycle () at src/disco/events/test_circq.c:21
21	  fd_circq_t * circq = fd_circq_join( fd_circq_new( buf, 256UL ) );
(gdb) print &buf
$1 = (uchar (*)[4352]) 0x7fffffffc570
(gdb) down
#0  0x0000555555563d4f in fd_circq_new (shmem=0x7fffffffc570, sz=256) at src/disco/events/fd_circq.c:32
32	  circq->cnt  = 0UL;
(gdb) info registers
rax            0x7fffffffc570      140737488340336
rbx            0x18c2d43e6c383f06  1784221766960824070
rcx            0x14f               335
rdx            0x0                 0
rsi            0x100               256
rdi            0x7fffffffc570      140737488340336 // same address with &buf
```
```assembly
(gdb) p (unsigned long)$rdi & 31
$2 = 16 
(gdb) p (unsigned long)$rdi & 15
$3 = 0
(gdb)
``` 
After the fix, the tests are all passing, with a warning from test_interleaved_ops(), but it shows the function doing its job
WARNING 07-16 20:14:53.524023 0         fd_circq.c(139): tried to push message which was too large 1025>1024
arch zen 3 