### PR TITLE
set-identity: fixing publish tower race

### DIFF
--- a/src/discof/admin/fd_admin_tile.c
+++ b/src/discof/admin/fd_admin_tile.c
@@ -129,15 +129,37 @@ unprivileged_init( fd_topo_t const *      topo,
      will not be used. */
 #define FD_SET_IDENTITY_STATE_LEADER_HALTED           (3UL)
 
-/* State 4: REPLAY_HALT_REQUESTED
-     Repair, Gossip, and Tower tiles will stop sending requests
-     downstream to the sign tile.  This is done to avoid any mismatches
-     with the identity key.  Their identity keys will be switched after
-     this step.  These tiles all use the identity key to make forward
-     progress on non-leader pipeline replay.
+/* State 4: TOWER_HALT_REQUESTED
+     Tower has been requested to stop producing new vote transactions,
+     drain its local publish queue, and switch identity.  Gossip and
+     TxSend remain active so Tower continues receiving output credits. */
+#define FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED    (4UL)
 
-     These tiles use the identity key to populate messages which are
-     signed by the sign tile:
+/* State 5: TOWER_HALTED
+     Tower has drained its pre-switch publish queue, switched identity,
+     and reported the sequence after the final drained message. */
+#define FD_SET_IDENTITY_STATE_TOWER_HALTED             (5UL)
+
+/* State 6: TXSEND_FLUSH_REQUESTED
+     TxSend has been told the Tower sequence through which it must
+     process messages before switching identity.  Gossip remains active
+     in this state so it continues returning credits on tower_out and
+     txsend_out. */
+#define FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED  (6UL)
+
+/* State 7: TXSEND_FLUSHED
+     TxSend has processed all Tower messages through the halt sequence,
+     switched its identity key, and stopped receiving Net fragments that
+     could invoke QUIC signing callbacks. */
+#define FD_SET_IDENTITY_STATE_TXSEND_FLUSHED          (7UL)
+
+/* State 8: SIGNERS_HALT_REQUESTED
+     Repair and Gossip will stop sending requests downstream to the sign
+     tile.  This is done to avoid any mismatches with the identity key.
+     Their identity keys will be switched after this step.
+
+     These tiles use the identity key to populate messages signed by the
+     sign tile:
        (a) Repair.  The repair tile uses the identity key as part of the
            repair protocol.  The identity key is included in and used
            for signing requests.  Because Repair uses an asynchronous
@@ -146,48 +168,15 @@ unprivileged_init( fd_topo_t const *      topo,
            sign tile before halting any new signing requests.
        (b) Gossip.  The gossip tile sends out ContactInfo messages with
            our identity key, and also uses the identity key to sign
-           outgoing gossip messages.
-       (c) Tower.  The tower tiles uses the identity key to generate
-           vote transactions which are sent to the send tile.  These
-           vote transactions are then signed downstream by the TxSend
-           tile instead of having its own keyguard client. */
-#define FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED   (4UL)
+           outgoing gossip messages. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED  (8UL)
 
-/* State 5: REPLAY_HALTED
-     Repair, Gossip, and Tower are no longer sending requests to the
-     sign tile.  Replay can keep progressing at this point. However,
-     the tower tile may have an in-flight vote transaction to the TxSend
-     tile that corresponds to the old identity key. */
-#define FD_SET_IDENTITY_STATE_REPLAY_HALTED           (5UL)
+/* State 9: SIGNERS_HALTED
+     Repair and Gossip are no longer sending requests to the sign tile.
+     Tower and TxSend remain halted. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_HALTED          (9UL)
 
-/* State 6: TXSEND_FLUSH_REQUESTED
-     Once the Tower tile has updated its identity key and stopped
-     sending vote transactions to the TxSend tile, any in-flight vote
-     transactions for the old identity key must be flushed to avoid
-     being badly signed.  We also know that Tower will send no more
-     vote transactions to the TxSend tile.
-
-     The TxSend tile is flushed by telling it the last sequence number
-     the Tower tile has produced for an outgoing vote transaction at the
-     time it was halted.  Once the TxSend tile has processed all vote
-     transactions up to and including that sequence number, it will
-     switch its own identity key.  There is a guarantee that the TxSend
-     tile will not request to sign any vote transactions until it is
-     unhalted.  At this point, the TxSend tile will stop receiving any
-     new frags from the Net tile.  The reason for this is to avoid any
-     QUIC callbacks that invoke key signing. */
-#define FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED  (6UL)
-
-/* State 7: TXSEND_FLUSHED
-     The TxSend tile confirms that it has seen and processed all votes
-     up to and including the last sequence number produced by the Tower
-     tile at the time it was halted.  The TxSend tile also switches its
-     own identity key which is used for signing votes and establishing
-     a QUIC connection.  The TxSend tile is now no longer receiving any
-     new frags from the Net tile. */
-#define FD_SET_IDENTITY_STATE_TXSEND_FLUSHED          (7UL)
-
-/* State 8: ALL_SWITCH_REQUESTED
+/* State 10: ALL_SWITCH_REQUESTED
      The client now requests that all other tiles which consume the
      identity key in some way switch to the new key.  The leader
      pipeline is still halted, although it doesn't strictly need to be,
@@ -212,31 +201,32 @@ unprivileged_init( fd_topo_t const *      topo,
            outgoing shreds.
        (f) Event.  Outgoing events to the event server are signed with
            the identity key to authenticate the sender. */
-#define FD_SET_IDENTITY_STATE_ALL_SWITCH_REQUESTED    (8UL)
+#define FD_SET_IDENTITY_STATE_ALL_SWITCH_REQUESTED    (10UL)
 
-/* State 9: ALL_SWITCHED
+/* State 11: ALL_SWITCHED
      All remaining tiles that use the identity key have confirmed that
      they have switched to the new key.  The validator is now fully
      switched over. */
-#define FD_SET_IDENTITY_STATE_ALL_SWITCHED            (9UL)
+#define FD_SET_IDENTITY_STATE_ALL_SWITCHED            (11UL)
 
-/* State 10: REPLAY_UNHALT_REQUESTED
+/* State 12: SIGNERS_UNHALT_REQUESTED
      Now that all of the tiles are using the switched identity key, the
      tiles that rely on the sign tile can be unhalted.  These are the
-     same tiles from REPLAY_HALT_REQUESTED. */
-#define FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED (10UL)
+     same tiles from SIGNERS_HALT_REQUESTED, along with Tower and
+     TxSend. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALT_REQUESTED (12UL)
 
-/* State 11: REPLAY_UNHALTED
+/* State 13: SIGNERS_UNHALTED
      All tiles that rely on the sign tile have been unhalted and now the
      validator can resume making progress on replay. */
-#define FD_SET_IDENTITY_STATE_REPLAY_UNHALTED         (11UL)
+#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED         (13UL)
 
-/* State 12: LEADER_UNHALT_REQUESTED
+/* State 14: LEADER_UNHALT_REQUESTED
      The final state, now that all tiles have switched, the leader
      pipeline can be unblocked and the validator can resume producing
      blocks.  The next state once the Replay tile confirms the leader
      pipeline is unlocked, is UNLOCKED. */
-#define FD_SET_IDENTITY_STATE_LEADER_UNHALT_REQUESTED (12UL)
+#define FD_SET_IDENTITY_STATE_LEADER_UNHALT_REQUESTED (14UL)
 
 static fd_keyswitch_t *
 find_identity_keyswitch( fd_admin_tile_ctx_t * ctx,
@@ -297,12 +287,63 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       break;
     }
     case FD_SET_IDENTITY_STATE_LEADER_HALTED: {
+      fd_keyswitch_t * tower = find_identity_keyswitch( ctx, "tower" );
+      memcpy( tower->bytes, keypair+32UL, 32UL );
+      FD_COMPILER_MFENCE();
+      tower->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
+      FD_COMPILER_MFENCE();
+
+      *state = FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED;
+      FD_LOG_INFO(( "Pausing Tower and draining queued messages..." ));
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED: {
+      fd_keyswitch_t * tower = find_identity_keyswitch( ctx, "tower" );
+      if( FD_LIKELY( tower->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
+        fd_memzero_explicit( tower->bytes, 64UL );
+        FD_COMPILER_MFENCE();
+        *state = FD_SET_IDENTITY_STATE_TOWER_HALTED;
+        FD_LOG_INFO(( "Tower successfully paused..." ));
+      } else if( FD_UNLIKELY( tower->state==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
+        FD_SPIN_PAUSE();
+      } else {
+        FD_LOG_ERR(( "Unexpected tower keyswitch state %lu", tower->state ));
+      }
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TOWER_HALTED: {
+      ulong tower_halted_seq = find_identity_keyswitch( ctx, "tower" )->result;
+      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
+      txsend->param = tower_halted_seq;
+      memcpy( txsend->bytes, keypair+32UL, 32UL );
+      FD_COMPILER_MFENCE();
+      txsend->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
+      FD_COMPILER_MFENCE();
+
+      *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED;
+      FD_LOG_INFO(( "Flushing old identity vote transactions from TxSend..." ));
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED: {
+      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
+      if( FD_LIKELY( txsend->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
+        fd_memzero_explicit( txsend->bytes, 64UL );
+        FD_COMPILER_MFENCE();
+        *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSHED;
+        FD_LOG_INFO(( "TxSend successfully flushed..." ));
+      } else if( FD_UNLIKELY( txsend->state==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
+        FD_SPIN_PAUSE();
+      } else {
+        FD_LOG_ERR(( "Unexpected txsend keyswitch state %lu", txsend->state ));
+      }
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TXSEND_FLUSHED: {
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
         if( FD_LIKELY( tile->id_keyswitch_obj_id==ULONG_MAX ) ) continue;
         if( strcmp( tile->name, "repair" ) &&
-            strcmp( tile->name, "gossip" ) &&
-            strcmp( tile->name, "tower" ) ) {
+            strcmp( tile->name, "gossip" ) ) {
           continue;
         }
 
@@ -313,18 +354,17 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
         tile_ks->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
         FD_COMPILER_MFENCE();
       }
-      *state = FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED;
-      FD_LOG_INFO(( "Requesting to halt all signers..." ));
+      *state = FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED;
+      FD_LOG_INFO(( "Requesting to halt remaining signers..." ));
       break;
     }
-    case FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED: {
+    case FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED: {
       int all_switched = 1;
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
         if( FD_LIKELY( tile->id_keyswitch_obj_id==ULONG_MAX ) ) continue;
         if( strcmp( tile->name, "repair" ) &&
-            strcmp( tile->name, "gossip" ) &&
-            strcmp( tile->name, "tower" ) ) {
+            strcmp( tile->name, "gossip" ) ) {
           continue;
         }
 
@@ -335,37 +375,14 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
         }
       }
       if( FD_LIKELY( all_switched ) ) {
-        FD_LOG_INFO(( "All successfully switched identity key..." ));
-        *state = FD_SET_IDENTITY_STATE_REPLAY_HALTED;
+        FD_LOG_INFO(( "All remaining signers successfully halted..." ));
+        *state = FD_SET_IDENTITY_STATE_SIGNERS_HALTED;
       } else {
         FD_SPIN_PAUSE();
       }
       break;
     }
-    case FD_SET_IDENTITY_STATE_REPLAY_HALTED: {
-      ulong tower_halted_seq = find_identity_keyswitch( ctx, "tower" )->result;
-      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
-      txsend->param = tower_halted_seq;
-      memcpy( txsend->bytes, keypair+32UL, 32UL );
-      FD_COMPILER_MFENCE();
-      txsend->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
-      FD_COMPILER_MFENCE();
-
-      *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED;
-      break;
-    }
-    case FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED: {
-      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
-      if( FD_LIKELY( txsend->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
-        fd_memzero_explicit( txsend->bytes, 64UL );
-        FD_COMPILER_MFENCE();
-        *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSHED;
-      } else {
-        FD_SPIN_PAUSE();
-      }
-      break;
-    }
-    case FD_SET_IDENTITY_STATE_TXSEND_FLUSHED: {
+    case FD_SET_IDENTITY_STATE_SIGNERS_HALTED: {
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
         if( strcmp( tile->name, "sign" ) ) continue;
@@ -453,10 +470,10 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       }
 
       FD_LOG_INFO(( "Requesting to unpause signers..." ));
-      *state = FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED;
+      *state = FD_SET_IDENTITY_STATE_SIGNERS_UNHALT_REQUESTED;
       break;
     }
-    case FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED: {
+    case FD_SET_IDENTITY_STATE_SIGNERS_UNHALT_REQUESTED: {
       int all_switched = 1;
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
@@ -476,13 +493,13 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       }
       if( FD_LIKELY( all_switched ) ) {
         FD_LOG_INFO(( "Successfully unpaused all non-leader signers..." ));
-        *state = FD_SET_IDENTITY_STATE_REPLAY_UNHALTED;
+        *state = FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED;
       } else {
         FD_SPIN_PAUSE();
       }
       break;
     }
-    case FD_SET_IDENTITY_STATE_REPLAY_UNHALTED: {
+    case FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED: {
       fd_keyswitch_t * replay = find_identity_keyswitch( ctx, "replay" );
       replay->state = FD_KEYSWITCH_STATE_UNHALT_PENDING;
       FD_LOG_INFO(( "Requesting to unpause leader pipeline..." ));

--- a/src/discof/admin/fd_admin_tile.c
+++ b/src/discof/admin/fd_admin_tile.c
@@ -160,44 +160,63 @@ unprivileged_init( fd_topo_t const *      topo,
      switch potentially being interleaved with another client. */
 #define FD_SET_IDENTITY_STATE_LOCKED                   (1UL)
 
-/* State 2: LEADER_HALT_REQUESTED
-     The first step in the key switch process is to pause the leader
-     pipeline of the validator, preventing us from becoming leader, but
-     finishing any currently in progress leader slot if there is one.
-     While in this state, the validator is waiting for the leader
-     pipeline to confirm that it has paused production, and is no longer
-     leader.
+/* State 2: REPLAY_HALT_REQUESTED
+     The first step in the key switch process is to pause Replay,
+     preventing us from becoming leader or completing additional slots,
+     but finishing any currently in progress leader slot if there is
+     one.  Replay continues polling incoming links while paused so
+     downstream tiles can drain without a reliable-link cycle.
 
      In Firedancer, this halt request goes to the Replay tile, which
      causes the tile to switch the identity key it uses to determine the
      identity's balance as well as when the validator is the leader.
-     After the leader pipeline has been halted, the validator will no
-     longer become a leader until the switch has been completed. */
-#define FD_SET_IDENTITY_STATE_LEADER_HALT_REQUESTED    (2UL)
+     Replay reports its replay_out producer sequence when it pauses. */
+#define FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED    (2UL)
 
-/* State 3: LEADER_HALTED
-     The Replay tile has confirmed that it has halted the leader
-     pipeline, and the validator is no longer leader.  No more blocks
-     will be produced until it is unhalted.  In addition, the Replay
-     tile has switched its own identity key.
+/* State 3: REPLAY_HALTED
+     Replay has paused and the validator is no longer leader.  No more
+     slots will complete until Replay is unhalted.  Replay has switched
+     its own identity key and reported its replay_out pause sequence.
 
      At this point, we also have the guarantee that there are no more
      outstanding shreds that have to be signed with the old key.  Any
      tiles related to the leader pipeline that rely on the identity key
      will not be used. */
-#define FD_SET_IDENTITY_STATE_LEADER_HALTED            (3UL)
+#define FD_SET_IDENTITY_STATE_REPLAY_HALTED            (3UL)
 
-/* State 4: SIGNERS_HALT_REQUESTED
-     Repair, Gossip, Tower, and Bundle tiles will stop sending requests
+/* State 4: TOWER_HALT_REQUESTED
+     Tower has been requested to consume replay_out through Replay's
+     pause sequence, stop producing new vote transactions, drain its
+     local publish queue, and switch identity. */
+#define FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED     (4UL)
+
+/* State 5: TOWER_HALTED
+     Tower has drained its pre-switch publish queue, switched identity,
+     and reported the sequence after the final drained message. */
+#define FD_SET_IDENTITY_STATE_TOWER_HALTED             (5UL)
+
+/* State 6: TXSEND_FLUSH_REQUESTED
+     TxSend has been told the Tower sequence through which it must
+     process messages before switching identity.  Gossip remains active
+     in this state so it continues returning credits on tower_out and
+     txsend_out. */
+#define FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED   (6UL)
+
+/* State 7: TXSEND_FLUSHED
+     TxSend has processed all Tower messages through the halt sequence,
+     switched its identity key, and stopped receiving Net fragments that
+     could invoke QUIC signing callbacks. */
+#define FD_SET_IDENTITY_STATE_TXSEND_FLUSHED           (7UL)
+
+/* State 8: SIGNERS_HALT_REQUESTED
+     Repair, Gossip, Bundle, and Rserve will stop sending requests
      downstream to the sign tile.  This is done to avoid any mismatches
      with the identity key.  Their identity keys will be switched during
      this step, except for Gossip, which switches during
-     SIGNERS_UNHALT_REQUESTED.  These tiles all use the identity key to
-     make forward progress on non-leader pipeline replay except for the
-     Bundle tile.
+     SIGNERS_UNHALT_REQUESTED.
 
-     These tiles use the identity key to populate messages which are
-     signed by the sign tile:
+     These tiles use the identity key to populate messages signed by the
+     sign tile:
        (a) Repair.  The repair tile uses the identity key as part of the
            repair protocol.  The identity key is included in and used
            for signing requests.  Because Repair uses an asynchronous
@@ -207,52 +226,19 @@ unprivileged_init( fd_topo_t const *      topo,
        (b) Gossip.  The gossip tile sends out ContactInfo messages with
            our identity key, and also uses the identity key to sign
            outgoing gossip messages.
-       (c) Tower.  The tower tile uses the identity key to generate
-           vote transactions which are sent to the send tile.  These
-           vote transactions are then signed downstream by the TxSend
-           tile instead of having its own keyguard client.
-       (d) Bundle.  The bundle tile uses the identity key to sign an
+       (c) Bundle.  The bundle tile uses the identity key to sign an
            authentication challenge from the bundle server.
-       (e) Rserve.  The rserve tile uses the identity key to sign
+       (d) Rserve.  The rserve tile uses the identity key to sign
            outgoing pings.
         */
-#define FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED   (4UL)
+#define FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED   (8UL)
 
-/* State 5: SIGNERS_HALTED
-     Repair, Gossip, Tower, and Bundle are no longer sending requests to
-     the sign tile.  Replay can keep progressing at this point.
-     However, the Tower tile may have an in-flight vote transaction to
-     the TxSend tile that corresponds to the old identity key. */
-#define FD_SET_IDENTITY_STATE_SIGNERS_HALTED           (5UL)
+/* State 9: SIGNERS_HALTED
+     Repair, Gossip, Bundle, and Rserve are no longer sending requests
+     to the sign tile.  Tower and TxSend remain halted. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_HALTED           (9UL)
 
-/* State 6: TXSEND_FLUSH_REQUESTED
-     Once the Tower tile has updated its identity key and stopped
-     sending vote transactions to the TxSend tile, any in-flight vote
-     transactions for the old identity key must be flushed to avoid
-     being badly signed.  We also know that Tower will send no more
-     vote transactions to the TxSend tile.
-
-     The TxSend tile is flushed by telling it the last sequence number
-     the Tower tile has produced for an outgoing vote transaction at the
-     time it was halted.  Once the TxSend tile has processed all vote
-     transactions up to and including that sequence number, it will
-     switch its own identity key.  There is a guarantee that the TxSend
-     tile will not request to sign any vote transactions until it is
-     unhalted.  At this point, the TxSend tile will stop receiving any
-     new frags from the Net tile.  The reason for this is to avoid any
-     QUIC callbacks that invoke key signing. */
-#define FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED   (6UL)
-
-/* State 7: TXSEND_FLUSHED
-     The TxSend tile confirms that it has seen and processed all votes
-     up to and including the last sequence number produced by the Tower
-     tile at the time it was halted.  The TxSend tile also switches its
-     own identity key which is used for signing votes and establishing
-     a QUIC connection.  The TxSend tile is now no longer receiving any
-     new frags from the Net tile. */
-#define FD_SET_IDENTITY_STATE_TXSEND_FLUSHED           (7UL)
-
-/* State 8: ALL_SWITCH_REQUESTED
+/* State 10: ALL_SWITCH_REQUESTED
      The client now requests that all other tiles which consume the
      identity key in some way switch to the new key.  The leader
      pipeline is still halted, although it doesn't strictly need to be,
@@ -274,32 +260,33 @@ unprivileged_init( fd_topo_t const *      topo,
            outgoing shreds.
        (e) Event.  Outgoing events to the event server are signed with
            the identity key to authenticate the sender. */
-#define FD_SET_IDENTITY_STATE_ALL_SWITCH_REQUESTED     (8UL)
+#define FD_SET_IDENTITY_STATE_ALL_SWITCH_REQUESTED     (10UL)
 
-/* State 9: ALL_SWITCHED
+/* State 11: ALL_SWITCHED
      All remaining tiles that use the identity key have confirmed that
      they have switched to the new key.  Gossip has not yet updated its
-     identity key.  Repair, Gossip, Tower, TxSend, and Bundle remain
-     halted. */
-#define FD_SET_IDENTITY_STATE_ALL_SWITCHED             (9UL)
+     identity key.  Repair, Gossip, Tower, TxSend, Bundle, and Rserve
+     remain halted. */
+#define FD_SET_IDENTITY_STATE_ALL_SWITCHED             (11UL)
 
-/* State 10: SIGNERS_UNHALT_REQUESTED
-     During this state, the tiles that rely on the sign tile can be
-     safely unhalted and have their keys switched.  After this state,
-     all tiles will be using the switched identity key. */
-#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALT_REQUESTED (10UL)
+/* State 12: SIGNERS_UNHALT_REQUESTED
+     Now that the sign tile is using the switched identity key, the
+     halted signers can be unhalted.  Gossip switches its identity key
+     during this step.  These are the same tiles from
+     SIGNERS_HALT_REQUESTED, along with Tower and TxSend. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALT_REQUESTED (12UL)
 
-/* State 11: SIGNERS_UNHALTED
-     All tiles that rely on the sign tile have been unhalted, and the
-     validator can now resume making progress on replay. */
-#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED         (11UL)
+/* State 13: SIGNERS_UNHALTED
+     All tiles that rely on the sign tile have been unhalted.  Replay
+     remains paused. */
+#define FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED         (13UL)
 
-/* State 12: LEADER_UNHALT_REQUESTED
-     The final state, now that all tiles have switched, the leader
-     pipeline can be unblocked and the validator can resume producing
-     blocks.  The next state once the Replay tile confirms the leader
-     pipeline is unlocked, is UNLOCKED. */
-#define FD_SET_IDENTITY_STATE_LEADER_UNHALT_REQUESTED  (12UL)
+/* State 14: REPLAY_UNHALT_REQUESTED
+     The final state, now that all tiles have switched, Replay can be
+     unpaused and the validator can resume processing and producing
+     blocks.  The next state once Replay confirms it is unpaused is
+     UNLOCKED. */
+#define FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED  (14UL)
 
 static fd_keyswitch_t *
 find_identity_keyswitch( fd_admin_tile_ctx_t * ctx,
@@ -317,7 +304,6 @@ find_identity_keyswitch( fd_admin_tile_ctx_t * ctx,
 static int FD_FN_SENSITIVE
 poll_set_identity( fd_admin_tile_ctx_t * ctx,
                    ulong *               state,
-                   ulong *               halted_seq,
                    ulong                 identity_outset,
                    uchar *               keypair ) {
   fd_topo_t const * topo = ctx->topo;
@@ -340,18 +326,17 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       FD_COMPILER_MFENCE();
       replay->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
       FD_COMPILER_MFENCE();
-      *state = FD_SET_IDENTITY_STATE_LEADER_HALT_REQUESTED;
-      FD_LOG_INFO(( "Pausing leader pipeline for key switch..." ));
+      *state = FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED;
+      FD_LOG_INFO(( "Pausing Replay for key switch..." ));
       break;
     }
-    case FD_SET_IDENTITY_STATE_LEADER_HALT_REQUESTED: {
+    case FD_SET_IDENTITY_STATE_REPLAY_HALT_REQUESTED: {
       fd_keyswitch_t * replay = find_identity_keyswitch( ctx, "replay" );
       if( FD_LIKELY( replay->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
         fd_memzero_explicit( replay->bytes, 64UL );
         FD_COMPILER_MFENCE();
-        *halted_seq = replay->result;
-        *state = FD_SET_IDENTITY_STATE_LEADER_HALTED;
-        FD_LOG_INFO(( "Leader pipeline successfully paused..." ));
+        *state = FD_SET_IDENTITY_STATE_REPLAY_HALTED;
+        FD_LOG_INFO(( "Replay successfully paused..." ));
       } else if( FD_UNLIKELY( replay->state==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
         FD_SPIN_PAUSE();
       } else {
@@ -359,13 +344,66 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       }
       break;
     }
-    case FD_SET_IDENTITY_STATE_LEADER_HALTED: {
+    case FD_SET_IDENTITY_STATE_REPLAY_HALTED: {
+      fd_keyswitch_t * replay = find_identity_keyswitch( ctx, "replay" );
+      fd_keyswitch_t * tower = find_identity_keyswitch( ctx, "tower" );
+      tower->param = replay->result;
+      memcpy( tower->bytes, keypair+32UL, 32UL );
+      FD_COMPILER_MFENCE();
+      tower->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
+      FD_COMPILER_MFENCE();
+
+      *state = FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED;
+      FD_LOG_INFO(( "Pausing Tower and draining queued messages..." ));
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TOWER_HALT_REQUESTED: {
+      fd_keyswitch_t * tower = find_identity_keyswitch( ctx, "tower" );
+      if( FD_LIKELY( tower->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
+        fd_memzero_explicit( tower->bytes, 64UL );
+        FD_COMPILER_MFENCE();
+        *state = FD_SET_IDENTITY_STATE_TOWER_HALTED;
+        FD_LOG_INFO(( "Tower successfully paused..." ));
+      } else if( FD_UNLIKELY( tower->state==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
+        FD_SPIN_PAUSE();
+      } else {
+        FD_LOG_ERR(( "Unexpected tower keyswitch state %lu", tower->state ));
+      }
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TOWER_HALTED: {
+      ulong tower_halted_seq = find_identity_keyswitch( ctx, "tower" )->result;
+      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
+      txsend->param = tower_halted_seq;
+      memcpy( txsend->bytes, keypair+32UL, 32UL );
+      FD_COMPILER_MFENCE();
+      txsend->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
+      FD_COMPILER_MFENCE();
+
+      *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED;
+      FD_LOG_INFO(( "Flushing old identity vote transactions from TxSend..." ));
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED: {
+      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
+      if( FD_LIKELY( txsend->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
+        fd_memzero_explicit( txsend->bytes, 64UL );
+        FD_COMPILER_MFENCE();
+        *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSHED;
+        FD_LOG_INFO(( "TxSend successfully flushed..." ));
+      } else if( FD_UNLIKELY( txsend->state==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
+        FD_SPIN_PAUSE();
+      } else {
+        FD_LOG_ERR(( "Unexpected txsend keyswitch state %lu", txsend->state ));
+      }
+      break;
+    }
+    case FD_SET_IDENTITY_STATE_TXSEND_FLUSHED: {
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
         if( FD_LIKELY( tile->id_keyswitch_obj_id==ULONG_MAX ) ) continue;
         if( strcmp( tile->name, "repair" ) &&
             strcmp( tile->name, "gossip" ) &&
-            strcmp( tile->name, "tower" ) &&
             strcmp( tile->name, "bundle" ) &&
             strcmp( tile->name, "rserve" ) ) {
           continue;
@@ -379,7 +417,7 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
         FD_COMPILER_MFENCE();
       }
       *state = FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED;
-      FD_LOG_INFO(( "Requesting to halt all signers..." ));
+      FD_LOG_INFO(( "Requesting to halt remaining signers..." ));
       break;
     }
     case FD_SET_IDENTITY_STATE_SIGNERS_HALT_REQUESTED: {
@@ -389,7 +427,6 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
         if( FD_LIKELY( tile->id_keyswitch_obj_id==ULONG_MAX ) ) continue;
         if( strcmp( tile->name, "repair" ) &&
             strcmp( tile->name, "gossip" ) &&
-            strcmp( tile->name, "tower" ) &&
             strcmp( tile->name, "bundle" ) &&
             strcmp( tile->name, "rserve" ) ) {
           continue;
@@ -402,7 +439,7 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
         }
       }
       if( FD_LIKELY( all_switched ) ) {
-        FD_LOG_INFO(( "All signers successfully halted..." ));
+        FD_LOG_INFO(( "All remaining signers successfully halted..." ));
         *state = FD_SET_IDENTITY_STATE_SIGNERS_HALTED;
       } else {
         FD_SPIN_PAUSE();
@@ -410,29 +447,6 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
       break;
     }
     case FD_SET_IDENTITY_STATE_SIGNERS_HALTED: {
-      ulong tower_halted_seq = find_identity_keyswitch( ctx, "tower" )->result;
-      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
-      txsend->param = tower_halted_seq;
-      memcpy( txsend->bytes, keypair+32UL, 32UL );
-      FD_COMPILER_MFENCE();
-      txsend->state = FD_KEYSWITCH_STATE_SWITCH_PENDING;
-      FD_COMPILER_MFENCE();
-
-      *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED;
-      break;
-    }
-    case FD_SET_IDENTITY_STATE_TXSEND_FLUSH_REQUESTED: {
-      fd_keyswitch_t * txsend = find_identity_keyswitch( ctx, "txsend" );
-      if( FD_LIKELY( txsend->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
-        fd_memzero_explicit( txsend->bytes, 64UL );
-        FD_COMPILER_MFENCE();
-        *state = FD_SET_IDENTITY_STATE_TXSEND_FLUSHED;
-      } else {
-        FD_SPIN_PAUSE();
-      }
-      break;
-    }
-    case FD_SET_IDENTITY_STATE_TXSEND_FLUSHED: {
       for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
         fd_topo_tile_t const * tile = &topo->tiles[ i ];
         if( strcmp( tile->name, "sign" ) ) continue;
@@ -560,14 +574,14 @@ poll_set_identity( fd_admin_tile_ctx_t * ctx,
     case FD_SET_IDENTITY_STATE_SIGNERS_UNHALTED: {
       fd_keyswitch_t * replay = find_identity_keyswitch( ctx, "replay" );
       replay->state = FD_KEYSWITCH_STATE_UNHALT_PENDING;
-      FD_LOG_INFO(( "Requesting to unpause leader pipeline..." ));
-      *state = FD_SET_IDENTITY_STATE_LEADER_UNHALT_REQUESTED;
+      FD_LOG_INFO(( "Requesting to unpause Replay..." ));
+      *state = FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED;
       break;
     }
-    case FD_SET_IDENTITY_STATE_LEADER_UNHALT_REQUESTED: {
+    case FD_SET_IDENTITY_STATE_REPLAY_UNHALT_REQUESTED: {
       fd_keyswitch_t * replay = find_identity_keyswitch( ctx, "replay" );
       if( FD_LIKELY( replay->state==FD_KEYSWITCH_STATE_COMPLETED ) ) {
-        FD_LOG_INFO(( "Leader pipeline unpaused..." ));
+        FD_LOG_INFO(( "Replay unpaused..." ));
         replay->state = FD_KEYSWITCH_STATE_UNLOCKED;
         *state = FD_SET_IDENTITY_STATE_UNLOCKED;
       } else if( FD_UNLIKELY( replay->state==FD_KEYSWITCH_STATE_UNHALT_PENDING ) ) {
@@ -629,10 +643,9 @@ set_identity( fd_admin_tile_ctx_t * ctx,
   }
 
   ulong state           = FD_SET_IDENTITY_STATE_UNLOCKED;
-  ulong halted_seq      = 0UL;
   ulong identity_outset = (ulong)fd_log_wallclock();
   for(;;) {
-    if( FD_UNLIKELY( poll_set_identity( ctx, &state, &halted_seq, identity_outset, req->keypair ) ) ) break;
+    if( FD_UNLIKELY( poll_set_identity( ctx, &state, identity_outset, req->keypair ) ) ) break;
   }
 
   memcpy( ctx->identity_pubkey, req->keypair+32UL, 32UL );

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1176,8 +1176,6 @@ maybe_switch_identity( fd_replay_tile_t * ctx ) {
   ctx->node_info->info.identity = *ctx->identity_pubkey;
   fd_node_info_write_end  ( ctx->node_info );
 
-  fd_keyswitch_state( ctx->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
-
   /* The next leader slot will be incorrect now that the identity has
      switched.  The next leader slot normally gets updated based on the
      reset slot returned by tower. */
@@ -1201,6 +1199,11 @@ maybe_switch_identity( fd_replay_tile_t * ctx ) {
   ctx->identity_vote_rooted = 0;
   ctx->identity_idx++;
   fd_vote_tracker_reset( ctx->vote_tracker );
+
+  /* Save the current sequence so downstream consumers, namely tower,
+     know what sequence to consume up to. */
+  ctx->keyswitch->result = fd_mcache_seq_query( ctx->replay_out_seq );
+  fd_keyswitch_state( ctx->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
 }
 
 /* leader_footer_certs copies the certificates votor sent for
@@ -1326,7 +1329,7 @@ try_become_leader_ag( fd_replay_tile_t *        ctx,
   }
 
   if( FD_UNLIKELY( ctx->replay_out->idx==ULONG_MAX || !ctx->wfs_complete ) ) return;
-  if( FD_UNLIKELY( ctx->halt_leader || !ctx->supports_leader ) ) return;
+  if( FD_UNLIKELY( ctx->halt_replay || !ctx->supports_leader ) ) return;
   if( FD_UNLIKELY( !fd_banks_can_start_bank( ctx->banks ) ) ) {
     FD_LOG_WARNING(( "ignoring leader trigger from votor for slot %lu because no bank can be started", leader_slot ));
     return;
@@ -1512,8 +1515,6 @@ try_fini_leader( fd_replay_tile_t *  ctx,
   ctx->recv_poh    = 0;
   ctx->is_leader   = 0;
 
-  maybe_switch_identity( ctx );
-
   if( FD_UNLIKELY( ctx->alpenglow && (curr_slot+1UL)%AG_SLOTS_PER_WINDOW ) ) {
     fd_votor_leader_t next[1] = {{
       .start_slot      = curr_slot+1UL,
@@ -1688,7 +1689,7 @@ try_become_leader( fd_replay_tile_t *  ctx,
   if( FD_UNLIKELY( !reset_bank || reset_bank->bank_seq!=block_id_ele->bank_seq || reset_bank->state==FD_BANK_STATE_PRUNABLE ) ) return 0;
 
   if( FD_UNLIKELY( !fd_banks_can_start_bank( ctx->banks ) ) ) return 0;
-  if( FD_UNLIKELY( ctx->halt_leader ) ) return 0;
+  if( FD_UNLIKELY( ctx->halt_replay ) ) return 0;
   if( !ctx->supports_leader ) return 0;
 
   FD_TEST( ctx->next_leader_slot>ctx->reset_slot );
@@ -1906,7 +1907,6 @@ process_poh_message( fd_replay_tile_t *                 ctx,
     ctx->recv_poh    = 0;
     ctx->is_leader   = 0;
     mark_bank_dead( ctx, stem, bank_idx, FD_EVENT_BLOCK_COMPLETED_DEAD_REASON_NOT_DEAD, FD_EVENT_BLOCK_COMPLETED_ABANDONED_REASON_RESET );
-    maybe_switch_identity( ctx );
     return;
   }
 
@@ -3296,6 +3296,7 @@ after_credit( fd_replay_tile_t *  ctx,
               fd_stem_context_t * stem,
               int *               opt_poll_in,
               int *               charge_busy ) {
+  if( FD_UNLIKELY( ctx->halt_replay && !ctx->is_leader ) ) return;
   if( FD_UNLIKELY( !ctx->is_booted || !ctx->wfs_complete ) ) return;
 
   /* The overall priority for the replay tile in order is:
@@ -4741,7 +4742,7 @@ unprivileged_init( fd_topo_t const *      topo,
 
   ctx->keyswitch = fd_keyswitch_join( fd_topo_obj_laddr( topo, tile->id_keyswitch_obj_id ) );
   FD_TEST( ctx->keyswitch );
-  ctx->halt_leader = 0;
+  ctx->halt_replay = 0;
 
   FD_TEST( tile->in_cnt<=sizeof(ctx->in)/sizeof(ctx->in[0]) );
   for( ulong i=0UL; i<tile->in_cnt; i++ ) {
@@ -4781,6 +4782,8 @@ unprivileged_init( fd_topo_t const *      topo,
   *ctx->replay_out = out1( topo, tile, "replay_out"   ); FD_TEST( ctx->replay_out->idx!=ULONG_MAX );
   *ctx->snapmk_out = out1( topo, tile, "replay_snapmk" ); FD_TEST( ctx->snapmk.supported == (ctx->snapmk_out->idx!=ULONG_MAX) );
   *ctx->exec_out   = out1( topo, tile, "replay_execrp"  ); FD_TEST( ctx->exec_out->idx!=ULONG_MAX );
+
+  ctx->replay_out_seq = fd_mcache_seq_laddr_const( topo->links[ tile->out_link_id[ ctx->replay_out->idx ] ].mcache );
 
   ctx->rpc_enabled = fd_topo_find_tile( topo, "rpc", 0UL )!=ULONG_MAX;
 
@@ -4869,16 +4872,16 @@ during_housekeeping( fd_replay_tile_t * ctx ) {
   if( FD_UNLIKELY( fd_clock_tile_recal_due( ctx->clock ) ) ) fd_clock_tile_recal( ctx->clock );
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->keyswitch )==FD_KEYSWITCH_STATE_UNHALT_PENDING ) ) {
-    FD_CHECK_CRIT( ctx->halt_leader, "state machine corruption" );
-    FD_LOG_DEBUG(( "keyswitch: unhalting leader" ));
-    ctx->halt_leader = 0;
+    FD_CHECK_CRIT( ctx->halt_replay, "state machine corruption" );
+    FD_LOG_DEBUG(( "keyswitch: unhalting replay" ));
+    ctx->halt_replay = 0;
     fd_keyswitch_state( ctx->keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
-    FD_LOG_DEBUG(( "keyswitch: halting leader" ));
-    ctx->halt_leader = 1;
-    if( !ctx->is_leader ) maybe_switch_identity( ctx );
+    if( FD_LIKELY( !ctx->halt_replay ) ) FD_LOG_DEBUG(( "keyswitch: halting replay" ));
+    ctx->halt_replay = 1;
+    if( !ctx->is_leader && ctx->is_booted ) maybe_switch_identity( ctx );
   }
 }
 

--- a/src/discof/replay/fd_replay_tile_private.h
+++ b/src/discof/replay/fd_replay_tile_private.h
@@ -479,7 +479,7 @@ struct fd_replay_tile {
   fd_node_info_box_t * node_info; /* shared */
 
   fd_keyswitch_t * keyswitch;
-  int              halt_leader;
+  int              halt_replay;
 
   ulong  resolv_tile_cnt;
 
@@ -489,6 +489,7 @@ struct fd_replay_tile {
   fd_replay_out_link_t exec_out[ 1 ];
 
   fd_replay_out_link_t replay_out[1];
+  ulong const *        replay_out_seq;
   fd_replay_out_link_t snapmk_out[1];
   ulong admin_out_idx;
 

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -2765,6 +2765,71 @@ test_stale_id_key_does_not_shadow_rebuild( fd_wksp_t * wksp ) {
   FD_LOG_NOTICE(( "pass: test_stale_id_key_does_not_shadow_rebuild" ));
 }
 
+static void
+test_identity_switch_quiesces_replay( fd_wksp_t * wksp ) {
+  static fd_replay_tile_t   ctx[1];
+  static fd_keyswitch_t     keyswitch[1];
+  static fd_node_info_box_t node_info[1];
+
+  setup_ctx( ctx, wksp );
+  memset( keyswitch, 0, sizeof(keyswitch) );
+  FD_TEST( fd_node_info_box_join( fd_node_info_box_new( node_info ) ) );
+  void * vote_tracker_mem = fd_wksp_alloc_laddr( wksp, fd_vote_tracker_align(), fd_vote_tracker_footprint(), 1UL );
+  FD_TEST( vote_tracker_mem );
+  ctx->vote_tracker = fd_vote_tracker_join( fd_vote_tracker_new( vote_tracker_mem, 0UL ) );
+  FD_TEST( ctx->vote_tracker );
+
+  fd_pubkey_t old_identity = { .ul = { 0x11UL } };
+  fd_pubkey_t new_identity = { .ul = { 0x22UL } };
+
+  ctx->keyswitch          = keyswitch;
+  ctx->node_info          = node_info;
+  ctx->identity_pubkey[0] = old_identity;
+  keyswitch->result       = ULONG_MAX;
+  memcpy( keyswitch->bytes, &new_identity, sizeof(new_identity) );
+  fd_keyswitch_state( keyswitch, FD_KEYSWITCH_STATE_SWITCH_PENDING );
+
+  ulong replay_out_idx = ctx->replay_out->idx;
+  fd_mcache_seq_update( fd_mcache_seq_laddr( test_stem_mcaches[ replay_out_idx ] ), 40UL );
+  ctx->replay_out_seq = fd_mcache_seq_laddr_const( test_stem_mcaches[ replay_out_idx ] );
+  ctx->is_booted = 0;
+
+  during_housekeeping( ctx );
+  FD_TEST( fd_keyswitch_state_query( keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING );
+  FD_TEST( fd_pubkey_eq( ctx->identity_pubkey, &old_identity ) );
+
+  ctx->is_booted = 1;
+  ctx->is_leader = 1;
+  fd_mcache_seq_update( fd_mcache_seq_laddr( test_stem_mcaches[ replay_out_idx ] ), 41UL );
+  during_housekeeping( ctx );
+  FD_TEST( fd_keyswitch_state_query( keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING );
+  FD_TEST( keyswitch->result==ULONG_MAX );
+  FD_TEST( fd_pubkey_eq( ctx->identity_pubkey, &old_identity ) );
+
+  ctx->is_leader = 0;
+  fd_mcache_seq_update( fd_mcache_seq_laddr( test_stem_mcaches[ replay_out_idx ] ), 42UL );
+  during_housekeeping( ctx );
+  FD_TEST( ctx->halt_replay );
+  FD_TEST( fd_keyswitch_state_query( keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+  FD_TEST( keyswitch->result==42UL );
+  FD_TEST( fd_pubkey_eq( ctx->identity_pubkey, &new_identity ) );
+
+  ulong idle_cnt = ctx->execrp_idle_cnt;
+  int poll_in = 1;
+  int charge_busy = 0;
+  after_credit( ctx, test_stem, &poll_in, &charge_busy );
+  FD_TEST( ctx->execrp_idle_cnt==idle_cnt );
+  FD_TEST( poll_in );
+  FD_TEST( !charge_busy );
+
+  fd_keyswitch_state( keyswitch, FD_KEYSWITCH_STATE_UNHALT_PENDING );
+  during_housekeeping( ctx );
+  FD_TEST( !ctx->halt_replay );
+  FD_TEST( fd_keyswitch_state_query( keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+
+  FD_LOG_NOTICE(( "pass: test_identity_switch_quiesces_replay" ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -2798,7 +2863,8 @@ main( int     argc,
   test_process_rotor_fec_skip_replayed( wksp );     fd_wksp_reset( wksp, 42U );
   test_rotor_fec_turbine_keying( wksp );            fd_wksp_reset( wksp, 42U );
   test_dead_block_children_drop( wksp );
-  test_stale_id_key_does_not_shadow_rebuild( wksp );
+  test_stale_id_key_does_not_shadow_rebuild( wksp ); fd_wksp_reset( wksp, 42U );
+  test_identity_switch_quiesces_replay( wksp );
 
   FD_TEST( mock_store_view_success_cnt==mock_store_view_release_cnt );
 

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -1715,13 +1715,15 @@ during_housekeeping( fd_tower_tile_t * ctx ) {
   }
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->identity_keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
-    FD_LOG_DEBUG(( "keyswitch: halting signing" ));
+    if( FD_LIKELY( !ctx->halt_signing ) ) FD_LOG_DEBUG(( "keyswitch: halting signing" ));
+    ctx->halt_signing = 1;
+    if( FD_UNLIKELY( !publishes_empty( ctx->publishes ) ) ) return;
+
     memcpy( ctx->identity_key, ctx->identity_keyswitch->bytes, 32UL );
     FD_BASE58_ENCODE_32_BYTES( ctx->identity_key->uc, pubkey_str );
     FD_LOG_INFO(( "my identity key: %s (key switched)", pubkey_str ));
-    fd_keyswitch_state( ctx->identity_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
-    ctx->halt_signing               = 1;
     ctx->identity_keyswitch->result = ctx->out_seq;
+    fd_keyswitch_state( ctx->identity_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }
 }
 

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -300,6 +300,7 @@ struct fd_tower_tile {
   ulong       out_wmark;
   ulong       out_chunk;
   ulong       out_seq;
+  ulong       replay_in_seq;
 
   /* metrics */
 
@@ -1751,13 +1752,18 @@ during_housekeeping( fd_tower_tile_t * ctx ) {
   }
 
   if( FD_UNLIKELY( fd_keyswitch_state_query( ctx->identity_keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING ) ) {
-    FD_LOG_DEBUG(( "keyswitch: halting signing" ));
+    ulong seq_must_complete = fd_keyswitch_param_query( ctx->identity_keyswitch );
+    if( FD_UNLIKELY( fd_seq_lt( ctx->replay_in_seq, seq_must_complete ) ) ) return;
+
+    if( FD_LIKELY( !ctx->halt_signing ) ) FD_LOG_DEBUG(( "keyswitch: halting signing" ));
+    ctx->halt_signing = 1;
+    if( FD_UNLIKELY( !publishes_empty( ctx->publishes ) ) ) return;
+
     memcpy( ctx->identity_key, ctx->identity_keyswitch->bytes, 32UL );
     FD_BASE58_ENCODE_32_BYTES( ctx->identity_key->uc, pubkey_str );
     FD_LOG_INFO(( "my identity key: %s (key switched)", pubkey_str ));
-    fd_keyswitch_state( ctx->identity_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
-    ctx->halt_signing               = 1;
     ctx->identity_keyswitch->result = ctx->out_seq;
+    fd_keyswitch_state( ctx->identity_keyswitch, FD_KEYSWITCH_STATE_COMPLETED );
   }
 }
 
@@ -1817,7 +1823,7 @@ after_credit( fd_tower_tile_t *   ctx,
 static inline int
 returnable_frag( fd_tower_tile_t *   ctx,
                  ulong               in_idx,
-                 ulong               seq FD_PARAM_UNUSED,
+                 ulong               seq,
                  ulong               sig,
                  ulong               chunk,
                  ulong               sz,
@@ -1884,7 +1890,7 @@ returnable_frag( fd_tower_tile_t *   ctx,
       break;
     case REPLAY_SIG_SLOT_DEAD:;
       fd_replay_slot_dead_t * slot_dead = (fd_replay_slot_dead_t *)fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
-      if( FD_UNLIKELY( slot_dead->slot < ctx->tower->root ) ) return 0; /* ignore dead slots before root */
+      if( FD_UNLIKELY( slot_dead->slot < ctx->tower->root ) ) break; /* ignore dead slots before root */
       fd_epoch_leaders_t const * lsched = fd_multi_epoch_leaders_get_lsched_for_slot( ctx->mleaders, slot_dead->slot );
       FD_TEST( lsched );
       FD_TEST( lsched->epoch==ctx->root_epoch || lsched->epoch==ctx->root_epoch + 1 );
@@ -1895,12 +1901,13 @@ returnable_frag( fd_tower_tile_t *   ctx,
     case REPLAY_SIG_TXN_EXECUTED:;
       FD_TEST( ctx->init ); /* replay_txn_executed should never be received before replay_slot_completed, which sets init to 1. */
       fd_replay_txn_executed_t * txn_executed = fd_type_pun( fd_chunk_to_laddr( ctx->in[in_idx].mem, chunk ) );
-      if( FD_UNLIKELY( !txn_executed->is_committable || txn_executed->is_fees_only || txn_executed->txn_err ) ) return 0;
+      if( FD_UNLIKELY( !txn_executed->is_committable || txn_executed->is_fees_only || txn_executed->txn_err ) ) break;
       count_vote_txn( ctx, TXN(txn_executed->txn), txn_executed->txn->payload );
       break;
     default:
       break;
     }
+    ctx->replay_in_seq = seq+1UL;
     return 0;
   }
   case IN_KIND_SHRED: {
@@ -2017,11 +2024,12 @@ unprivileged_init( fd_topo_t const *      topo,
     }
   }
 
-  ctx->out_mem    = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ 0 ] ].dcache_obj_id ].wksp_id ].wksp;
-  ctx->out_chunk0 = fd_dcache_compact_chunk0( ctx->out_mem, topo->links[ tile->out_link_id[ 0 ] ].dcache );
-  ctx->out_wmark  = fd_dcache_compact_wmark ( ctx->out_mem, topo->links[ tile->out_link_id[ 0 ] ].dcache, topo->links[ tile->out_link_id[ 0 ] ].mtu );
-  ctx->out_chunk  = ctx->out_chunk0;
-  ctx->out_seq    = 0UL;
+  ctx->out_mem       = topo->workspaces[ topo->objs[ topo->links[ tile->out_link_id[ 0 ] ].dcache_obj_id ].wksp_id ].wksp;
+  ctx->out_chunk0    = fd_dcache_compact_chunk0( ctx->out_mem, topo->links[ tile->out_link_id[ 0 ] ].dcache );
+  ctx->out_wmark     = fd_dcache_compact_wmark ( ctx->out_mem, topo->links[ tile->out_link_id[ 0 ] ].dcache, topo->links[ tile->out_link_id[ 0 ] ].mtu );
+  ctx->out_chunk     = ctx->out_chunk0;
+  ctx->out_seq       = 0UL;
+  ctx->replay_in_seq = 0UL;
 
   FD_BASE58_ENCODE_32_BYTES( ctx->vote_account->uc, vote_account_b58 );
   FD_BASE58_ENCODE_32_BYTES( ctx->identity_key->uc, identity_key_b58 );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -163,6 +163,112 @@ test_publish_slot_done_identity_mismatch( void ) {
 }
 
 static void
+test_identity_switch_waits_for_replay( void ) {
+  static fd_tower_tile_t ctx[1];
+  static fd_keyswitch_t  identity_keyswitch[1];
+  static fd_keyswitch_t  auth_vtr_keyswitch[1];
+  static uchar           publishes_mem[ 65536 ] __attribute__((aligned(128)));
+
+  fd_pubkey_t old_identity = { .ul = { 0x11UL } };
+  fd_pubkey_t new_identity = { .ul = { 0x22UL } };
+
+  memset( ctx,                0, sizeof(*ctx) );
+  memset( identity_keyswitch, 0, sizeof(*identity_keyswitch) );
+  memset( auth_vtr_keyswitch, 0, sizeof(*auth_vtr_keyswitch) );
+  memset( publishes_mem,      0, sizeof(publishes_mem) );
+
+  ctx->identity_key       [0] = old_identity;
+  ctx->identity_keyswitch     = identity_keyswitch;
+  ctx->auth_vtr_keyswitch     = auth_vtr_keyswitch;
+  ctx->publishes               = publishes_join( publishes_new( publishes_mem, 2UL ) );
+  identity_keyswitch->param    = 1UL;
+  identity_keyswitch->result   = ULONG_MAX;
+  memcpy( identity_keyswitch->bytes, &new_identity, sizeof(new_identity) );
+  fd_keyswitch_state( identity_keyswitch, FD_KEYSWITCH_STATE_SWITCH_PENDING );
+
+  during_housekeeping( ctx );
+
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING );
+  FD_TEST( !ctx->halt_signing );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &old_identity ) );
+  FD_TEST( identity_keyswitch->result==ULONG_MAX );
+
+  ctx->in_kind[ 0 ]        = IN_KIND_REPLAY;
+  ctx->in[ 0 ].mcache_only = 1;
+  FD_TEST( !returnable_frag( ctx, 0UL, 0UL, REPLAY_SIG_RESET,
+                             0UL, 0UL, 0UL, 0UL, 0UL, NULL ) );
+  FD_TEST( ctx->replay_in_seq==1UL );
+
+  during_housekeeping( ctx );
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+  FD_TEST( ctx->halt_signing );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &new_identity ) );
+
+  FD_LOG_NOTICE(( "pass: test_identity_switch_waits_for_replay" ));
+}
+
+static void
+test_halt_signing_backpressures_replay( void ) {
+  static fd_tower_tile_t ctx[1];
+  memset( ctx, 0, sizeof(*ctx) );
+
+  ctx->halt_signing          = 1;
+  ctx->replay_in_seq         = 7UL;
+  ctx->in_kind[ 0 ]          = IN_KIND_REPLAY;
+  ctx->in[ 0 ].mcache_only   = 1;
+
+  /* Authorized-voter removal has no Replay barrier and relies on this
+     fragment remaining unconsumed until signing is unhalted. */
+  FD_TEST( returnable_frag( ctx, 0UL, 7UL, REPLAY_SIG_SLOT_COMPLETED,
+                            0UL, 0UL, 0UL, 0UL, 0UL, NULL )==1 );
+  FD_TEST( ctx->replay_in_seq==7UL );
+
+  FD_LOG_NOTICE(( "pass: test_halt_signing_backpressures_replay" ));
+}
+
+static void
+test_identity_switch_waits_for_publishes( void ) {
+  static fd_tower_tile_t ctx[1];
+  static fd_keyswitch_t  identity_keyswitch[1];
+  static fd_keyswitch_t  auth_vtr_keyswitch[1];
+  static uchar           publishes_mem[ 65536 ] __attribute__((aligned(128)));
+
+  fd_pubkey_t old_identity = { .ul = { 0x11UL } };
+  fd_pubkey_t new_identity = { .ul = { 0x22UL } };
+
+  memset( ctx,                0, sizeof(*ctx) );
+  memset( identity_keyswitch, 0, sizeof(*identity_keyswitch) );
+  memset( auth_vtr_keyswitch, 0, sizeof(*auth_vtr_keyswitch) );
+  memset( publishes_mem,      0, sizeof(publishes_mem) );
+
+  ctx->identity_key       [0] = old_identity;
+  ctx->identity_keyswitch     = identity_keyswitch;
+  ctx->auth_vtr_keyswitch     = auth_vtr_keyswitch;
+  ctx->publishes               = publishes_join( publishes_new( publishes_mem, 2UL ) );
+  ctx->out_seq                 = 42UL;
+  identity_keyswitch->result   = ULONG_MAX;
+  memcpy( identity_keyswitch->bytes, &new_identity, sizeof(new_identity) );
+  fd_keyswitch_state( identity_keyswitch, FD_KEYSWITCH_STATE_SWITCH_PENDING );
+
+  publishes_push_head( ctx->publishes, (publish_t){ .sig = FD_TOWER_SIG_SLOT_DONE } );
+  during_housekeeping( ctx );
+
+  FD_TEST( ctx->halt_signing );
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &old_identity ) );
+  FD_TEST( identity_keyswitch->result==ULONG_MAX );
+
+  publishes_pop_head_nocopy( ctx->publishes );
+  during_housekeeping( ctx );
+
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &new_identity ) );
+  FD_TEST( identity_keyswitch->result==42UL );
+
+  FD_LOG_NOTICE(( "pass: test_identity_switch_waits_for_publishes" ));
+}
+
+static void
 test_count_vote_txn( void ) {
 
   /* Set up a minimal fd_tower_tile_t with just what count_vote_txn needs
@@ -887,6 +993,9 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   test_publish_slot_done_identity_mismatch();
+  test_identity_switch_waits_for_replay();
+  test_halt_signing_backpressures_replay();
+  test_identity_switch_waits_for_publishes();
   test_count_vote_txn();
   test_parent_vote_txn_recent_blockhash();
 

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -149,6 +149,48 @@ test_publish_slot_done_identity_mismatch( void ) {
 }
 
 static void
+test_identity_switch_waits_for_publishes( void ) {
+  static fd_tower_tile_t ctx[1];
+  static fd_keyswitch_t  identity_keyswitch[1];
+  static fd_keyswitch_t  auth_vtr_keyswitch[1];
+  static uchar           publishes_mem[ 65536 ] __attribute__((aligned(128)));
+
+  fd_pubkey_t old_identity = { .ul = { 0x11UL } };
+  fd_pubkey_t new_identity = { .ul = { 0x22UL } };
+
+  memset( ctx,                0, sizeof(*ctx) );
+  memset( identity_keyswitch, 0, sizeof(*identity_keyswitch) );
+  memset( auth_vtr_keyswitch, 0, sizeof(*auth_vtr_keyswitch) );
+  memset( publishes_mem,      0, sizeof(publishes_mem) );
+
+  ctx->identity_key       [0] = old_identity;
+  ctx->identity_keyswitch     = identity_keyswitch;
+  ctx->auth_vtr_keyswitch     = auth_vtr_keyswitch;
+  ctx->publishes               = publishes_join( publishes_new( publishes_mem, 2UL ) );
+  ctx->out_seq                 = 42UL;
+  identity_keyswitch->result   = ULONG_MAX;
+  memcpy( identity_keyswitch->bytes, &new_identity, sizeof(new_identity) );
+  fd_keyswitch_state( identity_keyswitch, FD_KEYSWITCH_STATE_SWITCH_PENDING );
+
+  publishes_push_head( ctx->publishes, (publish_t){ .sig = FD_TOWER_SIG_SLOT_DONE } );
+  during_housekeeping( ctx );
+
+  FD_TEST( ctx->halt_signing );
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_SWITCH_PENDING );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &old_identity ) );
+  FD_TEST( identity_keyswitch->result==ULONG_MAX );
+
+  publishes_pop_head_nocopy( ctx->publishes );
+  during_housekeeping( ctx );
+
+  FD_TEST( fd_keyswitch_state_query( identity_keyswitch )==FD_KEYSWITCH_STATE_COMPLETED );
+  FD_TEST( fd_pubkey_eq( ctx->identity_key, &new_identity ) );
+  FD_TEST( identity_keyswitch->result==42UL );
+
+  FD_LOG_NOTICE(( "pass: test_identity_switch_waits_for_publishes" ));
+}
+
+static void
 test_count_vote_txn( void ) {
 
   /* Set up a minimal fd_tower_tile_t with just what count_vote_txn needs
@@ -869,6 +911,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   test_publish_slot_done_identity_mismatch();
+  test_identity_switch_waits_for_publishes();
   test_count_vote_txn();
   test_parent_vote_txn_recent_blockhash();
 


### PR DESCRIPTION
need to make sure tower can safely drain queued publishes without getting backpressured and deadlocking the client. Fixes a very rare race for set identity