### PR TITLE
flamenco, gossip: fix FD_GOSSIP_CONTACT_INFO_MAX_SOCKETS

### DIFF
--- a/src/flamenco/gossip/fd_gossip_message.c
+++ b/src/flamenco/gossip/fd_gossip_message.c
@@ -336,25 +336,33 @@ deser_contact_info( fd_gossip_value_t * value,
      UDP header                   =    8
      PACKET_DATA_SIZE             = 1232   (= 1280 - 40 - 8)
 
+     Bytes consumed for preamble:
+       Push/Pull Response:
+         Protocol tag(4) + from(32) + values_len(8) = 44
+       Pull Request:
+         Protocol tag(4) + keys_len(8) + bloom_none(9) +
+         num_bits_set(8) + mask(8) + mask_bits(4) = 41
+       Minimum consumed for preamble: 41
+
      Bytes consumed before addrs loop:
-       Protocol tag(4) + from(32) + values_len(8) + signature(64) +
+       Preamble(41) + signature(64) +
        CrdsData tag(4) + origin(32) + wallclock_varint(1) + outset(8) +
        shred_version(2) + major(1) + minor(1) + patch(1) + commit(4) +
-       feature_set(4) + client(1) + addrs_len_varint(1)             = 168
+       feature_set(4) + client(1) + addrs_len_varint(1)             = 165
 
-     Remaining: 1232 - 168 = 1064
+     Remaining: 1232 - 165 = 1067
      Each addr: READ_ENUM(4) + READ_U32(4) = 8 bytes minimum
-     Max addrs = floor(1064/8) = 133
+     Max addrs = floor(1067/8) = 133
 
      Bytes consumed before sockets loop:
-       (same as above) + sockets_len_varint(1)                     = 169
+       (same as above) + sockets_len_varint(1)                     = 166
 
-     Remaining: 1232 - 169 = 1063
+     Remaining: 1232 - 166 = 1066
      Each socket: READ_U8(1) + READ_U8(1) + READ_U16_VARINT(1) = 3 bytes minimum
-     Max sockets = floor(1063/3) = 354  */
+     Max sockets = floor(1066/3) = 355 */
 
 #define FD_GOSSIP_CONTACT_INFO_MAX_ADDRESSES (133UL)
-#define FD_GOSSIP_CONTACT_INFO_MAX_SOCKETS   (354UL)
+#define FD_GOSSIP_CONTACT_INFO_MAX_SOCKETS   (355UL)
 
   uint is_ip6[ FD_GOSSIP_CONTACT_INFO_MAX_ADDRESSES ];
   union {


### PR DESCRIPTION
Fixes an off-by-one bug in the gossip parser which could cause a stack out of bounds write.

The sockets array is undersized for the worst case, because the preamble for a contact info embedded in a pull request is 3 bytes less than for a contact info embedded in a push or a pull response. This means we can fit 1 extra socket entry in a contact info in the worst case.

Octane finding: https://octane.firedancer.io/dashboard#/?lineage=audit_flamenco_gossip_crds&hash=bba1d224e33c