### PR TITLE
gui: fix late votes

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -2573,7 +2573,9 @@ initially replay one but the cluster votes on the other one.
 | priority_fee                 | `string\|null` | Total amount of priority fees that this slot collects in lamports after any burning |
 | tips                         | `string\|null` | Total amount of tips that this slot collects in lamports, across all block builders, after any commission to the block builder is subtracted |
 | vote_slot                    | `number\|null` | The most recent slot for which this validator had landed a vote as of the time that this slot was replayed.  This is equivalent to the largest voted-for slot in this validator's on-chain vote account after the execution of `slot`. `vote_slot` will typically be one less than `slot`, though `vote_slot` may be arbitrarily small if the last successfully landed vote from this validator was long before `slot`. May be `null` if the vote account for this node does not exist |
-| vote_latency                 | `number\|null` | The distance in slots between this slot and the slot which contains our vote for this slot.  This field is `null` if we have not yet landed a vote for this slot, and this message will be re-published once our vote lands. Due to forking or votes not landing, this field may be updated arbitrarily many times, or never |
+| vote_latency                 | `number\|null` | The distance in slots between this slot and the slot which contains our vote for this slot.  This field is `null` if we have not yet landed a vote for this slot, and this message will be re-published once our vote lands |
+| vote_latency_exact           | `number\|null` | The distance in slots between this slot and the slot which contains our vote for this slot, discounting slots that were skipped on the fork our vote landed on.  `null` when we have not landed a vote for this slot |
+| is_voter                     | `boolean` | True if this validator was structurally a voter (held the authorized voter key with a matching identity) at the time this slot was replayed.  This reflects the historical voting configuration and is unaffected by later runtime identity switches |
 
 #### `slot.skipped_history`
 | frequency | type       | example |
@@ -2605,17 +2607,13 @@ late or not at all. Specifically, the following slots are included
 - rooted slots with a vote latency > 1
 - rooted slots that were never voted for that were not skipped
 
-The slot array is run-length encoded. For example
+The `slot` array is run-length encoded: it holds pairs
+`[run_start, run_end]` (both inclusive) describing contiguous ranges of
+affected slots.  Each run shares the same `latency_exact` value.
 
-```
-[ a, b, c, d, e, f ]
-```
-
-means that slots `[a, b]`, slots `[c, d]`, and slots `[e, f]` all
-received late or non-existent votes.
-
-The latency array is not run-length encoded. That means if the decoded
-slots array has `n` slots, then the length of `latency` will be `n`.
+The `latency_exact` array holds one entry per run, so its length is
+exactly half the length of the `slot`. It is the skip-discounted vote
+latency (`null` for missing vote).
 
 :::details Example
 
@@ -2624,8 +2622,9 @@ slots array has `n` slots, then the length of `latency` will be `n`.
 	"topic": "slot",
 	"key": "late_votes_history",
 	"value": {
-        "slot": [286576808, 286576808, 286576810, 286576811, 286625025, 286625026],
-        "latency": [2, 3, null, 2, 2]
+        "slot": [286576808, 286576808, 286576810, 286576810, 286576811, 286576811, 286625025, 286625025],
+        "latency": [2, null, 4, 2],
+        "latency_exact": [2, null, 3, 2]
     }
 }
 ```

--- a/src/app/firedancer-dev/commands/send_test/send_test_helpers.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test_helpers.c
@@ -220,6 +220,9 @@ encode_vote( send_test_ctx_t * ctx, fd_tower_slot_done_t * slot_done ) {
   FD_TEST( txn->payload_sz && txn->payload_sz<=FD_TPU_MTU );
   fd_memcpy( slot_done->vote_txn, txn->payload, txn->payload_sz );
   slot_done->vote_txn_sz = txn->payload_sz;
+  slot_done->is_voting   = 1;
+  slot_done->has_vote_txn = 1;
+  slot_done->authority_idx = ULONG_MAX;
 
   uchar txn_mem[ FD_TXN_MAX_SZ ] __attribute__((aligned(alignof(fd_txn_t))));
   FD_TEST( fd_txn_parse( slot_done->vote_txn, slot_done->vote_txn_sz, txn_mem, NULL ) );

--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -190,11 +190,9 @@ fd_vote_acc_desc( fd_vote_acc_desc_t * desc,
 }
 
 int
-fd_txn_parse_simple_vote( fd_txn_t const * txn,
-                          uchar    const * payload,
-                          fd_pubkey_t *    opt_identity,
-                          fd_pubkey_t *    opt_vote_acct,
-                          ulong *          opt_vote_slot ) {
+fd_txn_parse_simple_vote( fd_txn_t const *                txn,
+                          uchar    const *                payload,
+                          fd_compact_tower_sync_serde_t * opt_tower_sync ) {
   fd_txn_instr_t const * instr      = &txn->instr[ 0 ];
   ulong required_accts = txn->signature_cnt==1 ? 2UL : 3UL;
   if( FD_UNLIKELY( !fd_txn_is_simple_vote_transaction( txn, payload ) || instr->data_sz < sizeof(uint) || txn->acct_addr_cnt < required_accts ) ) return 0;
@@ -206,20 +204,7 @@ fd_txn_parse_simple_vote( fd_txn_t const * txn,
     fd_compact_tower_sync_serde_t compact_tower_sync_serde[ 1 ];
     int err = fd_compact_tower_sync_de( compact_tower_sync_serde, instr_data + sizeof(uint), instr->data_sz - sizeof(uint) );
     if( FD_LIKELY( !err ) ) {
-      if( !!opt_vote_slot ) {
-        *opt_vote_slot =  fd_ulong_if( compact_tower_sync_serde->root==ULONG_MAX, 0, compact_tower_sync_serde->root );
-        for( ulong i = 0; i < compact_tower_sync_serde->lockouts_cnt; i++ ) {
-          if( FD_UNLIKELY( __builtin_uaddl_overflow( *opt_vote_slot, compact_tower_sync_serde->lockouts[ i ].offset, opt_vote_slot ) ) ) return 0;
-        }
-      }
-      fd_pubkey_t const * accs = (fd_pubkey_t const *)fd_type_pun_const( payload + txn->acct_addr_off );
-      if( !!opt_vote_acct ) {
-        if( FD_UNLIKELY( txn->signature_cnt==1 ) ) *opt_vote_acct = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 1 ] ); /* identity and authority same, account idx 1 is the vote account address */
-        else                                       *opt_vote_acct = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 2 ] ); /* identity and authority diff, account idx 2 is the vote account address */
-      }
-      if( !!opt_identity ) {
-        *opt_identity = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 0 ] );
-      }
+      if( !!opt_tower_sync ) *opt_tower_sync = *compact_tower_sync_serde;
       return 1;
     }
   }

--- a/src/choreo/tower/fd_tower_serdes.h
+++ b/src/choreo/tower/fd_tower_serdes.h
@@ -189,15 +189,13 @@ fd_vote_acc_desc_vote( fd_vote_acc_desc_t const * desc,
   return data + desc->votes_off + idx*desc->vote_stride;
 }
 
-/* fd_txn_parse_simple_vote optionally extracts the vote account pubkey,
-   identity pubkey, and largest voted-for slot from a vote transaction. */
+/* fd_txn_parse_simple_vote optionally extracts the decoded tower sync
+   from a vote transaction. */
 
 int
-fd_txn_parse_simple_vote( fd_txn_t const * txn,
-                          uchar    const * payload,
-                          fd_pubkey_t *    opt_identity,
-                          fd_pubkey_t *    opt_vote_acct,
-                          ulong *          opt_vote_slot );
+fd_txn_parse_simple_vote( fd_txn_t const *                txn,
+                          uchar    const *                payload,
+                          fd_compact_tower_sync_serde_t * opt_tower_sync );
 
 FD_PROTOTYPES_END
 

--- a/src/disco/gui/Local.mk
+++ b/src/disco/gui/Local.mk
@@ -2,13 +2,13 @@ ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_gui.h fd_gui_printf.h fd_gui_peers.h fd_gui_config_parse.h fd_gui_metrics.h fd_gui_store.h fd_gui_hist.h)
 $(call add-objs,fd_gui fd_gui_printf fd_gui_peers fd_gui_config_parse fd_gui_tile fd_gui_store fd_gui_hist generated/http_import_dist,fd_disco)
 $(OBJDIR)/obj/disco/gui/fd_gui_tile.o: book/public/fire.svg
-$(call make-unit-test,test_live_table,test_live_table,fd_disco fd_util)
+$(call make-unit-test,test_live_table,test_live_table,fd_disco fd_choreo fd_flamenco fd_util)
 $(call make-unit-test,test_gui_geoip,test_gui_geoip,fd_util)
 $(call make-fuzz-test,fuzz_config_parser,fuzz_config_parser,fd_disco fd_ballet fd_util)
 
-$(call make-unit-test,test_gui_store,test_gui_store,fd_disco fd_util)
+$(call make-unit-test,test_gui_store,test_gui_store,fd_disco fd_choreo fd_flamenco fd_util)
 $(call run-unit-test,test_gui_store)
-$(call make-unit-test,test_gui_hist_evict,test_gui_hist_evict,fd_disco fd_flamenco fd_waltz fd_tango fd_ballet fd_util)
+$(call make-unit-test,test_gui_hist_evict,test_gui_hist_evict,fd_disco fd_choreo fd_flamenco fd_waltz fd_tango fd_ballet fd_util)
 $(call run-unit-test,test_gui_hist_evict)
 
 src/disco/gui/dist_cmp/%.zst: src/disco/gui/dist/% $(OBJDIR)/bin/fd_zstd_pack

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -12,6 +12,7 @@
 #include "../../disco/genesis/fd_genesis_cluster.h"
 #include "../../disco/pack/fd_pack.h"
 #include "../../disco/pack/fd_pack_cost.h"
+#include "../../choreo/tower/fd_tower_serdes.h"
 
 #include <stdio.h>
 
@@ -353,7 +354,7 @@ fd_gui_new( void *                   shmem,
   memset( gui->summary.tile_timers_current,   0, sizeof(gui->summary.tile_timers_current)   );
   memset( gui->summary.tile_timers_packed,    0, sizeof(gui->summary.tile_timers_packed)    );
 
-  gui->tower_cnt = 0UL;
+  gui->landed_vote_cnt = 0UL;
 
   gui->block_engine.has_block_engine = 0;
 
@@ -383,12 +384,15 @@ fd_gui_set_identity( fd_gui_t *    gui,
 
   gui->summary.vote_distance = 0UL;
   if( FD_LIKELY( gui->summary.vote_state!=FD_GUI_VOTE_STATE_NON_VOTING ) ) gui->summary.vote_state = FD_GUI_VOTE_STATE_VOTING;
+  gui->landed_vote_cnt = 0UL;
 
   fd_gui_printf_identity_key( gui );
   fd_http_server_ws_broadcast( gui->http );
   fd_gui_printf_vote_distance( gui );
   fd_http_server_ws_broadcast( gui->http );
   fd_gui_printf_vote_state( gui );
+  fd_http_server_ws_broadcast( gui->http );
+  fd_gui_printf_late_votes_history( gui );
   fd_http_server_ws_broadcast( gui->http );
 }
 
@@ -425,7 +429,6 @@ fd_gui_ws_open( fd_gui_t * gui,
     fd_gui_printf_live_tile_timers,
     fd_gui_printf_live_tile_metrics,
     fd_gui_printf_catch_up_history,
-    fd_gui_printf_vote_latency_history,
     fd_gui_printf_late_votes_history,
     fd_gui_printf_health
   };
@@ -2089,7 +2092,7 @@ fd_gui_slot_get_canon_safe( fd_gui_t * gui, ulong _slot ) {
       .completed_time   = LONG_MAX,
       .parent_completed_time = LONG_MAX,
       .max_compute_units= UINT_MAX,
-      .mine             = (uchar)fd_gui_slot_is_mine( gui, _slot ),
+      .mine             = (uchar)(fd_gui_slot_is_mine( gui, _slot ) & 1),
       .skip             = slot_get_skip_status( gui, _slot ),
       .level            = level,
       .compute_units    = UINT_MAX,
@@ -2098,6 +2101,8 @@ fd_gui_slot_get_canon_safe( fd_gui_t * gui, ulong _slot ) {
       .tips             = ULONG_MAX,
       .shred_cnt        = UINT_MAX,
       .vote_latency     = UCHAR_MAX,
+      .vote_latency_exact = FD_GUI_VOTE_LATENCY_NOT_VOTED,
+      .is_voter         = 0,
       .vote_success     = UINT_MAX,
       .vote_failed      = UINT_MAX,
       .nonvote_success  = UINT_MAX,
@@ -2145,10 +2150,12 @@ fd_gui_handle_epoch_info( fd_gui_t *                  gui,
     epoch->target_slot_duration_ns = (long)epoch_info->ns_per_slot;
     epoch->my_total_slots = 0UL;
     epoch->my_skipped_slots = 0UL;
-    epoch->late_votes_sz  = 0UL;
     epoch->rankings_slot  = epoch_info->start_slot;
     memset( epoch->rankings,    (int)(UINT_MAX), sizeof(epoch->rankings)    );
     memset( epoch->my_rankings, (int)(UINT_MAX), sizeof(epoch->my_rankings) );
+    memset( epoch->latency,       (int)FD_GUI_VOTE_LATENCY_NOT_VOTED, sizeof(epoch->latency)       );
+    memset( epoch->latency_exact, (int)FD_GUI_VOTE_LATENCY_NOT_VOTED, sizeof(epoch->latency_exact) );
+    memset( epoch->is_voter,      0,                                 sizeof(epoch->is_voter)      );
     epoch->epoch_schedule = epoch_info->epoch_schedule;
     epoch->pub_cnt        = fd_ulong_min( lsched->pub_cnt, FD_GUI_EPOCH_PUB_CNT );
     epoch->stakes_cnt     = fd_ulong_min( epoch_info->staked_vote_cnt, MAX_COMPRESSED_STAKE_WEIGHTS );
@@ -2262,48 +2269,61 @@ fd_gui_handle_exec_txn_done( fd_gui_t * gui,
   }
 }
 
+/* fd_gui_compute_vote_latency walks the fork whose landing block is
+   (landed_slot, landed_bank_seq) down toward voted_slot.  On success
+   (voted_slot is an ancestor on this fork) returns 1 and writes
+   voted_slot's bank_seq on this fork to *out_voted_bank_seq and the
+   skip-discounted latency to *out_exact.  Returns 0 if voted_slot is
+   not an ancestor on this fork, or the ancestry is not yet
+   replayed/linked. */
+
+static int
+fd_gui_compute_vote_latency( fd_gui_t * gui,
+                             ulong      landed_slot,
+                             ulong      landed_bank_seq,
+                             ulong      voted_slot,
+                             ulong *    out_voted_bank_seq,
+                             ulong *    out_exact ) {
+  ulong on_fork_between = 0UL;
+  ulong cur_slot        = landed_slot;
+  ulong cur_bank_seq    = landed_bank_seq;
+  for( ulong steps=0UL; steps<1024UL; steps++ ) {
+    fd_gui_slot_t const * c = fd_gui_slot_get( gui, cur_slot, cur_bank_seq );
+    if( FD_UNLIKELY( !c ) ) return 0;
+    ulong pslot = c->parent_slot;
+    ulong pseq  = c->parent_bank_seq;
+    if( FD_UNLIKELY( pslot==ULONG_MAX ) ) return 0;
+    if( FD_UNLIKELY( pslot<voted_slot ) ) return 0;
+    if( FD_LIKELY( pslot==voted_slot ) ) {
+      *out_voted_bank_seq = pseq;
+      *out_exact          = 1UL + on_fork_between;
+      return 1;
+    }
+    on_fork_between++;
+    cur_slot     = pslot;
+    cur_bank_seq = pseq;
+  }
+  return 0;
+}
+
+/* fd_gui_record_vote_latency records the minimum vote_latency_exact
+   observed for the (voted_slot, voted_bank_seq) fork. */
+
 static void
-fd_gui_root_advance_late_votes( fd_gui_t * gui, ulong root_slot ) {
-  fd_gui_epoch_t * epoch = fd_gui_get_epoch_by_slot( gui, root_slot );
-  if( FD_UNLIKELY( !epoch ) ) return;
+fd_gui_record_vote_latency( fd_gui_t * gui,
+                            ulong      voted_slot,
+                            ulong      voted_bank_seq,
+                            uchar      vote_latency,
+                            uchar      vote_latency_exact ) {
+  vote_latency_exact = (uchar)fd_ulong_min( vote_latency_exact, FD_GUI_VOTE_LATENCY_MAX );
 
-  ulong epoch_start = epoch->start_slot;
-  ulong epoch_end   = epoch->start_slot + epoch->slot_cnt - 1UL;
-
-  /* fd_gui_slot_is_late_vote returns 1 if slot number `_s`'s vote was late
-     (unknown latency, or latency >1) and the slot is in the current epoch. */
-#define fd_gui_slot_is_late_vote( _s, meta ) \
-  ( epoch_start<=(_s) && epoch_end>=(_s) && ( (meta)->vote_latency==UCHAR_MAX || (meta)->vote_latency>1UL ) )
-
-  /* Epoch boundary or startup -- backfill history. */
-  if( FD_UNLIKELY( epoch->late_votes_sz==0UL ) ) {
-    for( ulong s=epoch_start; s<fd_ulong_min( root_slot, epoch_end+1UL ); s++ ) {
-      fd_gui_slot_t * slot = fd_gui_slot_get_canon( gui, s );
-      if( FD_UNLIKELY( !slot ) ) continue;
-      if( FD_UNLIKELY( slot->level<FD_GUI_SLOT_LEVEL_ROOTED ) ) break;
-
-      if( FD_UNLIKELY( fd_gui_slot_is_late_vote( s, slot ) ) ) {
-        fd_gui_try_insert_run_length_slot( epoch->late_votes, MAX_SLOTS_PER_EPOCH, &epoch->late_votes_sz, s );
-      }
-    }
+  fd_gui_slot_t * slot = fd_gui_slot_get( gui, voted_slot, voted_bank_seq );
+  if( FD_LIKELY( slot ) && FD_LIKELY( vote_latency_exact<slot->vote_latency_exact ) ) {
+    slot->vote_latency       = vote_latency;
+    slot->vote_latency_exact = vote_latency_exact;
+    fd_gui_printf_slot( gui, voted_slot, slot );
+    fd_http_server_ws_broadcast( gui->http );
   }
-
-  /* Start at the new root and move backwards towards the old root,
-     recording late votes for everything in-between. */
-  for( ulong i=0UL; i<fd_ulong_min( root_slot, MAX_SLOTS_PER_EPOCH ); i++ ) {
-    ulong parent_slot = root_slot - i;
-
-    fd_gui_slot_t * slot = fd_gui_slot_get_canon( gui, parent_slot );
-    if( FD_UNLIKELY( !slot ) ) break;
-
-    if( FD_UNLIKELY( fd_gui_slot_is_late_vote( parent_slot, slot ) ) ) {
-      fd_gui_try_insert_run_length_slot( epoch->late_votes, MAX_SLOTS_PER_EPOCH, &epoch->late_votes_sz, parent_slot );
-    }
-
-    if( FD_UNLIKELY( slot->level>=FD_GUI_SLOT_LEVEL_ROOTED ) ) break;
-  }
-
-#undef fd_gui_slot_is_late_vote
 }
 
 void
@@ -2317,9 +2337,6 @@ fd_gui_handle_root_advanced( fd_gui_t * gui,
   /* Rooting only ever advances. */
   if( FD_UNLIKELY( gui->summary.slot_rooted!=ULONG_MAX && _slot<=gui->summary.slot_rooted ) ) return;
 
-  /* Record late votes for the newly rooted slots. */
-  fd_gui_root_advance_late_votes( gui, _slot );
-
   ulong prev_rooted = gui->summary.slot_rooted;
 
   gui->summary.slot_rooted = _slot;
@@ -2331,8 +2348,35 @@ fd_gui_handle_root_advanced( fd_gui_t * gui,
     if( FD_UNLIKELY( !c || c->level>=FD_GUI_SLOT_LEVEL_ROOTED ) ) break;
 
     c->level = FD_GUI_SLOT_LEVEL_ROOTED;
+
     fd_gui_printf_slot( gui, cslot, c );
     fd_http_server_ws_broadcast( gui->http );
+
+    /* Finalize vote latencies from votes that landed in this block. */
+    for( ulong r=0UL; r<gui->landed_vote_cnt; r++ ) {
+      if( FD_UNLIKELY( gui->landed_votes[ r ].landed_slot!=cslot || gui->landed_votes[ r ].landed_bank_seq!=cbank_seq ) ) continue;
+      ulong voted_slot = gui->landed_votes[ r ].voted_slot;
+      ulong raw = fd_ulong_min( cslot - voted_slot, FD_GUI_VOTE_LATENCY_MAX );
+      ulong voted_bank_seq, exact;
+      if( FD_UNLIKELY( !fd_gui_compute_vote_latency( gui, cslot, cbank_seq, voted_slot, &voted_bank_seq, &exact ) ) ) continue;
+      uchar raw_exact = (uchar)fd_ulong_min( exact, FD_GUI_VOTE_LATENCY_MAX );
+      fd_gui_record_vote_latency( gui, voted_slot, voted_bank_seq, (uchar)raw, raw_exact );
+
+      fd_gui_epoch_t * vepoch = fd_gui_get_epoch_by_slot( gui, voted_slot );
+      if( FD_UNLIKELY( !vepoch ) ) continue;
+      ulong vidx = voted_slot - vepoch->start_slot;
+      if( FD_UNLIKELY( vidx>=vepoch->slot_cnt ) ) continue;
+      if( FD_LIKELY( raw_exact<vepoch->latency_exact[ vidx ] ) ) {
+        vepoch->latency      [ vidx ] = (uchar)raw;
+        vepoch->latency_exact[ vidx ] = raw_exact;
+      }
+    }
+
+    fd_gui_epoch_t * epoch = fd_gui_get_epoch_by_slot( gui, cslot );
+    if( FD_LIKELY( epoch ) ) {
+      ulong cidx = cslot - epoch->start_slot;
+      if( FD_LIKELY( cidx<epoch->slot_cnt ) ) epoch->is_voter[ cidx ] = c->is_voter;
+    }
 
     ulong pslot = c->parent_slot, pseq = c->parent_bank_seq;
     if( FD_UNLIKELY( pslot==ULONG_MAX || pslot>=cslot ) ) break;
@@ -2350,6 +2394,14 @@ fd_gui_handle_root_advanced( fd_gui_t * gui,
 
     cslot = pslot; cbank_seq = pseq;
   }
+
+  ulong rooted_slot = gui->summary.slot_rooted;
+  ulong w = 0UL;
+  for( ulong r=0UL; r<gui->landed_vote_cnt; r++ ) {
+    if( FD_UNLIKELY( gui->landed_votes[ r ].landed_slot<=rooted_slot ) ) continue;
+    gui->landed_votes[ w++ ] = gui->landed_votes[ r ];
+  }
+  gui->landed_vote_cnt = w;
 }
 
 void
@@ -2554,16 +2606,37 @@ handle_tower_slot( fd_gui_t * gui, ulong reset_slot, ulong reset_bank_seq, long 
 }
 
 static inline void
-publish_vote_status( fd_gui_t * gui ) {
+set_vote_state( fd_gui_t * gui,
+                int        vote_state ) {
+  if( FD_UNLIKELY( gui->summary.vote_state!=vote_state ) ) {
+    gui->summary.vote_state = vote_state;
+    fd_gui_printf_vote_state( gui );
+    fd_http_server_ws_broadcast( gui->http );
+  }
+}
+
+static inline void
+publish_vote_status( fd_gui_t * gui,
+                     int        is_voting ) {
+  if( FD_UNLIKELY( !is_voting ) ) {
+    set_vote_state( gui, FD_GUI_VOTE_STATE_NON_VOTING );
+    return;
+  }
+
   fd_gui_slot_t * slot = fd_gui_slot_get( gui, gui->summary.slot_tower, gui->summary.slot_tower_bank_seq );
   FD_TEST( slot );
 
-  if( FD_UNLIKELY( slot->vote_slot==ULONG_MAX || gui->summary.slot_tower==ULONG_MAX ) ) return;
+  if( FD_UNLIKELY( gui->summary.slot_tower==ULONG_MAX ) ) return;
+
+  if( FD_UNLIKELY( slot->vote_slot==ULONG_MAX ) ) {
+    /* Voting is enabled but no vote has landed yet. */
+    set_vote_state( gui, FD_GUI_VOTE_STATE_DELINQUENT );
+    return;
+  }
 
   /* Snapshot the fields before the inner loop (which re-resolves slots). */
   ulong vote_slot  = slot->vote_slot;
   ulong reset_slot = gui->summary.slot_tower;
-  int   is_voting  = gui->summary.vote_state!=FD_GUI_VOTE_STATE_NON_VOTING;
 
   ulong vote_distance = reset_slot-vote_slot;
   if( FD_LIKELY( vote_distance<FD_GUI_MAX_VOTE_DISTANCE ) ) {
@@ -2578,20 +2651,10 @@ publish_vote_status( fd_gui_t * gui ) {
     fd_http_server_ws_broadcast( gui->http );
   }
 
-  if( FD_LIKELY( is_voting ) ) {
-    if( FD_UNLIKELY( vote_slot==ULONG_MAX || vote_distance>150UL ) ) {
-      if( FD_UNLIKELY( gui->summary.vote_state!=FD_GUI_VOTE_STATE_DELINQUENT ) ) {
-        gui->summary.vote_state = FD_GUI_VOTE_STATE_DELINQUENT;
-        fd_gui_printf_vote_state( gui );
-        fd_http_server_ws_broadcast( gui->http );
-      }
-    } else {
-      if( FD_UNLIKELY( gui->summary.vote_state!=FD_GUI_VOTE_STATE_VOTING ) ) {
-        gui->summary.vote_state = FD_GUI_VOTE_STATE_VOTING;
-        fd_gui_printf_vote_state( gui );
-        fd_http_server_ws_broadcast( gui->http );
-      }
-    }
+  if( FD_UNLIKELY( vote_slot==ULONG_MAX || vote_distance>150UL ) ) {
+    set_vote_state( gui, FD_GUI_VOTE_STATE_DELINQUENT );
+  } else {
+    set_vote_state( gui, FD_GUI_VOTE_STATE_VOTING );
   }
 }
 
@@ -2599,9 +2662,9 @@ publish_vote_status( fd_gui_t * gui ) {
    manages consensus related fork switching, rooting, slot confirmation.
 
    The gui tile consumes tower_out via returnable_frag and defers any
-   update whose reset tip has not yet been recorded from replay, so by
-   the time this runs tower->reset_slot is guaranteed to have a DB
-   record. */
+   update whose replay_slot has not yet been recorded from replay, so by
+   the time this runs both tower->replay_slot and tower->reset_slot are
+   guaranteed to have a DB record. */
 void
 fd_gui_handle_tower_update( fd_gui_t *                   gui,
                             fd_tower_slot_done_t const * tower,
@@ -2612,9 +2675,25 @@ fd_gui_handle_tower_update( fd_gui_t *                   gui,
     fd_http_server_ws_broadcast( gui->http );
   }
 
+  fd_gui_slot_t * replay_slot = fd_gui_slot_get( gui, tower->replay_slot, tower->replay_bank_seq );
+  FD_TEST( replay_slot );
+  replay_slot->is_voter = (uchar)(!!tower->is_voting);
+
+  /* Handle already-rooted edge case. */
+  if( FD_UNLIKELY( replay_slot->level>=FD_GUI_SLOT_LEVEL_ROOTED ) ) {
+    fd_gui_epoch_t * epoch = fd_gui_get_epoch_by_slot( gui, tower->replay_slot );
+    if( FD_LIKELY( epoch ) ) {
+      ulong cidx = tower->replay_slot - epoch->start_slot;
+      if( FD_LIKELY( cidx<epoch->slot_cnt ) ) epoch->is_voter[ cidx ] = replay_slot->is_voter;
+    }
+  }
+
   if( FD_LIKELY( tower->reset_slot!=ULONG_MAX ) ) {
     handle_tower_slot( gui, tower->reset_slot, tower->reset_bank_seq, now );
-    publish_vote_status( gui );
+    publish_vote_status( gui, tower->is_voting );
+  } else if( FD_UNLIKELY( !tower->is_voting ) ) {
+    /* NON_VOTING does not need a reset slot, unlike publish_vote_status. */
+    set_vote_state( gui, FD_GUI_VOTE_STATE_NON_VOTING );
   }
 
   if( FD_LIKELY( gui->summary.slot_reset!=tower->reset_slot ) ) {
@@ -2629,31 +2708,58 @@ fd_gui_handle_tower_update( fd_gui_t *                   gui,
     fd_http_server_ws_broadcast( gui->http );
   }
 
-  /* update slot history vote latencies with new votes. */
-  for( ulong i=0UL; i<tower->tower_cnt; i++ ) {
-    ulong          tslot = tower->tower[ i ].slot;
-    uchar          latency = tower->tower[ i ].latency;
-    fd_gui_slot_t * slot = fd_gui_slot_get_canon( gui, tslot );
-    if( FD_UNLIKELY( slot && slot->vote_latency!=latency ) ) {
-      slot->vote_latency = latency;
-      fd_gui_printf_slot( gui, tslot, slot );
-      fd_http_server_ws_broadcast( gui->http );
-    }
-    if( FD_LIKELY( slot ) ) slot->vote_latency = latency;
+  /* Update vote latencies.  This is the speculative, true correct
+     latencies are published as a vote's landed slot is rooted. */
+  for( ulong r=0UL; r<gui->landed_vote_cnt; r++ ) {
+    ulong raw_latency = fd_ulong_min( gui->landed_votes[ r ].landed_slot - gui->landed_votes[ r ].voted_slot, FD_GUI_VOTE_LATENCY_MAX );
+    if( FD_UNLIKELY( gui->landed_votes[ r ].landed_slot>gui->summary.slot_tower ) ) continue;
 
-    if( FD_UNLIKELY( i+1UL>=tower->tower_cnt ) ) break;
-    for( ulong s=tower->tower[ i ].slot+1UL; s<tower->tower[ i+1 ].slot; s++ ) {
-      fd_gui_slot_t * gap = fd_gui_slot_get_canon( gui, s );
-      if( FD_LIKELY( gap && gap->vote_latency!=UCHAR_MAX ) ) {
-        gap->vote_latency = UCHAR_MAX;
-        fd_gui_printf_slot( gui, s, gap );
-        fd_http_server_ws_broadcast( gui->http );
-      }
+    ulong voted_bank_seq, exact_latency;
+    if( FD_UNLIKELY( !fd_gui_compute_vote_latency( gui, gui->landed_votes[ r ].landed_slot, gui->landed_votes[ r ].landed_bank_seq, gui->landed_votes[ r ].voted_slot, &voted_bank_seq, &exact_latency ) ) ) continue;
 
-      gap = fd_gui_slot_get_any( gui, s );
-      if( FD_UNLIKELY( gap ) ) gap->vote_latency = UCHAR_MAX;
-    }
+    fd_gui_slot_t * slot = fd_gui_slot_get( gui, gui->landed_votes[ r ].voted_slot, voted_bank_seq );
+    if( FD_UNLIKELY( !slot ) ) continue;
+
+    uchar e = (uchar)fd_ulong_min( exact_latency, FD_GUI_VOTE_LATENCY_MAX );
+    if( FD_LIKELY( e>=slot->vote_latency_exact ) ) continue;
+    fd_gui_record_vote_latency( gui, gui->landed_votes[ r ].voted_slot, voted_bank_seq, (uchar)raw_latency, e );
   }
+}
+
+void
+fd_gui_stage_landed_vote( fd_gui_t * gui,
+                          ulong      landed_slot,
+                          ulong      landed_bank_seq,
+                          ulong      voted_slot ) {
+  if( FD_UNLIKELY( voted_slot==ULONG_MAX || voted_slot>=landed_slot ) ) return;
+
+  /* Handle already-rooted edge case. */
+  if( FD_UNLIKELY( gui->summary.slot_rooted!=ULONG_MAX && landed_slot<=gui->summary.slot_rooted ) ) {
+    fd_gui_slot_t const * canon = fd_gui_slot_get_canon( gui, landed_slot );
+    if( FD_UNLIKELY( !canon || canon->bank_seq!=landed_bank_seq ) ) return;
+    ulong raw = fd_ulong_min( landed_slot - voted_slot, FD_GUI_VOTE_LATENCY_MAX );
+    ulong voted_bank_seq, exact;
+    if( FD_UNLIKELY( !fd_gui_compute_vote_latency( gui, landed_slot, landed_bank_seq, voted_slot, &voted_bank_seq, &exact ) ) ) return;
+    uchar raw_exact = (uchar)fd_ulong_min( exact, FD_GUI_VOTE_LATENCY_MAX );
+    fd_gui_record_vote_latency( gui, voted_slot, voted_bank_seq, (uchar)raw, raw_exact );
+
+    fd_gui_epoch_t * vepoch = fd_gui_get_epoch_by_slot( gui, voted_slot );
+    if( FD_UNLIKELY( !vepoch ) ) return;
+    ulong vidx = voted_slot - vepoch->start_slot;
+    if( FD_UNLIKELY( vidx>=vepoch->slot_cnt ) ) return;
+    if( FD_LIKELY( raw_exact<vepoch->latency_exact[ vidx ] ) ) {
+      vepoch->latency      [ vidx ] = (uchar)raw;
+      vepoch->latency_exact[ vidx ] = raw_exact;
+    }
+    return;
+  }
+
+  if( FD_UNLIKELY( gui->landed_vote_cnt>=FD_GUI_LANDED_VOTE_MAX ) ) return;
+
+  gui->landed_votes[ gui->landed_vote_cnt ].landed_slot     = landed_slot;
+  gui->landed_votes[ gui->landed_vote_cnt ].landed_bank_seq = landed_bank_seq;
+  gui->landed_votes[ gui->landed_vote_cnt ].voted_slot      = voted_slot;
+  gui->landed_vote_cnt++;
 }
 
 void
@@ -2860,6 +2966,30 @@ fd_gui_microblock_execution_begin( fd_gui_t *   gui,
   lslot->begin_microblocks += (uint)txn_cnt;
 }
 
+static void
+fd_gui_stage_leader_block_votes( fd_gui_t *   gui,
+                                 ulong        landed_slot,
+                                 ulong        landed_bank_seq,
+                                 fd_txn_p_t * txn_p ) {
+  if( FD_LIKELY( !(txn_p->flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS) || (txn_p->flags & (FD_TXN_P_FLAGS_FEES_ONLY | FD_TXN_P_FLAGS_RESULT_MASK)) ) ) return;
+
+  fd_txn_t const * txn     = TXN( txn_p );
+  uchar const *    payload = txn_p->payload;
+
+  fd_compact_tower_sync_serde_t tower_sync[ 1 ];
+  if( FD_UNLIKELY( !fd_txn_parse_simple_vote( txn, payload, tower_sync ) ) ) return;
+
+  fd_acct_addr_t const * accs = fd_txn_get_acct_addrs( txn, payload );
+  if( FD_UNLIKELY( memcmp( &accs[ 0 ], gui->summary.identity_key->uc, sizeof(fd_pubkey_t) ) ) ) return; /* not our identity */
+  if( FD_UNLIKELY( gui->summary.has_vote_key && memcmp( &accs[ txn->signature_cnt==1 ? 1 : 2 ], gui->summary.vote_key->uc, sizeof(fd_pubkey_t) ) ) ) return; /* not our vote account */
+
+  ulong cur = fd_ulong_if( tower_sync->root==ULONG_MAX, 0UL, tower_sync->root );
+  for( ulong i=0UL; i<tower_sync->lockouts_cnt; i++ ) {
+    if( FD_UNLIKELY( __builtin_uaddl_overflow( cur, tower_sync->lockouts[ i ].offset, &cur ) ) ) return;
+    fd_gui_stage_landed_vote( gui, landed_slot, landed_bank_seq, cur );
+  }
+}
+
 void
 fd_gui_microblock_execution_end( fd_gui_t *     gui,
                                  long           tspub_ns,
@@ -2900,6 +3030,9 @@ fd_gui_microblock_execution_end( fd_gui_t *     gui,
       .flags                   = flags
     };
     fd_gui_hist_ts_append( gui, FD_GUI_HIST_TXN_END, now, tspub_ns, &rec );
+
+    /* Record our own votes that land in our own leader block. */
+    fd_gui_stage_leader_block_votes( gui, _slot, bank_seq, txn_p );
   }
 
   lslot->end_microblocks = lslot->end_microblocks + (uint)txn_cnt;

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -14,8 +14,6 @@
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../../discof/tower/fd_tower_tile.h"
 #include "../../discof/replay/fd_replay_tile.h"
-#include "../../choreo/tower/fd_tower.h"
-#include "../../choreo/tower/fd_tower_serdes.h"
 #include "../../flamenco/leaders/fd_leaders.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h" /* fd_slot_to_epoch */
 #include "../../util/fd_util_base.h"
@@ -159,6 +157,8 @@ typedef struct fd_gui_rate_entry fd_gui_rate_entry_t;
 #define FD_GUI_VOTE_STATE_DELINQUENT (2)
 
 #define FD_GUI_MAX_VOTE_DISTANCE     (512UL)
+
+#define FD_GUI_LANDED_VOTE_MAX      (4096UL)
 
 #define FD_GUI_SLOT_SHRED_REPAIR_REQUEST          (0UL)
 #define FD_GUI_SLOT_SHRED_SHRED_RECEIVED_TURBINE  (1UL)
@@ -310,12 +310,14 @@ struct __attribute__((packed)) fd_gui_slot {
   long      completed_time;   /* slot completion wallclock ns (LONG_MAX if unknown) */
   uint      shred_cnt;        /* slot->shred_cnt at completion */
   fd_hash_t block_hash;       /* block hash of the slot */
-  uchar     mine;             /* 1 if this was our leader slot */
+  uchar     mine:1;           /* 1 if this was our leader slot */
+  uchar     is_voter:1;       /* 1 if we were structurally a voter when this slot was replayed */
   uint      vote_success;     /* successful vote txn count     (UINT_MAX if unknown) */
   uint      vote_failed;      /* failed vote txn count         (UINT_MAX if unknown) */
   uint      nonvote_success;  /* successful nonvote txn count  (UINT_MAX if unknown) */
   uint      nonvote_failed;   /* failed nonvote txn count      (UINT_MAX if unknown) */
-  uchar     vote_latency;     /* our vote latency for the slot (UCHAR_MAX if did not vote) */
+  uchar     vote_latency;     /* our raw vote latency for the slot (UCHAR_MAX if did not vote) */
+  uchar     vote_latency_exact;/* our vote latency minus skipped slots on the landed fork, or FD_GUI_VOTE_LATENCY_NOT_VOTED if no vote landed. */
   uint      max_compute_units;/* block compute unit limit      (UINT_MAX if unknown) */
   uint      compute_units;    /* block compute units consumed  (UINT_MAX if unknown) */
   ulong     transaction_fee;  /* total transaction fee         (ULONG_MAX if unknown) */
@@ -375,6 +377,9 @@ typedef struct fd_gui_slot_rankings fd_gui_slot_rankings_t;
 #define FD_GUI_EPOCH_SCHED_CNT ((MAX_SLOTS_PER_EPOCH+FD_EPOCH_SLOTS_PER_ROTATION-1UL)/FD_EPOCH_SLOTS_PER_ROTATION)
 #define FD_GUI_EPOCH_PUB_CNT   (MAX_COMPRESSED_STAKE_WEIGHTS+1UL) /* +1 for indeterminate leader */
 
+#define FD_GUI_VOTE_LATENCY_NOT_VOTED ((uchar)(UCHAR_MAX))     /* vote missing */
+#define FD_GUI_VOTE_LATENCY_MAX       ((uchar)(UCHAR_MAX-1UL)) /* largest observable vote latency */
+
 struct fd_gui_epoch {
   ulong epoch;
   ulong start_slot;
@@ -385,10 +390,13 @@ struct fd_gui_epoch {
   ulong my_total_slots;                  /* our leader slots seen this epoch */
   ulong my_skipped_slots;                /* our skipped leader slots this epoch */
   ulong rankings_slot;                   /* one more than the largest slot processed into rankings */
-  ulong late_votes_sz;                   /* number of entries in late_votes[] */
   fd_gui_slot_rankings_t rankings   [ 1 ]; /* global slot rankings */
   fd_gui_slot_rankings_t my_rankings[ 1 ]; /* my slots only */
-  ulong late_votes[ MAX_SLOTS_PER_EPOCH ]; /* run-length-encoded late-vote slots */
+
+  /* Arrays of FD_GUI_VOTE_LATENCY_* */
+  uchar latency      [ MAX_SLOTS_PER_EPOCH ];
+  uchar latency_exact[ MAX_SLOTS_PER_EPOCH ];
+  uchar is_voter     [ MAX_SLOTS_PER_EPOCH ]; /* 1 if we were structurally a voter when this slot was replayed */
 
   fd_epoch_schedule_t epoch_schedule;    /* slot<->epoch conversion (fd_slot_to_epoch) */
   ulong               pub_cnt;           /* number of deduped leader pubkeys in pub[] */
@@ -753,8 +761,8 @@ struct fd_gui_summary {
   fd_gui_ephemeral_slot_t slots_max_turbine[ FD_GUI_TURBINE_SLOT_HISTORY_SZ+1UL ];
   fd_gui_ephemeral_slot_t slots_max_repair [ FD_GUI_REPAIR_SLOT_HISTORY_SZ +1UL ];
 
-  /* catchup_* and late_votes are run-length encoded. i.e. adjacent
-     pairs represent contiguous runs */
+  /* catchup_* is run-length encoded. i.e. adjacent pairs represent
+     contiguous runs */
   ulong catch_up_turbine[ FD_GUI_TURBINE_CATCH_UP_HISTORY_SZ ];
   ulong catch_up_turbine_sz;
 
@@ -849,8 +857,12 @@ struct fd_gui {
     fd_gui_slot_txn_join_t    joined[ FD_MAX_TXN_PER_SLOT ];
   } slot_txn_scratch;
 
-  ulong tower_cnt;
-  fd_vote_acc_vote_t tower[ FD_TOWER_VOTE_MAX ];
+  struct {
+    ulong landed_slot;
+    ulong landed_bank_seq;
+    ulong voted_slot;
+  } landed_votes[ FD_GUI_LANDED_VOTE_MAX ];
+  ulong landed_vote_cnt;
 
   struct {
     int has_block_engine;
@@ -1044,6 +1056,12 @@ fd_gui_handle_replay_update( fd_gui_t *                         gui,
                              fd_replay_slot_completed_t const * slot_completed,
                              ulong                              vote_slot,
                              long                               now );
+
+void
+fd_gui_stage_landed_vote( fd_gui_t * gui,
+                          ulong      landed_slot,
+                          ulong      landed_bank_seq,
+                          ulong      voted_slot );
 
 void
 fd_gui_handle_genesis_hash( fd_gui_t *        gui,
@@ -1327,12 +1345,14 @@ fd_gui_slot_get_or_create( fd_gui_t * gui,
   meta->bank_seq          = bank_seq;
   meta->parent_bank_seq   = parent_bank_seq;
   meta->parent_slot       = _parent_slot;
-  meta->vote_slot         = ULONG_MAX;
-  meta->vote_latency      = UCHAR_MAX;
+  meta->vote_slot          = ULONG_MAX;
+  meta->vote_latency       = UCHAR_MAX;
+  meta->vote_latency_exact = FD_GUI_VOTE_LATENCY_NOT_VOTED;
   meta->max_compute_units = UINT_MAX;
   meta->completed_time    = LONG_MAX;
   meta->parent_completed_time = LONG_MAX;
-  meta->mine              = (uchar)mine;
+  meta->mine              = (uchar)(mine & 1);
+  meta->is_voter          = 0;
   meta->skip              = FD_GUI_SKIP_STATUS_UNKNOWN;
   meta->level             = (uchar)( _slot ? FD_GUI_SLOT_LEVEL_INCOMPLETE : FD_GUI_SLOT_LEVEL_ROOTED ); /* slot 0 always rooted */
   meta->vote_failed       = UINT_MAX;

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -442,39 +442,59 @@ fd_gui_printf_skipped_history_cluster( fd_gui_t * gui, ulong epoch ) {
   jsonp_close_envelope( gui->http );
 }
 
-/* TODO: deprecated */
-void
-fd_gui_printf_vote_latency_history( fd_gui_t * gui ) {
-  fd_gui_epoch_t * rec = fd_gui_current_epoch( gui );
-  ulong   lv_sz = FD_LIKELY( rec ) ? rec->late_votes_sz : 0UL;
-  ulong * lv    = FD_LIKELY( rec ) ? rec->late_votes    : NULL;
-  jsonp_open_envelope( gui->http, "slot", "vote_latency_history" );
-      jsonp_open_array( gui->http, "value" );
-        FD_TEST( lv_sz % 2UL == 0UL );
-        for( ulong i=0UL; i<lv_sz; i++ ) jsonp_ulong( gui->http, NULL, lv[ i ] );
-      jsonp_close_array( gui->http );
-  jsonp_close_envelope( gui->http );
+/* fd_gui_slot_is_late returns 1 if slot s belongs in the
+   late_votes_history output (voted for late, or canonical but never
+   voted for), 0 otherwise. */
+
+static inline int
+fd_gui_slot_is_late( fd_gui_epoch_t const * rec, ulong s ) {
+  ulong  idx   = s-rec->start_slot;
+  uchar  exact = rec->latency_exact[ idx ];
+  return fd_int_if( exact==FD_GUI_VOTE_LATENCY_NOT_VOTED, rec->is_voter[ idx ], exact>=2 );
 }
 
 void
 fd_gui_printf_late_votes_history( fd_gui_t * gui ) {
   fd_gui_epoch_t * rec = fd_gui_current_epoch( gui );
-  ulong   lv_sz = FD_LIKELY( rec ) ? rec->late_votes_sz : 0UL;
-  ulong * lv    = FD_LIKELY( rec ) ? rec->late_votes    : NULL;
+  ulong first_replay_slot = fd_ulong_if( gui->summary.slot_caught_up!=ULONG_MAX, fd_gui_first_replay_slot( gui ), ULONG_MAX );
+  ulong start_slot = FD_LIKELY( rec ) ? fd_ulong_max( rec->start_slot, fd_ulong_if( first_replay_slot!=ULONG_MAX, first_replay_slot, 0UL ) ) : 0UL;
+  ulong end_slot   = FD_LIKELY( rec ) ? fd_ulong_min( rec->start_slot+rec->slot_cnt-1UL, gui->summary.slot_rooted ) : 0UL;
+  int   have_any   = rec && gui->summary.slot_rooted!=ULONG_MAX;
+
   jsonp_open_envelope( gui->http, "slot", "late_votes_history" );
       jsonp_open_object( gui->http, "value" );
         jsonp_open_array( gui->http, "slot" );
-          for( ulong i=0UL; i<lv_sz; i++ ) jsonp_ulong( gui->http, NULL, lv[ i ] );
+          if( FD_LIKELY( have_any ) ) {
+            ulong s = start_slot;
+            while( s<=end_slot ) {
+              if( FD_LIKELY( !fd_gui_slot_is_late( rec, s ) ) ) { s++; continue; }
+              ulong run_start = s;
+              uchar run_exact = rec->latency_exact[ s-rec->start_slot ];
+              while( s<=end_slot && fd_gui_slot_is_late( rec, s ) && rec->latency_exact[ s-rec->start_slot ]==run_exact ) s++;
+              jsonp_ulong( gui->http, NULL, run_start );
+              jsonp_ulong( gui->http, NULL, s-1UL );
+            }
+          }
         jsonp_close_array( gui->http );
         jsonp_open_array( gui->http, "latency" );
-          for( long i=0UL; i<(long)lv_sz-1L; i+=2L ) {
-            FD_TEST( (ulong)i+1<lv_sz );
-            ulong s = lv[ i ];
-            ulong s2 = lv[ i + 1 ];
-            for( ulong j=s; j<=fd_ulong_min( s2, s+MAX_SLOTS_PER_EPOCH ); j++ ) {
-              fd_gui_slot_t const * slot = fd_gui_slot_get_canon_safe( gui, j );
-              if( FD_UNLIKELY( slot && slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, NULL, slot->vote_latency );
-              else                                                       jsonp_null( gui->http, NULL );
+          if( FD_LIKELY( have_any ) ) {
+            for( ulong s=start_slot; s<=end_slot; s++ ) {
+              if( FD_LIKELY( !fd_gui_slot_is_late( rec, s ) ) ) continue;
+              uchar l = rec->latency[ s-rec->start_slot ];
+              if( FD_LIKELY( l<=FD_GUI_VOTE_LATENCY_MAX ) ) jsonp_ulong( gui->http, NULL, l );
+              else                                          jsonp_null( gui->http, NULL );
+            }
+          }
+        jsonp_close_array( gui->http );
+        jsonp_open_array( gui->http, "latency_exact" );
+          if( FD_LIKELY( have_any ) ) {
+            ulong s = start_slot;
+            while( s<=end_slot ) {
+              if( FD_LIKELY( !fd_gui_slot_is_late( rec, s ) ) ) { s++; continue; }
+              uchar run_exact = rec->latency_exact[ s-rec->start_slot ];
+              while( s<=end_slot && fd_gui_slot_is_late( rec, s ) && rec->latency_exact[ s-rec->start_slot ]==run_exact ) s++;
+              if( FD_LIKELY( run_exact!=FD_GUI_VOTE_LATENCY_NOT_VOTED ) ) jsonp_ulong( gui->http, NULL, run_exact );
+              else                                                        jsonp_null ( gui->http, NULL );
             }
           }
         jsonp_close_array( gui->http );
@@ -1370,11 +1390,11 @@ fd_gui_printf_accounts_stats( fd_gui_t * gui ) {
               double acq_rate    = WRATE( gui->summary.accdb->class_acq_win        [ c ] );
               double acq_wr_rate = WRATE( gui->summary.accdb->class_acq_wr_win     [ c ] );
               double nf_rate     = WRATE( gui->summary.accdb->class_not_found_win  [ c ] );
-              jsonp_double( gui->http, "not_found_per_sec",          nf_rate                                                          );
-              jsonp_double( gui->http, "evicted_per_sec",             WRATE( gui->summary.accdb->class_evicted_win    [ c ] )                );
-              jsonp_double( gui->http, "preevicted_per_sec",          WRATE( gui->summary.accdb->class_preevicted_win [ c ] )                );
-              jsonp_double( gui->http, "committed_new_per_sec",       WRATE( gui->summary.accdb->class_commit_new_win [ c ] )                );
-              jsonp_double( gui->http, "committed_overwrite_per_sec", WRATE( gui->summary.accdb->class_commit_over_win[ c ] )                );
+              jsonp_double( gui->http, "not_found_per_sec",           nf_rate                                                 );
+              jsonp_double( gui->http, "evicted_per_sec",             WRATE( gui->summary.accdb->class_evicted_win    [ c ] ) );
+              jsonp_double( gui->http, "preevicted_per_sec",          WRATE( gui->summary.accdb->class_preevicted_win [ c ] ) );
+              jsonp_double( gui->http, "committed_new_per_sec",       WRATE( gui->summary.accdb->class_commit_new_win [ c ] ) );
+              jsonp_double( gui->http, "committed_overwrite_per_sec", WRATE( gui->summary.accdb->class_commit_over_win[ c ] ) );
               /* reads_per_sec = acquired - acquired_writable (per class);
                  writes_per_sec = acquired_writable (per class). */
               jsonp_double( gui->http, "reads_per_sec",  fmax( 0.0, acq_rate - acq_wr_rate ) );
@@ -1813,6 +1833,9 @@ fd_gui_printf_slot( fd_gui_t *            gui,
         else                                            jsonp_null( gui->http, "vote_slot" );
         if( FD_UNLIKELY( slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, "vote_latency", slot->vote_latency );
         else                                               jsonp_null( gui->http, "vote_latency" );
+        if( FD_LIKELY( slot->vote_latency_exact!=FD_GUI_VOTE_LATENCY_NOT_VOTED ) ) jsonp_ulong( gui->http, "vote_latency_exact", slot->vote_latency_exact );
+        else                                                                       jsonp_null( gui->http, "vote_latency_exact" );
+        jsonp_bool( gui->http, "is_voter", slot->is_voter );
 
         if( FD_UNLIKELY( have_lmeta && lmeta->leader_start_time!=LONG_MAX ) ) jsonp_long_as_str( gui->http, "start_timestamp_nanos", lmeta->leader_start_time  );
         else                                                                  jsonp_null       ( gui->http, "start_timestamp_nanos" );
@@ -1938,6 +1961,9 @@ fd_gui_printf_slot_request( fd_gui_t *            gui,
         else                                            jsonp_null( gui->http, "vote_slot" );
         if( FD_UNLIKELY( slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, "vote_latency", slot->vote_latency );
         else                                               jsonp_null( gui->http, "vote_latency" );
+        if( FD_LIKELY( slot->vote_latency_exact!=FD_GUI_VOTE_LATENCY_NOT_VOTED ) ) jsonp_ulong( gui->http, "vote_latency_exact", slot->vote_latency_exact );
+        else                                                                       jsonp_null( gui->http, "vote_latency_exact" );
+        jsonp_bool( gui->http, "is_voter", slot->is_voter );
 
         if( FD_UNLIKELY( have_lmeta && lmeta->leader_start_time!=LONG_MAX ) ) jsonp_long_as_str( gui->http, "start_timestamp_nanos", lmeta->leader_start_time  );
         else                                                                  jsonp_null       ( gui->http, "start_timestamp_nanos" );
@@ -2016,6 +2042,9 @@ fd_gui_printf_slot_transactions_request( fd_gui_t *            gui,
         else                                            jsonp_null( gui->http, "vote_slot" );
         if( FD_UNLIKELY( slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, "vote_latency", slot->vote_latency );
         else                                               jsonp_null( gui->http, "vote_latency" );
+        if( FD_LIKELY( slot->vote_latency_exact!=FD_GUI_VOTE_LATENCY_NOT_VOTED ) ) jsonp_ulong( gui->http, "vote_latency_exact", slot->vote_latency_exact );
+        else                                                                       jsonp_null( gui->http, "vote_latency_exact" );
+        jsonp_bool( gui->http, "is_voter", slot->is_voter );
 
         if( FD_UNLIKELY( have_lmeta && lmeta->leader_start_time!=LONG_MAX ) ) jsonp_long_as_str( gui->http, "start_timestamp_nanos", lmeta->leader_start_time  );
         else                                                                  jsonp_null       ( gui->http, "start_timestamp_nanos" );
@@ -2346,6 +2375,9 @@ fd_gui_printf_slot_request_detailed( fd_gui_t *            gui,
         else                                            jsonp_null( gui->http, "vote_slot" );
         if( FD_UNLIKELY( slot->vote_latency!=UCHAR_MAX ) ) jsonp_ulong( gui->http, "vote_latency", slot->vote_latency );
         else                                               jsonp_null( gui->http, "vote_latency" );
+        if( FD_LIKELY( slot->vote_latency_exact!=FD_GUI_VOTE_LATENCY_NOT_VOTED ) ) jsonp_ulong( gui->http, "vote_latency_exact", slot->vote_latency_exact );
+        else                                                                       jsonp_null( gui->http, "vote_latency_exact" );
+        jsonp_bool( gui->http, "is_voter", slot->is_voter );
 
         if( FD_UNLIKELY( have_lmeta && lmeta->leader_start_time!=LONG_MAX ) ) jsonp_long_as_str( gui->http, "start_timestamp_nanos", lmeta->leader_start_time  );
         else                                                                  jsonp_null       ( gui->http, "start_timestamp_nanos" );

--- a/src/disco/gui/fd_gui_printf.h
+++ b/src/disco/gui/fd_gui_printf.h
@@ -21,7 +21,6 @@ void fd_gui_printf_repair_slot( fd_gui_t * gui );
 void fd_gui_printf_slot_caught_up( fd_gui_t * gui );
 void fd_gui_printf_skipped_history( fd_gui_t * gui, ulong epoch );
 void fd_gui_printf_skipped_history_cluster( fd_gui_t * gui, ulong epoch );
-void fd_gui_printf_vote_latency_history( fd_gui_t * gui );
 void fd_gui_printf_late_votes_history( fd_gui_t * gui );
 void fd_gui_printf_tps_history( fd_gui_t * gui );
 void fd_gui_printf_boot_progress( fd_gui_t * gui );

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -375,10 +375,17 @@ after_frag( fd_gui_ctx_t *      ctx,
 
         int txn_succeeded = msg->txn_exec->is_committable && !msg->txn_exec->is_fees_only && !msg->txn_exec->txn_err;
         if( FD_UNLIKELY( msg->txn_exec->vote.slot!=ULONG_MAX && txn_succeeded ) ) {
+          int vote_acct_is_us = !ctx->gui->summary.has_vote_key || !memcmp( ctx->gui->summary.vote_key->uc, msg->txn_exec->vote.vote_acct->uc, sizeof(fd_pubkey_t) );
+          int is_us = vote_acct_is_us && !memcmp( ctx->gui->summary.identity_key->uc, msg->txn_exec->vote.identity->uc, sizeof(fd_pubkey_t) );
           fd_gui_peers_handle_vote( ctx->peers,
                                     msg->txn_exec->vote.vote_acct,
                                     msg->txn_exec->vote.slot,
-                                    !memcmp(ctx->gui->summary.identity_key->uc, msg->txn_exec->vote.identity->uc, sizeof(fd_pubkey_t) ) );
+                                    is_us );
+          if( FD_UNLIKELY( is_us ) ) {
+            for( ulong i=0UL; i<msg->txn_exec->vote.vote_slot_cnt; i++ ) {
+              fd_gui_stage_landed_vote( ctx->gui, msg->txn_exec->slot, msg->txn_exec->bank_seq, msg->txn_exec->vote.vote_slots[ i ] );
+            }
+          }
         }
       }
 
@@ -565,7 +572,7 @@ returnable_frag( fd_gui_ctx_t *      ctx,
   if( FD_LIKELY( sig==FD_TOWER_SIG_SLOT_DONE ) ) {
     FD_TEST( sz>=sizeof(fd_tower_slot_done_t) );
     fd_tower_slot_done_t const * tower = (fd_tower_slot_done_t const *)src;
-    if( FD_UNLIKELY( !(tower->reset_slot==ULONG_MAX || !!fd_gui_slot_get( ctx->gui, tower->reset_slot, tower->reset_bank_seq )) ) ) return 1; /* block not replayed yet: defer polling */
+    if( FD_UNLIKELY( !fd_gui_slot_get( ctx->gui, tower->replay_slot, tower->replay_bank_seq ) ) ) return 1; /* block not replayed yet: defer polling */
     fd_gui_handle_tower_update( ctx->gui, tower, fd_clock_tile_now( ctx->clock ) );
   }
 

--- a/src/disco/gui/test_gui_hist_evict.c
+++ b/src/disco/gui/test_gui_hist_evict.c
@@ -429,9 +429,8 @@ test_resident_meta_mutation_survives_evict( fd_gui_t * gui ) {
   FD_TEST( rec );
   rec->my_total_slots          = 7UL;
   rec->my_skipped_slots        = 3UL;
-  rec->late_votes_sz           = 2UL;
-  rec->late_votes[ 0 ]         = RM_NEW_START + 1UL;
-  rec->late_votes[ 1 ]         = RM_NEW_START + 2UL;
+  rec->latency[ 0 ]            = 5;
+  rec->latency_exact[ 0 ]      = 2;
   rec->rankings->largest_tips[ 0 ].slot  = RM_NEW_START + 4UL;
   rec->rankings->largest_tips[ 0 ].value = 12345UL;
 
@@ -440,7 +439,7 @@ test_resident_meta_mutation_survives_evict( fd_gui_t * gui ) {
   FD_TEST( rec2==rec ); /* stable map pointer */
   FD_TEST( rec2->my_total_slots==7UL );
   FD_TEST( rec2->my_skipped_slots==3UL );
-  FD_TEST( rec2->late_votes_sz==2UL );
+  FD_TEST( rec2->latency[ 0 ]==5 );
 
   /* Evict the older epoch; the newer epoch's record and its mutated fields
      must be untouched, and its map pointer must remain valid. */
@@ -454,9 +453,8 @@ test_resident_meta_mutation_survives_evict( fd_gui_t * gui ) {
   FD_TEST( rec3->epoch==RM_NEW_EPOCH );
   FD_TEST( rec3->my_total_slots==7UL );
   FD_TEST( rec3->my_skipped_slots==3UL );
-  FD_TEST( rec3->late_votes_sz==2UL );
-  FD_TEST( rec3->late_votes[ 0 ]==RM_NEW_START + 1UL );
-  FD_TEST( rec3->late_votes[ 1 ]==RM_NEW_START + 2UL );
+  FD_TEST( rec3->latency[ 0 ]==5 );
+  FD_TEST( rec3->latency_exact[ 0 ]==2 );
   FD_TEST( rec3->rankings->largest_tips[ 0 ].slot==RM_NEW_START + 4UL );
   FD_TEST( rec3->rankings->largest_tips[ 0 ].value==12345UL );
 

--- a/src/discof/backtest/fd_backtest_tile.c
+++ b/src/discof/backtest/fd_backtest_tile.c
@@ -364,6 +364,7 @@ returnable_frag( fd_backt_tile_t *   ctx,
         dst->active_fork_cnt       = 1UL;
         dst->authority_idx         = ULONG_MAX;
         dst->vote_acct_bal         = ULONG_MAX;
+        dst->is_voting             = 1;
         fd_stem_publish( stem, ctx->tower_out->idx, FD_TOWER_SIG_SLOT_DONE, ctx->tower_out->chunk, sizeof(fd_tower_slot_done_t), 0UL, tspub, fd_frag_meta_ts_comp( fd_tickcount() ) );
         ctx->tower_out->chunk = fd_dcache_compact_next( ctx->tower_out->chunk, sizeof(fd_tower_slot_done_t), ctx->tower_out->chunk0, ctx->tower_out->wmark );
         return 0;
@@ -456,6 +457,7 @@ returnable_frag( fd_backt_tile_t *   ctx,
       dst->active_fork_cnt       = 1UL;
       dst->authority_idx         = ULONG_MAX;
       dst->vote_acct_bal         = ULONG_MAX;
+      dst->is_voting             = 1;
 
       fd_stem_publish( stem, ctx->tower_out->idx, FD_TOWER_SIG_SLOT_DONE, ctx->tower_out->chunk, sizeof(fd_tower_slot_done_t), 0UL, tspub, fd_frag_meta_ts_comp( fd_tickcount() ) );
       ctx->tower_out->chunk = fd_dcache_compact_next( ctx->tower_out->chunk, sizeof(fd_tower_slot_done_t), ctx->tower_out->chunk0, ctx->tower_out->wmark );

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -177,13 +177,40 @@ publish_txn_finalized_msg( fd_execrp_tile_t *  ctx,
   msg->txn_exec->is_fees_only    = ctx->txn_out.err.is_fees_only;
   msg->txn_exec->txn_err         = ctx->txn_out.err.txn_err;
   msg->txn_exec->slot            = ctx->slot;
+  msg->txn_exec->bank_seq        = ctx->bank->bank_seq;
   msg->txn_exec->start_shred_idx = ctx->txn_in.txn->start_shred_idx;
   msg->txn_exec->end_shred_idx   = ctx->txn_in.txn->end_shred_idx;
 
-  if( FD_UNLIKELY( !ctx->txn_out.details.is_simple_vote || !fd_txn_parse_simple_vote( TXN( ctx->txn_in.txn ), ctx->txn_in.txn->payload, msg->txn_exec->vote.identity, msg->txn_exec->vote.vote_acct, &msg->txn_exec->vote.slot ) ) ) {
-    msg->txn_exec->vote.slot       = ULONG_MAX;
-    *msg->txn_exec->vote.identity  = (fd_pubkey_t){ 0 };
-    *msg->txn_exec->vote.vote_acct = (fd_pubkey_t){ 0 };
+  int is_vote = 0;
+  if( FD_LIKELY( ctx->txn_out.details.is_simple_vote ) ) {
+    fd_txn_t const * txn = TXN( ctx->txn_in.txn );
+    uchar const *    payload = ctx->txn_in.txn->payload;
+    fd_compact_tower_sync_serde_t tower_sync[ 1 ];
+    if( FD_LIKELY( fd_txn_parse_simple_vote( txn, payload, tower_sync ) ) ) {
+      fd_acct_addr_t const * accs = fd_txn_get_acct_addrs( txn, payload );
+      *msg->txn_exec->vote.identity  = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ 0 ] );
+      *msg->txn_exec->vote.vote_acct = *(fd_pubkey_t const *)fd_type_pun_const( &accs[ txn->signature_cnt==1 ? 1 : 2 ] );
+
+      ulong cur       = fd_ulong_if( tower_sync->root==ULONG_MAX, 0UL, tower_sync->root );
+      ulong cnt       = 0UL;
+      int   overflow  = 0;
+      for( ulong i=0UL; i<tower_sync->lockouts_cnt; i++ ) {
+        if( FD_UNLIKELY( __builtin_uaddl_overflow( cur, tower_sync->lockouts[ i ].offset, &cur ) ) ) { overflow = 1; break; }
+        msg->txn_exec->vote.vote_slots[ cnt++ ] = cur;
+      }
+      if( FD_LIKELY( !overflow ) ) {
+        msg->txn_exec->vote.vote_slot_cnt = (uchar)cnt;
+        msg->txn_exec->vote.slot          = cnt ? msg->txn_exec->vote.vote_slots[ cnt-1UL ] : cur;
+        is_vote                           = 1;
+      }
+    }
+  }
+
+  if( FD_UNLIKELY( !is_vote ) ) {
+    msg->txn_exec->vote.slot          = ULONG_MAX;
+    msg->txn_exec->vote.vote_slot_cnt = (uchar)0;
+    *msg->txn_exec->vote.identity     = (fd_pubkey_t){ 0 };
+    *msg->txn_exec->vote.vote_acct    = (fd_pubkey_t){ 0 };
   }
 
   if( FD_UNLIKELY( !msg->txn_exec->is_committable ) ) {

--- a/src/discof/replay/fd_execrp.h
+++ b/src/discof/replay/fd_execrp.h
@@ -3,6 +3,7 @@
 
 #include "../../disco/fd_txn_p.h"
 #include "../../flamenco/fd_flamenco_base.h"
+#include "../../choreo/tower/fd_tower_serdes.h"
 
 /* Exec tile task types. */
 #define FD_EXECRP_TT_TXN_EXEC      (1UL) /* Transaction execution. */
@@ -86,12 +87,15 @@ struct fd_execrp_txn_exec_done_msg {
 
   /* used by monitoring tools */
   ulong  slot;
+  ulong  bank_seq;
   ushort start_shred_idx;
   ushort end_shred_idx;
 
   /* vote.slot==ULONG_MAX if this was not a vote transaction */
   struct {
-    ulong slot;
+    ulong       slot;
+    ulong       vote_slots[ 31UL ];
+    uchar       vote_slot_cnt;
     fd_pubkey_t identity[ 1 ];
     fd_pubkey_t vote_acct[ 1 ];
   } vote;

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -724,6 +724,8 @@ publish_slot_done( fd_tower_tile_t *            ctx,
   /* Refuse to vote if our node identity does not match the one
      specified in the vote account (hot spare check) */
   int identity_matches = found_authority && fd_pubkey_eq( identity, ctx->identity_key );
+  msg->is_voting = found_authority && identity_matches;
+
   if( FD_LIKELY( out->vote_slot!=ULONG_MAX &&
                  found_authority &&
                  identity_matches &&
@@ -747,9 +749,6 @@ publish_slot_done( fd_tower_tile_t *            ctx,
   } else {
     msg->has_vote_txn = 0;
   }
-
-  msg->tower_cnt = 0UL; /* FIXME */
-  if( FD_LIKELY( found ) ) msg->tower_cnt = fd_tower_with_lat_from_vote_acc( msg->tower, ctx->our_vote_acct, ctx->our_vote_acct_sz );
 }
 
 static void

--- a/src/discof/tower/fd_tower_tile.h
+++ b/src/discof/tower/fd_tower_tile.h
@@ -142,21 +142,18 @@ struct fd_tower_slot_done {
 
   ulong active_fork_cnt;
 
-  /* This always contains a vote transaction with our current tower,
-     regardless of whether there is a new vote slot or not (ie. vote
-     slot can be ULONG_MAX and vote_txn will contain a txn of our
-     current tower).  The vote is not yet signed.  This is necessary to
-     support refreshing our last vote, ie. we retransmit our vote even
-     when we are locked out / can't switch vote forks.  If the vote
-     account's authorized voter is either the identity or one of the
-     authorized voters, then is_valid_vote will be 1; otherwise it will
-     be 0.
+  /* is_voting reflects whether this validator is structurally a voter
+     (holds the authorized voter key and its identity matches the vote
+     account's node identity).  Unlike has_vote_txn, it is independent
+     of whether a vote txn was produced this slot, so transient
+     non-votes (lockout, failed switch threshold, empty tower, etc.) do
+     not clear it.  A hot spare running under a dummy identity has
+     is_voting=0. */
 
-     The authority_idx is the index of the authorized voter that needs
-     to sign the vote transaction.  If the authorized voter is the
-     identity, the authority_idx will be ULONG_MAX.
+  int   is_voting;
 
-     TODO: Need to implement "refresh last vote" logic. */
+  /* authority_idx is the index of the authorized voter that needs to
+     sign the vote transaction, or ULONG_MAX if it is the identity. */
 
   int   has_vote_txn;
   ulong authority_idx;
@@ -167,11 +164,6 @@ struct fd_tower_slot_done {
      our account is not found. */
 
   ulong vote_acct_bal;
-
-  /* Our current on-chain tower with latencies optionally included. */
-
-  ulong              tower_cnt;
-  fd_vote_acc_vote_t tower[FD_TOWER_VOTE_MAX];
 };
 typedef struct fd_tower_slot_done fd_tower_slot_done_t;
 

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -131,7 +131,19 @@ test_publish_slot_done_identity_mismatch( void ) {
   FD_TEST( pub );
   FD_TEST( pub->sig==FD_TOWER_SIG_SLOT_DONE );
   FD_TEST( pub->msg.slot_done.has_vote_txn==1 );
+  FD_TEST( pub->msg.slot_done.is_voting==1 );
   FD_TEST( pub->msg.slot_done.authority_idx==ULONG_MAX );
+  publishes_pop_head_nocopy( ctx->publishes );
+
+  /* Matching identity but no votable slot: voter with no vote txn */
+  fd_tower_out_t out_no_vote = out;
+  out_no_vote.vote_slot = ULONG_MAX;
+  publish_slot_done( ctx, &sc, &out_no_vote, 1, 100UL, 0UL, NULL );
+  pub = publishes_peek_head( ctx->publishes );
+  FD_TEST( pub );
+  FD_TEST( pub->sig==FD_TOWER_SIG_SLOT_DONE );
+  FD_TEST( pub->msg.slot_done.has_vote_txn==0 );
+  FD_TEST( pub->msg.slot_done.is_voting==1 );
   publishes_pop_head_nocopy( ctx->publishes );
 
   /* Other identity prevents vote publishing */
@@ -142,6 +154,7 @@ test_publish_slot_done_identity_mismatch( void ) {
   FD_TEST( pub );
   FD_TEST( pub->sig==FD_TOWER_SIG_SLOT_DONE );
   FD_TEST( pub->msg.slot_done.has_vote_txn==0 );
+  FD_TEST( pub->msg.slot_done.is_voting==0 );
 
   fd_wksp_delete( fd_wksp_leave( wksp ) );
 


### PR DESCRIPTION
- make late vote accounting fork-correct by deriving from actual votes pushed out of execle/execrp instead of on-chain vote account
- fix "endless missing votes" perf regression for unstaked nodes
- publish correct, skip-discounted vote latency instead of the raw latency (frontend no longer needs to compute thing at render-time)