### PR TITLE
quic: implement PATH_CHALLENGE response (RFC 9000 Section 8.2)

### DIFF
--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -3414,6 +3414,32 @@ fd_quic_gen_ping_frame( fd_quic_conn_t             * conn,
   return frame_sz;
 }
 
+static ulong
+fd_quic_gen_path_response_frame( fd_quic_conn_t * conn,
+                                 uchar          * payload_ptr,
+                                 uchar          * payload_end ) {
+
+  if( ~conn->flags & FD_QUIC_CONN_FLAGS_PATH_RESPONSE ) return 0UL;
+
+  fd_quic_path_response_frame_t response = {
+    .data = conn->path_response_data
+  };
+
+  ulong frame_sz = fd_quic_encode_path_response_frame( payload_ptr,
+      (ulong)( payload_end - payload_ptr ),
+      &response );
+  if( FD_UNLIKELY( frame_sz==FD_QUIC_ENCODE_FAIL ) ) return 0UL;
+
+  conn->flags &= ~FD_QUIC_CONN_FLAGS_PATH_RESPONSE;
+
+  /* PATH_RESPONSE is not retransmitted per RFC 9000 Section 8.2.4:
+     "A PATH_RESPONSE frame MUST NOT be sent more than once in response
+     to a PATH_CHALLENGE frame." The peer will re-send PATH_CHALLENGE
+     if needed. */
+
+  return frame_sz;
+}
+
 uchar *
 fd_quic_gen_stream_frames( fd_quic_conn_t             * conn,
                            uchar                      * payload_ptr,
@@ -3548,9 +3574,10 @@ fd_quic_gen_frames( fd_quic_conn_t           * conn,
     if( pkt_meta_tmpl->enc_level == fd_quic_enc_level_appdata_id ) {
       payload_ptr += fd_quic_gen_handshake_done_frame( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
       if( conn->upd_pkt_number >= pkt_meta_tmpl->key.pkt_num ) {
-        payload_ptr += fd_quic_gen_max_data_frame   ( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
-        payload_ptr += fd_quic_gen_max_streams_frame( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
-        payload_ptr += fd_quic_gen_ping_frame       ( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
+        payload_ptr += fd_quic_gen_max_data_frame      ( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
+        payload_ptr += fd_quic_gen_max_streams_frame   ( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
+        payload_ptr += fd_quic_gen_ping_frame          ( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
+        payload_ptr += fd_quic_gen_path_response_frame ( conn, payload_ptr, payload_end );
       }
       if( FD_LIKELY( !conn->tls_hs ) ) {
         payload_ptr = fd_quic_gen_stream_frames( conn, payload_ptr, payload_end, pkt_meta_tmpl, tracker );
@@ -5249,9 +5276,15 @@ fd_quic_handle_path_challenge_frame(
     fd_quic_path_challenge_frame_t * data,
     uchar const *                    p    FD_PARAM_UNUSED,
     ulong                            p_sz FD_PARAM_UNUSED ) {
-  /* FIXME The recipient of this frame MUST generate a PATH_RESPONSE frame (Section 19.18) containing the same Data value. */
-  FD_DTRACE_PROBE_1( quic_handle_path_challenge_frame, context->conn->our_conn_id );
-  (void)data;
+  fd_quic_conn_t * conn = context->conn;
+
+  FD_DTRACE_PROBE_1( quic_handle_path_challenge_frame, conn->our_conn_id );
+
+  /* RFC 9000 Section 8.2.2: MUST respond with PATH_RESPONSE containing same Data */
+  conn->path_response_data = data->data;
+  conn->flags             |= FD_QUIC_CONN_FLAGS_PATH_RESPONSE;
+  conn->upd_pkt_number     = FD_QUIC_PKT_NUM_PENDING;
+
   return 0UL;
 }
 

--- a/src/waltz/quic/fd_quic_conn.h
+++ b/src/waltz/quic/fd_quic_conn.h
@@ -200,6 +200,10 @@ struct fd_quic_conn {
 # define FD_QUIC_CONN_FLAGS_MAX_STREAMS_UNIDIR (1u<<2u)
 # define FD_QUIC_CONN_FLAGS_PING               (1u<<4u)
 # define FD_QUIC_CONN_FLAGS_PING_SENT          (1u<<5u)
+# define FD_QUIC_CONN_FLAGS_PATH_RESPONSE      (1u<<6u)
+
+  /* PATH_RESPONSE data to echo back (RFC 9000 Section 8.2) */
+  ulong                path_response_data;
 
   /* max stream data per stream type */
   ulong                tx_initial_max_stream_data_uni;


### PR DESCRIPTION
Right now fd_quic receives PATH_CHALLENGE frames and does nothing with them.
RFC 9000 §8.2 says the recipient MUST send back a PATH_RESPONSE with the
same 8 bytes — if it doesn't, path validation fails on the sender's side
and some clients won't proceed with sending stream data.

I ran into this while looking at the QUIC networking layer after my
RESET_STREAM finding. Noticed #3791 had been sitting open for a while
so wrote the fix.

The implementation follows the same pattern as PING frames — store the
8-byte payload on the connection struct, set a flag, generate the response
in the next packet's frame assembly pass. No retransmission on my end
since §8.2.4 says PATH_RESPONSE is sent once and the sender is responsible
for retrying with a new PATH_CHALLENGE if it doesn't hear back.

Changes are in two files:

fd_quic_conn.h gets a new flag (FD_QUIC_CONN_FLAGS_PATH_RESPONSE, bit 6)
and an 8-byte field to hold the challenge data between receiving the
challenge and generating the response.

fd_quic.c: the existing handler now stores the data and sets the flag
instead of ignoring the frame, and there's a new 26-line generator
(fd_quic_gen_path_response_frame) that writes the response frame when
the flag is set.

The test_quic_proto.c already has test_path_response covering the
encoding side. Happy to add handler integration tests if you want them
in a specific location.

Fixes #3791