### PR TITLE
pktgen: fix pktgen ntuple rules

### DIFF
--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -197,6 +197,7 @@ pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
 
   ushort const listen_port = 9000;
   net_tile->net.legacy_transaction_listen_port = listen_port;
+  config->tiles.quic.regular_transaction_listen_port = listen_port;
 
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->tiles.metric.prometheus_listen_address, &metric_tile->metric.prometheus_listen_addr ) ) )
     FD_LOG_ERR(( "failed to parse prometheus listen address `%s`", config->tiles.metric.prometheus_listen_address ));

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -88,6 +88,7 @@ udpecho_cmd_fn( args_t *   args,
   fd_topo_tile_t * metric_tile = &topo->tiles[ fd_topo_find_tile( topo, "metric", 0UL ) ];
 
   net_tile->net.legacy_transaction_listen_port = args->udpecho.listen_port;
+  config->tiles.quic.regular_transaction_listen_port = args->udpecho.listen_port;
 
   if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->tiles.metric.prometheus_listen_address, &metric_tile->metric.prometheus_listen_addr ) ) )
     FD_LOG_ERR(( "failed to parse prometheus listen address `%s`", config->tiles.metric.prometheus_listen_address ));


### PR DESCRIPTION
If rss_queue_mode is set to "dedicated" either by the user or by the preexisting auto functionality, then pktgen (and udpecho) cannot receive packets properly as they are hardcoded to use a different port (like 9000 for pktgen).

With rss_queue_mode "simple" this is fine as there is only one rx queue so all the traffic goes to pktgen/udpecho correctly, but if there are many like in dedicated, then pktgen/udpecho don't receive the rx packets if the flow steering sends them to a queue other than 0 (which is very common).

IMO the most clean solution which doesn't require changing anything other than pktgen and udpecho is to set the config's quic.regular_transaction_listen_port to the port udpecho/pktgen is hardcoded to. This leads to a correct ntuple rule getting set.