### PR TITLE
util: bench fd_hash ns/byte

### DIFF
--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -121,6 +121,7 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
+  int extra_benchmark = fd_env_strip_cmdline_contains( &argc, &argv, "--extra-bench" );
   fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
   /* Test signed integer overflow is wrapping.  Needs to be at run time
@@ -440,6 +441,31 @@ main( int     argc,
   FD_TEST( fd_memeq( quine_binary, quine_cstr, quine_binary_sz ) );
 
   /* FIXME: ADD HASH QUALITY CHECKER HERE */
+  if( extra_benchmark ) {
+    ulong const workload_iter = 8192UL;
+    ulong const warmup        = 1024UL;
+
+    FD_LOG_NOTICE(( "BENCHMARK HASH FUNCTION" ));
+
+    char const * buf = "The quick brown fox jumps over the lazy dog.";
+    ulong        sz  = strlen( buf )+1UL;
+
+    for( ulong i = 0UL; i < warmup; i++ ) {
+      ulong result = fd_hash( i, buf, sz );
+      FD_COMPILER_FORGET( result );
+    }
+    FD_HW_MFENCE();
+    long t0 = fd_tickcount();
+    for( ulong i = 0UL; i < workload_iter; i++ ) {
+      ulong result = fd_hash( i, buf, sz );
+      FD_COMPILER_FORGET( result );
+    }
+    long t1 = fd_tickcount();
+    FD_COMPILER_MFENCE();
+    ulong cycles_op = (ulong)(t1 - t0) / workload_iter;
+    FD_LOG_NOTICE(( "%lu cycles/op", cycles_op ));
+    FD_LOG_NOTICE(( "BENCHMARK HASH FUNCTION END" ));
+  }
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -445,24 +445,28 @@ main( int     argc,
     ulong const workload_iter = 8192UL;
     ulong const warmup        = 1024UL;
 
-    #define BUF_SZ 32UL
-    char buf[BUF_SZ];
-    for( ulong i = 0UL; i < BUF_SZ; i++ )
+    ulong const sizes[] = { 32UL, 64UL, 128UL, 512UL, 1232UL };
+    ulong const size_cnt = sizeof(sizes) / sizeof(sizes[0]);
+    char buf[1232UL];
+    for( ulong i = 0UL; i < sizeof(buf); i++ )
       buf[i] = (char)fd_rng_uchar( rng );
 
-    for( ulong i = 0UL; i < warmup; i++ ) {
-      ulong result = fd_hash( i, buf, BUF_SZ );
-      FD_COMPILER_FORGET( result );
+    for( ulong j = 0UL; j < size_cnt; j++ ) {
+      ulong sz = sizes[j];
+      for( ulong i = 0UL; i < warmup; i++ ) {
+        ulong result = fd_hash( i, buf, sz );
+        FD_COMPILER_FORGET( result );
+      }
+      FD_HW_MFENCE();
+      long dt = fd_log_wallclock();
+      for( ulong i = 0UL; i < workload_iter; i++ ) {
+        ulong result = fd_hash( i, buf, sz );
+        FD_COMPILER_FORGET( result );
+      }
+      dt = fd_log_wallclock() - dt;
+      double ns_byte = ((double)(dt)) / ((double)(workload_iter * sz));
+      FD_LOG_NOTICE(( "fd_hash: %.3f ns/byte (sz %lu)", ns_byte, sz ));
     }
-    FD_HW_MFENCE();
-    long dt = fd_log_wallclock();
-    for( ulong i = 0UL; i < workload_iter; i++ ) {
-      ulong result = fd_hash( i, buf, BUF_SZ );
-      FD_COMPILER_FORGET( result );
-    }
-    dt = fd_log_wallclock() - dt;
-    double ns_byte = ((double)(dt)) / ((double)(workload_iter * BUF_SZ));
-    FD_LOG_NOTICE(( "fd_hash: %.3f ns/byte (sz %lu)", ns_byte, BUF_SZ ));
   }
 
   fd_rng_delete( fd_rng_leave( rng ) );

--- a/src/util/test_util_base.c
+++ b/src/util/test_util_base.c
@@ -445,26 +445,24 @@ main( int     argc,
     ulong const workload_iter = 8192UL;
     ulong const warmup        = 1024UL;
 
-    FD_LOG_NOTICE(( "BENCHMARK HASH FUNCTION" ));
-
-    char const * buf = "The quick brown fox jumps over the lazy dog.";
-    ulong        sz  = strlen( buf )+1UL;
+    #define BUF_SZ 32UL
+    char buf[BUF_SZ];
+    for( ulong i = 0UL; i < BUF_SZ; i++ )
+      buf[i] = (char)fd_rng_uchar( rng );
 
     for( ulong i = 0UL; i < warmup; i++ ) {
-      ulong result = fd_hash( i, buf, sz );
+      ulong result = fd_hash( i, buf, BUF_SZ );
       FD_COMPILER_FORGET( result );
     }
     FD_HW_MFENCE();
-    long t0 = fd_tickcount();
+    long dt = fd_log_wallclock();
     for( ulong i = 0UL; i < workload_iter; i++ ) {
-      ulong result = fd_hash( i, buf, sz );
+      ulong result = fd_hash( i, buf, BUF_SZ );
       FD_COMPILER_FORGET( result );
     }
-    long t1 = fd_tickcount();
-    FD_COMPILER_MFENCE();
-    ulong cycles_op = (ulong)(t1 - t0) / workload_iter;
-    FD_LOG_NOTICE(( "%lu cycles/op", cycles_op ));
-    FD_LOG_NOTICE(( "BENCHMARK HASH FUNCTION END" ));
+    dt = fd_log_wallclock() - dt;
+    double ns_byte = ((double)(dt)) / ((double)(workload_iter * BUF_SZ));
+    FD_LOG_NOTICE(( "fd_hash: %.3f ns/byte (sz %lu)", ns_byte, BUF_SZ ));
   }
 
   fd_rng_delete( fd_rng_leave( rng ) );


### PR DESCRIPTION
Added the bench because of the   /* TODO: This takes >100 cycles! */
at file src/disco/pack_fd_pack.c:361 requires a feedback loop first. 
 I got the --extra-bench name from another test, which has performance tests ( src/disco/pack/test_pack.c ) but I'm not sure it explains what the code is doing well. 
The thing is, the cycles/op value is affected so much by the buf variable. When I add a longer text to buf, the cycles/op is even increasing to 170+ cycles/op, so I'm open for ideas. I think a longer text will be better so we can actually see small improvements easier, think current one as a dummy. 
Tried to provide more info at the benchmark, such as p99, jitter etc. with histf, but it requires to call functions one by one, which means 2 fd_tickcount() per function call, so high noise. It even makes it impossible to understand how much cycles/op the function is. 
For making sure the function is really calculated, I removed all the code but this test, run perf report, and saw realistic cycles/op values at instructions:
```perf
  18.89 │       cmp    r10,rcx                                                                                             ▒
        │     ↑ jne    2a0                                                                                                 ▒
        │       mov    rax,rdx                                                                                             ▒
        │       nop                                                                                                        ▒
        │2c0:   mov    rdx,rax                                                                                             ▒
        │       shr    rdx,0x21                                                                                            ▒
   4.53 │       xor    rax,rdx                                                                                             ▒
        │       movabs rdx,0xc2b2ae3d27d4eb4f                                                                              ▒
        │       imul   rax,rdx                                                                                             ▒
   5.68 │       mov    rbx,QWORD PTR [rbp-0x28]                                                                            ▒
        │       leave                                                                                                      ▒
        │       mov    rdx,rax                                                                                             ▒
        │       shr    rdx,0x1d                                                                                            ▒
   6.22 │       xor    rdx,rax                                                                                             ▒
        │       movabs rax,0x165667b19e3779f9                                                                              ▒
        │       imul   rdx,rax                                                                                             ▒
  14.99 │       mov    rax,rdx                                                                                             ▒
        │       shr    rax,0x20                                                                                            ▒
   7.08 │       xor    rax,rdx                                                                                             ▒
        │     ← ret
```
