### PR TITLE
stakes: tighter stake inclusion rules

### DIFF
--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -17,7 +17,7 @@
 static ulong
 banks_footprint( fd_topo_t const *     topo,
                  fd_topo_obj_t const * obj ) {
-  return fd_banks_footprint( VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_VOTE_ACCOUNTS );
+  return fd_banks_footprint( VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK, FD_RUNTIME_MAX_VOTE_ACCOUNTS );
 }
 
 static ulong
@@ -31,7 +31,7 @@ banks_new( fd_topo_t const *     topo,
            fd_topo_obj_t const * obj ) {
   int larger_max_cost_per_block = fd_pod_queryf_int( topo->props, 0, "obj.%lu.larger_max_cost_per_block", obj->id );
   ulong seed = fd_pod_queryf_ulong( topo->props, 0UL, "obj.%lu.seed", obj->id );
-  FD_TEST( fd_banks_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_VOTE_ACCOUNTS, larger_max_cost_per_block, seed ) );
+  FD_TEST( fd_banks_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK, FD_RUNTIME_MAX_VOTE_ACCOUNTS, larger_max_cost_per_block, seed ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_banks = {

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -292,9 +292,9 @@ setup_ctx_with_fork_width( fd_replay_tile_t * ctx,
 
   /* Real banks — initialize root bank. */
 
-  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( TEST_BANKS_MAX, max_fork_width, 2048UL, 2048UL ), 1UL );
+  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( TEST_BANKS_MAX, max_fork_width, 2048UL, 32768UL, 2048UL ), 1UL );
   FD_TEST( banks_mem );
-  ctx->banks = fd_banks_join( fd_banks_new( banks_mem, TEST_BANKS_MAX, max_fork_width, 2048UL, 2048UL, 0, 42UL ) );
+  ctx->banks = fd_banks_join( fd_banks_new( banks_mem, TEST_BANKS_MAX, max_fork_width, 2048UL, 32768UL, 2048UL, 0, 42UL ) );
   FD_TEST( ctx->banks );
   fd_bank_t * root_bank = fd_banks_init_bank( ctx->banks );
   FD_TEST( root_bank );
@@ -486,9 +486,9 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
   setup_stem( ctx, wksp );
 
   ulong const bank_cnt = 4UL;
-  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( bank_cnt, bank_cnt, 8UL, 8UL ), 1UL );
+  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( bank_cnt, bank_cnt, 8UL, 128UL, 8UL ), 1UL );
   FD_TEST( banks_mem );
-  ctx->banks = fd_banks_join( fd_banks_new( banks_mem, bank_cnt, bank_cnt, 8UL, 8UL, 0, 43UL ) );
+  ctx->banks = fd_banks_join( fd_banks_new( banks_mem, bank_cnt, bank_cnt, 8UL, 128UL, 8UL, 0, 43UL ) );
   FD_TEST( ctx->banks );
 
   fd_bank_t * root = fd_banks_init_bank( ctx->banks );

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -455,9 +455,6 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
   fd_stake_delegations_reset( stake_delegations );
   for( ulong i=0UL; i<manifest->stake_delegations_len; i++ ) {
     fd_snapshot_manifest_stake_delegation_t const * elem = &manifest->stake_delegations[ i ];
-    if( FD_UNLIKELY( elem->stake_delegation==0UL ) ) {
-      continue;
-    }
     fd_stake_delegations_root_update(
         stake_delegations,
         (fd_pubkey_t *)elem->stake_pubkey,

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -536,18 +536,19 @@ test_recover_back_to_back_reset( fd_wksp_t * wksp, fd_snapshot_manifest_t * mani
 
   ulong max_banks = 16UL;
   ulong max_forks =  4UL;
-  ulong max_stake = 64UL;
-  ulong max_vote  = 64UL;
-  ulong seed      = 42UL;
+  ulong max_stake          = 64UL;
+  ulong max_fallback_stake = 1024UL;
+  ulong max_vote           = 64UL;
+  ulong seed               = 42UL;
 
   ulong banks_footprint = fd_banks_footprint( max_banks, max_forks,
-                                              max_stake, max_vote );
+                                              max_stake, max_fallback_stake, max_vote );
   void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(),
                                           banks_footprint, 2UL );
   FD_TEST( banks_mem );
 
   fd_banks_t * banks = fd_banks_join( fd_banks_new( banks_mem, max_banks, max_forks,
-                                                    max_stake, max_vote,
+                                                    max_stake, max_fallback_stake, max_vote,
                                                     0 /* larger_max_cost_per_block */, seed ) );
   FD_TEST( banks );
 
@@ -597,7 +598,7 @@ test_recover_back_to_back_reset( fd_wksp_t * wksp, fd_snapshot_manifest_t * mani
   /* Verify entries from first apply are present. */
   fd_stake_delegations_t * sd = fd_banks_stake_delegations_root_query( banks );
   FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_a )!=NULL );
-  FD_TEST( fd_stake_delegations_cnt( sd )==1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( sd )==1UL );
 
   fd_vote_stakes_t * vs = fd_bank_vote_stakes( bank );
   ushort root_idx = fd_vote_stakes_get_root_idx( vs );
@@ -649,7 +650,7 @@ test_recover_back_to_back_reset( fd_wksp_t * wksp, fd_snapshot_manifest_t * mani
      be present, exactly 1 entry (not 2). */
   FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_a )==NULL );
   FD_TEST( fd_stake_delegation_root_query( sd, (fd_pubkey_t *)pubkey_b )!=NULL );
-  FD_TEST( fd_stake_delegations_cnt( sd )==1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( sd )==1UL );
 
   /* Vote stakes: pubkey_X must have been removed, pubkey_Y must be
      present, exactly 1 entry (not 2). */

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -400,10 +400,26 @@ fd_rewards_get_reward_distribution_num_blocks( fd_epoch_schedule_t const * epoch
   return get_reward_distribution_num_blocks( epoch_schedule, slot, total_stake_accounts, stake_account_stores_per_block );
 }
 
+static void
+read_stake_history( fd_accdb_t *         accdb,
+                    fd_accdb_fork_id_t   fork_id,
+                    uchar                data[ static FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ ],
+                    fd_stake_history_t * stake_history ) {
+  fd_acc_t ro = fd_accdb_read_one( accdb, fork_id, fd_sysvar_stake_history_id.uc );
+  if( FD_UNLIKELY( !ro.lamports ) ) FD_LOG_ERR(( "Unable to read stake history sysvar" ));
+  ulong copy_sz = fd_ulong_min( ro.data_len, FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ );
+  fd_memcpy( data, ro.data, copy_sz );
+  fd_accdb_unread_one( accdb, &ro );
+  if( FD_UNLIKELY( !fd_sysvar_stake_history_view( stake_history, data, copy_sz ) ) ) {
+    FD_LOG_ERR(( "Unable to decode stake history sysvar" ));
+  }
+}
+
 /* Calculates epoch reward points from stake/vote accounts.
    https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L445 */
 static uint128
 calculate_reward_points_partitioned( fd_bank_t *                    bank,
+                                     fd_accdb_t *                   accdb,
                                      fd_stake_delegations_t const * stake_delegations,
                                      fd_stake_history_t const *     stake_history,
                                      fd_runtime_stack_t *           runtime_stack ) {
@@ -414,7 +430,7 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
   fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
 
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, bank->f.epoch, &bank->f.warmup_cooldown_rate_epoch );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * stake_delegation     = fd_stake_delegations_iter_ele( iter );
@@ -484,6 +500,7 @@ delegation_may_need_adjustment( ulong current_delegation,
    https://github.com/anza-xyz/agave/blob/v2.3.1/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L323 */
 static void
 calculate_stake_vote_rewards( fd_bank_t *                    bank,
+                              fd_accdb_t *                   accdb,
                               fd_stake_delegations_t const * stake_delegations,
                               fd_capture_ctx_t *             capture_ctx FD_PARAM_UNUSED,
                               fd_stake_history_t const *     stake_history,
@@ -498,7 +515,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
   fd_calculated_stake_rewards_t calculated_stake_rewards_[1];
 
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, bank->f.epoch, &bank->f.warmup_cooldown_rate_epoch );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * stake_delegation     = fd_stake_delegations_iter_ele( iter );
@@ -628,6 +645,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
 
 static void
 setup_stake_partitions( fd_bank_t *                    bank,
+                        fd_accdb_t *                   accdb,
                         fd_stake_history_t const *     stake_history,
                         fd_stake_delegations_t const * stake_delegations,
                         fd_runtime_stack_t *           runtime_stack,
@@ -643,7 +661,7 @@ setup_stake_partitions( fd_bank_t *                    bank,
   bank->stake_rewards_fork_id = fork_idx;
 
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, bank->f.epoch, &bank->f.warmup_cooldown_rate_epoch );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * stake_delegation     = fd_stake_delegations_iter_ele( iter );
@@ -750,16 +768,14 @@ calculate_validator_rewards( fd_bank_t *                    bank,
                              fd_capture_ctx_t *             capture_ctx,
                              ulong                          rewarded_epoch,
                              ulong *                        rewards_out ) {
-  fd_acc_t ro = fd_accdb_read_one( accdb, bank->accdb_fork_id, fd_sysvar_stake_history_id.uc );
-  if( FD_UNLIKELY( !ro.lamports ) ) FD_LOG_ERR(( "Unable to read stake history sysvar" ));
+  uchar              stake_history_data[ FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ ];
   fd_stake_history_t stake_history[1];
-  if( FD_UNLIKELY( !fd_sysvar_stake_history_view( stake_history, ro.data, ro.data_len ) ) ) {
-    FD_LOG_ERR(( "Unable to decode stake history sysvar" ));
-  }
+  read_stake_history( accdb, bank->accdb_fork_id, stake_history_data, stake_history );
 
   /* Calculate the epoch reward points from stake/vote accounts */
   uint128 total_points = calculate_reward_points_partitioned(
       bank,
+      accdb,
       stake_delegations,
       stake_history,
       runtime_stack );
@@ -782,6 +798,7 @@ calculate_validator_rewards( fd_bank_t *                    bank,
      use the vote states from the end of the current_epoch. */
   calculate_stake_vote_rewards(
       bank,
+      accdb,
       stake_delegations,
       capture_ctx,
       stake_history,
@@ -800,6 +817,7 @@ calculate_validator_rewards( fd_bank_t *                    bank,
 
   setup_stake_partitions(
       bank,
+      accdb,
       stake_history,
       stake_delegations,
       runtime_stack,
@@ -810,7 +828,6 @@ calculate_validator_rewards( fd_bank_t *                    bank,
       *rewards_out,
       total_points );
 
-  fd_accdb_unread_one( accdb, &ro );
   return total_points;
 }
 
@@ -1325,17 +1342,15 @@ fd_rewards_recalculate_partitioned_rewards( fd_banks_t *              banks,
   ulong const epoch          = bank->f.epoch;
   ulong const rewarded_epoch = fd_ulong_sat_sub( epoch, 1UL );
 
-  fd_acc_t ro = fd_accdb_read_one( accdb, bank->accdb_fork_id, fd_sysvar_stake_history_id.uc );
-  if( FD_UNLIKELY( !ro.lamports ) ) FD_LOG_ERR(( "Unable to read stake history sysvar" ));
+  uchar              stake_history_data[ FD_SYSVAR_STAKE_HISTORY_BINCODE_SZ ];
   fd_stake_history_t stake_history[1];
-  if( FD_UNLIKELY( !fd_sysvar_stake_history_view( stake_history, ro.data, ro.data_len ) ) ) {
-    FD_LOG_ERR(( "Unable to decode stake history sysvar" ));
-  }
+  read_stake_history( accdb, bank->accdb_fork_id, stake_history_data, stake_history );
 
   fd_stake_delegations_t const * stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank );
 
   calculate_stake_vote_rewards(
       bank,
+      accdb,
       stake_delegations,
       capture_ctx,
       stake_history,
@@ -1347,6 +1362,7 @@ fd_rewards_recalculate_partitioned_rewards( fd_banks_t *              banks,
 
   setup_stake_partitions(
       bank,
+      accdb,
       stake_history,
       stake_delegations,
       runtime_stack,
@@ -1357,6 +1373,5 @@ fd_rewards_recalculate_partitioned_rewards( fd_banks_t *              banks,
       epoch_rewards_sysvar->total_rewards,
       epoch_rewards_sysvar->total_points.ud );
 
-  fd_accdb_unread_one( accdb, &ro );
   fd_bank_stake_delegations_end_frontier_query( banks, bank );
 }

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -259,6 +259,7 @@ ulong
 fd_banks_footprint( ulong max_total_banks,
                     ulong max_fork_width,
                     ulong max_stake_accounts,
+                    ulong max_fallback_stake_accounts,
                     ulong max_vote_accounts ) {
 
   /* max_fork_width is used in the macro below. */
@@ -269,7 +270,7 @@ fd_banks_footprint( ulong max_total_banks,
 
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, fd_banks_align(),                  sizeof(fd_banks_t) );
-  l = FD_LAYOUT_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( max_stake_accounts, expected_stake_accounts, max_total_banks ) );
+  l = FD_LAYOUT_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_total_banks ) );
   l = FD_LAYOUT_APPEND( l, FD_EPOCH_LEADERS_ALIGN,            2UL * epoch_leaders_footprint );
   l = FD_LAYOUT_APPEND( l, fd_banks_pool_align(),             fd_banks_pool_footprint( max_total_banks ) );
   l = FD_LAYOUT_APPEND( l, fd_banks_dead_align(),             fd_banks_dead_footprint() );
@@ -288,6 +289,7 @@ fd_banks_new( void * shmem,
               ulong  max_total_banks,
               ulong  max_fork_width,
               ulong  max_stake_accounts,
+              ulong  max_fallback_stake_accounts,
               ulong  max_vote_accounts,
               int    larger_max_cost_per_block,
               ulong  seed ) {
@@ -323,7 +325,7 @@ fd_banks_new( void * shmem,
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
   fd_banks_t * banks_data              = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_align(),                  sizeof(fd_banks_t) );
-  void *       stake_delegations_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( max_stake_accounts, expected_stake_accounts, max_total_banks ) );
+  void *       stake_delegations_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_total_banks ) );
   void *       epoch_leaders_mem       = FD_SCRATCH_ALLOC_APPEND( l, FD_EPOCH_LEADERS_ALIGN,            2UL * epoch_leaders_footprint );
   void *       pool_mem                = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_pool_align(),             fd_banks_pool_footprint( max_total_banks ) );
   void *       dead_banks_deque_mem    = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_dead_align(),             fd_banks_dead_footprint() );
@@ -335,7 +337,7 @@ fd_banks_new( void * shmem,
   void *       snapshot_commission_t_3 = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_stashed_commission_t),  sizeof(fd_stashed_commission_t) * max_vote_accounts );
   void *       collector_overrides_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_collector_overrides_align(),    fd_collector_overrides_footprint( FD_COLLECTOR_OVERRIDES_MAX( max_fork_width ) ) );
 
-  if( FD_UNLIKELY( FD_SCRATCH_ALLOC_FINI( l, fd_banks_align() ) != (ulong)banks_data + fd_banks_footprint( max_total_banks, max_fork_width, max_stake_accounts, max_vote_accounts ) ) ) {
+  if( FD_UNLIKELY( FD_SCRATCH_ALLOC_FINI( l, fd_banks_align() ) != (ulong)banks_data + fd_banks_footprint( max_total_banks, max_fork_width, max_stake_accounts, max_fallback_stake_accounts, max_vote_accounts ) ) ) {
     FD_LOG_WARNING(( "fd_banks_new: bad layout" ));
     return NULL;
   }
@@ -369,7 +371,7 @@ fd_banks_new( void * shmem,
      each of the elements in the pool as well as set up the lock for
      each of the pools. */
 
-  fd_stake_delegations_t * stake_delegations = fd_stake_delegations_join( fd_stake_delegations_new( stake_delegations_mem, seed, max_stake_accounts, expected_stake_accounts, max_total_banks ) );
+  fd_stake_delegations_t * stake_delegations = fd_stake_delegations_join( fd_stake_delegations_new( stake_delegations_mem, seed, max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_total_banks ) );
   if( FD_UNLIKELY( !stake_delegations ) ) {
     FD_LOG_WARNING(( "Unable to create stake delegations root" ));
     return NULL;
@@ -446,6 +448,7 @@ fd_banks_new( void * shmem,
   banks_data->max_total_banks    = max_total_banks;
   banks_data->max_fork_width     = max_fork_width;
   banks_data->max_stake_accounts = max_stake_accounts;
+  banks_data->max_fallback_stake_accounts = max_fallback_stake_accounts;
   banks_data->max_vote_accounts  = max_vote_accounts;
   banks_data->root_idx           = ULONG_MAX;
   banks_data->evict_rr_idx       = seed;
@@ -484,7 +487,7 @@ fd_banks_join( void * banks_data_mem ) {
 
   FD_SCRATCH_ALLOC_INIT( l, banks_data );
   banks_data                   = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_align(),                  sizeof(fd_banks_t) );
-  void * stake_delegations_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( banks_data->max_stake_accounts, expected_stake_accounts, banks_data->max_total_banks ) );
+  void * stake_delegations_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_stake_delegations_align(),      fd_stake_delegations_footprint( banks_data->max_stake_accounts, banks_data->max_fallback_stake_accounts, expected_stake_accounts, banks_data->max_total_banks ) );
   void * epoch_leaders_mem     = FD_SCRATCH_ALLOC_APPEND( l, FD_EPOCH_LEADERS_ALIGN,            2UL * banks_data->epoch_leaders_footprint );
   void * pool_mem              = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_pool_align(),             fd_banks_pool_footprint( banks_data->max_total_banks ) );
   void * dead_banks_deque_mem  = FD_SCRATCH_ALLOC_APPEND( l, fd_banks_dead_align(),             fd_banks_dead_footprint() );
@@ -720,6 +723,10 @@ static inline void
 fd_bank_stake_delegation_mark_deltas( fd_banks_t *             banks,
                                       fd_bank_t *              bank,
                                       fd_stake_delegations_t * stake_delegations ) {
+  /* TODO: mark_deltas and unmark_deltas should be refactored to live
+     inside of the stake delegations struct. */
+
+  fd_rwlock_write( &stake_delegations->lock );
 
   ushort pool_indices[ banks->max_total_banks ];
   ulong  pool_indices_len = 0UL;
@@ -768,6 +775,8 @@ fd_bank_stake_delegation_unmark_deltas( fd_banks_t *             banks,
     ushort idx = pool_indices[i-1UL];
     fd_stake_delegations_unmark_delta( stake_delegations, bank->f.epoch-1UL, stake_history, &bank->f.warmup_cooldown_rate_epoch, FD_FEATURE_ACTIVE_BANK( bank, upgrade_bpf_stake_program_to_v5_1 ), idx );
   }
+
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -393,15 +393,16 @@ typedef struct fd_bank_idx_seq fd_bank_idx_seq_t;
 #include "../../util/tmpl/fd_deque.c"
 
 struct fd_banks {
-  ulong magic;              /* ==FD_BANKS_MAGIC */
-  ulong max_total_banks;    /* Maximum number of banks */
-  ulong max_fork_width;     /* Maximum fork width executing through any given slot. */
-  ulong max_stake_accounts; /* Maximum number of stake accounts */
-  ulong max_vote_accounts;  /* Maximum number of vote accounts */
-  ulong root_idx;           /* root idx */
-  ulong bank_seq;           /* app-wide bank sequence number counter; starts at 1 (0 is reserved as an invalid bank_seq sentinel) */
-  ulong evict_rr_idx;       /* internal index for round-robin banks eviction */
-  ulong prunable_idx;       /* index of pending prunable bank, ULONG_MAX if none */
+  ulong magic;                       /* ==FD_BANKS_MAGIC */
+  ulong max_total_banks;             /* Maximum number of banks */
+  ulong max_fork_width;              /* Maximum fork width executing through any given slot. */
+  ulong max_stake_accounts;          /* Maximum number of stake accounts */
+  ulong max_vote_accounts;           /* Maximum number of vote accounts */
+  ulong root_idx;                    /* root idx */
+  ulong bank_seq;                    /* app-wide bank sequence number counter; starts at 1 (0 is reserved as an invalid bank_seq sentinel) */
+  ulong evict_rr_idx;                /* internal index for round-robin banks eviction */
+  ulong prunable_idx;                /* index of pending prunable bank, ULONG_MAX if none */
+  ulong max_fallback_stake_accounts; /* Maximum number of stake accounts nameable by the pubkey fallback tier */
 
   ulong curr_fork_width;
 
@@ -503,9 +504,9 @@ void
 fd_bank_lthash_end_locking_modify( fd_bank_t * bank );
 
 /* fd_bank_stake_delegations_frontier_query() will return a pointer to
-   the full stake delegations for the current frontier. The caller is
-   responsible that there are no concurrent readers or writers to
-   the stake delegations returned by this function.
+   the full stake delegations for the current frontier.  It takes the
+   stake delegations write lock, excluding mutators in other tiles until
+   fd_bank_stake_delegations_end_frontier_query() releases it.
 
    Under the hood, the function applies all of the stake delegation
    deltas from all banks starting from the root down to the current bank
@@ -601,6 +602,7 @@ ulong
 fd_banks_footprint( ulong max_total_banks,
                     ulong max_fork_width,
                     ulong max_stake_accounts,
+                    ulong max_fallback_stake_accounts,
                     ulong max_vote_accounts );
 
 /* fd_banks_new() creates a new fd_banks_t struct.  This function
@@ -613,6 +615,7 @@ fd_banks_new( void * mem,
               ulong  max_total_banks,
               ulong  max_fork_width,
               ulong  max_stake_accounts,
+              ulong  max_fallback_stake_accounts,
               ulong  max_vote_accounts,
               int    larger_max_cost_per_block,
               ulong  seed );

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1537,12 +1537,11 @@ fd_runtime_init_bank_from_genesis( fd_banks_t *         banks,
 
     if( !memcmp( account->owner.uc, fd_solana_stake_program_id.key, sizeof(fd_pubkey_t) ) ) {
       /* If an account is a stake account, then it must be added to the
-         stake delegations cache. We should only add stake accounts that
-         have a valid non-zero stake. */
+         stake delegations cache.  Like Agave, membership is decided by
+         the variant alone: a delegation of zero is still a delegation. */
       fd_stake_state_t const * stake_state = fd_stake_state_view( acc_data, account->data_len );
       if( FD_UNLIKELY( !stake_state ) ) { FD_BASE58_ENCODE_32_BYTES( account->pubkey.uc, stake_b58 ); FD_LOG_ERR(( "invalid stake account %s", stake_b58 )); }
       if( stake_state->stake_type!=FD_STAKE_STATE_STAKE ) continue;
-      if( !stake_state->stake.stake.delegation.stake ) continue;
 
       fd_stake_delegations_root_update(
           stake_delegations,

--- a/src/flamenco/runtime/fd_runtime_const.h
+++ b/src/flamenco/runtime/fd_runtime_const.h
@@ -48,6 +48,17 @@ FD_PROTOTYPES_BEGIN
 #define FD_RUNTIME_MAX_VOTE_ACCOUNTS  (19000000UL)
 #define FD_RUNTIME_MAX_STAKE_ACCOUNTS (2150000UL)
 
+
+/* FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK is the number of stake
+   accounts that the system can support.  FD_RUNTIME_STAKE_ACCOUNTS is
+   the measure of active stake accounts while _FALLBACK is the measure
+   of total stake accounts that the network can support.  This is a
+   measured and chosen threshold based on what the wider network on
+   mainnet can reasonably support across clients and valdiator
+   hardware. */
+
+#define FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK (100000000UL)
+
 /* The expected stake and vote account values are based on observed
    values on mainnet and testnet allowing for some growth.  These are
    chosen to size various caches and maps: they are not intended to be

--- a/src/flamenco/runtime/program/test_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/test_bpf_loader_program.c
@@ -90,10 +90,10 @@ deploy_env_init( deploy_env_t * env,
                  fd_wksp_t *    wksp ) {
   ulong tag = 1UL;
 
-  ulong banks_footprint = fd_banks_footprint( 1UL, 1UL, 2048UL, 2048UL );
+  ulong banks_footprint = fd_banks_footprint( 1UL, 1UL, 2048UL, 32768UL, 2048UL );
   void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), banks_footprint, tag++ );
   FD_TEST( banks_mem );
-  env->banks = fd_banks_join( fd_banks_new( banks_mem, 1UL, 1UL, 2048UL, 2048UL, 0, 42UL ) );
+  env->banks = fd_banks_join( fd_banks_new( banks_mem, 1UL, 1UL, 2048UL, 32768UL, 2048UL, 0, 42UL ) );
   FD_TEST( env->banks );
 
   env->bank = fd_banks_init_bank( env->banks );

--- a/src/flamenco/runtime/test_bank.c
+++ b/src/flamenco/runtime/test_bank.c
@@ -7,12 +7,17 @@
 #define TEST_BANK_STAKE_LAMPORTS (123456789UL)
 #define TEST_BANK_STAKE_ACC_DLEN (197U)
 
+/* These tests never drive stake delegations into pubkey fallback mode, so
+   the iterator never needs to resolve anything out of an accounts
+   database. */
+#define NO_RESOLVE NULL, ((fd_accdb_fork_id_t){ .val = USHORT_MAX }), 0UL, NULL
+
 static fd_stake_delegation_t const *
 test_bank_frontier_delegation_query( fd_banks_t *                   banks FD_PARAM_UNUSED,
                                      fd_stake_delegations_t const * stake_delegations,
                                      fd_pubkey_t const *            stake_account ) {
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, NO_RESOLVE );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * stake_delegation = fd_stake_delegations_iter_ele( iter );
@@ -33,7 +38,7 @@ test_bank_assert_stake_metadata( fd_stake_delegation_t const * stake_delegation 
 
 static void
 test_bank_advancing( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 8888UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
   /* Create the following fork tree with refcnts:
 
          P(0)
@@ -317,7 +322,7 @@ test_bank_advancing( void * mem ) {
 
 static void
 test_bank_dead_eviction( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 8888UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
   fd_bank_t * bank_data_pool = fd_type_pun( (uchar *)banks + banks->pool_offset );
 
   fd_bank_t * bank_P = fd_banks_init_bank( banks );
@@ -519,7 +524,7 @@ test_bank_dead_eviction( void * mem ) {
 
 static void
 test_bank_evictable( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 8UL, 2048UL, 2048UL, 0, 8888UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 8UL, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
   banks->evict_rr_idx = 0UL; /* This test verifies a specific RR order. */
 
   /*     A
@@ -643,7 +648,7 @@ test_bank_evictable( void * mem ) {
 
 static void
 test_bank_evictable_protected( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 4UL, 4UL, 8UL, 8UL, 0, 8889UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 4UL, 4UL, 8UL, 128UL, 8UL, 0, 8889UL ) );
   FD_TEST( banks );
 
   fd_bank_t * root = fd_banks_init_bank( banks );
@@ -687,10 +692,11 @@ test_bank_stake_delegations_dynamic_sizing( void * mem ) {
   ulong const max_vote_accounts     = 2048UL;
   ulong const max_stake_small       = 32UL;
   ulong const max_stake_large       = 2048UL;
-  ulong const stake_footprint_small = fd_stake_delegations_footprint( max_stake_small, max_stake_small, max_total_banks );
-  ulong const stake_footprint_large = fd_stake_delegations_footprint( max_stake_large, max_stake_large, max_total_banks );
+  ulong const max_fallback_stake    = 32768UL;
+  ulong const stake_footprint_small = fd_stake_delegations_footprint( max_stake_small, max_fallback_stake, max_stake_small, max_total_banks );
+  ulong const stake_footprint_large = fd_stake_delegations_footprint( max_stake_large, max_fallback_stake, max_stake_large, max_total_banks );
 
-  fd_banks_t * banks_small = fd_banks_join( fd_banks_new( mem, max_total_banks, max_fork_width, max_stake_small, max_vote_accounts, 0, 9991UL ) );
+  fd_banks_t * banks_small = fd_banks_join( fd_banks_new( mem, max_total_banks, max_fork_width, max_stake_small, max_fallback_stake, max_vote_accounts, 0, 9991UL ) );
   FD_TEST( banks_small );
 
   uchar * root_mem_small      = fd_type_pun( (uchar *)banks_small + banks_small->stake_delegations_offset );
@@ -719,7 +725,7 @@ test_bank_stake_delegations_dynamic_sizing( void * mem ) {
   fd_stake_delegations_root_update( root_stake_delegations, &stake_0, &vote_0, 11UL, 1UL, 2UL, 3UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
 
   fd_stake_delegations_t * frontier_stake_delegations = fd_bank_stake_delegations_frontier_query( banks_small, root_bank );
-  FD_TEST( fd_stake_delegations_cnt( frontier_stake_delegations )==1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( frontier_stake_delegations )==1UL );
   fd_stake_delegation_t const * stake_delegation = test_bank_frontier_delegation_query( banks_small, frontier_stake_delegations, &stake_0 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake==11UL );
@@ -739,7 +745,7 @@ test_bank_stake_delegations_dynamic_sizing( void * mem ) {
   fd_stake_delegations_fork_update( sd, child_bank->stake_delegations_fork_id, &stake_0, &vote_0, 33UL, 4UL, 5UL, 6UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   fd_stake_delegations_fork_update( sd, child_bank->stake_delegations_fork_id, &stake_1, &vote_1, 22UL, 4UL, 5UL, 6UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   frontier_stake_delegations = fd_bank_stake_delegations_frontier_query( banks_small, child_bank );
-  FD_TEST( fd_stake_delegations_cnt( frontier_stake_delegations )==2UL );
+  FD_TEST( fd_stake_delegations_base_cnt( frontier_stake_delegations )==2UL );
   stake_delegation = test_bank_frontier_delegation_query( banks_small, frontier_stake_delegations, &stake_0 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake==33UL );
@@ -770,7 +776,7 @@ test_bank_stake_delegations_dynamic_sizing( void * mem ) {
   FD_TEST( stake_delegation->stake==22UL );
   test_bank_assert_stake_metadata( stake_delegation );
 
-  fd_banks_t * banks_large = fd_banks_join( fd_banks_new( mem, max_total_banks, max_fork_width, max_stake_large, max_vote_accounts, 0, 9992UL ) );
+  fd_banks_t * banks_large = fd_banks_join( fd_banks_new( mem, max_total_banks, max_fork_width, max_stake_large, max_fallback_stake, max_vote_accounts, 0, 9992UL ) );
   FD_TEST( banks_large );
 
   uchar * root_mem_large      = fd_type_pun( (uchar *)banks_large + banks_large->stake_delegations_offset );
@@ -787,7 +793,7 @@ test_bank_stake_delegations_dynamic_sizing( void * mem ) {
 
 static void
 test_bank_new_votes_lifecycle( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 6666UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 6666UL ) );
   FD_TEST( banks );
 
   fd_bank_t * root = fd_banks_init_bank( banks );
@@ -833,7 +839,7 @@ test_bank_new_votes_lifecycle( void * mem ) {
 
 static void
 test_bank_new_votes_fork_indices( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 5555UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 5555UL ) );
   FD_TEST( banks );
 
   /* Root bank (no fork id). */
@@ -883,7 +889,7 @@ test_bank_new_votes_fork_indices( void * mem ) {
 
 static void
 test_bank_advance_root_preserves_inherited_stake_rewards( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 6666UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 6666UL ) );
   FD_TEST( banks );
 
   fd_bank_t * bank_A = fd_banks_init_bank( banks );
@@ -931,7 +937,7 @@ test_bank_advance_root_preserves_inherited_stake_rewards( void * mem ) {
 
 static void
 test_bank_advance_root_purges_losing_vote_stakes_fork( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 6667UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 6667UL ) );
   FD_TEST( banks );
 
   fd_bank_t * root = fd_banks_init_bank( banks );
@@ -975,7 +981,7 @@ test_bank_advance_root_purges_losing_vote_stakes_fork( void * mem ) {
 
 static void
 test_bank_clear( void * mem ) {
-  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 7777UL ) );
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 7777UL ) );
   FD_TEST( banks );
 
   fd_bank_t * root = fd_banks_init_bank( banks );
@@ -1034,13 +1040,13 @@ test_bank_clear( void * mem ) {
 static void
 test_bank_max_fork_width_limit( fd_wksp_t * wksp ) {
   ulong   width = FD_COLLECTOR_OVERRIDES_MAX_FORK_WIDTH;
-  ulong   fp    = fd_banks_footprint( 16UL, width, 2048UL, 2048UL );
+  ulong   fp    = fd_banks_footprint( 16UL, width, 2048UL, 32768UL, 2048UL );
   uchar * mem   = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fp, 1UL );
   FD_TEST( mem );
 
-  FD_TEST( !fd_banks_new( mem, 16UL, width+1UL, 2048UL, 2048UL, 0, 8888UL ) );
+  FD_TEST( !fd_banks_new( mem, 16UL, width+1UL, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
 
-  void * banks_mem = fd_banks_new( mem, 16UL, width, 2048UL, 2048UL, 0, 8888UL );
+  void * banks_mem = fd_banks_new( mem, 16UL, width, 2048UL, 32768UL, 2048UL, 0, 8888UL );
   FD_TEST( banks_mem );
   fd_banks_t * banks = fd_banks_join( banks_mem );
   FD_TEST( banks );
@@ -1071,14 +1077,14 @@ main( int argc, char ** argv ) {
 
   test_bank_max_fork_width_limit( wksp );
 
-  ulong const fp = fd_banks_footprint( 16UL, 8UL, 2048UL, 2048UL );
+  ulong const fp = fd_banks_footprint( 16UL, 8UL, 2048UL, 32768UL, 2048UL );
   uchar * mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fp, 1UL );
   FD_TEST( mem );
 # if !FD_HAS_MSAN
   for( ulong i=0UL; i<fp; i+=8 ) FD_STORE( ulong, mem+i, fd_ulong_hash( i ) );
 # endif
 
-  mem = fd_banks_new( mem, 16UL, 4UL, 2048UL, 2048UL, 0, 8888UL );
+  mem = fd_banks_new( mem, 16UL, 4UL, 2048UL, 32768UL, 2048UL, 0, 8888UL );
   FD_TEST( mem );
 
   /* Init banks */
@@ -1108,7 +1114,7 @@ main( int argc, char ** argv ) {
   fd_stake_delegations_fork_update( sd_test, bank->stake_delegations_fork_id, &key_0, &key_9, 100UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
 
   fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 1UL );
   fd_stake_delegation_t const * stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_0 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 100UL );
@@ -1138,7 +1144,7 @@ main( int argc, char ** argv ) {
      after a new bank has been created. */
 
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 1UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_0 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 100UL );
@@ -1150,7 +1156,7 @@ main( int argc, char ** argv ) {
   fd_stake_delegations_fork_update( sd_test, bank2->stake_delegations_fork_id, &key_0, &key_0, 200UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   fd_stake_delegations_fork_update( sd_test, bank2->stake_delegations_fork_id, &key_1, &key_8, 100UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank2 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 2UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 2UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_0 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 200UL );
@@ -1178,7 +1184,7 @@ main( int argc, char ** argv ) {
   sd_test = fd_bank_stake_delegations_modify( bank3 );
   fd_stake_delegations_fork_update( sd_test, bank3->stake_delegations_fork_id, &key_2, &key_7, 10UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank3 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 2UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 2UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_2 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 10UL );
@@ -1239,7 +1245,7 @@ main( int argc, char ** argv ) {
   fd_stake_delegations_fork_update( sd_test, bank7->stake_delegations_fork_id, &key_3, &key_6, 7UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank7 );
 
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
   FD_TEST( test_bank_frontier_delegation_query( banks, stake_delegations, &key_0 ) ); // bank2
   FD_TEST( test_bank_frontier_delegation_query( banks, stake_delegations, &key_1 ) ); // bank2
   FD_TEST( test_bank_frontier_delegation_query( banks, stake_delegations, &key_3 ) ); // bank7
@@ -1269,7 +1275,7 @@ main( int argc, char ** argv ) {
   sd_test = fd_bank_stake_delegations_modify( bank8 );
   fd_stake_delegations_fork_update( sd_test, bank8->stake_delegations_fork_id, &key_4, &key_5, 4UL, 100UL, 100UL, 100UL, TEST_BANK_STAKE_LAMPORTS, TEST_BANK_STAKE_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank8 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 4UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 4UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_4 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 4UL );
@@ -1290,7 +1296,7 @@ main( int argc, char ** argv ) {
      published any delegations. */
 
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, bank9 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_3 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 7UL );
@@ -1330,7 +1336,7 @@ main( int argc, char ** argv ) {
   FD_TEST( !fd_banks_bank_query( banks, bank_idx3 ) );
 
   stake_delegations = fd_bank_stake_delegations_frontier_query( banks, new_root );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_3 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 7UL );
@@ -1340,7 +1346,7 @@ main( int argc, char ** argv ) {
   fd_bank_stake_delegations_end_frontier_query( banks, new_root );
 
   stake_delegations = fd_banks_stake_delegations_root_query( banks );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
   stake_delegation = test_bank_frontier_delegation_query( banks, stake_delegations, &key_3 );
   FD_TEST( stake_delegation );
   FD_TEST( stake_delegation->stake == 7UL );

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -21,6 +21,11 @@
 #define TEST_PARENT_SLOT             (9UL)
 #define TEST_CHILD_SLOT              (10UL)
 
+/* These tests never drive stake delegations into pubkey fallback mode, so
+   the iterator never needs to resolve anything out of an accounts
+   database. */
+#define NO_RESOLVE NULL, ((fd_accdb_fork_id_t){ .val = USHORT_MAX }), 0UL, NULL
+
 struct test_env {
   fd_svm_mini_t *    mini;
   fd_bank_t *        bank;
@@ -54,7 +59,7 @@ static fd_stake_delegation_t const *
 find_visible_stake_delegation( fd_stake_delegations_t const * stake_delegations,
                                fd_pubkey_t const *            stake_account ) {
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, NO_RESOLVE );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * d = fd_stake_delegations_iter_ele( iter );
@@ -1283,9 +1288,8 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
 
   FD_LOG_NOTICE(( "test bundle non-owner stake_update carry... ok" ));
 
-  /* Test: stake metadata not represented in the delegation cache must
-     not create a fork delta.  Lamports may also differ (for example due
-     to dust), but the visible delegation should remain the root entry. */
+  /* Test: a lamport-only stake account change must create a fork delta
+     so the delegation cache tracks the balance used by epoch rewards. */
   {
     reset_world();
     fd_pubkey_t stake_acct = { .ul[0] = 0x53544B454E4F4F50UL };
@@ -1299,7 +1303,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
                                             .activation_epoch = 0UL, .deactivation_epoch = ULONG_MAX,
                                             .warmup_cooldown_rate = 0.25 } } } }) );
     fd_memcpy( data, prior_data, sizeof(data) );
-    FD_STORE( long, data + offsetof(fd_stake_state_t, stake.meta.unix_timestamp), 1L );
 
     fd_stake_delegations_t * root = fd_banks_stake_delegations_root_query( env->mini->banks );
     fd_stake_delegations_root_update( root, &stake_acct, &vote_acct, 5UL, 0UL, ULONG_MAX, 0UL,
@@ -1322,11 +1325,60 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     fd_stakes_update_stake_delegation( &stake_acct, &acc, env->bank );
 
     fd_stake_delegations_t * frontier = fd_bank_stake_delegations_frontier_query( env->mini->banks, env->bank );
-    FD_TEST( find_visible_stake_delegation( frontier, &stake_acct )==root_delegation );
+    fd_stake_delegation_t const * updated_delegation = find_visible_stake_delegation( frontier, &stake_acct );
+    FD_TEST( updated_delegation );
+    FD_TEST( updated_delegation!=root_delegation );
+    FD_TEST( updated_delegation->lamports==2000000001UL );
     fd_bank_stake_delegations_end_frontier_query( env->mini->banks, env->bank );
   }
 
-  FD_LOG_NOTICE(( "test cache-equivalent stake states skip delta... ok" ));
+  FD_LOG_NOTICE(( "test lamport-only stake change creates delta... ok" ));
+
+  /* Test: a change outside the cached delegation fields must still
+     create a fork delta. */
+  {
+    reset_world();
+    fd_pubkey_t stake_acct = { .ul[0] = 0x53544B454D455441UL };
+    fd_pubkey_t vote_acct  = { .ul[0] = 0x564F54454D455441UL };
+    uchar prior_data[ FD_STAKE_STATE_SZ ] = {0};
+    uchar data      [ FD_STAKE_STATE_SZ ] = {0};
+    FD_STORE( fd_stake_state_t, prior_data, ((fd_stake_state_t){
+      .stake_type = FD_STAKE_STATE_STAKE,
+      .stake = { .meta = { .staker = stake_acct, .withdrawer = stake_acct },
+                 .stake = { .delegation = { .voter_pubkey = vote_acct, .stake = 5UL,
+                                            .activation_epoch = 0UL, .deactivation_epoch = ULONG_MAX,
+                                            .warmup_cooldown_rate = 0.25 } } } }) );
+    fd_memcpy( data, prior_data, sizeof(data) );
+    FD_STORE( long, data + offsetof(fd_stake_state_t, stake.meta.unix_timestamp), 1L );
+
+    fd_stake_delegations_t * root = fd_banks_stake_delegations_root_query( env->mini->banks );
+    fd_stake_delegations_root_update( root, &stake_acct, &vote_acct, 5UL, 0UL, ULONG_MAX, 0UL,
+                                      2000000000UL, (uint)FD_STAKE_STATE_SZ,
+                                      FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegation_t const * root_delegation = fd_stake_delegation_root_query( root, &stake_acct );
+    FD_TEST( root_delegation );
+
+    fd_acc_t acc = {
+      .lamports       = 2000000000UL,
+      .data_len       = FD_STAKE_STATE_SZ,
+      .data           = data,
+      .prior_lamports = 2000000000UL,
+      .prior_data_len = FD_STAKE_STATE_SZ,
+      .prior_data     = prior_data,
+    };
+    fd_memcpy( acc.owner,       fd_solana_stake_program_id.uc, 32UL );
+    fd_memcpy( acc.prior_owner, fd_solana_stake_program_id.uc, 32UL );
+
+    fd_stakes_update_stake_delegation( &stake_acct, &acc, env->bank );
+
+    fd_stake_delegations_t * frontier = fd_bank_stake_delegations_frontier_query( env->mini->banks, env->bank );
+    fd_stake_delegation_t const * updated_delegation = find_visible_stake_delegation( frontier, &stake_acct );
+    FD_TEST( updated_delegation );
+    FD_TEST( updated_delegation!=root_delegation );
+    fd_bank_stake_delegations_end_frontier_query( env->mini->banks, env->bank );
+  }
+
+  FD_LOG_NOTICE(( "test stake metadata change creates delta... ok" ));
 
   /* Test: closing an initialized (never delegated) stake account must
      not create a removal tombstone. */

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -5,6 +5,7 @@
 #include "fd_alut.h"
 #include "../stakes/fd_stake_delegations.h"
 #include "../stakes/fd_stake_types.h"
+#include "../stakes/fd_stakes.h"
 #include "program/fd_system_program.h"
 #include "program/fd_bpf_loader_program.h"
 #include "sysvar/fd_sysvar.h"
@@ -1281,6 +1282,82 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   }
 
   FD_LOG_NOTICE(( "test bundle non-owner stake_update carry... ok" ));
+
+  /* Test: stake metadata not represented in the delegation cache must
+     not create a fork delta.  Lamports may also differ (for example due
+     to dust), but the visible delegation should remain the root entry. */
+  {
+    reset_world();
+    fd_pubkey_t stake_acct = { .ul[0] = 0x53544B454E4F4F50UL };
+    fd_pubkey_t vote_acct  = { .ul[0] = 0x564F54454E4F4F50UL };
+    uchar prior_data[ FD_STAKE_STATE_SZ ] = {0};
+    uchar data      [ FD_STAKE_STATE_SZ ] = {0};
+    FD_STORE( fd_stake_state_t, prior_data, ((fd_stake_state_t){
+      .stake_type = FD_STAKE_STATE_STAKE,
+      .stake = { .meta = { .staker = stake_acct, .withdrawer = stake_acct },
+                 .stake = { .delegation = { .voter_pubkey = vote_acct, .stake = 5UL,
+                                            .activation_epoch = 0UL, .deactivation_epoch = ULONG_MAX,
+                                            .warmup_cooldown_rate = 0.25 } } } }) );
+    fd_memcpy( data, prior_data, sizeof(data) );
+    FD_STORE( long, data + offsetof(fd_stake_state_t, stake.meta.unix_timestamp), 1L );
+
+    fd_stake_delegations_t * root = fd_banks_stake_delegations_root_query( env->mini->banks );
+    fd_stake_delegations_root_update( root, &stake_acct, &vote_acct, 5UL, 0UL, ULONG_MAX, 0UL,
+                                      2000000000UL, (uint)FD_STAKE_STATE_SZ,
+                                      FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegation_t const * root_delegation = fd_stake_delegation_root_query( root, &stake_acct );
+    FD_TEST( root_delegation );
+
+    fd_acc_t acc = {
+      .lamports       = 2000000001UL,
+      .data_len       = FD_STAKE_STATE_SZ,
+      .data           = data,
+      .prior_lamports = 2000000000UL,
+      .prior_data_len = FD_STAKE_STATE_SZ,
+      .prior_data     = prior_data,
+    };
+    fd_memcpy( acc.owner,       fd_solana_stake_program_id.uc, 32UL );
+    fd_memcpy( acc.prior_owner, fd_solana_stake_program_id.uc, 32UL );
+
+    fd_stakes_update_stake_delegation( &stake_acct, &acc, env->bank );
+
+    fd_stake_delegations_t * frontier = fd_bank_stake_delegations_frontier_query( env->mini->banks, env->bank );
+    FD_TEST( find_visible_stake_delegation( frontier, &stake_acct )==root_delegation );
+    fd_bank_stake_delegations_end_frontier_query( env->mini->banks, env->bank );
+  }
+
+  FD_LOG_NOTICE(( "test cache-equivalent stake states skip delta... ok" ));
+
+  /* Test: closing an initialized (never delegated) stake account must
+     not create a removal tombstone. */
+  {
+    reset_world();
+    fd_pubkey_t stake_acct = { .ul[0] = 0x53544B454E4F4445UL };
+    uchar prior_data[ 124UL ] = {0};
+    FD_STORE( uint, prior_data, FD_STAKE_STATE_INITIALIZED );
+
+    fd_acc_t acc = {
+      .lamports       = 0UL,
+      .data_len       = 0UL,
+      .data           = NULL,
+      .prior_lamports = 2000000000UL,
+      .prior_data_len = sizeof(prior_data),
+      .prior_data     = prior_data,
+    };
+    fd_memcpy( acc.prior_owner, fd_solana_stake_program_id.uc, 32UL );
+
+    fd_stake_delegations_t * root = fd_banks_stake_delegations_root_query( env->mini->banks );
+    FD_TEST( !fd_stake_delegation_root_query( root, &stake_acct ) );
+
+    fd_stakes_update_stake_delegation( &stake_acct, &acc, env->bank );
+
+    fd_stake_delegations_t * frontier = fd_bank_stake_delegations_frontier_query( env->mini->banks, env->bank );
+    FD_TEST( frontier );
+    FD_TEST( !fd_stake_delegation_root_query( root, &stake_acct ) );
+    fd_bank_stake_delegations_end_frontier_query( env->mini->banks, env->bank );
+  }
+
+  FD_LOG_NOTICE(( "test nondelegated stake close skips tombstone... ok" ));
 
   /* Test: a fully-cancelled bundle must not apply any vote op.  tx0
      queues rm_vote then the bundle is cancelled (not committed); the

--- a/src/flamenco/runtime/test_vat_refresh_vote_accounts.c
+++ b/src/flamenco/runtime/test_vat_refresh_vote_accounts.c
@@ -366,9 +366,9 @@ test_env_create_vat( test_env_t * env, fd_wksp_t * wksp, ulong vat_activation_sl
   env->accdb = fd_accdb_join( fd_accdb_new( env->accdb_join, shmem, env->accdb_fd, 0UL, NULL ) );
   FD_TEST( env->accdb );
 
-  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width, 2048UL, 2048UL ), env->tag );
+  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), fd_banks_footprint( max_total_banks, max_fork_width, 2048UL, 32768UL, 2048UL ), env->tag );
   FD_TEST( banks_mem );
-  env->banks = fd_banks_join( fd_banks_new( banks_mem, max_total_banks, max_fork_width, 2048UL, 2048UL, 0, 8888UL ) );
+  env->banks = fd_banks_join( fd_banks_new( banks_mem, max_total_banks, max_fork_width, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
   FD_TEST( env->banks );
 
   env->bank = fd_banks_init_bank( env->banks );

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -606,7 +606,7 @@ create_block_context_protobuf_from_block( fd_block_dump_ctx_t * dump_ctx,
 
   /* Dump stake accounts for this epoch */
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, parent_bank->accdb_fork_id, parent_bank->f.epoch, &parent_bank->f.warmup_cooldown_rate_epoch );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * stake_delegation = fd_stake_delegations_iter_ele( iter );

--- a/src/flamenco/runtime/tests/fd_solfuzz.c
+++ b/src/flamenco/runtime/tests/fd_solfuzz.c
@@ -104,7 +104,7 @@ fd_solfuzz_runner_new( fd_wksp_t *                         wksp,
   void *                pcache_mem   = fd_wksp_alloc_laddr( wksp, fd_progcache_shmem_align(),   fd_progcache_shmem_footprint( txn_max, rec_max ),            wksp_tag );
   uchar *               scratch      = fd_wksp_alloc_laddr( wksp, FD_PROGCACHE_SCRATCH_ALIGN,   FD_PROGCACHE_SCRATCH_FOOTPRINT,                              wksp_tag );
   void *                spad_mem     = fd_wksp_alloc_laddr( wksp, fd_spad_align(),              fd_spad_footprint( spad_max ),                               wksp_tag );
-  void *                banks_mem    = fd_wksp_alloc_laddr( wksp, fd_banks_align(),             fd_banks_footprint( bank_max, fork_max, 2048UL, 2048UL ),    wksp_tag );
+  void *                banks_mem    = fd_wksp_alloc_laddr( wksp, fd_banks_align(),             fd_banks_footprint( bank_max, fork_max, 2048UL, 32768UL, 2048UL ), wksp_tag );
   if( FD_UNLIKELY( !runner       ) ) { FD_LOG_WARNING(( "fd_wksp_alloc(solfuzz_runner) failed"                                            )); goto bail1; }
   if( FD_UNLIKELY( !accdb_shmem  ) ) { FD_LOG_WARNING(( "fd_wksp_alloc(accdb_shmem) failed"                                               )); goto bail1; }
   if( FD_UNLIKELY( !accdb_join   ) ) { FD_LOG_WARNING(( "fd_wksp_alloc(accdb_join) failed"                                                )); goto bail1; }
@@ -149,7 +149,7 @@ fd_solfuzz_runner_new( fd_wksp_t *                         wksp,
   runner->spad = fd_spad_join( fd_spad_new( spad_mem, spad_max ) );
   if( FD_UNLIKELY( !runner->spad ) ) goto bail2;
   /* Use 2048 for max_vote_accounts to match fd_banks_footprint above (avoids buffer overrun) */
-  runner->banks = fd_banks_join( fd_banks_new( banks_mem, bank_max, fork_max, 2048UL, 2048UL, 0, 8888UL ) );
+  runner->banks = fd_banks_join( fd_banks_new( banks_mem, bank_max, fork_max, 2048UL, 32768UL, 2048UL, 0, 8888UL ) );
   if( FD_UNLIKELY( !runner->banks ) ) goto bail2;
   runner->bank = fd_banks_init_bank( runner->banks );
   if( FD_UNLIKELY( !runner->bank ) ) goto bail2;

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -107,7 +107,7 @@ fd_svm_mini_wksp_data_max( fd_svm_mini_limits_t const * limits ) {
   ulong pcache_sz         = fd_progcache_shmem_footprint( txn_max, limits->max_progcache_recs );
   ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot, 0 );
   ulong txncache_sz       = fd_txncache_footprint( txn_max );
-  ulong banks_sz          = fd_banks_footprint( txn_max, limits->max_fork_width, limits->max_stake_accounts, limits->max_vote_accounts );
+  ulong banks_sz          = fd_banks_footprint( txn_max, limits->max_fork_width, limits->max_stake_accounts, limits->max_fallback_stake_accounts, limits->max_vote_accounts );
   ulong runtime_stack_sz  = fd_runtime_stack_footprint( limits->max_vote_accounts, limits->max_vote_accounts, limits->max_stake_accounts );
 
   ulong accdb_shmem_sz = fd_accdb_shmem_footprint( limits->max_accounts, limits->max_live_slots,
@@ -147,7 +147,8 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
   ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot, 0 );
   ulong txncache_sz       = fd_txncache_footprint( txn_max );
   ulong banks_sz         = fd_banks_footprint( txn_max, limits->max_fork_width,
-                                               limits->max_stake_accounts, limits->max_vote_accounts );
+                                               limits->max_stake_accounts, limits->max_fallback_stake_accounts,
+                                               limits->max_vote_accounts );
   ulong runtime_stack_sz = fd_runtime_stack_footprint( limits->max_vote_accounts, limits->max_vote_accounts, limits->max_stake_accounts );
 
   ulong accdb_shmem_sz = fd_accdb_shmem_footprint( limits->max_accounts, limits->max_live_slots,
@@ -205,7 +206,8 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
   FD_TEST( (mini->txncache = fd_txncache_join( fd_txncache_new( txncache_mem, shtxncache ) )) );
 
   mini->banks = fd_banks_join( fd_banks_new( banks_mem, txn_max, limits->max_fork_width,
-                               limits->max_stake_accounts, limits->max_vote_accounts, 0, 8888UL ) );
+                               limits->max_stake_accounts, limits->max_fallback_stake_accounts,
+                               limits->max_vote_accounts, 0, 8888UL ) );
   FD_TEST( mini->banks );
 
   mini->runtime = runtime;

--- a/src/flamenco/runtime/tests/fd_svm_mini.h
+++ b/src/flamenco/runtime/tests/fd_svm_mini.h
@@ -65,6 +65,7 @@ struct fd_svm_mini_limits {
   /* consensus */
   ulong max_vote_accounts;
   ulong max_stake_accounts;
+  ulong max_fallback_stake_accounts;
 
   /* accdb */
   ulong max_accounts;
@@ -165,6 +166,7 @@ fd_svm_mini_limits_default( fd_svm_mini_limits_t * limits ) {
     .max_fork_width           = 4UL,
     .max_vote_accounts        = 256UL,
     .max_stake_accounts       = 256UL,
+    .max_fallback_stake_accounts = 4096UL,
     .max_accounts             = 128UL,
     .max_account_space_bytes  = 32UL<<20,
     .max_progcache_recs       = 256UL,

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -1,6 +1,5 @@
 #include "fd_stake_delegations.h"
 #include "fd_stakes.h"
-#include <string.h>
 
 #define POOL_NAME  root_pool
 #define POOL_T     fd_stake_delegation_t
@@ -19,19 +18,22 @@
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"
 
+#define MAP_NAME               fork_map
+#define MAP_KEY_T              fd_pubkey_t
+#define MAP_ELE_T              fd_stake_delegation_t
+#define MAP_KEY                stake_account
+#define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
+#define MAP_KEY_HASH(key,seed) (fd_accdb_hash( key->uc, seed ))
+#define MAP_NEXT               next_
+#define MAP_IDX_T              uint
+#include "../../util/tmpl/fd_map_chain.c"
+
 #define POOL_NAME  delta_pool
 #define POOL_T     fd_stake_delegation_t
 #define POOL_NEXT  next_
 #define POOL_IDX_T uint
 #define POOL_LAZY  1
 #include "../../util/tmpl/fd_pool.c"
-
-#define DLIST_NAME  fork_dlist
-#define DLIST_ELE_T fd_stake_delegation_t
-#define DLIST_PREV  prev_
-#define DLIST_NEXT  next_
-#define DLIST_IDX_T uint
-#include "../../util/tmpl/fd_dlist.c"
 
 struct fork_pool_ele { ushort next; };
 typedef struct fork_pool_ele fork_pool_ele_t;
@@ -65,10 +67,11 @@ get_fork_pool( fd_stake_delegations_t const * stake_delegations ) {
   return fd_type_pun( (uchar *)stake_delegations + stake_delegations->fork_pool_offset_ );
 }
 
-static inline fork_dlist_t *
-get_fork_dlist( fd_stake_delegations_t const * stake_delegations,
-                ushort                         fork_idx ) {
-  return fd_type_pun( (uchar *)stake_delegations + stake_delegations->dlist_offsets_[ fork_idx ] );
+static inline fork_map_t *
+get_fork_map( fd_stake_delegations_t const * stake_delegations,
+              ushort                         fork_idx ) {
+  ulong map_footprint = fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT );
+  return fd_type_pun( (uchar *)stake_delegations + stake_delegations->fork_map_offset_ + (ulong)fork_idx*map_footprint );
 }
 
 ulong
@@ -89,9 +92,7 @@ fd_stake_delegations_footprint( ulong max_stake_accounts,
   l = FD_LAYOUT_APPEND( l, root_map_align(),             root_map_footprint( map_chain_cnt ) );
   l = FD_LAYOUT_APPEND( l, delta_pool_align(),           delta_pool_footprint( max_stake_accounts ) );
   l = FD_LAYOUT_APPEND( l, fork_pool_align(),            fork_pool_footprint( max_live_slots ) );
-  for( ulong i=0UL; i<max_live_slots; i++ ) {
-    l = FD_LAYOUT_APPEND( l, fork_dlist_align(), fork_dlist_footprint() );
-  }
+  l = FD_LAYOUT_APPEND( l, fork_map_align(),             max_live_slots*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT ) );
 
   return FD_LAYOUT_FINI( l, fd_stake_delegations_align() );
 }
@@ -130,14 +131,14 @@ fd_stake_delegations_new( void * mem,
   void *                   map_mem           = FD_SCRATCH_ALLOC_APPEND( l, root_map_align(),             root_map_footprint( map_chain_cnt ) );
   void *                   delta_pool_mem    = FD_SCRATCH_ALLOC_APPEND( l, delta_pool_align(),           delta_pool_footprint( max_stake_accounts ) );
   void *                   fork_pool_mem     = FD_SCRATCH_ALLOC_APPEND( l, fork_pool_align(),            fork_pool_footprint( max_live_slots ) );
+  void *                   fork_map_mem      = FD_SCRATCH_ALLOC_APPEND( l, fork_map_align(),             max_live_slots*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT ) );
   for( ushort i=0; i<(ushort)max_live_slots; i++ ) {
-    void * fork_dlist_mem = FD_SCRATCH_ALLOC_APPEND( l, fork_dlist_align(), fork_dlist_footprint() );
-    fork_dlist_t * dlist = fork_dlist_join( fork_dlist_new( fork_dlist_mem ) );
-    if( FD_UNLIKELY( !dlist ) ) {
-      FD_LOG_WARNING(( "Failed to create fork dlist" ));
+    void * fork_map_mem_i = (uchar *)fork_map_mem + (ulong)i*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT );
+    fork_map_t * map = fork_map_join( fork_map_new( fork_map_mem_i, FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT, seed ) );
+    if( FD_UNLIKELY( !map ) ) {
+      FD_LOG_WARNING(( "Failed to create fork map" ));
       return NULL;
     }
-    stake_delegations->dlist_offsets_[ i ] = (ulong)dlist - (ulong)mem;
   }
 
   if( FD_UNLIKELY( FD_SCRATCH_ALLOC_FINI( l, fd_stake_delegations_align() )!=(ulong)mem+fd_stake_delegations_footprint( max_stake_accounts, expected_stake_accounts, max_live_slots ) ) ) {
@@ -175,6 +176,7 @@ fd_stake_delegations_new( void * mem,
   stake_delegations->map_offset_              = (ulong)root_map - (ulong)mem;
   stake_delegations->delta_pool_offset_       = (ulong)delta_pool - (ulong)mem;
   stake_delegations->fork_pool_offset_        = (ulong)fork_pool - (ulong)mem;
+  stake_delegations->fork_map_offset_         = (ulong)fork_map_mem - (ulong)mem;
 
   stake_delegations->effective_stake    = 0UL;
   stake_delegations->activating_stake   = 0UL;
@@ -214,14 +216,13 @@ fd_stake_delegations_join( void * mem ) {
 
 void
 fd_stake_delegations_reset( fd_stake_delegations_t * stake_delegations ) {
-  root_pool_reset ( get_root_pool ( stake_delegations ) );
-  root_map_reset  ( get_root_map  ( stake_delegations ) );
+  root_pool_reset( get_root_pool( stake_delegations ) );
+  root_map_reset( get_root_map( stake_delegations ) );
   delta_pool_reset( get_delta_pool( stake_delegations ) );
   fork_pool_ele_t * fork_pool = get_fork_pool( stake_delegations );
-  fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
   ulong max_forks = fork_pool_max( fork_pool );
   for( ulong i=0UL; i<max_forks; i++ ) {
-    fork_dlist_remove_all( get_fork_dlist( stake_delegations, (ushort)i ), delta_pool );
+    fork_map_reset( get_fork_map( stake_delegations, (ushort)i ) );
   }
   fork_pool_reset( fork_pool );
   stake_delegations->effective_stake    = 0UL;
@@ -251,15 +252,15 @@ fd_stake_delegations_root_update( fd_stake_delegations_t * stake_delegations,
                                   uint                     acc_dlen,
                                   uchar                    warmup_cooldown_rate ) {
   fd_stake_delegation_t * pool = get_root_pool( stake_delegations );
-  root_map_t *            map = get_root_map( stake_delegations );
+  root_map_t *            map  = get_root_map( stake_delegations );
 
   fd_stake_delegation_t * stake_delegation = root_map_ele_query( map, stake_account, NULL, pool );
-  if( !stake_delegation ) {
+  if( FD_LIKELY( !stake_delegation ) ) {
     FD_CHECK_CRIT( root_pool_free( pool ), "no free stake delegations in pool" );
-    stake_delegation = root_pool_ele_acquire( pool );
-    stake_delegation->stake_account = *stake_account;
-    FD_CHECK_CRIT( root_map_ele_insert( map, stake_delegation, pool ), "unable to insert stake delegation into map" );
+    stake_delegation                 = root_pool_ele_acquire( pool );
+    stake_delegation->stake_account  = *stake_account;
     stake_delegations->pool_idx_wmk_ = fd_ulong_max( stake_delegations->pool_idx_wmk_, root_pool_idx( pool, stake_delegation )+1UL );
+    FD_CHECK_CRIT( root_map_ele_insert( map, stake_delegation, pool ), "unable to insert stake delegation into map" );
   }
 
   stake_delegation->vote_account         = *vote_account;
@@ -273,20 +274,6 @@ fd_stake_delegations_root_update( fd_stake_delegations_t * stake_delegations,
   stake_delegation->dne_in_root          = 0;
   stake_delegation->delta_idx            = UINT_MAX;
   stake_delegation->in_use               = 1;
-}
-
-static inline void
-fd_stake_delegations_remove( fd_stake_delegations_t * stake_delegations,
-                             fd_pubkey_t const *      stake_account ) {
-  fd_stake_delegation_t * pool = get_root_pool( stake_delegations );
-  root_map_t *            map  = get_root_map( stake_delegations );
-
-  ulong delegation_idx = root_map_idx_query( map, stake_account, UINT_MAX, pool );
-  if( FD_UNLIKELY( delegation_idx==UINT_MAX ) ) return;
-
-  root_map_idx_remove( map, stake_account, delegation_idx, pool );
-  pool[ delegation_idx ].in_use = 0;
-  root_pool_idx_release( pool, delegation_idx );
 }
 
 #if FD_HAS_DOUBLE
@@ -406,16 +393,16 @@ fd_stake_delegations_fork_update( fd_stake_delegations_t * stake_delegations,
                                   uchar                    warmup_cooldown_rate ) {
   fd_rwlock_write( &stake_delegations->delta_lock );
 
-  fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
-  FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
+  fd_stake_delegation_t * delta_pool       = get_delta_pool( stake_delegations );
+  fork_map_t *            map              = get_fork_map( stake_delegations, fork_idx );
+  fd_stake_delegation_t * stake_delegation = fork_map_ele_query( map, stake_account, NULL, delta_pool );
+  if( FD_LIKELY( !stake_delegation ) ) {
+    FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
+    stake_delegation                = delta_pool_ele_acquire( delta_pool );
+    stake_delegation->stake_account = *stake_account;
+    fork_map_ele_insert( map, stake_delegation, delta_pool );
+  }
 
-  fork_dlist_t * dlist = get_fork_dlist( stake_delegations, fork_idx );
-
-  fd_stake_delegation_t * stake_delegation = delta_pool_ele_acquire( delta_pool );
-
-  fork_dlist_ele_push_tail( dlist, stake_delegation, delta_pool );
-
-  stake_delegation->stake_account        = *stake_account;
   stake_delegation->vote_account         = *vote_account;
   stake_delegation->stake                = stake;
   stake_delegation->lamports             = lamports;
@@ -439,18 +426,19 @@ fd_stake_delegations_fork_remove( fd_stake_delegations_t * stake_delegations,
                                   fd_pubkey_t const *      stake_account ) {
   fd_rwlock_write( &stake_delegations->delta_lock );
 
-  fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
-  FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
+  fd_stake_delegation_t * delta_pool       = get_delta_pool( stake_delegations );
+  fork_map_t *            map              = get_fork_map( stake_delegations, fork_idx );
+  fd_stake_delegation_t * stake_delegation = fork_map_ele_query( map, stake_account, NULL, delta_pool );
+  if( FD_LIKELY( !stake_delegation ) ) {
+    FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
+    stake_delegation                = delta_pool_ele_acquire( delta_pool );
+    stake_delegation->stake_account = *stake_account;
+    fork_map_ele_insert( map, stake_delegation, delta_pool );
+  }
 
-  fd_stake_delegation_t * stake_delegation = delta_pool_ele_acquire( delta_pool );
-
-  fork_dlist_t * dlist = get_fork_dlist( stake_delegations, fork_idx );
-  fork_dlist_ele_push_tail( dlist, stake_delegation, delta_pool );
-
-  stake_delegation->stake_account = *stake_account;
-  stake_delegation->lamports      = 0UL;
-  stake_delegation->acc_dlen      = 0U;
-  stake_delegation->is_tombstone  = 1;
+  stake_delegation->lamports     = 0UL;
+  stake_delegation->acc_dlen     = 0U;
+  stake_delegation->is_tombstone = 1;
 
   FD_BASE58_ENCODE_32_BYTES( stake_delegation->stake_account.uc, stake_account_out );
   FD_LOG_DEBUG(( "fork_remove: stake_account=%s", stake_account_out ));
@@ -466,12 +454,15 @@ fd_stake_delegations_evict_fork( fd_stake_delegations_t * stake_delegations,
   fd_rwlock_write( &stake_delegations->delta_lock );
 
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
+  fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
 
-  fork_dlist_t * dlist = get_fork_dlist( stake_delegations, fork_idx );
-  while( !fork_dlist_is_empty( dlist, delta_pool ) ) {
-    fd_stake_delegation_t * ele = fork_dlist_ele_pop_head( dlist, delta_pool );
+  fork_map_iter_t iter = fork_map_iter_init( fork_map, delta_pool );
+  while( !fork_map_iter_done( iter, fork_map, delta_pool ) ) {
+    fd_stake_delegation_t * ele = fork_map_iter_ele( iter, fork_map, delta_pool );
+    iter = fork_map_iter_next( iter, fork_map, delta_pool );
     delta_pool_ele_release( delta_pool, ele );
   }
+  fork_map_reset( fork_map );
 
   fork_pool_idx_release( get_fork_pool( stake_delegations ), fork_idx );
 
@@ -486,13 +477,13 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
                                        fd_stake_delegations_t *   stake_delegations,
                                        ushort                     fork_idx ) {
 
-  fork_dlist_t *          dlist      = get_fork_dlist( stake_delegations, fork_idx );
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
+  fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
 
-  for( fork_dlist_iter_t iter = fork_dlist_iter_fwd_init( dlist, delta_pool );
-       !fork_dlist_iter_done( iter, dlist, delta_pool );
-       iter = fork_dlist_iter_fwd_next( iter, dlist, delta_pool ) ) {
-    fd_stake_delegation_t * stake_delegation = fork_dlist_iter_ele( iter, dlist, delta_pool );
+  for( fork_map_iter_t iter = fork_map_iter_init( fork_map, delta_pool );
+       !fork_map_iter_done( iter, fork_map, delta_pool );
+       iter = fork_map_iter_next( iter, fork_map, delta_pool ) ) {
+    fd_stake_delegation_t * stake_delegation = fork_map_iter_ele( iter, fork_map, delta_pool );
     if( FD_LIKELY( !stake_delegation->is_tombstone ) ) {
       /* If the acc in the delta is an update:
          - If the acc already exists, subtract the old version's stake
@@ -500,7 +491,7 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
          - Add the new version's stake to the totals */
       fd_stake_delegation_t const * old_delegation = fd_stake_delegation_root_query( stake_delegations, &stake_delegation->stake_account );
       if( FD_LIKELY( old_delegation ) ) {
-        fd_stake_history_entry_t old_entry = fd_stakes_activating_and_deactivating( old_delegation, epoch, stake_history, warmup_cooldown_rate_epoch, use_fixed_point_stake_math );
+        fd_stake_history_entry_t old_entry     = fd_stakes_activating_and_deactivating( old_delegation, epoch, stake_history, warmup_cooldown_rate_epoch, use_fixed_point_stake_math );
         stake_delegations->effective_stake    -= old_entry.effective;
         stake_delegations->activating_stake   -= old_entry.activating;
         stake_delegations->deactivating_stake -= old_entry.deactivating;
@@ -525,15 +516,20 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
     } else {
       /* If the stake delegation in the delta is a tombstone, just
          remove the stake delegation from the root map and subtract
-         it's stake from the totals. */
-      fd_stake_delegation_t const * old_delegation = fd_stake_delegation_root_query( stake_delegations, &stake_delegation->stake_account );
-      if( FD_LIKELY( old_delegation ) ) {
+         its stake from the totals. */
+      fd_stake_delegation_t * root_pool = get_root_pool( stake_delegations );
+      root_map_t *            root_map  = get_root_map( stake_delegations );
+      ulong delegation_idx = root_map_idx_query( root_map, &stake_delegation->stake_account, UINT_MAX, root_pool );
+      if( FD_LIKELY( delegation_idx!=UINT_MAX ) ) {
+        fd_stake_delegation_t * old_delegation = root_pool + delegation_idx;
         fd_stake_history_entry_t old_entry = fd_stakes_activating_and_deactivating( old_delegation, epoch, stake_history, warmup_cooldown_rate_epoch, use_fixed_point_stake_math );
         stake_delegations->effective_stake    -= old_entry.effective;
         stake_delegations->activating_stake   -= old_entry.activating;
         stake_delegations->deactivating_stake -= old_entry.deactivating;
+        root_map_idx_remove( root_map, &stake_delegation->stake_account, delegation_idx, root_pool );
+        old_delegation->in_use = 0;
+        root_pool_idx_release( root_pool, delegation_idx );
       }
-      fd_stake_delegations_remove( stake_delegations, &stake_delegation->stake_account );
     }
   }
   FD_LOG_DEBUG(( "effective_stake=%lu, activating_stake=%lu, deactivating_stake=%lu", stake_delegations->effective_stake, stake_delegations->activating_stake, stake_delegations->deactivating_stake ));
@@ -567,26 +563,25 @@ fd_stake_delegations_mark_delta( fd_stake_delegations_t *   stake_delegations,
   root_map_t *            root_map   = get_root_map( stake_delegations );
   fd_stake_delegation_t * root_pool  = get_root_pool( stake_delegations );
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
-  fork_dlist_t *          fork_dlist = get_fork_dlist( stake_delegations, fork_idx );
+  fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
 
-  for( fork_dlist_iter_t iter = fork_dlist_iter_fwd_init( fork_dlist, delta_pool );
-       !fork_dlist_iter_done( iter, fork_dlist, delta_pool );
-       iter = fork_dlist_iter_fwd_next( iter, fork_dlist, delta_pool ) ) {
-    fd_stake_delegation_t * delta_delegation = fork_dlist_iter_ele( iter, fork_dlist, delta_pool );
-
-    fd_stake_delegation_t * base_delegation = root_map_ele_query( root_map, &delta_delegation->stake_account, NULL, root_pool);
+  for( fork_map_iter_t iter = fork_map_iter_init( fork_map, delta_pool );
+       !fork_map_iter_done( iter, fork_map, delta_pool );
+       iter = fork_map_iter_next( iter, fork_map, delta_pool ) ) {
+    fd_stake_delegation_t * delta_delegation = fork_map_iter_ele( iter, fork_map, delta_pool );
+    fd_stake_delegation_t * base_delegation  = root_map_ele_query( root_map, &delta_delegation->stake_account, NULL, root_pool);
     if( FD_UNLIKELY( !base_delegation ) ) {
-      base_delegation                = root_pool_ele_acquire( root_pool );
-      base_delegation->stake_account = delta_delegation->stake_account;
-      base_delegation->lamports      = 0UL;
-      base_delegation->acc_dlen      = 0U;
-      base_delegation->dne_in_root   = 1;
-      base_delegation->delta_idx     = (uint)delta_pool_idx( delta_pool, delta_delegation );
-      base_delegation->in_use        = 1;
-      root_map_ele_insert( root_map, base_delegation, root_pool );
+      base_delegation                  = root_pool_ele_acquire( root_pool );
+      base_delegation->stake_account   = delta_delegation->stake_account;
+      base_delegation->lamports        = 0UL;
+      base_delegation->acc_dlen        = 0U;
+      base_delegation->dne_in_root     = 1;
+      base_delegation->delta_idx       = (uint)delta_pool_idx( delta_pool, delta_delegation );
+      base_delegation->in_use          = 1;
       stake_delegations->pool_idx_wmk_ = fd_ulong_max( stake_delegations->pool_idx_wmk_, root_pool_idx( root_pool, base_delegation )+1UL );
+      root_map_ele_insert( root_map, base_delegation, root_pool );
     } else {
-      /* Only subtract the old version's stake if it's not a tombstone.*/
+      /* Subtract the old version's stake if it's not a tombstone. */
       fd_stake_delegation_t *  old_delegation = base_delegation->delta_idx==UINT_MAX ? base_delegation : delta_pool_ele( delta_pool, base_delegation->delta_idx );
       if( FD_LIKELY( base_delegation->delta_idx==UINT_MAX || !old_delegation->is_tombstone ) ) {
         fd_stake_history_entry_t old_entry      = fd_stakes_activating_and_deactivating( old_delegation, epoch, stake_history, warmup_cooldown_rate_epoch, use_fixed_point_stake_math );
@@ -619,18 +614,15 @@ fd_stake_delegations_unmark_delta( fd_stake_delegations_t *   stake_delegations,
 
   root_map_t *            root_map   = get_root_map( stake_delegations );
   fd_stake_delegation_t * root_pool  = get_root_pool( stake_delegations );
-  fork_dlist_t *          fork_dlist = get_fork_dlist( stake_delegations, fork_idx );
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
+  fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
 
-  for( fork_dlist_iter_t iter = fork_dlist_iter_fwd_init( fork_dlist, delta_pool );
-       !fork_dlist_iter_done( iter, fork_dlist, delta_pool );
-       iter = fork_dlist_iter_fwd_next( iter, fork_dlist, delta_pool ) ) {
-    fd_stake_delegation_t * delta_delegation = fork_dlist_iter_ele( iter, fork_dlist, delta_pool );
-
-    fd_stake_delegation_t * base_delegation = root_map_ele_query( root_map, &delta_delegation->stake_account, NULL, root_pool );
-    if( FD_UNLIKELY( !base_delegation ) ) {
-      continue;
-    }
+  for( fork_map_iter_t iter = fork_map_iter_init( fork_map, delta_pool );
+       !fork_map_iter_done( iter, fork_map, delta_pool );
+       iter = fork_map_iter_next( iter, fork_map, delta_pool ) ) {
+    fd_stake_delegation_t * delta_delegation = fork_map_iter_ele( iter, fork_map, delta_pool );
+    fd_stake_delegation_t * base_delegation  = root_map_ele_query( root_map, &delta_delegation->stake_account, NULL, root_pool );
+    if( FD_UNLIKELY( !base_delegation ) ) continue;
 
     uint delta_idx = (uint)delta_pool_idx( delta_pool, delta_delegation );
     if( FD_UNLIKELY( base_delegation->delta_idx!=delta_idx ) ) continue;

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -43,6 +43,23 @@ typedef struct fork_pool_ele fork_pool_ele_t;
 #define POOL_IDX_T ushort
 #include "../../util/tmpl/fd_pool.c"
 
+#define POOL_NAME  pubkey_pool
+#define POOL_T     fd_stake_delegation_ref_t
+#define POOL_NEXT  next_
+#define POOL_IDX_T uint
+#define POOL_LAZY  1
+#include "../../util/tmpl/fd_pool.c"
+
+#define MAP_NAME               pubkey_map
+#define MAP_KEY_T              fd_pubkey_t
+#define MAP_ELE_T              fd_stake_delegation_ref_t
+#define MAP_KEY                stake_account
+#define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
+#define MAP_KEY_HASH(key,seed) (fd_accdb_hash( key->uc, seed ))
+#define MAP_NEXT               next_
+#define MAP_IDX_T              uint
+#include "../../util/tmpl/fd_map_chain.c"
+
 /* Internal getters for base map + pool */
 
 static inline fd_stake_delegation_t *
@@ -74,6 +91,64 @@ get_fork_map( fd_stake_delegations_t const * stake_delegations,
   return fd_type_pun( (uchar *)stake_delegations + stake_delegations->fork_map_offset_ + (ulong)fork_idx*map_footprint );
 }
 
+static inline fd_stake_delegation_ref_t *
+get_pubkey_pool( fd_stake_delegations_t const * stake_delegations ) {
+  return fd_type_pun( (uchar *)stake_delegations + stake_delegations->pubkey_pool_offset_ );
+}
+
+static inline pubkey_map_t *
+get_pubkey_map( fd_stake_delegations_t const * stake_delegations ) {
+  return fd_type_pun( (uchar *)stake_delegations + stake_delegations->pubkey_map_offset_ );
+}
+
+static void
+pubkey_ref_acquire( fd_stake_delegations_t * stake_delegations,
+                    fd_pubkey_t const *      stake_account ) {
+  fd_stake_delegation_ref_t * pool = get_pubkey_pool( stake_delegations );
+  pubkey_map_t *              map  = get_pubkey_map( stake_delegations );
+
+  fd_stake_delegation_ref_t * ref = pubkey_map_ele_query( map, stake_account, NULL, pool );
+  if( FD_UNLIKELY( !ref ) ) {
+    FD_CHECK_CRIT( pubkey_pool_free( pool ), "no free entries in stake delegation pubkey pool" );
+    ref                = pubkey_pool_ele_acquire( pool );
+    ref->stake_account = *stake_account;
+    ref->refcnt        = 0U;
+    stake_delegations->pubkey_idx_wmk_ = fd_ulong_max( stake_delegations->pubkey_idx_wmk_, pubkey_pool_idx( pool, ref )+1UL );
+    FD_CHECK_CRIT( pubkey_map_ele_insert( map, ref, pool ), "unable to insert into stake delegation pubkey map" );
+  }
+  ref->refcnt++;
+}
+
+static void
+pubkey_ref_release( fd_stake_delegations_t * stake_delegations,
+                    fd_pubkey_t const *      stake_account ) {
+  if( FD_UNLIKELY( stake_delegations->pubkey_fallback ) ) return;
+
+  fd_stake_delegation_ref_t * pool = get_pubkey_pool( stake_delegations );
+  pubkey_map_t *              map  = get_pubkey_map( stake_delegations );
+
+  fd_stake_delegation_ref_t * ref = pubkey_map_ele_query( map, stake_account, NULL, pool );
+  if( FD_UNLIKELY( !ref ) ) return;
+  if( FD_UNLIKELY( !ref->refcnt ) ) return;
+
+  if( FD_LIKELY( !--ref->refcnt ) ) {
+    pubkey_map_ele_remove( map, stake_account, NULL, pool );
+    pubkey_pool_ele_release( pool, ref );
+  }
+}
+
+static void
+pubkey_fallback_enter( fd_stake_delegations_t * stake_delegations,
+                       fd_pubkey_t const *      stake_account ) {
+  if( FD_UNLIKELY( !stake_delegations->pubkey_fallback ) ) {
+    FD_LOG_WARNING(( "stake delegation pool exhausted at %lu stake accounts; falling back to "
+                     "resolving stake delegations from the accounts database at the epoch boundary",
+                     fd_stake_delegations_pubkey_cnt( stake_delegations ) ));
+    stake_delegations->pubkey_fallback = 1;
+  }
+  pubkey_ref_acquire( stake_delegations, stake_account );
+}
+
 ulong
 fd_stake_delegations_align( void ) {
   return FD_STAKE_DELEGATIONS_ALIGN;
@@ -81,10 +156,13 @@ fd_stake_delegations_align( void ) {
 
 ulong
 fd_stake_delegations_footprint( ulong max_stake_accounts,
+                                ulong max_fallback_stake_accounts,
                                 ulong expected_stake_accounts,
                                 ulong max_live_slots ) {
 
-  ulong map_chain_cnt = root_map_chain_cnt_est( expected_stake_accounts );
+  ulong map_chain_cnt    = root_map_chain_cnt_est( expected_stake_accounts );
+  ulong pubkey_max       = max_fallback_stake_accounts;
+  ulong pubkey_chain_cnt = pubkey_map_chain_cnt_est( pubkey_max );
 
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, fd_stake_delegations_align(), sizeof(fd_stake_delegations_t) );
@@ -93,6 +171,8 @@ fd_stake_delegations_footprint( ulong max_stake_accounts,
   l = FD_LAYOUT_APPEND( l, delta_pool_align(),           delta_pool_footprint( max_stake_accounts ) );
   l = FD_LAYOUT_APPEND( l, fork_pool_align(),            fork_pool_footprint( max_live_slots ) );
   l = FD_LAYOUT_APPEND( l, fork_map_align(),             max_live_slots*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT ) );
+  l = FD_LAYOUT_APPEND( l, pubkey_pool_align(),          pubkey_pool_footprint( pubkey_max ) );
+  l = FD_LAYOUT_APPEND( l, pubkey_map_align(),           pubkey_map_footprint( pubkey_chain_cnt ) );
 
   return FD_LAYOUT_FINI( l, fd_stake_delegations_align() );
 }
@@ -101,6 +181,7 @@ void *
 fd_stake_delegations_new( void * mem,
                           ulong  seed,
                           ulong  max_stake_accounts,
+                          ulong  max_fallback_stake_accounts,
                           ulong  expected_stake_accounts,
                           ulong  max_live_slots ) {
   if( FD_UNLIKELY( !mem ) ) {
@@ -123,7 +204,9 @@ fd_stake_delegations_new( void * mem,
     return NULL;
   }
 
-  ulong map_chain_cnt = root_map_chain_cnt_est( expected_stake_accounts );
+  ulong map_chain_cnt    = root_map_chain_cnt_est( expected_stake_accounts );
+  ulong pubkey_max       = max_fallback_stake_accounts;
+  ulong pubkey_chain_cnt = pubkey_map_chain_cnt_est( pubkey_max );
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
   fd_stake_delegations_t * stake_delegations = FD_SCRATCH_ALLOC_APPEND( l, fd_stake_delegations_align(), sizeof(fd_stake_delegations_t) );
@@ -132,6 +215,8 @@ fd_stake_delegations_new( void * mem,
   void *                   delta_pool_mem    = FD_SCRATCH_ALLOC_APPEND( l, delta_pool_align(),           delta_pool_footprint( max_stake_accounts ) );
   void *                   fork_pool_mem     = FD_SCRATCH_ALLOC_APPEND( l, fork_pool_align(),            fork_pool_footprint( max_live_slots ) );
   void *                   fork_map_mem      = FD_SCRATCH_ALLOC_APPEND( l, fork_map_align(),             max_live_slots*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT ) );
+  void *                   pubkey_pool_mem   = FD_SCRATCH_ALLOC_APPEND( l, pubkey_pool_align(),          pubkey_pool_footprint( pubkey_max ) );
+  void *                   pubkey_map_mem    = FD_SCRATCH_ALLOC_APPEND( l, pubkey_map_align(),           pubkey_map_footprint( pubkey_chain_cnt ) );
   for( ushort i=0; i<(ushort)max_live_slots; i++ ) {
     void * fork_map_mem_i = (uchar *)fork_map_mem + (ulong)i*fork_map_footprint( FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT );
     fork_map_t * map = fork_map_join( fork_map_new( fork_map_mem_i, FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT, seed ) );
@@ -141,7 +226,7 @@ fd_stake_delegations_new( void * mem,
     }
   }
 
-  if( FD_UNLIKELY( FD_SCRATCH_ALLOC_FINI( l, fd_stake_delegations_align() )!=(ulong)mem+fd_stake_delegations_footprint( max_stake_accounts, expected_stake_accounts, max_live_slots ) ) ) {
+  if( FD_UNLIKELY( FD_SCRATCH_ALLOC_FINI( l, fd_stake_delegations_align() )!=(ulong)mem+fd_stake_delegations_footprint( max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_live_slots ) ) ) {
     FD_LOG_WARNING(( "fd_stake_delegations_new: bad layout" ));
     return NULL;
   }
@@ -170,6 +255,18 @@ fd_stake_delegations_new( void * mem,
     return NULL;
   }
 
+  fd_stake_delegation_ref_t * pubkey_pool = pubkey_pool_join( pubkey_pool_new( pubkey_pool_mem, pubkey_max ) );
+  if( FD_UNLIKELY( !pubkey_pool ) ) {
+    FD_LOG_WARNING(( "Failed to create stake delegation pubkey pool" ));
+    return NULL;
+  }
+
+  pubkey_map_t * pubkey_map = pubkey_map_join( pubkey_map_new( pubkey_map_mem, pubkey_chain_cnt, seed ) );
+  if( FD_UNLIKELY( !pubkey_map ) ) {
+    FD_LOG_WARNING(( "Failed to create stake delegation pubkey map" ));
+    return NULL;
+  }
+
   stake_delegations->max_stake_accounts_      = max_stake_accounts;
   stake_delegations->expected_stake_accounts_ = expected_stake_accounts;
   stake_delegations->pool_offset_             = (ulong)root_pool - (ulong)mem;
@@ -177,13 +274,18 @@ fd_stake_delegations_new( void * mem,
   stake_delegations->delta_pool_offset_       = (ulong)delta_pool - (ulong)mem;
   stake_delegations->fork_pool_offset_        = (ulong)fork_pool - (ulong)mem;
   stake_delegations->fork_map_offset_         = (ulong)fork_map_mem - (ulong)mem;
+  stake_delegations->pubkey_pool_offset_      = (ulong)pubkey_pool - (ulong)mem;
+  stake_delegations->pubkey_map_offset_       = (ulong)pubkey_map - (ulong)mem;
+  stake_delegations->max_pubkeys_             = pubkey_max;
+  stake_delegations->pubkey_idx_wmk_          = 0UL;
 
   stake_delegations->effective_stake    = 0UL;
   stake_delegations->activating_stake   = 0UL;
   stake_delegations->deactivating_stake = 0UL;
   stake_delegations->pool_idx_wmk_      = 0UL;
+  stake_delegations->pubkey_fallback    = 0;
 
-  fd_rwlock_new( &stake_delegations->delta_lock );
+  fd_rwlock_new( &stake_delegations->lock );
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( stake_delegations->magic ) = FD_STAKE_DELEGATIONS_MAGIC;
@@ -216,6 +318,7 @@ fd_stake_delegations_join( void * mem ) {
 
 void
 fd_stake_delegations_reset( fd_stake_delegations_t * stake_delegations ) {
+  fd_rwlock_write( &stake_delegations->lock );
   root_pool_reset( get_root_pool( stake_delegations ) );
   root_map_reset( get_root_map( stake_delegations ) );
   delta_pool_reset( get_delta_pool( stake_delegations ) );
@@ -225,10 +328,15 @@ fd_stake_delegations_reset( fd_stake_delegations_t * stake_delegations ) {
     fork_map_reset( get_fork_map( stake_delegations, (ushort)i ) );
   }
   fork_pool_reset( fork_pool );
+  pubkey_pool_reset( get_pubkey_pool( stake_delegations ) );
+  pubkey_map_reset( get_pubkey_map( stake_delegations ) );
   stake_delegations->effective_stake    = 0UL;
   stake_delegations->activating_stake   = 0UL;
   stake_delegations->deactivating_stake = 0UL;
   stake_delegations->pool_idx_wmk_      = 0UL;
+  stake_delegations->pubkey_idx_wmk_    = 0UL;
+  stake_delegations->pubkey_fallback    = 0;
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 fd_stake_delegation_t const *
@@ -240,27 +348,34 @@ fd_stake_delegation_root_query( fd_stake_delegations_t const * stake_delegations
   return root_map_ele_query_const( map, stake_account, NULL, pool );
 }
 
-void
-fd_stake_delegations_root_update( fd_stake_delegations_t * stake_delegations,
-                                  fd_pubkey_t const *      stake_account,
-                                  fd_pubkey_t const *      vote_account,
-                                  ulong                    stake,
-                                  ulong                    activation_epoch,
-                                  ulong                    deactivation_epoch,
-                                  ulong                    credits_observed,
-                                  ulong                    lamports,
-                                  uint                     acc_dlen,
-                                  uchar                    warmup_cooldown_rate ) {
+/* root_update is the unlocked core of fd_stake_delegations_root_update.
+   Callers that already hold the lock use it directly. */
+
+static void
+root_update( fd_stake_delegations_t * stake_delegations,
+             fd_pubkey_t const *      stake_account,
+             fd_pubkey_t const *      vote_account,
+             ulong                    stake,
+             ulong                    activation_epoch,
+             ulong                    deactivation_epoch,
+             ulong                    credits_observed,
+             ulong                    lamports,
+             uint                     acc_dlen,
+             uchar                    warmup_cooldown_rate ) {
   fd_stake_delegation_t * pool = get_root_pool( stake_delegations );
   root_map_t *            map  = get_root_map( stake_delegations );
 
   fd_stake_delegation_t * stake_delegation = root_map_ele_query( map, stake_account, NULL, pool );
   if( FD_LIKELY( !stake_delegation ) ) {
-    FD_CHECK_CRIT( root_pool_free( pool ), "no free stake delegations in pool" );
+    if( FD_UNLIKELY( !root_pool_free( pool ) ) ) {
+      pubkey_fallback_enter( stake_delegations, stake_account );
+      return;
+    }
     stake_delegation                 = root_pool_ele_acquire( pool );
     stake_delegation->stake_account  = *stake_account;
     stake_delegations->pool_idx_wmk_ = fd_ulong_max( stake_delegations->pool_idx_wmk_, root_pool_idx( pool, stake_delegation )+1UL );
     FD_CHECK_CRIT( root_map_ele_insert( map, stake_delegation, pool ), "unable to insert stake delegation into map" );
+    pubkey_ref_acquire( stake_delegations, stake_account );
   }
 
   stake_delegation->vote_account         = *vote_account;
@@ -276,6 +391,23 @@ fd_stake_delegations_root_update( fd_stake_delegations_t * stake_delegations,
   stake_delegation->in_use               = 1;
 }
 
+void
+fd_stake_delegations_root_update( fd_stake_delegations_t * stake_delegations,
+                                  fd_pubkey_t const *      stake_account,
+                                  fd_pubkey_t const *      vote_account,
+                                  ulong                    stake,
+                                  ulong                    activation_epoch,
+                                  ulong                    deactivation_epoch,
+                                  ulong                    credits_observed,
+                                  ulong                    lamports,
+                                  uint                     acc_dlen,
+                                  uchar                    warmup_cooldown_rate ) {
+  fd_rwlock_write( &stake_delegations->lock );
+  root_update( stake_delegations, stake_account, vote_account, stake, activation_epoch,
+               deactivation_epoch, credits_observed, lamports, acc_dlen, warmup_cooldown_rate );
+  fd_rwlock_unwrite( &stake_delegations->lock );
+}
+
 #if FD_HAS_DOUBLE
 
 void
@@ -286,31 +418,41 @@ fd_stake_delegations_refresh( fd_stake_delegations_t *   stake_delegations,
                               int                        use_fixed_point_stake_math,
                               fd_accdb_t *               accdb,
                               fd_accdb_fork_id_t         fork_id ) {
+  fd_rwlock_write( &stake_delegations->lock );
 
   stake_delegations->effective_stake    = 0UL;
   stake_delegations->activating_stake   = 0UL;
   stake_delegations->deactivating_stake = 0UL;
 
-  root_map_t *            map  = get_root_map( stake_delegations );
-  fd_stake_delegation_t * pool = get_root_pool( stake_delegations );
+  root_map_t *                map      = get_root_map( stake_delegations );
+  fd_stake_delegation_t *     pool     = get_root_pool( stake_delegations );
+  pubkey_map_t *              ref_map  = get_pubkey_map( stake_delegations );
+  fd_stake_delegation_ref_t * ref_pool = get_pubkey_pool( stake_delegations );
 
-  ulong const job_cnt = fd_stake_delegations_cnt( stake_delegations );
+  /* Drive the refresh off the pubkey tier rather than the root pool.  The
+     tier is a superset of the root by construction, so in the normal case
+     this visits exactly the same accounts, and in fallback mode it also
+     visits the accounts that never made it into the root map.  Refresh
+     runs at boot before any fork exists, which is what makes it safe to
+     rebuild both tiers in place and to reclaim entries whose refcounts
+     fallback mode left meaningless. */
+
+  ulong const wmk = stake_delegations->pubkey_idx_wmk_;
 
 #define BATCH 64UL
   uchar const * pubkeys[ BATCH ];
   int           writable[ BATCH ];
   fd_acc_t      accs[ BATCH ];
-  fd_stake_delegation_t * delegations[ BATCH ];
+  ulong         ref_idx[ BATCH ];
 
   ulong i = 0UL;
-  while( i<job_cnt ) {
+  while( i<wmk ) {
     ulong batch_n = 0UL;
-    while( i<job_cnt && batch_n<BATCH ) {
-      fd_stake_delegation_t * delegation = root_map_ele_query( map, &pool[ i ].stake_account, NULL, pool );
-      if( FD_LIKELY( delegation ) ) {
-        delegations[ batch_n ] = delegation;
-        pubkeys[ batch_n ]     = pool[ i ].stake_account.uc;
-        writable[ batch_n ]    = 0;
+    while( i<wmk && batch_n<BATCH ) {
+      if( FD_LIKELY( ref_pool[ i ].refcnt ) ) {
+        pubkeys[ batch_n ]  = ref_pool[ i ].stake_account.uc;
+        writable[ batch_n ] = 0;
+        ref_idx[ batch_n ]  = i;
         batch_n++;
       }
       i++;
@@ -320,25 +462,23 @@ fd_stake_delegations_refresh( fd_stake_delegations_t *   stake_delegations,
     fd_accdb_acquire( accdb, fork_id, batch_n, pubkeys, writable, accs );
 
     for( ulong j=0UL; j<batch_n; j++ ) {
-      fd_stake_delegation_t * delegation = delegations[ j ];
-      fd_pubkey_t const *     stake_account = (fd_pubkey_t const *)pubkeys[ j ];
+      fd_pubkey_t const *      stake_account = (fd_pubkey_t const *)pubkeys[ j ];
+      fd_stake_state_t const * stake         = accs[ j ].lamports ? fd_stakes_get_state( &accs[ j ] ) : NULL;
 
-      if( FD_UNLIKELY( !accs[ j ].lamports ) ) {
-        root_map_idx_remove( map, stake_account, UINT_MAX, pool );
-        delegation->in_use = 0;
-        root_pool_ele_release( pool, delegation );
-        continue;
-      }
-
-      fd_stake_state_t const * stake = fd_stakes_get_state( &accs[ j ] );
       if( FD_UNLIKELY( !stake || stake->stake_type!=FD_STAKE_STATE_STAKE ) ) {
-        root_map_idx_remove( map, stake_account, UINT_MAX, pool );
-        delegation->in_use = 0;
-        root_pool_ele_release( pool, delegation );
+        fd_stake_delegation_t * delegation = root_map_ele_query( map, stake_account, NULL, pool );
+        if( FD_LIKELY( delegation ) ) {
+          root_map_idx_remove( map, stake_account, UINT_MAX, pool );
+          delegation->in_use = 0;
+          root_pool_ele_release( pool, delegation );
+        }
+        pubkey_map_ele_remove( ref_map, stake_account, NULL, ref_pool );
+        ref_pool[ ref_idx[ j ] ].refcnt = 0U;
+        pubkey_pool_ele_release( ref_pool, &ref_pool[ ref_idx[ j ] ] );
         continue;
       }
 
-      fd_stake_delegations_root_update(
+      root_update(
           stake_delegations,
           stake_account,
           &stake->stake.stake.delegation.voter_pubkey,
@@ -359,22 +499,48 @@ fd_stake_delegations_refresh( fd_stake_delegations_t *   stake_delegations,
     fd_accdb_release( accdb, batch_n, accs );
   }
 #undef BATCH
+
+  /* Every surviving entry now holds exactly one reference, the root map's,
+     because there are no fork deltas at boot.  Rewriting the refcounts
+     repairs any that fallback mode left unpaired. */
+  for( ulong idx=0UL; idx<stake_delegations->pubkey_idx_wmk_; idx++ ) {
+    if( FD_LIKELY( ref_pool[ idx ].refcnt ) ) ref_pool[ idx ].refcnt = 1U;
+  }
+
+  /* If pruning freed enough room for every account to sit in the root map,
+     the fallback is no longer needed.  This is the only place the sticky
+     flag is cleared. */
+  if( FD_UNLIKELY( stake_delegations->pubkey_fallback ) &&
+      pubkey_pool_used( ref_pool )==root_pool_used( pool ) ) {
+    FD_LOG_NOTICE(( "stake delegations no longer need the pubkey fallback; %lu stake accounts fit in the root map",
+                    root_pool_used( pool ) ));
+    stake_delegations->pubkey_fallback = 0;
+  }
+
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 #endif
 
 ulong
-fd_stake_delegations_cnt( fd_stake_delegations_t const * stake_delegations ) {
+fd_stake_delegations_base_cnt( fd_stake_delegations_t const * stake_delegations ) {
   return root_pool_used( get_root_pool( stake_delegations ) );
+}
+
+ulong
+fd_stake_delegations_pubkey_cnt( fd_stake_delegations_t const * stake_delegations ) {
+  return pubkey_pool_used( get_pubkey_pool( stake_delegations ) );
 }
 
 /* Fork-aware delta operations */
 
 ushort
 fd_stake_delegations_new_fork( fd_stake_delegations_t * stake_delegations ) {
+  fd_rwlock_write( &stake_delegations->lock );
   fork_pool_ele_t * fork_pool = get_fork_pool( stake_delegations );
   FD_CHECK_CRIT( fork_pool_free( fork_pool ), "no free forks in pool. The system has forked too wide." );
   ushort fork_idx = (ushort)fork_pool_idx_acquire( fork_pool );
+  fd_rwlock_unwrite( &stake_delegations->lock );
 
   return fork_idx;
 }
@@ -391,59 +557,75 @@ fd_stake_delegations_fork_update( fd_stake_delegations_t * stake_delegations,
                                   ulong                    lamports,
                                   uint                     acc_dlen,
                                   uchar                    warmup_cooldown_rate ) {
-  fd_rwlock_write( &stake_delegations->delta_lock );
+  fd_rwlock_write( &stake_delegations->lock );
 
   fd_stake_delegation_t * delta_pool       = get_delta_pool( stake_delegations );
   fork_map_t *            map              = get_fork_map( stake_delegations, fork_idx );
   fd_stake_delegation_t * stake_delegation = fork_map_ele_query( map, stake_account, NULL, delta_pool );
   if( FD_LIKELY( !stake_delegation ) ) {
-    FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
-    stake_delegation                = delta_pool_ele_acquire( delta_pool );
-    stake_delegation->stake_account = *stake_account;
-    fork_map_ele_insert( map, stake_delegation, delta_pool );
+    if( FD_UNLIKELY( !delta_pool_free( delta_pool ) ) ) {
+      /* The delta pool cannot take this stake account.  Record it in the
+         pubkey fallback tier and drop the delegation state on the floor:
+         the epoch boundary will read it back out of the accounts
+         database. */
+      pubkey_fallback_enter( stake_delegations, stake_account );
+    } else {
+      stake_delegation                = delta_pool_ele_acquire( delta_pool );
+      stake_delegation->stake_account = *stake_account;
+      fork_map_ele_insert( map, stake_delegation, delta_pool );
+      pubkey_ref_acquire( stake_delegations, stake_account );
+    }
   }
 
-  stake_delegation->vote_account         = *vote_account;
-  stake_delegation->stake                = stake;
-  stake_delegation->lamports             = lamports;
-  stake_delegation->acc_dlen             = acc_dlen;
-  stake_delegation->activation_epoch     = (ushort)fd_ulong_min( activation_epoch, USHORT_MAX );
-  stake_delegation->deactivation_epoch   = (ushort)fd_ulong_min( deactivation_epoch, USHORT_MAX );
-  stake_delegation->credits_observed     = credits_observed;
-  stake_delegation->warmup_cooldown_rate = warmup_cooldown_rate;
-  stake_delegation->is_tombstone         = 0;
+  if( FD_LIKELY( stake_delegation ) ) {
+    stake_delegation->vote_account         = *vote_account;
+    stake_delegation->stake                = stake;
+    stake_delegation->lamports             = lamports;
+    stake_delegation->acc_dlen             = acc_dlen;
+    stake_delegation->activation_epoch     = (ushort)fd_ulong_min( activation_epoch, USHORT_MAX );
+    stake_delegation->deactivation_epoch   = (ushort)fd_ulong_min( deactivation_epoch, USHORT_MAX );
+    stake_delegation->credits_observed     = credits_observed;
+    stake_delegation->warmup_cooldown_rate = warmup_cooldown_rate;
+    stake_delegation->is_tombstone         = 0;
 
-  FD_BASE58_ENCODE_32_BYTES( stake_delegation->stake_account.uc, stake_account_out );
-  FD_LOG_DEBUG(( "fork_update: stake_account=%s, stake=%lu, activation_epoch=%u, deactivation_epoch=%u",
-      stake_account_out, stake_delegation->stake, stake_delegation->activation_epoch, stake_delegation->deactivation_epoch ));
+    FD_BASE58_ENCODE_32_BYTES( stake_delegation->stake_account.uc, stake_account_out );
+    FD_LOG_DEBUG(( "fork_update: stake_account=%s, stake=%lu, activation_epoch=%u, deactivation_epoch=%u",
+        stake_account_out, stake_delegation->stake, stake_delegation->activation_epoch, stake_delegation->deactivation_epoch ));
+  }
 
-  fd_rwlock_unwrite( &stake_delegations->delta_lock );
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 void
 fd_stake_delegations_fork_remove( fd_stake_delegations_t * stake_delegations,
                                   ushort                   fork_idx,
                                   fd_pubkey_t const *      stake_account ) {
-  fd_rwlock_write( &stake_delegations->delta_lock );
+  fd_rwlock_write( &stake_delegations->lock );
 
   fd_stake_delegation_t * delta_pool       = get_delta_pool( stake_delegations );
   fork_map_t *            map              = get_fork_map( stake_delegations, fork_idx );
   fd_stake_delegation_t * stake_delegation = fork_map_ele_query( map, stake_account, NULL, delta_pool );
   if( FD_LIKELY( !stake_delegation ) ) {
-    FD_CHECK_CRIT( delta_pool_free( delta_pool ), "no free stake delegations in pool" );
-    stake_delegation                = delta_pool_ele_acquire( delta_pool );
-    stake_delegation->stake_account = *stake_account;
-    fork_map_ele_insert( map, stake_delegation, delta_pool );
+    if( FD_UNLIKELY( !delta_pool_free( delta_pool ) ) ) {
+      pubkey_fallback_enter( stake_delegations, stake_account );
+    } else {
+      stake_delegation                = delta_pool_ele_acquire( delta_pool );
+      stake_delegation->stake_account = *stake_account;
+      fork_map_ele_insert( map, stake_delegation, delta_pool );
+      pubkey_ref_acquire( stake_delegations, stake_account );
+    }
   }
 
-  stake_delegation->lamports     = 0UL;
-  stake_delegation->acc_dlen     = 0U;
-  stake_delegation->is_tombstone = 1;
+  if( FD_LIKELY( stake_delegation ) ) {
+    stake_delegation->lamports     = 0UL;
+    stake_delegation->acc_dlen     = 0U;
+    stake_delegation->is_tombstone = 1;
 
-  FD_BASE58_ENCODE_32_BYTES( stake_delegation->stake_account.uc, stake_account_out );
-  FD_LOG_DEBUG(( "fork_remove: stake_account=%s", stake_account_out ));
+    FD_BASE58_ENCODE_32_BYTES( stake_delegation->stake_account.uc, stake_account_out );
+    FD_LOG_DEBUG(( "fork_remove: stake_account=%s", stake_account_out ));
+  }
 
-  fd_rwlock_unwrite( &stake_delegations->delta_lock );
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 void
@@ -451,7 +633,7 @@ fd_stake_delegations_evict_fork( fd_stake_delegations_t * stake_delegations,
                                  ushort                   fork_idx ) {
   if( fork_idx==USHORT_MAX ) return;
 
-  fd_rwlock_write( &stake_delegations->delta_lock );
+  fd_rwlock_write( &stake_delegations->lock );
 
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
   fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
@@ -460,13 +642,14 @@ fd_stake_delegations_evict_fork( fd_stake_delegations_t * stake_delegations,
   while( !fork_map_iter_done( iter, fork_map, delta_pool ) ) {
     fd_stake_delegation_t * ele = fork_map_iter_ele( iter, fork_map, delta_pool );
     iter = fork_map_iter_next( iter, fork_map, delta_pool );
+    pubkey_ref_release( stake_delegations, &ele->stake_account );
     delta_pool_ele_release( delta_pool, ele );
   }
   fork_map_reset( fork_map );
 
   fork_pool_idx_release( get_fork_pool( stake_delegations ), fork_idx );
 
-  fd_rwlock_unwrite( &stake_delegations->delta_lock );
+  fd_rwlock_unwrite( &stake_delegations->lock );
 }
 
 void
@@ -476,6 +659,7 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
                                        int                        use_fixed_point_stake_math,
                                        fd_stake_delegations_t *   stake_delegations,
                                        ushort                     fork_idx ) {
+  fd_rwlock_write( &stake_delegations->lock );
 
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
   fork_map_t *            fork_map   = get_fork_map( stake_delegations, fork_idx );
@@ -497,7 +681,7 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
         stake_delegations->deactivating_stake -= old_entry.deactivating;
       }
 
-      fd_stake_delegations_root_update(
+      root_update(
           stake_delegations,
           &stake_delegation->stake_account,
           &stake_delegation->vote_account,
@@ -529,24 +713,123 @@ fd_stake_delegations_apply_fork_delta( ulong                      epoch,
         root_map_idx_remove( root_map, &stake_delegation->stake_account, delegation_idx, root_pool );
         old_delegation->in_use = 0;
         root_pool_idx_release( root_pool, delegation_idx );
+        pubkey_ref_release( stake_delegations, &stake_delegation->stake_account );
       }
     }
   }
   FD_LOG_DEBUG(( "effective_stake=%lu, activating_stake=%lu, deactivating_stake=%lu", stake_delegations->effective_stake, stake_delegations->activating_stake, stake_delegations->deactivating_stake ));
+
+  fd_rwlock_unwrite( &stake_delegations->lock );
+}
+
+void
+fd_stake_delegations_iter_advance_fallback( fd_stake_delegations_iter_t * iter ) {
+  fd_stake_delegations_t const * stake_delegations = iter->stake_delegations;
+  fd_stake_delegation_ref_t *    pool              = get_pubkey_pool( stake_delegations );
+
+  for(;;) {
+    if( FD_LIKELY( iter->batch_idx<iter->batch_cnt ) ) {
+      iter->ele = &iter->batch[ iter->batch_idx ];
+      iter->idx = iter->batch_pool_idx[ iter->batch_idx ];
+      return;
+    }
+
+    if( FD_UNLIKELY( iter->scan_idx>=iter->wmk ) ) {
+      iter->ele = NULL;
+      return;
+    }
+
+    uchar const * pubkeys [ FD_STAKE_DELEGATIONS_ITER_BATCH ];
+    int           writable[ FD_STAKE_DELEGATIONS_ITER_BATCH ];
+    ulong         pool_idx[ FD_STAKE_DELEGATIONS_ITER_BATCH ];
+    fd_acc_t      accs    [ FD_STAKE_DELEGATIONS_ITER_BATCH ];
+
+    ulong batch_n = 0UL;
+    while( iter->scan_idx<iter->wmk && batch_n<FD_STAKE_DELEGATIONS_ITER_BATCH ) {
+      fd_stake_delegation_ref_t * ref = pool + iter->scan_idx;
+      if( FD_LIKELY( ref->refcnt ) ) {
+        pubkeys [ batch_n ] = ref->stake_account.uc;
+        writable[ batch_n ] = 0;
+        pool_idx[ batch_n ] = iter->scan_idx;
+        batch_n++;
+      }
+      iter->scan_idx++;
+    }
+    if( FD_UNLIKELY( !batch_n ) ) continue;
+
+    fd_accdb_acquire( iter->accdb, iter->accdb_fork_id, batch_n, pubkeys, writable, accs );
+
+    ulong out = 0UL;
+    for( ulong j=0UL; j<batch_n; j++ ) {
+      if( FD_UNLIKELY( !accs[ j ].lamports ) ) continue;
+
+      fd_stake_state_t const * stake = fd_stakes_get_state( &accs[ j ] );
+      if( FD_UNLIKELY( !stake || stake->stake_type!=FD_STAKE_STATE_STAKE ) ) continue;
+
+      fd_delegation_t const * delegation = &stake->stake.stake.delegation;
+      fd_stake_delegation_t * ele        = &iter->batch[ out ];
+
+      ele->stake_account        = *(fd_pubkey_t const *)pubkeys[ j ];
+      ele->vote_account         = delegation->voter_pubkey;
+      ele->stake                = delegation->stake;
+      ele->lamports             = accs[ j ].lamports;
+      ele->credits_observed     = stake->stake.stake.credits_observed;
+      ele->acc_dlen             = (uint)accs[ j ].data_len;
+      ele->next_                = UINT_MAX;
+      ele->delta_idx            = UINT_MAX;
+      ele->activation_epoch     = (ushort)fd_ulong_min( delegation->activation_epoch, USHORT_MAX );
+      ele->deactivation_epoch   = (ushort)fd_ulong_min( delegation->deactivation_epoch, USHORT_MAX );
+      ele->is_tombstone         = 0;
+      ele->warmup_cooldown_rate = fd_stake_warmup_cooldown_rate( iter->epoch, iter->warmup_cooldown_rate_epoch );
+      ele->in_use               = 1;
+
+      iter->batch_pool_idx[ out ] = pool_idx[ j ];
+      out++;
+    }
+
+    fd_accdb_release( iter->accdb, batch_n, accs );
+
+    iter->batch_cnt = out;
+    iter->batch_idx = 0UL;
+  }
 }
 
 fd_stake_delegations_iter_t *
 fd_stake_delegations_iter_init( fd_stake_delegations_iter_t *  iter,
-                                fd_stake_delegations_t const * stake_delegations ) {
+                                fd_stake_delegations_t const * stake_delegations,
+                                fd_accdb_t *                   accdb,
+                                fd_accdb_fork_id_t             accdb_fork_id,
+                                ulong                          epoch,
+                                ulong *                        warmup_cooldown_rate_epoch ) {
   if( FD_UNLIKELY( !stake_delegations ) ) {
     FD_LOG_CRIT(( "NULL stake_delegations" ));
   }
 
-  iter->root_pool  = get_root_pool( stake_delegations );
-  iter->delta_pool = get_delta_pool( stake_delegations );
-  iter->idx        = 0UL;
-  iter->wmk        = stake_delegations->pool_idx_wmk_;
+  iter->root_pool         = get_root_pool( stake_delegations );
+  iter->delta_pool        = get_delta_pool( stake_delegations );
+  iter->stake_delegations = stake_delegations;
+  iter->idx               = 0UL;
+  iter->scan_idx          = 0UL;
+  iter->batch_cnt         = 0UL;
+  iter->batch_idx         = 0UL;
+  iter->fallback          = stake_delegations->pubkey_fallback;
 
+  if( FD_UNLIKELY( iter->fallback ) ) {
+    if( FD_UNLIKELY( !accdb ) ) {
+      FD_LOG_CRIT(( "stake delegations are in pubkey fallback mode but no accounts database was "
+                    "supplied to resolve them; iterating the root map alone would silently drop "
+                    "stake accounts" ));
+    }
+    iter->accdb                      = accdb;
+    iter->accdb_fork_id              = accdb_fork_id;
+    iter->epoch                      = epoch;
+    iter->warmup_cooldown_rate_epoch = warmup_cooldown_rate_epoch;
+    iter->wmk                        = stake_delegations->pubkey_idx_wmk_;
+    fd_stake_delegations_iter_advance_fallback( iter );
+    return iter;
+  }
+
+  iter->wmk = stake_delegations->pool_idx_wmk_;
   fd_stake_delegations_iter_advance_private( iter );
 
   return iter;
@@ -559,7 +842,6 @@ fd_stake_delegations_mark_delta( fd_stake_delegations_t *   stake_delegations,
                                  ulong *                    warmup_cooldown_rate_epoch,
                                  int                        use_fixed_point_stake_math,
                                  ushort                     fork_idx ) {
-
   root_map_t *            root_map   = get_root_map( stake_delegations );
   fd_stake_delegation_t * root_pool  = get_root_pool( stake_delegations );
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );
@@ -571,6 +853,18 @@ fd_stake_delegations_mark_delta( fd_stake_delegations_t *   stake_delegations,
     fd_stake_delegation_t * delta_delegation = fork_map_iter_ele( iter, fork_map, delta_pool );
     fd_stake_delegation_t * base_delegation  = root_map_ele_query( root_map, &delta_delegation->stake_account, NULL, root_pool);
     if( FD_UNLIKELY( !base_delegation ) ) {
+      if( FD_UNLIKELY( !root_pool_free( root_pool ) ) ) {
+        /* No room to project this delta into the root for the duration of
+           the iteration.  The stake totals are recomputed from scratch in
+           fallback mode, so skipping the bookkeeping below is safe, and
+           the boundary sweep picks the account up from the fallback
+           tier. */
+        pubkey_fallback_enter( stake_delegations, &delta_delegation->stake_account );
+        continue;
+      }
+      /* No pubkey tier reference is taken for this projection, and
+         correspondingly none is dropped when unmark_delta releases it: the
+         delta entry driving this loop already holds one. */
       base_delegation                  = root_pool_ele_acquire( root_pool );
       base_delegation->stake_account   = delta_delegation->stake_account;
       base_delegation->lamports        = 0UL;
@@ -611,7 +905,6 @@ fd_stake_delegations_unmark_delta( fd_stake_delegations_t *   stake_delegations,
                                    ulong *                    warmup_cooldown_rate_epoch,
                                    int                        use_fixed_point_stake_math,
                                    ushort                     fork_idx ) {
-
   root_map_t *            root_map   = get_root_map( stake_delegations );
   fd_stake_delegation_t * root_pool  = get_root_pool( stake_delegations );
   fd_stake_delegation_t * delta_pool = get_delta_pool( stake_delegations );

--- a/src/flamenco/stakes/fd_stake_delegations.h
+++ b/src/flamenco/stakes/fd_stake_delegations.h
@@ -23,9 +23,9 @@
       representation of the stake delegations.  Each fork will hold its
       own set of deltas.  These are then applied to the root set when
       the fork is finalized.  This is implemented as each bank having
-      its own dlist of deltas which are allocated from a pool which is
-      shared across all stake delegation forks.  The caller is expected
-      to create a new fork index for each bank and add deltas to it.
+      its own map of deltas which are allocated from a pool shared
+      across all stake delegation forks.  The caller is expected to
+      create a new fork index for each bank and add deltas to it.
 
    There are some important invariants wrt fd_stake_delegations_t:
    1. After execution has started, there will be no invalid stake
@@ -69,9 +69,9 @@
    can simultaneously be calling fd_stake_delegations_evict_fork()
    */
 
-#define FD_STAKE_DELEGATIONS_ALIGN (128UL)
-
-#define FD_STAKE_DELEGATIONS_FORK_MAX (4096UL)
+#define FD_STAKE_DELEGATIONS_ALIGN              (128UL)
+#define FD_STAKE_DELEGATIONS_FORK_MAX           (4096UL)
+#define FD_STAKE_DELEGATIONS_FORK_MAP_CHAIN_CNT (8192UL)
 
 /* The warmup cooldown rate can only be one of two values: 0.25 or 0.09.
    The reason that the double is mapped to an enum is to save space in
@@ -101,16 +101,12 @@ struct fd_stake_delegation {
   ulong       lamports;
   ulong       credits_observed;
   uint        acc_dlen;
-  uint        next_; /* Internal pool/map/dlist usage */
-
-  union {
-    uint      prev_; /* Internal dlist usage for delta  */
-    uint      delta_idx; /* Tracking for stake delegation iteration */
-  };
+  uint        next_;     /* Internal pool/map usage */
+  uint        delta_idx; /* Tracking for stake delegation iteration */
   ushort      activation_epoch;
   ushort      deactivation_epoch;
   union {
-    uchar     is_tombstone; /* Internal dlist/delta usage */
+    uchar     is_tombstone; /* Internal delta usage */
     uchar     dne_in_root;  /* Tracking for stake delegation iteration */
   };
   uchar       warmup_cooldown_rate; /* enum representing 0.25 or 0.09 */
@@ -132,10 +128,10 @@ struct fd_stake_delegations {
                           [0, wmk) has been acquired at least once, so its in_use byte is
                           well defined. */
 
-  /* Delta pool + fork  */
+  /* Delta pool + fork and fork map  */
   ulong       delta_pool_offset_;
   ulong       fork_pool_offset_;
-  ulong       dlist_offsets_[ FD_STAKE_DELEGATIONS_FORK_MAX ];
+  ulong       fork_map_offset_;
   fd_rwlock_t delta_lock;
 
   /* Stake totals for the current root. */
@@ -268,12 +264,9 @@ fd_stake_delegations_cnt( fd_stake_delegations_t const * stake_delegations );
 ushort
 fd_stake_delegations_new_fork( fd_stake_delegations_t * stake_delegations );
 
-/* fd_stake_delegations_fork_update will insert a new stake delegation
-   delta for the fork.  If an entry already exists in the fork, a new
-   one will be inserted without removing the old one.
-
-   TODO: Add a per fork map so multiple entries aren't needed for the
-   same stake account. */
+/* fd_stake_delegations_fork_update upserts a stake delegation delta for
+   the fork.  If an entry already exists for the stake account in this
+   fork, it is overwritten in place. */
 
 void
 fd_stake_delegations_fork_update( fd_stake_delegations_t * stake_delegations,
@@ -292,10 +285,8 @@ fd_stake_delegations_fork_update( fd_stake_delegations_t * stake_delegations,
    entry for the given fork.  The function will not actually remove or
    free any resources corresponding to the stake account.  The reason a
    tombstone is stored is because each fork corresponds to a set of
-   stake delegation deltas for a given slot.  This function may insert a
-   'duplicate' entry for the same stake account but it will be resolved
-   by the time the delta is applied to a base stake delegations
-   object. */
+   stake delegation deltas for a given slot.  If an entry already exists
+   for the stake account in this fork, it is overwritten in place. */
 
 void
 fd_stake_delegations_fork_remove( fd_stake_delegations_t * stake_delegations,

--- a/src/flamenco/stakes/fd_stake_delegations.h
+++ b/src/flamenco/stakes/fd_stake_delegations.h
@@ -1,12 +1,12 @@
 #ifndef HEADER_fd_src_flamenco_stakes_fd_stake_delegations_h
 #define HEADER_fd_src_flamenco_stakes_fd_stake_delegations_h
 
+#include "../runtime/fd_runtime_const.h"
 #include "../runtime/sysvar/fd_sysvar_base.h"
 #include "../accdb/fd_accdb.h"
 #include "../fd_rwlock.h"
-#include "../../util/tmpl/fd_map.h"
 
-#define FD_STAKE_DELEGATIONS_MAGIC (0xF17EDA2CE757A3E0) /* FIREDANCER STAKE V0 */
+#define FD_STAKE_DELEGATIONS_MAGIC (0xF17EDA2CE757A3E1) /* FIREDANCER STAKE V1 */
 
 /* fd_stake_delegations_t is a cache of stake accounts mapping the
    pubkey of the stake account to various information including
@@ -26,6 +26,16 @@
       its own map of deltas which are allocated from a pool shared
       across all stake delegation forks.  The caller is expected to
       create a new fork index for each bank and add deltas to it.
+
+   There is a third structure, the pubkey fallback tier, which just
+   holds one slim (pubkey, refcnt) entry for every stake account
+   referenced by the root or by a live fork delta.  It will contain a
+   superset of all stake accounts across forks and the root.  The
+   purpose of this is to handle cases where the existing capacity gets
+   exceeded.  Regular operation will never use this tier for execution.
+   It is meant to allow rewards to continue (with the help of the
+   accounts database) in the event that the existing capacity gets
+   exceeded.
 
    There are some important invariants wrt fd_stake_delegations_t:
    1. After execution has started, there will be no invalid stake
@@ -57,17 +67,11 @@
       reward distribution.
    The stake accounts are read-only during the epoch boundary.
 
-   The concurrency model is limited: most operations are not allowed to
-   be concurrent with each other with the exception of operations that
-   operate on the stake delegations's delta pool:
-    fd_stake_delegations_fork_update()
-    fd_stake_delegations_fork_remove()
-    fd_stake_delegations_evict_fork()
-   These operations are internally synchronized with a read-write lock
-   because multiple executor tiles may be trying to call
-   stake_delegations_fork_update() at the same time, and the replay tile
-   can simultaneously be calling fd_stake_delegations_evict_fork()
-   */
+   The concurrency model is: every mutating operation takes the struct's
+   write lock for its whole duration, so mutators are safe to call
+   concurrently from any tile.  fd_stake_delegations_{mark,unmark}_delta
+   and the iterator are the exception: the caller holds the write lock
+   across the whole mark/iterate/unmark bracket. */
 
 #define FD_STAKE_DELEGATIONS_ALIGN              (128UL)
 #define FD_STAKE_DELEGATIONS_FORK_MAX           (4096UL)
@@ -116,6 +120,16 @@ struct fd_stake_delegation {
 };
 typedef struct fd_stake_delegation fd_stake_delegation_t;
 
+/* Used for the pubkey fallback tier.  Holds a reference to a stake
+   account that is referenced by the root or by a live fork delta. */
+
+struct fd_stake_delegation_ref {
+  fd_pubkey_t stake_account;
+  uint        next_;  /* Internal pool/map usage */
+  uint        refcnt;
+};
+typedef struct fd_stake_delegation_ref fd_stake_delegation_ref_t;
+
 struct fd_stake_delegations {
   ulong magic;
   ulong expected_stake_accounts_;
@@ -129,10 +143,19 @@ struct fd_stake_delegations {
                           well defined. */
 
   /* Delta pool + fork and fork map  */
-  ulong       delta_pool_offset_;
-  ulong       fork_pool_offset_;
-  ulong       fork_map_offset_;
-  fd_rwlock_t delta_lock;
+  ulong delta_pool_offset_;
+  ulong fork_pool_offset_;
+  ulong fork_map_offset_;
+
+  /* Guards every mutating operation on the struct. */
+  fd_rwlock_t lock;
+
+  /* Pubkey fallback tier. */
+  ulong pubkey_pool_offset_;
+  ulong pubkey_map_offset_;
+  ulong max_pubkeys_;
+  ulong pubkey_idx_wmk_; /* One past the highest pubkey pool index ever acquired */
+  int   pubkey_fallback;
 
   /* Stake totals for the current root. */
   ulong effective_stake;
@@ -141,12 +164,27 @@ struct fd_stake_delegations {
 };
 typedef struct fd_stake_delegations fd_stake_delegations_t;
 
+#define FD_STAKE_DELEGATIONS_ITER_BATCH (32UL)
+
 struct fd_stake_delegations_iter {
   fd_stake_delegation_t * root_pool;
   fd_stake_delegation_t * delta_pool;
   fd_stake_delegation_t * ele;
   ulong                   idx;
   ulong                   wmk;
+
+  /* Fallback mode only. */
+  int                            fallback;
+  ulong                          scan_idx;
+  ulong                          batch_cnt;
+  ulong                          batch_idx;
+  fd_stake_delegations_t const * stake_delegations;
+  fd_accdb_t *                   accdb;
+  fd_accdb_fork_id_t             accdb_fork_id;
+  ulong                          epoch;
+  ulong *                        warmup_cooldown_rate_epoch;
+  ulong                          batch_pool_idx[ FD_STAKE_DELEGATIONS_ITER_BATCH ];
+  fd_stake_delegation_t          batch[ FD_STAKE_DELEGATIONS_ITER_BATCH ];
 };
 typedef struct fd_stake_delegations_iter fd_stake_delegations_iter_t;
 
@@ -167,23 +205,26 @@ ulong
 fd_stake_delegations_align( void );
 
 /* fd_stake_delegations_footprint returns the footprint of the stake
-   delegations struct for a given amount of max stake accounts,
-   expected stake accounts, and max live slots. */
+   delegations struct for a given amount of max stake accounts, max
+   fallback stake accounts, expected stake accounts, and max live slots . */
 
 ulong
 fd_stake_delegations_footprint( ulong max_stake_accounts,
+                                ulong max_fallback_stake_accounts,
                                 ulong expected_stake_accounts,
                                 ulong max_live_slots );
 
 /* fd_stake_delegations_new creates a new stake delegations struct
-   with a given amount of max and expected stake accounts and max live
-   slots.  It formats a memory region which is sized based off the pool
-   capacity, expected map occupancy, and per-fork delta structures. */
+   with a given amount of max, max fallback, and expected stake accounts
+   and max live slots.  It formats a memory region which is sized based
+   off the pool capacity, expected map occupancy, and per-fork delta
+   structures. */
 
 void *
 fd_stake_delegations_new( void * mem,
                           ulong  seed,
                           ulong  max_stake_accounts,
+                          ulong  max_fallback_stake_accounts,
                           ulong  expected_stake_accounts,
                           ulong  max_live_slots );
 
@@ -252,11 +293,25 @@ fd_stake_delegations_refresh( fd_stake_delegations_t *   stake_delegations,
                               fd_accdb_t *               accdb,
                               fd_accdb_fork_id_t         fork_id );
 
-/* fd_stake_delegations_cnt returns the number of stake delegations
+/* fd_stake_delegations_base_cnt returns the number of stake delegations
    in the base of stake delegations struct. */
 
 ulong
-fd_stake_delegations_cnt( fd_stake_delegations_t const * stake_delegations );
+fd_stake_delegations_base_cnt( fd_stake_delegations_t const * stake_delegations );
+
+/* fd_stake_delegations_pubkey_cnt returns the number of entries in the
+   pubkey fallback tier. */
+
+ulong
+fd_stake_delegations_pubkey_cnt( fd_stake_delegations_t const * stake_delegations );
+
+/* fd_stake_delegations_pubkey_fallback returns non-zero if the stake
+   delegations struct has entered fallback mode. */
+
+FD_FN_PURE static inline int
+fd_stake_delegations_pubkey_fallback( fd_stake_delegations_t const * stake_delegations ) {
+  return stake_delegations->pubkey_fallback;
+}
 
 /* fd_stake_delegations_new_fork allocates a new fork index for the
    stake delegations.  The fork index is returned to the caller. */
@@ -360,13 +415,17 @@ fd_stake_delegations_unmark_delta( fd_stake_delegations_t *   stake_delegations,
    stake delegation.  It is not safe to modify the stake delegation
    while iterating through it.
 
-   Under the hood, the iterator is just a wrapper over the iterator in
-   fd_map_chain.c.
+   Under the hood, the iterator walks the root pool, redirecting to the
+   delta pool for entries a marked fork has changed.  If the struct is
+   in fallback mode it instead walks the pubkey fallback tier and reads
+   each stake account out of the accounts database, in which case the
+   pointer returned by fd_stake_delegations_iter_ele is only valid until
+   the next call to fd_stake_delegations_iter_next.
 
    Example use:
 
    fd_stake_delegations_iter_t iter_[1];
-   for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+   for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, fork_id, epoch, warmup_cooldown_rate_epoch );
         !fd_stake_delegations_iter_done( iter );
         fd_stake_delegations_iter_next( iter ) ) {
      fd_stake_delegation_t * stake_delegation = fd_stake_delegations_iter_ele( iter );
@@ -374,8 +433,18 @@ fd_stake_delegations_unmark_delta( fd_stake_delegations_t *   stake_delegations,
 */
 
 fd_stake_delegations_iter_t *
-fd_stake_delegations_iter_init( fd_stake_delegations_iter_t *  iter,
-                                fd_stake_delegations_t const * stake_delegations );
+fd_stake_delegations_iter_init( fd_stake_delegations_iter_t *   iter,
+                                fd_stake_delegations_t const *  stake_delegations,
+                                fd_accdb_t *                    accdb,
+                                fd_accdb_fork_id_t              accdb_fork_id,
+                                ulong                           epoch,
+                                ulong *                         warmup_cooldown_rate_epoch );
+
+/* fd_stake_delegations_iter_advance_fallback is the out-of-line advance
+   used in fallback mode.  Not for direct use. */
+
+void
+fd_stake_delegations_iter_advance_fallback( fd_stake_delegations_iter_t * iter );
 
 static inline fd_stake_delegation_t *
 fd_stake_delegations_iter_ele( fd_stake_delegations_iter_t * iter ) {
@@ -389,13 +458,18 @@ fd_stake_delegations_iter_idx( fd_stake_delegations_iter_t * iter ) {
 
 static inline void
 fd_stake_delegations_iter_next( fd_stake_delegations_iter_t * iter ) {
+  if( FD_UNLIKELY( iter->fallback ) ) {
+    iter->batch_idx++;
+    fd_stake_delegations_iter_advance_fallback( iter );
+    return;
+  }
   iter->idx++;
   fd_stake_delegations_iter_advance_private( iter );
 }
 
 static inline int
 fd_stake_delegations_iter_done( fd_stake_delegations_iter_t * iter ) {
-  return iter->idx>=iter->wmk;
+  return !iter->ele;
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -611,7 +611,7 @@ fd_refresh_vote_accounts_vat( fd_bank_t *                    bank,
 
   /* Accumulate stakes across all delegations for all vote accounts. */
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, epoch, new_rate_activation_epoch );
       !fd_stake_delegations_iter_done( iter );
       fd_stake_delegations_iter_next( iter ) ) {
 
@@ -945,7 +945,7 @@ fd_refresh_vote_accounts_no_vat( fd_bank_t *                    bank,
   /* Now accumulate vote stakes for all stake delegations. */
 
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, epoch, new_rate_activation_epoch );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
 
@@ -1175,8 +1175,12 @@ fd_stakes_activate_epoch( fd_bank_t *                    bank,
      entry are summed using the new fixed point arithmetic. We only
      need to do this once, at the feature activation epoch boundary.
 
-     https://github.com/anza-xyz/agave/blob/v4.2.0-beta.1/runtime/src/stakes.rs#L444-L477 */
-  if( FD_UNLIKELY( FD_FEATURE_JUST_ACTIVATED_BANK( bank, upgrade_bpf_stake_program_to_v5_1 ) ) ) {
+     https://github.com/anza-xyz/agave/blob/v4.2.0-beta.1/runtime/src/stakes.rs#L444-L477
+
+     The same recomputation needs to be done as soon as fallback stake
+     accounts are enabled. */
+  int fallback = fd_stake_delegations_pubkey_fallback( stake_delegations );
+  if( FD_UNLIKELY( fallback || FD_FEATURE_JUST_ACTIVATED_BANK( bank, upgrade_bpf_stake_program_to_v5_1 ) ) ) {
     fd_stake_history_t history[1];
     if( FD_UNLIKELY( !fd_sysvar_cache_stake_history_view( &bank->f.sysvar_cache, history ) ) ) {
       FD_LOG_CRIT(( "invariant violation: StakeHistory sysvar missing or invalid" ));
@@ -1185,13 +1189,15 @@ fd_stakes_activate_epoch( fd_bank_t *                    bank,
     ulong activating   = 0UL;
     ulong deactivating = 0UL;
 
+    int use_fixed_point_stake_math = FD_FEATURE_ACTIVE_BANK( bank, upgrade_bpf_stake_program_to_v5_1 );
+
     fd_stake_delegations_iter_t iter_[1];
-    for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+    for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, accdb, bank->accdb_fork_id, bank->f.epoch, new_rate_activation_epoch );
          !fd_stake_delegations_iter_done( iter );
          fd_stake_delegations_iter_next( iter ) ) {
       fd_stake_delegation_t const * stake_delegation = fd_stake_delegations_iter_ele( iter );
       fd_stake_history_entry_t      acc              = fd_stakes_activating_and_deactivating(
-          stake_delegation, bank->f.epoch, history, new_rate_activation_epoch, 1 );
+          stake_delegation, bank->f.epoch, history, new_rate_activation_epoch, use_fixed_point_stake_math );
       effective    += acc.effective;
       activating   += acc.activating;
       deactivating += acc.deactivating;
@@ -1247,12 +1253,12 @@ fd_stakes_update_stake_delegation( fd_pubkey_t const * pubkey,
     prior_stake_state = fd_stake_state_view( acc->prior_data, acc->prior_data_len );
   }
 
-  int current_has_delegation = stake_state && stake_state->stake_type==FD_STAKE_STATE_STAKE && stake_state->stake.stake.delegation.stake;
-  int prior_has_delegation   = prior_stake_state && prior_stake_state->stake_type==FD_STAKE_STATE_STAKE && prior_stake_state->stake.stake.delegation.stake;
+  int current_has_delegation = stake_state && stake_state->stake_type==FD_STAKE_STATE_STAKE;
+  int prior_has_delegation   = prior_stake_state && prior_stake_state->stake_type==FD_STAKE_STATE_STAKE;
 
-  /* If the current stake state isn't an active delegation and it was an
-     active delegation in the previous stake state, insert a tombstone
-     into the stake delegation's fork. */
+  /* If the current stake state isn't a delegation and it was a
+     delegation in the previous stake state, insert a tombstone into the
+     stake delegation's fork. */
   if( FD_UNLIKELY( !current_has_delegation ) ) {
     if( FD_LIKELY( !prior_has_delegation ) ) return; /* nothing to remove from */
     fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_modify( bank );
@@ -1260,11 +1266,17 @@ fd_stakes_update_stake_delegation( fd_pubkey_t const * pubkey,
     return;
   }
 
-  /* If the stake account's stake hasn't changed from the previous
-     account's stake state, don't attempt to update the delegation. */
-  if( FD_LIKELY( prior_has_delegation &&
-                 acc->prior_data_len==acc->data_len &&
-                 !memcmp( &prior_stake_state->stake.stake, &stake_state->stake.stake, sizeof(fd_stake_t) ) ) ) return;
+  /* Agave replaces the cached version of the account whenever the
+     account changes. */
+
+  int account_changed = acc->prior_lamports  !=acc->lamports   ||
+                        acc->prior_executable!=acc->executable ||
+                        acc->prior_data_len  !=acc->data_len   ||
+                        memcmp( acc->prior_owner, acc->owner, sizeof(fd_pubkey_t) );
+  if( FD_LIKELY( !account_changed && acc->data_len ) ) {
+    account_changed = !!memcmp( acc->prior_data, acc->data, acc->data_len );
+  }
+  if( FD_LIKELY( prior_has_delegation && !account_changed ) ) return;
 
   fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_modify( bank );
   ulong new_stake = stake_state->stake.stake.delegation.stake;

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -1241,26 +1241,40 @@ fd_stakes_update_stake_delegation( fd_pubkey_t const * pubkey,
                                    fd_acc_t const *    acc,
                                    fd_bank_t *         bank ) {
 
-  fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_modify( bank );
-
-  /* fd_stakes_get_state returns NULL for closed/invalid accounts. */
-  fd_stake_state_t const * stake_state = fd_stakes_get_state( acc );
-  if( FD_LIKELY( stake_state != NULL &&
-                 stake_state->stake_type == FD_STAKE_STATE_STAKE &&
-                 stake_state->stake.stake.delegation.stake != 0UL ) ) {
-
-    ulong new_stake = stake_state->stake.stake.delegation.stake;
-    fd_stake_delegations_fork_update( stake_delegations, bank->stake_delegations_fork_id, pubkey,
-                                      &stake_state->stake.stake.delegation.voter_pubkey,
-                                      new_stake,
-                                      stake_state->stake.stake.delegation.activation_epoch,
-                                      stake_state->stake.stake.delegation.deactivation_epoch,
-                                      stake_state->stake.stake.credits_observed,
-                                      acc->lamports,
-                                      (uint)acc->data_len,
-                                      fd_stake_warmup_cooldown_rate( bank->f.epoch, &bank->f.warmup_cooldown_rate_epoch ) );
-
-  } else {
-    fd_stake_delegations_fork_remove( stake_delegations, bank->stake_delegations_fork_id, pubkey );
+  fd_stake_state_t const * stake_state       = fd_stakes_get_state( acc );
+  fd_stake_state_t const * prior_stake_state = NULL;
+  if( FD_LIKELY( acc->prior_lamports && !memcmp( acc->prior_owner, &fd_solana_stake_program_id, 32UL ) ) ) {
+    prior_stake_state = fd_stake_state_view( acc->prior_data, acc->prior_data_len );
   }
+
+  int current_has_delegation = stake_state && stake_state->stake_type==FD_STAKE_STATE_STAKE && stake_state->stake.stake.delegation.stake;
+  int prior_has_delegation   = prior_stake_state && prior_stake_state->stake_type==FD_STAKE_STATE_STAKE && prior_stake_state->stake.stake.delegation.stake;
+
+  /* If the current stake state isn't an active delegation and it was an
+     active delegation in the previous stake state, insert a tombstone
+     into the stake delegation's fork. */
+  if( FD_UNLIKELY( !current_has_delegation ) ) {
+    if( FD_LIKELY( !prior_has_delegation ) ) return; /* nothing to remove from */
+    fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_modify( bank );
+    fd_stake_delegations_fork_remove( stake_delegations, bank->stake_delegations_fork_id, pubkey );
+    return;
+  }
+
+  /* If the stake account's stake hasn't changed from the previous
+     account's stake state, don't attempt to update the delegation. */
+  if( FD_LIKELY( prior_has_delegation &&
+                 acc->prior_data_len==acc->data_len &&
+                 !memcmp( &prior_stake_state->stake.stake, &stake_state->stake.stake, sizeof(fd_stake_t) ) ) ) return;
+
+  fd_stake_delegations_t * stake_delegations = fd_bank_stake_delegations_modify( bank );
+  ulong new_stake = stake_state->stake.stake.delegation.stake;
+  fd_stake_delegations_fork_update( stake_delegations, bank->stake_delegations_fork_id, pubkey,
+                                    &stake_state->stake.stake.delegation.voter_pubkey,
+                                    new_stake,
+                                    stake_state->stake.stake.delegation.activation_epoch,
+                                    stake_state->stake.stake.delegation.deactivation_epoch,
+                                    stake_state->stake.stake.credits_observed,
+                                    acc->lamports,
+                                    (uint)acc->data_len,
+                                    fd_stake_warmup_cooldown_rate( bank->f.epoch, &bank->f.warmup_cooldown_rate_epoch ) );
 }

--- a/src/flamenco/stakes/test_stake_delegations.c
+++ b/src/flamenco/stakes/test_stake_delegations.c
@@ -30,11 +30,15 @@ FD_STATIC_ASSERT( sizeof  ( fd_stake_delegation_t        )==112UL, layout );
 #define TEST_STAKE_DELEGATION_LAMPORTS (123456789UL)
 #define TEST_STAKE_DELEGATION_ACC_DLEN ((uint)sizeof(fd_stake_state_t))
 
+/* These tests never drive the struct into pubkey fallback mode, so the
+   iterator never needs to resolve anything out of an accounts database. */
+#define NO_RESOLVE NULL, ((fd_accdb_fork_id_t){ .val = USHORT_MAX }), 0UL, NULL
+
 static fd_stake_delegation_t const *
 test_stake_delegations_find( fd_stake_delegations_t const * stake_delegations,
                              fd_pubkey_t const *            stake_account ) {
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, NO_RESOLVE );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * d = fd_stake_delegations_iter_ele( iter );
@@ -48,7 +52,7 @@ static ulong
 count_visible_delegations( fd_stake_delegations_t const * stake_delegations ) {
   ulong cnt = 0UL;
   fd_stake_delegations_iter_t iter_[1];
-  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations );
+  for( fd_stake_delegations_iter_t * iter = fd_stake_delegations_iter_init( iter_, stake_delegations, NO_RESOLVE );
        !fd_stake_delegations_iter_done( iter );
        fd_stake_delegations_iter_next( iter ) ) {
     fd_stake_delegation_t const * d = fd_stake_delegations_iter_ele( iter );
@@ -100,16 +104,20 @@ int main( int argc, char ** argv ) {
   ulong const max_stake_accounts = 10UL;
   ulong const expected_stake_accounts = fd_ulong_min( max_stake_accounts, FD_RUNTIME_EXPECTED_STAKE_ACCOUNTS );
 
+  /* Leaves headroom above the root plus delta maximum of 90 so that the
+     fallback cases below have somewhere to put entries. */
+  ulong const max_fallback_stake_accounts = 512UL;
+
   ulong const max_live_slots = 32UL;
-  void * stake_delegations_mem = fd_wksp_alloc_laddr( wksp, fd_stake_delegations_align(), fd_stake_delegations_footprint( max_stake_accounts, expected_stake_accounts, max_live_slots ), wksp_tag );
+  void * stake_delegations_mem = fd_wksp_alloc_laddr( wksp, fd_stake_delegations_align(), fd_stake_delegations_footprint( max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_live_slots ), wksp_tag );
   FD_TEST( stake_delegations_mem );
 
   FD_TEST( fd_stake_delegations_align()>=alignof(fd_stake_delegations_t)  );
   FD_TEST( fd_stake_delegations_align()==FD_STAKE_DELEGATIONS_ALIGN );
 
-  FD_TEST( !fd_stake_delegations_new( NULL, 0UL, max_stake_accounts, expected_stake_accounts, max_live_slots ) );
-  FD_TEST( !fd_stake_delegations_new( stake_delegations_mem, 0UL, 0UL, expected_stake_accounts, max_live_slots ) );
-  void * new_stake_delegations_mem = fd_stake_delegations_new( stake_delegations_mem, 0UL, max_stake_accounts, expected_stake_accounts, max_live_slots );
+  FD_TEST( !fd_stake_delegations_new( NULL, 0UL, max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_live_slots ) );
+  FD_TEST( !fd_stake_delegations_new( stake_delegations_mem, 0UL, 0UL, max_fallback_stake_accounts, expected_stake_accounts, max_live_slots ) );
+  void * new_stake_delegations_mem = fd_stake_delegations_new( stake_delegations_mem, 0UL, max_stake_accounts, max_fallback_stake_accounts, expected_stake_accounts, max_live_slots );
   FD_TEST( new_stake_delegations_mem );
 
   FD_TEST( !fd_stake_delegations_join( NULL ) );
@@ -128,13 +136,13 @@ int main( int argc, char ** argv ) {
   fd_pubkey_t voter_pubkey_0 = { .ul = { 5, 6 } };
   fd_pubkey_t voter_pubkey_1 = { .ul = { 7, 8 } };
 
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 0UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 0UL );
   fd_stake_delegations_root_update( stake_delegations, &stake_account_0, &voter_pubkey_0, 100UL, 0UL, 0UL, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 1UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 1UL );
   fd_stake_delegations_root_update( stake_delegations, &stake_account_1, &voter_pubkey_1, 200UL, 0UL, 0UL, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 2UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 2UL );
   fd_stake_delegations_root_update( stake_delegations, &stake_account_2, &voter_pubkey_1, 300UL, 0UL, 0UL, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
 
   fd_stake_delegation_t const * stake_delegation_0 = test_stake_delegations_find( stake_delegations, &stake_account_0 );
   FD_TEST( stake_delegation_0 );
@@ -181,7 +189,7 @@ int main( int argc, char ** argv ) {
   FD_TEST( stake_delegation_0->activation_epoch == 0UL );
   FD_TEST( stake_delegation_0->deactivation_epoch == 0UL );
   FD_TEST( stake_delegation_0->warmup_cooldown_rate == FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
 
   ushort remove_fork = fd_stake_delegations_new_fork( stake_delegations );
   fd_stake_delegations_fork_remove( stake_delegations, remove_fork, &stake_account_1 );
@@ -193,7 +201,7 @@ int main( int argc, char ** argv ) {
   fd_stake_delegations_apply_fork_delta( epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, stake_delegations, remove_fork );
   fd_stake_delegations_evict_fork( stake_delegations, remove_fork );
   FD_TEST( !test_stake_delegations_find( stake_delegations, &stake_account_1 ) );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 2UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 2UL );
 
   fd_stake_delegations_root_update( stake_delegations, &stake_account_1, &voter_pubkey_1, 10000UL, 0UL, 0UL, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
   stake_delegation_1 = test_stake_delegations_find( stake_delegations, &stake_account_1 );
@@ -206,7 +214,7 @@ int main( int argc, char ** argv ) {
   FD_TEST( stake_delegation_1->activation_epoch == 0UL );
   FD_TEST( stake_delegation_1->deactivation_epoch == 0UL );
   FD_TEST( stake_delegation_1->warmup_cooldown_rate == FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-  FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+  FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
 
   /* Test stake delegation delta mark/unmark */
 
@@ -242,10 +250,10 @@ int main( int argc, char ** argv ) {
     fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
     fd_stake_delegation_t const * d3 = test_stake_delegations_find( stake_delegations, &stake_account_3 );
     assert_delegation( d3, &stake_account_3, &voter_pubkey_0, 777UL, 0UL, 0UL, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
-    FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 4UL );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 4UL );
     fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
     FD_TEST( !test_stake_delegations_find( stake_delegations, &stake_account_3 ) );
-    FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == 3UL );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == 3UL );
     fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
   }
 
@@ -338,15 +346,15 @@ int main( int argc, char ** argv ) {
     fd_stake_delegations_evict_fork( stake_delegations, fork2 );
   }
 
-  /* Case 12: fd_stake_delegations_cnt */
+  /* Case 12: fd_stake_delegations_base_cnt */
   {
     ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
-    ulong  cnt_before = fd_stake_delegations_cnt( stake_delegations );
+    ulong  cnt_before = fd_stake_delegations_base_cnt( stake_delegations );
     fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_3, &voter_pubkey_0, 1UL, 0UL, 0UL, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
     fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
-    FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == cnt_before + 1UL );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == cnt_before + 1UL );
     fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
-    FD_TEST( fd_stake_delegations_cnt( stake_delegations ) == cnt_before );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations ) == cnt_before );
     fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
   }
 
@@ -583,7 +591,7 @@ int main( int argc, char ** argv ) {
     ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
     fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_0, 907UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
     fd_stake_delegations_reset( stake_delegations );
-    FD_TEST( fd_stake_delegations_cnt( stake_delegations )==0UL );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations )==0UL );
 
     ushort reset_fork_idx = fd_stake_delegations_new_fork( stake_delegations );
     fd_stake_delegations_fork_update( stake_delegations, reset_fork_idx, &stake_account_0, &voter_pubkey_1, 908UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
@@ -592,6 +600,125 @@ int main( int argc, char ** argv ) {
     fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, reset_fork_idx );
     FD_TEST( !test_stake_delegations_find( stake_delegations, &stake_account_0 ) );
     fd_stake_delegations_evict_fork( stake_delegations, reset_fork_idx );
+  }
+
+  /* Case 28: Delta entries are drawn from the delta pool, which has its
+     own capacity separate from the root pool. */
+  {
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    for( ulong i=0UL; i<max_stake_accounts; i++ ) {
+      fd_pubkey_t stake_account = { .ul = { 1000UL+i, 2000UL+i } };
+      fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account, &voter_pubkey_0, i+1UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    }
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+  }
+
+  /* Case 29: The pubkey fallback tier tracks one entry per stake account
+     and refcounts the root and delta references, so it drains back to
+     empty once every reference is dropped. */
+  {
+    fd_stake_delegations_reset( stake_delegations );
+    FD_TEST( !fd_stake_delegations_pubkey_cnt( stake_delegations ) );
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+
+    fd_stake_delegations_root_update( stake_delegations, &stake_account_0, &voter_pubkey_0, 100UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==1UL );
+
+    /* A fork touching an account the root already has takes a second
+       reference rather than adding a second entry. */
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_1, 101UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==1UL );
+
+    /* An account only a fork has seen still gets an entry. */
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_1, &voter_pubkey_1, 102UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==2UL );
+
+    /* Discarding the fork drops its references, leaving the root's. */
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==1UL );
+
+    /* Rooting a tombstone drops the last reference. */
+    ushort remove_fork = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_remove( stake_delegations, remove_fork, &stake_account_0 );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==1UL );
+    fd_stake_delegations_apply_fork_delta( epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, stake_delegations, remove_fork );
+    fd_stake_delegations_evict_fork( stake_delegations, remove_fork );
+    FD_TEST( !fd_stake_delegations_pubkey_cnt( stake_delegations ) );
+    FD_TEST( !fd_stake_delegations_base_cnt( stake_delegations ) );
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+  }
+
+  /* Case 30: Exhausting the root pool enters fallback mode.  The stake
+     account is still recorded in the pubkey tier, but it does not reach
+     the root map, and the mode is sticky. */
+  {
+    fd_stake_delegations_reset( stake_delegations );
+
+    for( ulong i=0UL; i<max_stake_accounts; i++ ) {
+      fd_pubkey_t k = { .ul = { 5000UL+i, 6000UL+i } };
+      fd_stake_delegations_root_update( stake_delegations, &k, &voter_pubkey_0, i+1UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    }
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations )==max_stake_accounts );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==max_stake_accounts );
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+
+    fd_pubkey_t overflow = { .ul = { 7777UL, 8888UL } };
+    fd_stake_delegations_root_update( stake_delegations, &overflow, &voter_pubkey_0, 1UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations )==max_stake_accounts );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==max_stake_accounts+1UL );
+    FD_TEST( !fd_stake_delegation_root_query( stake_delegations, &overflow ) );
+
+    /* Freeing a root slot does not clear the mode, and because refcounts
+       are no longer paired the tier retains the entry. */
+    fd_pubkey_t first       = { .ul = { 5000UL, 6000UL } };
+    ushort      remove_fork = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_remove( stake_delegations, remove_fork, &first );
+    fd_stake_delegations_apply_fork_delta( epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, stake_delegations, remove_fork );
+    fd_stake_delegations_evict_fork( stake_delegations, remove_fork );
+    FD_TEST( fd_stake_delegations_base_cnt( stake_delegations )==max_stake_accounts-1UL );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==max_stake_accounts+1UL );
+    FD_TEST( fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+
+    /* Reset is the other way out of fallback mode. */
+    fd_stake_delegations_reset( stake_delegations );
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+    FD_TEST( !fd_stake_delegations_pubkey_cnt( stake_delegations ) );
+  }
+
+  /* Case 31: Exhausting the delta pool enters fallback mode too, and the
+     pubkey tier has room to spare because it is sized to cover both pools
+     plus headroom. */
+  {
+    fd_stake_delegations_reset( stake_delegations );
+
+    ushort      fork_idx  = fd_stake_delegations_new_fork( stake_delegations );
+    ulong const delta_max = max_stake_accounts;
+    for( ulong i=0UL; i<delta_max; i++ ) {
+      fd_pubkey_t k = { .ul = { 20000UL+i, 30000UL+i } };
+      fd_stake_delegations_fork_update( stake_delegations, fork_idx, &k, &voter_pubkey_0, i+1UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    }
+    FD_TEST( !fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==delta_max );
+
+    fd_pubkey_t overflow = { .ul = { 40000UL, 50000UL } };
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &overflow, &voter_pubkey_0, 1UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( fd_stake_delegations_pubkey_fallback( stake_delegations ) );
+    FD_TEST( fd_stake_delegations_pubkey_cnt( stake_delegations )==delta_max+1UL );
+
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+    fd_stake_delegations_reset( stake_delegations );
+  }
+
+  /* Case 32: The pubkey tier is large enough to hold the root and delta
+     pools simultaneously.  If it were not, filling the delta pool would
+     exhaust the tier at the same moment fallback mode engaged, turning the
+     graceful degradation back into a crash. */
+  {
+    FD_TEST( stake_delegations->max_pubkeys_==max_fallback_stake_accounts );
+    FD_TEST( stake_delegations->max_pubkeys_ > 2UL*max_stake_accounts );
   }
 
   /* Test stake delegations refresh */

--- a/src/flamenco/stakes/test_stake_delegations.c
+++ b/src/flamenco/stakes/test_stake_delegations.c
@@ -25,6 +25,7 @@ FD_STATIC_ASSERT( sizeof  ( fd_delegation_t                            )==64UL, 
 FD_STATIC_ASSERT( offsetof( fd_stake_t, delegation       )== 0UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_stake_t, credits_observed )==64UL, layout );
 FD_STATIC_ASSERT( sizeof  ( fd_stake_t                   )==72UL, layout );
+FD_STATIC_ASSERT( sizeof  ( fd_stake_delegation_t        )==112UL, layout );
 
 #define TEST_STAKE_DELEGATION_LAMPORTS (123456789UL)
 #define TEST_STAKE_DELEGATION_ACC_DLEN ((uint)sizeof(fd_stake_state_t))
@@ -492,6 +493,105 @@ int main( int argc, char ** argv ) {
     fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
     FD_TEST( stake_delegations->effective_stake == eff_before );
     fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+  }
+
+  /* Case 22: Same-fork updates must consume only one delta pool element. */
+  {
+    ulong eff_before = stake_delegations->effective_stake;
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    for( ulong i=0UL; i<=max_stake_accounts; i++ ) {
+      fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_1, 600UL+i, USHORT_MAX, USHORT_MAX, i, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    }
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
+    fd_stake_delegation_t const * d = test_stake_delegations_find( stake_delegations, &stake_account_0 );
+    assert_delegation( d, &stake_account_0, &voter_pubkey_1, 600UL+max_stake_accounts, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( d->credits_observed==max_stake_accounts );
+    FD_TEST( stake_delegations->effective_stake==eff_before-200UL+600UL+max_stake_accounts );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
+    FD_TEST( stake_delegations->effective_stake==eff_before );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+  }
+
+  /* Case 23: The same stake account has independent deltas across forks. */
+  {
+    ushort fork_a = fd_stake_delegations_new_fork( stake_delegations );
+    ushort fork_b = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, fork_a, &stake_account_0, &voter_pubkey_0, 901UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_fork_update( stake_delegations, fork_b, &stake_account_0, &voter_pubkey_1, 902UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_a );
+    assert_delegation( test_stake_delegations_find( stake_delegations, &stake_account_0 ), &stake_account_0, &voter_pubkey_0, 901UL, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_a );
+
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_b );
+    assert_delegation( test_stake_delegations_find( stake_delegations, &stake_account_0 ), &stake_account_0, &voter_pubkey_1, 902UL, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_b );
+
+    fd_stake_delegations_evict_fork( stake_delegations, fork_a );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_b );
+  }
+
+  /* Case 24: Same-fork removals must consume only one delta pool element. */
+  {
+    ulong eff_before = stake_delegations->effective_stake;
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    for( ulong i=0UL; i<=max_stake_accounts; i++ ) {
+      fd_stake_delegations_fork_remove( stake_delegations, fork_idx, &stake_account_0 );
+    }
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
+    FD_TEST( !test_stake_delegations_find( stake_delegations, &stake_account_0 ) );
+    FD_TEST( stake_delegations->effective_stake==eff_before-200UL );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, fork_idx );
+    FD_TEST( stake_delegations->effective_stake==eff_before );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+  }
+
+  /* Case 25: Reused fork indices start with an empty delta map. */
+  {
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_0, 903UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+
+    ushort reused_fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    FD_TEST( reused_fork_idx==fork_idx );
+    fd_stake_delegations_fork_update( stake_delegations, reused_fork_idx, &stake_account_0, &voter_pubkey_1, 904UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, reused_fork_idx );
+    assert_delegation( test_stake_delegations_find( stake_delegations, &stake_account_0 ), &stake_account_0, &voter_pubkey_1, 904UL, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, reused_fork_idx );
+    fd_stake_delegations_evict_fork( stake_delegations, reused_fork_idx );
+  }
+
+  /* Case 26: Applying a deduplicated delta commits only the latest state. */
+  {
+    ulong eff_before = stake_delegations->effective_stake;
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_0, 905UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_1, 906UL, USHORT_MAX, USHORT_MAX, 1UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_apply_fork_delta( epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, stake_delegations, fork_idx );
+    fd_stake_delegation_t const * d = fd_stake_delegation_root_query( stake_delegations, &stake_account_0 );
+    assert_delegation( d, &stake_account_0, &voter_pubkey_1, 906UL, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    FD_TEST( d->credits_observed==1UL );
+    FD_TEST( stake_delegations->effective_stake==eff_before-200UL+906UL );
+    fd_stake_delegations_evict_fork( stake_delegations, fork_idx );
+
+    fd_stake_delegations_root_update( stake_delegations, &stake_account_0, &voter_pubkey_0, 200UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    stake_delegations->effective_stake = eff_before;
+  }
+
+  /* Case 27: Reset clears populated fork maps before fork indices are reused. */
+  {
+    ushort fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, fork_idx, &stake_account_0, &voter_pubkey_0, 907UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_reset( stake_delegations );
+    FD_TEST( fd_stake_delegations_cnt( stake_delegations )==0UL );
+
+    ushort reset_fork_idx = fd_stake_delegations_new_fork( stake_delegations );
+    fd_stake_delegations_fork_update( stake_delegations, reset_fork_idx, &stake_account_0, &voter_pubkey_1, 908UL, USHORT_MAX, USHORT_MAX, 0UL, TEST_STAKE_DELEGATION_LAMPORTS, TEST_STAKE_DELEGATION_ACC_DLEN, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_mark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, reset_fork_idx );
+    assert_delegation( test_stake_delegations_find( stake_delegations, &stake_account_0 ), &stake_account_0, &voter_pubkey_1, 908UL, USHORT_MAX, USHORT_MAX, FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+    fd_stake_delegations_unmark_delta( stake_delegations, epoch, stake_history, &warmup_cooldown_rate_epoch, use_fixed_point_stake_math, reset_fork_idx );
+    FD_TEST( !test_stake_delegations_find( stake_delegations, &stake_account_0 ) );
+    fd_stake_delegations_evict_fork( stake_delegations, reset_fork_idx );
   }
 
   /* Test stake delegations refresh */


### PR DESCRIPTION
1. dedup entries for a given bank
2. only insert cache entry if the stake truly updates/deletes