### PR TITLE
accdb: scale acc_map chain head count by 4x

### DIFF
--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -223,7 +223,7 @@ fd_accdb_new( void *              ljoin,
   ulong max_account_writes_per_slot = shmem->max_account_writes_per_slot;
   ulong partition_cnt = shmem->partition_cnt;
 
-  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+  ulong chain_cnt = fd_accdb_chain_cnt( max_accounts );
   ulong txn_max = max_live_slots * max_account_writes_per_slot;
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
@@ -573,7 +573,7 @@ fd_accdb_join_readonly( void *             ljoin,
   ulong max_account_writes_per_slot  = shmem->max_account_writes_per_slot;
   ulong partition_cnt                = shmem->partition_cnt;
 
-  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+  ulong chain_cnt = fd_accdb_chain_cnt( max_accounts );
   ulong txn_max   = max_live_slots * max_account_writes_per_slot;
 
   /* Recompute the same shmem scratch layout that fd_accdb_shmem_new

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -223,7 +223,7 @@ fd_accdb_new( void *              ljoin,
   ulong max_account_writes_per_slot = shmem->max_account_writes_per_slot;
   ulong partition_cnt = shmem->partition_cnt;
 
-  ulong chain_cnt = fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) );
+  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
   ulong txn_max = max_live_slots * max_account_writes_per_slot;
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
@@ -573,7 +573,7 @@ fd_accdb_join_readonly( void *             ljoin,
   ulong max_account_writes_per_slot  = shmem->max_account_writes_per_slot;
   ulong partition_cnt                = shmem->partition_cnt;
 
-  ulong chain_cnt = fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) );
+  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
   ulong txn_max   = max_live_slots * max_account_writes_per_slot;
 
   /* Recompute the same shmem scratch layout that fd_accdb_shmem_new

--- a/src/flamenco/accdb/fd_accdb_private.h
+++ b/src/flamenco/accdb/fd_accdb_private.h
@@ -104,6 +104,11 @@ typedef struct fd_accdb_fork_shmem fd_accdb_fork_shmem_t;
 
 #include "../../util/tmpl/fd_pool_para.c"
 
+static FD_FN_CONST inline ulong
+fd_accdb_chain_cnt( ulong max_accounts ) {
+  return fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+}
+
 struct fd_accdb_partition {
   ulong marked_compaction;
   ulong write_offset;

--- a/src/flamenco/accdb/fd_accdb_private.h
+++ b/src/flamenco/accdb/fd_accdb_private.h
@@ -4,6 +4,9 @@
 #include "fd_accdb_shmem.h"
 #include "fd_accdb_cache.h"
 
+/* Multiplier on the acc_map chain head count.  Must be a power of two. */
+#define FD_ACCDB_CHAIN_SCALE (4UL)
+
 /* Maximum accounts a single acquire may request.
    FD_ACCDB_MAX_TX_ACCOUNT_LOCKS mirrors the mainnet per-transaction
    account-lock limit (Agave get_transaction_account_lock_limit == 64;

--- a/src/flamenco/accdb/fd_accdb_private.h
+++ b/src/flamenco/accdb/fd_accdb_private.h
@@ -106,7 +106,8 @@ typedef struct fd_accdb_fork_shmem fd_accdb_fork_shmem_t;
 
 static FD_FN_CONST inline ulong
 fd_accdb_chain_cnt( ulong max_accounts ) {
-  return fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+  return fd_ulong_min( (ulong)UINT_MAX+1UL,
+                       fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) ) );
 }
 
 struct fd_accdb_partition {

--- a/src/flamenco/accdb/fd_accdb_shmem.c
+++ b/src/flamenco/accdb/fd_accdb_shmem.c
@@ -87,7 +87,7 @@ fd_accdb_shmem_footprint( ulong max_accounts,
   if( FD_UNLIKELY( !descends_fp                          ) ) return 0UL;
   if( FD_UNLIKELY( max_live_slots>ULONG_MAX/descends_fp  ) ) return 0UL;
 
-  ulong chain_cnt = fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) );
+  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
 
   if( FD_UNLIKELY( chain_cnt>ULONG_MAX/sizeof(uint) ) ) return 0UL;
 
@@ -242,7 +242,7 @@ fd_accdb_shmem_new( void * shmem,
     return NULL;
   }
 
-  ulong chain_cnt = fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) );
+  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
 
   if( FD_UNLIKELY( chain_cnt>ULONG_MAX/sizeof(uint) ) ) {
     FD_LOG_WARNING(( "chain_cnt*sizeof(uint) overflows" ));

--- a/src/flamenco/accdb/fd_accdb_shmem.c
+++ b/src/flamenco/accdb/fd_accdb_shmem.c
@@ -87,7 +87,7 @@ fd_accdb_shmem_footprint( ulong max_accounts,
   if( FD_UNLIKELY( !descends_fp                          ) ) return 0UL;
   if( FD_UNLIKELY( max_live_slots>ULONG_MAX/descends_fp  ) ) return 0UL;
 
-  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+  ulong chain_cnt = fd_accdb_chain_cnt( max_accounts );
 
   if( FD_UNLIKELY( chain_cnt>ULONG_MAX/sizeof(uint) ) ) return 0UL;
 
@@ -242,7 +242,7 @@ fd_accdb_shmem_new( void * shmem,
     return NULL;
   }
 
-  ulong chain_cnt = fd_ulong_pow2_up( FD_ACCDB_CHAIN_SCALE*((max_accounts>>1) + (max_accounts&1UL)) );
+  ulong chain_cnt = fd_accdb_chain_cnt( max_accounts );
 
   if( FD_UNLIKELY( chain_cnt>ULONG_MAX/sizeof(uint) ) ) {
     FD_LOG_WARNING(( "chain_cnt*sizeof(uint) overflows" ));

--- a/src/flamenco/accdb/test_accdb.c
+++ b/src/flamenco/accdb/test_accdb.c
@@ -937,6 +937,14 @@ test_many_accounts_hash_chains( void ) {
   test_teardown( accdb, fd );
 }
 
+static void
+test_chain_cnt( void ) {
+  ulong chain_max = (ulong)UINT_MAX + 1UL;
+  FD_TEST( fd_accdb_chain_cnt( 1UL<<31        )==chain_max );
+  FD_TEST( fd_accdb_chain_cnt( (1UL<<31)+1UL )==chain_max );
+  FD_TEST( fd_accdb_chain_cnt( UINT_MAX-1UL   )==chain_max );
+}
+
 void
 test_mainnet_footprint( void ) {
   /* Mainnet-scale parameters:
@@ -1489,6 +1497,9 @@ main( int     argc,
 
   FD_LOG_NOTICE(( "test_many_accounts_hash_chains ..." ));
   test_many_accounts_hash_chains();
+
+  FD_LOG_NOTICE(( "test_chain_cnt ..." ));
+  test_chain_cnt();
 
   FD_LOG_NOTICE(( "test_mainnet_footprint ..." ));
   test_mainnet_footprint();

--- a/src/flamenco/accdb/test_accdb.c
+++ b/src/flamenco/accdb/test_accdb.c
@@ -971,7 +971,8 @@ test_mainnet_footprint( void ) {
 
   /* Derived values for component breakdown */
   ulong txn_max   = max_live_slots * max_account_writes_per_slot;
-  ulong chain_cnt = fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) );
+  ulong chain_cnt = fd_accdb_chain_cnt( max_accounts );
+  FD_TEST( chain_cnt==FD_ACCDB_CHAIN_SCALE*fd_ulong_pow2_up( (max_accounts>>1) + (max_accounts&1UL) ) );
 
   ulong cache_class_max[ FD_ACCDB_CACHE_CLASS_CNT ];
   FD_TEST( fd_accdb_cache_class_cnt( cache_footprint, 640UL, cache_class_max ) );


### PR DESCRIPTION
`acc_map` is sized at `max_accounts/2` chain heads, so a full database averages ~2 accounts per chain. Widening it 4x shortens the chains walked per account in `fd_accdb_snapshot_write_batch`.

The multiplier is a single constant (`FD_ACCDB_CHAIN_SCALE`) rather than four edited expressions, because the sizing appears in four places that must agree — two in `fd_accdb_shmem.c` computing the footprint, two in `fd_accdb.c` computing the layout inside it. If they disagree the layout writes past the reserved region.

## Measurements

117 GiB mainnet snapshot via `firedancer-dev snapshot-load`, sampling the `snapin` tile for 30s at a fixed 3% progress point. The sweep was run twice, ascending then descending, to rule out ordering effects (warm page cache, leftover `accounts.db` state):

| scale | acc_map | snapin busy% (asc/desc) | dTLB misses (asc/desc) | acc M/s |
|---|---|---|---|---|
| 1 | 4 GiB | 73.4 / 73.5 | 25.5K / 10.3K | 8.05 |
| 2 | 8 GiB | 69.6 / 70.0 | 18.6K / 15.4K | 8.05 |
| **4** | **16 GiB** | **67.6 / 67.6** | **27.9K / 25.1K** | **8.05** |
| 8 | 32 GiB | 66.2 / 66.0 | 66.4K / 66.5K | 8.05 |
| 16 | 64 GiB | 65.5 / 65.5 | 4.4M / 4.0M | 8.03 |

Every point reproduces within 0.4 percentage points across the two orderings.

## Why 4x

4x captures most of the available reduction for 12 GiB of extra memory. 8x buys another 1.6 points for 16 GiB more. 16x regresses: the randomly-accessed working set crosses this CPU's 64-entry 1 GiB data TLB (`cpuid` leaf `0x80000019`), producing a ~150x blowup in page walks for 0.5 points.

## Notes

- Total cache misses are flat across the whole sweep (524–540M). The win is fewer *dependent* misses in series, not fewer misses.
- Throughput is unchanged at ~8.05 M accounts/s because `snapdc` saturates at 100% and caps the pipeline. This buys `snapin` headroom for future parallelisation of decompression, not load time today.
- Hash distribution was checked separately: the xxh3 finaliser avalanches into the low bits, and bucket occupancy matches Poisson at every chain count tested, so widening the mask does not skew placement.
- `test_accdb` passes.

Draft: benchmarks are from a single machine (EPYC 9754, 1 NUMA node). The 16x TLB cliff in particular is CPU-specific, so the 4x-vs-8x choice may want confirming elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)