### PR TITLE
fdctl: increase max_pending_shred_sets to 32768

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1424,7 +1424,7 @@ dynamic_port_range = "8900-9000"
         # To compute an appropriate value, multiply the expected Turbine
         # worst-case latency (tenths of seconds) by the expected
         # transaction rate, and divide by approx 25.
-        max_pending_shred_sets = 512
+        max_pending_shred_sets = 32768
 
         # The shred tile listens on a specific port for shreds to
         # forward.  This argument controls which port that is.  The port


### PR DESCRIPTION
Increases Frank's default `max_pending_shred_sets` from 512 to 32768 (Firedancer's default), costing 9 additional gigantic pages (80 -> 89, +9 GiB locked) in the shred_store workspace.