### PR TITLE
validate loop unrolling & branch eliminations at fixed size loops 

### DIFF
--- a/src/groove/fd_groove_data.h
+++ b/src/groove/fd_groove_data.h
@@ -342,8 +342,7 @@ fd_groove_data_szc( ulong footprint ) {
 
   /* Fixed count loop without early exit to make it easy for compiler to
      unroll and nominally eliminate all branches for fast, highly
-     deterministic performance with no consumption of BTB resources.
-     FIXME: check the compiler is doing the right thing here. */
+     deterministic performance with no consumption of BTB resources. */
 
   for( ulong r=0UL; r<5UL; r++ ) { /* Assumes SZC_CNT<=32 */
 

--- a/src/util/alloc/fd_alloc.c
+++ b/src/util/alloc/fd_alloc.c
@@ -32,9 +32,7 @@ fd_alloc_preferred_sizeclass( ulong footprint ) {
 
   /* Fixed count loop without early exit to make it easy for compiler to
      unroll and nominally eliminate all branches for fast, highly
-     deterministic performance with no consumption of BTB resources.
-     FIXME: check the compiler is doing the right thing here with
-     unrolling and branch elimination. */
+     deterministic performance with no consumption of BTB resources. */
 
   for( ulong r=0UL; r<FD_ALLOC_SIZECLASS_ITER_MAX; r++ ) {
 


### PR DESCRIPTION
edit: to prevent scope shift with the other commits I want to PR, I'm lefting this pr as is. 
Putting only related terminal dumps as short as possible to commit messages for future check. 
Full objdumps if someone wants to check:
```objdump
objdump -S -Mintel  --disassemble=fd_alloc_preferred_sizeclass  build/linux/gcc/zen3/unit-test/test_alloc

build/linux/gcc/zen3/unit-test/test_alloc:     file format elf64-x86-64


Disassembly of section .text:

0000000000016520 <fd_alloc_preferred_sizeclass>:
FD_FN_CONST static inline T    fd_##T##_rotate_right( T x, int n        ) { return (T)((x >> (n&(w-1))) | (x << ((-n)&(w-1))));  }

FD_SRC_UTIL_BITS_FD_BITS_IMPL(uchar,  8)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(ushort,16)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(uint,  32)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(ulong, 64)
   16520:	48 81 ff c1 03 00 00 	cmp    rdi,0x3c1

    ulong m = (l+h)>>1; /* Note: no overflow for reasonable sizeclass_cnt and l<=m<=h */
    int   c = (((ulong)fd_alloc_sizeclass_cfg[ m ].block_footprint)>=footprint);
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
    h = fd_ulong_if( c, m, h     ); /* cmov */
   16527:	48 8d 35 f2 5c ff ff 	lea    rsi,[rip+0xffffffffffff5cf2]        # c220 <fd_alloc_sizeclass_cfg>
   1652e:	48 19 c0             	sbb    rax,rax
   16531:	48 f7 d0             	not    rax
   16534:	83 e0 1f             	and    eax,0x1f
   16537:	48 81 ff c1 03 00 00 	cmp    rdi,0x3c1
   1653e:	48 19 d2             	sbb    rdx,rdx
   16541:	48 83 e2 e2          	and    rdx,0xffffffffffffffe2
   16545:	48 83 c2 3c          	add    rdx,0x3c
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
   16549:	48 8d 0c 02          	lea    rcx,[rdx+rax*1]
   1654d:	48 d1 e9             	shr    rcx,1
    h = fd_ulong_if( c, m, h     ); /* cmov */
   16550:	44 8b 0c ce          	mov    r9d,DWORD PTR [rsi+rcx*8]
   16554:	4c 8d 41 01          	lea    r8,[rcx+0x1]
   16558:	49 39 f9             	cmp    r9,rdi
   1655b:	49 0f 42 c0          	cmovb  rax,r8
   1655f:	48 0f 42 ca          	cmovb  rcx,rdx
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
   16563:	48 8d 14 01          	lea    rdx,[rcx+rax*1]
   16567:	48 d1 ea             	shr    rdx,1
    h = fd_ulong_if( c, m, h     ); /* cmov */
   1656a:	44 8b 0c d6          	mov    r9d,DWORD PTR [rsi+rdx*8]
   1656e:	4c 8d 42 01          	lea    r8,[rdx+0x1]
   16572:	49 39 f9             	cmp    r9,rdi
   16575:	49 0f 42 c0          	cmovb  rax,r8
   16579:	48 0f 42 d1          	cmovb  rdx,rcx
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
   1657d:	48 8d 0c 02          	lea    rcx,[rdx+rax*1]
   16581:	48 d1 e9             	shr    rcx,1
    h = fd_ulong_if( c, m, h     ); /* cmov */
   16584:	44 8b 0c ce          	mov    r9d,DWORD PTR [rsi+rcx*8]
   16588:	4c 8d 41 01          	lea    r8,[rcx+0x1]
   1658c:	49 39 f9             	cmp    r9,rdi
   1658f:	49 0f 42 c0          	cmovb  rax,r8
   16593:	48 0f 42 ca          	cmovb  rcx,rdx
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
   16597:	48 8d 14 01          	lea    rdx,[rcx+rax*1]
   1659b:	48 d1 ea             	shr    rdx,1
    h = fd_ulong_if( c, m, h     ); /* cmov */
   1659e:	44 8b 0c d6          	mov    r9d,DWORD PTR [rsi+rdx*8]
   165a2:	4c 8d 42 01          	lea    r8,[rdx+0x1]
   165a6:	49 39 f9             	cmp    r9,rdi
   165a9:	48 0f 42 d1          	cmovb  rdx,rcx
   165ad:	49 0f 42 c0          	cmovb  rax,r8
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
   165b1:	48 01 d0             	add    rax,rdx
   165b4:	48 d1 e8             	shr    rax,1
    h = fd_ulong_if( c, m, h     ); /* cmov */
   165b7:	8b 0c c6             	mov    ecx,DWORD PTR [rsi+rax*8]
   165ba:	48 39 f9             	cmp    rcx,rdi
   165bd:	48 0f 42 c2          	cmovb  rax,rdx
  }

  return h;
}

/* fd_alloc_block_set *************************************************/
   165c1:	c3                   	ret
   ```
   Will handle other fixmes/todos related, this is too small to pr. 
   ```objdump
   objdump -S -Mintel  --disassemble=fd_groove_data_szc  build/linux/gcc/zen3/unit-test/test_groove_data

build/linux/gcc/zen3/unit-test/test_groove_data:     file format elf64-x86-64


Disassembly of section .text:

0000000000015bc0 <fd_groove_data_szc>:
       decreased to at least floor((h-l)/2) every iteration.  If this
       range is empty, m==l==h and c==1 as there m must be the tightest
       size class such that the l/h updates are no-ops. */

    ulong m = (l+h)>>1; /* No overflow for reasonable SZC_CNT */
    int   c = (((ulong)fd_groove_data_szc_cfg[ m ].obj_footprint)>=footprint);
   15bc0:	48 8d 35 99 5a ff ff 	lea    rsi,[rip+0xffffffffffff5a99]        # b660 <fd_groove_data_szc_cfg>
   15bc7:	8b 56 78             	mov    edx,DWORD PTR [rsi+0x78]
FD_FN_CONST static inline T    fd_##T##_rotate_right( T x, int n        ) { return (T)((x >> (n&(w-1))) | (x << ((-n)&(w-1))));  }

FD_SRC_UTIL_BITS_FD_BITS_IMPL(uchar,  8)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(ushort,16)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(uint,  32)
FD_SRC_UTIL_BITS_FD_BITS_IMPL(ulong, 64)
   15bca:	48 39 fa             	cmp    rdx,rdi
   15bcd:	48 19 c0             	sbb    rax,rax
   15bd0:	83 e0 10             	and    eax,0x10
   15bd3:	48 8d 48 0f          	lea    rcx,[rax+0xf]
    ulong m = (l+h)>>1; /* No overflow for reasonable SZC_CNT */
   15bd7:	48 8d 14 08          	lea    rdx,[rax+rcx*1]
   15bdb:	48 d1 ea             	shr    rdx,1
    int   c = (((ulong)fd_groove_data_szc_cfg[ m ].obj_footprint)>=footprint);
   15bde:	44 8b 0c d6          	mov    r9d,DWORD PTR [rsi+rdx*8]
   15be2:	4c 8d 42 01          	lea    r8,[rdx+0x1]
   15be6:	49 39 f9             	cmp    r9,rdi
   15be9:	49 0f 42 c0          	cmovb  rax,r8
   15bed:	48 0f 42 d1          	cmovb  rdx,rcx
    ulong m = (l+h)>>1; /* No overflow for reasonable SZC_CNT */
   15bf1:	48 8d 0c 02          	lea    rcx,[rdx+rax*1]
   15bf5:	48 d1 e9             	shr    rcx,1
    int   c = (((ulong)fd_groove_data_szc_cfg[ m ].obj_footprint)>=footprint);
   15bf8:	44 8b 0c ce          	mov    r9d,DWORD PTR [rsi+rcx*8]
   15bfc:	4c 8d 41 01          	lea    r8,[rcx+0x1]
   15c00:	49 39 f9             	cmp    r9,rdi
   15c03:	49 0f 42 c0          	cmovb  rax,r8
   15c07:	48 0f 42 ca          	cmovb  rcx,rdx
    ulong m = (l+h)>>1; /* No overflow for reasonable SZC_CNT */
   15c0b:	48 8d 14 01          	lea    rdx,[rcx+rax*1]
   15c0f:	48 d1 ea             	shr    rdx,1
    int   c = (((ulong)fd_groove_data_szc_cfg[ m ].obj_footprint)>=footprint);
   15c12:	44 8b 0c d6          	mov    r9d,DWORD PTR [rsi+rdx*8]
   15c16:	4c 8d 42 01          	lea    r8,[rdx+0x1]
   15c1a:	49 39 f9             	cmp    r9,rdi
   15c1d:	48 0f 42 d1          	cmovb  rdx,rcx
   15c21:	49 0f 42 c0          	cmovb  rax,r8
    ulong m = (l+h)>>1; /* No overflow for reasonable SZC_CNT */
   15c25:	48 01 d0             	add    rax,rdx
   15c28:	48 d1 e8             	shr    rax,1
    int   c = (((ulong)fd_groove_data_szc_cfg[ m ].obj_footprint)>=footprint);
   15c2b:	8b 0c c6             	mov    ecx,DWORD PTR [rsi+rax*8]
   15c2e:	48 39 f9             	cmp    rcx,rdi
   15c31:	48 0f 42 c2          	cmovb  rax,rdx
    l = fd_ulong_if( c, l, m+1UL ); /* cmov */
    h = fd_ulong_if( c, m, h     ); /* cmov */
  }

  return h;
}
   15c35:	c3                   	ret
   ```
   also checked vinyl_data, to fixme/todo to remove so not committed anything.
 ```objdump
 objdump -S -Mintel  --disassemble=fd_vinyl_data_szc  build/linux/gcc/zen3/unit-test/test_vinyl_data |& rg "m =" | wc -l
7
 objdump -S -Mintel  --disassemble=fd_vinyl_data_szc  build/linux/gcc/zen3/unit-test/test_vinyl_data |& rg 'jmp|je|jne|jg|jge|jl|jle|ja|jae|jb|jbe|js|jns|jo|jno|jc|jnc|jp|jnp|call|ret'
FD_FN_CONST static inline T    fd_##T##_rotate_right( T x, int n        ) { return (T)((x >> (n&(w-1))) | (x << ((-n)&(w-1))));  }
  return l;
   118b8:	c3                   	ret
   same things
  ```