### PR TITLE
rent: update rent exempt to int arithmetic

### DIFF
--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent1.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent1.c
@@ -1,12 +1,30 @@
 #include "fd_sysvar_rent.h"
 #include "../../types/fd_cast.h"
 
-/* https://github.com/solana-labs/solana/blob/8f2c8b8388a495d2728909e30460aa40dcc5d733/sdk/program/src/rent.rs#L36 */
-#define ACCOUNT_STORAGE_OVERHEAD (128)
+/* https://github.com/anza-xyz/solana-sdk/blob/rent%40v4.2.1/rent/src/lib.rs#L86 */
+#define ACCOUNT_STORAGE_OVERHEAD (128UL)
+
+/* Bit patterns of 1.0 and 2.0, the two exemption thresholds computed in
+   integer arithmetic.
+   https://github.com/anza-xyz/solana-sdk/blob/rent%40v4.2.1/rent/src/lib.rs#L59-L66 */
+
+#define EXEMPTION_THRESHOLD_1_BITS (0x3ff0000000000000UL)
+#define EXEMPTION_THRESHOLD_2_BITS (0x4000000000000000UL)
 
 ulong
 fd_rent_exempt_minimum_balance( fd_rent_t const * rent,
                                 ulong             data_len ) {
-  /* https://github.com/anza-xyz/agave/blob/d2124a995f89e33c54f41da76bfd5b0bd5820898/sdk/program/src/rent.rs#L74 */
-  return fd_rust_cast_double_to_ulong( (double)((data_len + ACCOUNT_STORAGE_OVERHEAD) * rent->lamports_per_uint8_year) * rent->exemption_threshold );
+  ulong bytes = data_len + ACCOUNT_STORAGE_OVERHEAD;
+
+  /* For thresholds 1.0 and 2.0 the product is exact in integer
+     arithmetic, whereas the double round trip below rounds it once it
+     exceeds 2^53.  The threshold is matched bit-for-bit, as upstream
+     compares the raw 8 bytes.
+     https://github.com/anza-xyz/solana-sdk/blob/rent%40v4.2.1/rent/src/lib.rs#L136-L162 */
+
+  ulong threshold_bits = fd_dblbits( rent->exemption_threshold );
+  if( FD_LIKELY( threshold_bits==EXEMPTION_THRESHOLD_1_BITS ) ) return       bytes * rent->lamports_per_uint8_year;
+  if( FD_LIKELY( threshold_bits==EXEMPTION_THRESHOLD_2_BITS ) ) return 2UL * bytes * rent->lamports_per_uint8_year;
+
+  return fd_rust_cast_double_to_ulong( (double)( bytes * rent->lamports_per_uint8_year ) * rent->exemption_threshold );
 }

--- a/src/flamenco/runtime/sysvar/test_sysvar_rent.c
+++ b/src/flamenco/runtime/sysvar/test_sysvar_rent.c
@@ -54,7 +54,24 @@ test_rent_exempt_vector[] = {
   { .data_len=    82, .lamports_per_byte_year=46980000, .exemption_threshold_bits=0x3f236b06e70b7421UL, .min_balance=   1461600UL },
   { .data_len=     8, .lamports_per_byte_year=    3480, .exemption_threshold_bits=0x4000000000000000UL, .min_balance=    946560UL },
   { .data_len=     8, .lamports_per_byte_year=46980000, .exemption_threshold_bits=0x3f236b06e70b7421UL, .min_balance=    946560UL },
-  { .data_len=     9, .lamports_per_byte_year=46980000, .exemption_threshold_bits=0x3f236b06e70b7421UL, .min_balance=    953520UL }
+  { .data_len=     9, .lamports_per_byte_year=46980000, .exemption_threshold_bits=0x3f236b06e70b7421UL, .min_balance=    953520UL },
+
+  /* Thresholds 1.0 and 2.0 with a product exceeding 2^53, where integer
+     and double arithmetic disagree.  lamports_per_byte_year sits at the
+     largest value each threshold admits, and 10485760 is the largest
+     account data length. */
+  { .data_len=    4993, .lamports_per_byte_year=1759197129867UL, .exemption_threshold_bits=0x3ff0000000000000UL, .min_balance=    9008848502048907UL },
+  { .data_len=10485760, .lamports_per_byte_year=1759197129867UL, .exemption_threshold_bits=0x3ff0000000000000UL, .min_balance=18446744073706816896UL },
+  { .data_len=   10113, .lamports_per_byte_year= 879598564933UL, .exemption_threshold_bits=0x4000000000000000UL, .min_balance=   18015937806957706UL },
+  { .data_len=10485760, .lamports_per_byte_year= 879598564933UL, .exemption_threshold_bits=0x4000000000000000UL, .min_balance=18446744073696331008UL },
+  { .data_len=10485760, .lamports_per_byte_year= 116163352091UL, .exemption_threshold_bits=0x3ff0000000000000UL, .min_balance= 1218075899730791808UL },
+  { .data_len=10485760, .lamports_per_byte_year= 116163352091UL, .exemption_threshold_bits=0x4000000000000000UL, .min_balance= 2436151799461583616UL },
+  { .data_len=10485760, .lamports_per_byte_year=         6960UL, .exemption_threshold_bits=0x3ff0000000000000UL, .min_balance=         72981780480UL },
+
+  /* Any other threshold keeps the double computation, saturating like a
+     Rust `as u64` cast. */
+  { .data_len=     200, .lamports_per_byte_year=         3480UL, .exemption_threshold_bits=0x3ff8000000000000UL, .min_balance=             1712160UL },
+  { .data_len=10485760, .lamports_per_byte_year=1759197129867UL, .exemption_threshold_bits=0x3ff8000000000000UL, .min_balance=18446744073709551615UL }
 };
 #define test_rent_exempt_vector_end (fd_rent_exempt_fixture_t const *)( (uchar const *)test_rent_exempt_vector + sizeof(test_rent_exempt_vector) )
 


### PR DESCRIPTION
Align with solana-rent=4.2.1 (agave 4.2 / 4.3)