### PR TITLE
restore: remove unused account_data.owner field

### DIFF
--- a/src/discof/restore/utils/fd_ssparse.c
+++ b/src/discof/restore/utils/fd_ssparse.c
@@ -453,7 +453,6 @@ advance_account_header( fd_ssparse_t *                ssparse,
   result->account_header.hash       = hdr+104UL;
   result->account_header.slot       = ssparse->slot;
 
-  ssparse->account.owner               = hdr+64UL;
   ssparse->account.data_len            = result->account_header.data_len;
   ssparse->account.data_bytes_consumed = 0UL;
   ssparse->state = FD_SSPARSE_STATE_ACCOUNT_DATA;
@@ -488,7 +487,6 @@ advance_account_data( fd_ssparse_t *                ssparse,
   ssparse->account.data_bytes_consumed += consume;
   result->bytes_consumed                = consume;
 
-  result->account_data.owner    = ssparse->account.owner;
   result->account_data.data_sz  = consume;
   result->account_data.data     = data;
 

--- a/src/discof/restore/utils/fd_ssparse.h
+++ b/src/discof/restore/utils/fd_ssparse.h
@@ -36,7 +36,6 @@ struct fd_ssparse {
   } tar;
 
   struct {
-    uchar const * owner;
     uchar header[ 136UL ];
     ulong header_bytes_consumed;
     ulong data_bytes_consumed;
@@ -81,7 +80,6 @@ struct fd_ssparse_advance_result {
     } account_header;
 
     struct {
-      uchar const * owner;
       uchar const * data;
       ulong         data_sz;
     } account_data;


### PR DESCRIPTION
Added by b564cf0 for a check cee3317e later moved to account_header.owner.