### PR TITLE
net: networking stack auto configuration

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -902,24 +902,47 @@ dynamic_port_range = "8900-9000"
 # fanning in from these various network senders to transmit on the
 # queues we have available.
 [net]
+    # Firedancer can automatically configure most networking
+    # options. The auto_level determines how the network stack
+    # is optimized. Options set to an explicit value are never
+    # modified regardless of auto_level's value.
+    #
+    #  "standard"
+    #   Enables networking features which auto configuration
+    #   determines are safe and supported on this system.
+    #
+    #  "minimal" (default)
+    #   Resolves all "auto" options to their most conservative
+    #   values.  This will reduce networking performance and is
+    #   a worst case backup.
+    #
+    #   If you suspect an error is caused by Firedancer's auto
+    #   configuration, try setting this to "minimal" to see if
+    #   the issue resolves. If you need "minimal" to make
+    #   your validator work, please report your issue with "standard"
+    #   as a bug at https://github.com/firedancer-io/firedancer/issues
+    #   with the prefix "auto config: ", alongside your log file.
+    auto_level = "minimal"
+
     # The provider determines which Linux networking stack is used by
     # Firedancer.  Possible values for the option are:
     #
     #  "xdp" (default)
-    #   Use Linux express data path APIs for high performance networking.
-    #   These APIs map memory from the network device directly into
-    #   Firedancer to bypass parts of the kernel when reading and writing
-    #   data.
+    #   Use Linux express data path APIs for high performance
+    #   networking. These APIs map memory from the network device
+    #   directly into Firedancer to bypass parts of the kernel when
+    #   reading and writing data.
     #
     #  "socket"
     #   Use UDP sockets and system calls like `send(2)` for networking.
-    #   Sockets are slower and socket support is provided on a best-effort
-    #   basis.  The socket option is provided as a fallback for hosts which
-    #   do not support XDP, and to support experimental features that are
-    #   not yet implemented in the XDP stack.
+    #   Sockets are slower and socket support is provided on a
+    #   best-effort basis.  The socket option is provided as a fallback
+    #   for hosts which do not support XDP, and to support experimental
+    #   features that are not yet implemented in the XDP stack.
     #
-    # Using the XDP networking stack is strongly preferred where possible,
-    # as it is faster and better tested by the development team.
+    # Using the XDP networking stack is strongly preferred where
+    # possible, as it is faster and better tested by the development
+    # team.
     provider = "xdp"
 
     # Which interface to bind to for network traffic.  Currently,
@@ -952,7 +975,10 @@ dynamic_port_range = "8900-9000"
         # This option selects the XDP provider.  Possible values for
         # this option are:
         #
-        # "skb" (default)
+        # "auto" (default)
+        #   Firedancer auto selects based on what your system is safely capable of.
+        #
+        # "skb"
         #   XDP provided by the kernel's generic network code.  This is
         #   the slowest mode, but it is well tested and compatible with
         #   all Linux network devices and drivers.
@@ -961,18 +987,12 @@ dynamic_port_range = "8900-9000"
         #   XDP provided by the device driver.  This mode is much faster
         #   than "skb" but only works for certain hardware.  May require
         #   very recent Linux versions.  Can be less stable than "skb"
-        #   mode.  Tested extensively with ConnectX NICs (mlx5), Intel
-        #   X710 (i40e), and Intel E810 (ice).
-        #   Full list of network drivers supporting XDP:
-        #   https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp
+        #   mode.  Tested extensively with ConnectX NICs (mlx5).
         #
-        # "default"
-        #   Selects "skb" or "drv" automatically.
-        #
-        # If the kernel/hardware does not support driver mode, then
-        # `fdctl run` will fail to start up with "operation not
+        # With "drv" mode chosen on kernel/hardware which does not support driver
+        # mode, then `fdctl run` will fail to start up with "operation not
         # supported".
-        xdp_mode = "skb"
+        xdp_mode = "auto"
 
         # This option helps reduce CPU usage when receiving packets.
         # If enabled, the net tile instructs the network device to copy
@@ -981,38 +1001,52 @@ dynamic_port_range = "8900-9000"
         # to 100 Gbps per net tile.
         #
         # Only works when XDP is provided by the network driver (see
-        # the xdp_mode option above).  If the kernel/hardware does not
-        # support zero copy, `fdctl run` will fail to start up with
-        # "operation not supported".
-        xdp_zero_copy = false
+        # the xdp_mode option above).  If set to "true" on kernel/hardware
+        # which does not support zero copy, `fdctl run` will fail to
+        # start up with "operation not supported".
+        #
+        # xdp_zero_copy can be broken even when enabled on drivers/kernels
+        # which supposedly support it.  Support varies wildly by exact Linux
+        # version, with regressions being common.  Therefore we recommend
+        # leaving this option set to "auto".
+        #
+        # If "auto" is in use for xdp_mode or native_bond, do not manually set
+        # xdp_zero_copy to "true", and instead leave as either "auto" or "false".
+        #
+        # Its possible values are:
+        #  "true", "false" or "auto" (default)
+        xdp_zero_copy = "auto"
 
         # The poll_mode option determines how Firedancer polls NAPI (Linux's
         # high perf networking mechanisms).  Its possible values are:
         #
-        #  "softirq" (default)
+        #  "auto" (default)
+        #   Firedancer auto selects based on what your system is safely capable of.
+        #
+        #  "softirq"
         #   Relies significantly more on Linux to manage NAPI through wakeups,
         #   softirqs, and under higher network load, a separate ksoftirqd
         #   thread which Linux schedules onto a separate core.
         #
         #  "prefbusy"
-        #   Experimental option which gives Firedancer significantly more
-        #   control over how and when NAPI is polled.  Reduces networking
-        #   related IRQs and ksoftirqds to near zero on well supported NIC
-        #   drivers, increasing determinism and stability during DoS attacks
-        #   and high net load.
+        #   Option which gives Firedancer significantly more control
+        #   over how and when NAPI is polled.  Reduces networking related
+        #   IRQs and ksoftirqds to near zero on well supported NIC drivers,
+        #   increasing determinism and stability during DoS attacks and
+        #   high net load.
         #
         #   Hardware Support: Currently best supported on mlx5 (Mellanox).
         #   Depending on the driver, XDP Copy Mode can see noticeable throughput
         #   gains (up to 2.4x on mlx5, 1.5x on i40e).  Zero-copy RX throughput
         #   generally remains the same across both poll modes.
         #
-        # Extra info
+        # Extra info:
         #
-        #  Requires a kernel version of at least v5.11 (Feb 2021).
+        #  Prefbusy requires a kernel version of at least v5.11 (Feb 2021).
         #
         #  Prefbusy mode increases tail latency for other applications on
         #  the system sharing the same network interface.
-        poll_mode = "softirq"
+        poll_mode = "auto"
 
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
@@ -1053,7 +1087,8 @@ dynamic_port_range = "8900-9000"
         #
         # "auto"
         #   Attempts to run in "dedicated" mode but automatically falls
-        #   back to "simple" mode if necessary.
+        #   back to "simple" mode if necessary.  Not affected by auto_level
+        #   and is separate from the auto configure system.
         rss_queue_mode = "simple"
 
         # Some specialized networking setups, including DoubleZero,
@@ -1073,21 +1108,24 @@ dynamic_port_range = "8900-9000"
 
         # Enable native network bonding support.
         #
-        # If native_bond is set to 'true' and [net.interface] is a 'bond'
-        # type network device, install XDP config at bond slave devices
-        # instead of the bond device itself.
+        # If native_bond is set to "true" and [net.interface] is a
+        # bond type network device, install XDP config at bond slave
+        # devices instead of the bond device itself.
         #
         # Requires net_tile_count to be divisible by the number of slave
         # devices.  This causes outgoing traffic to be load balanced with
         # an arbitrary/opaque hash policy.  Supports up to 16 slave devices.
         #
-        # Assumes that bond memberships don't change, i.e. running
-        # `ip link set dev eth1 master bond0` will crash Firedancer.
+        # Assumes that bond memberships don't change, i.e. running `ip
+        # link set dev eth1 master bond0` will crash Firedancer.
         # However, it is fine to bring individual bonded devices down,
         # or unplug cables for maintenance.  In other words, executing
         # `ip link set dev eth1 down` while Firedancer is running is
         # just fine.
-        native_bond = false
+        #
+        # Its possible values are:
+        #  "true", "false" or "auto" (default)
+        native_bond = "auto"
 
     [net.socket]
         # Sets the socket receive buffer size via SO_RCVBUF.

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -907,11 +907,11 @@ dynamic_port_range = "8900-9000"
     # is optimized. Options set to an explicit value are never
     # modified regardless of auto_level's value.
     #
-    #  "standard"
+    #  "standard" (default)
     #   Enables networking features which auto configuration
     #   determines are safe and supported on this system.
     #
-    #  "minimal" (default)
+    #  "minimal"
     #   Resolves all "auto" options to their most conservative
     #   values.  This will reduce networking performance and is
     #   a worst case backup.
@@ -922,7 +922,7 @@ dynamic_port_range = "8900-9000"
     #   your validator work, please report your issue with "standard"
     #   as a bug at https://github.com/firedancer-io/firedancer/issues
     #   with the prefix "auto config: ", alongside your log file.
-    auto_level = "minimal"
+    auto_level = "standard"
 
     # The provider determines which Linux networking stack is used by
     # Firedancer.  Possible values for the option are:

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -991,6 +991,28 @@ telemetry = true
 # fanning in from these various network senders to transmit on the
 # queues we have available.
 [net]
+    # Firedancer can automatically configure most networking
+    # options. The auto_level determines how the network stack
+    # is optimized. Options set to an explicit value are never
+    # modified regardless of auto_level's value.
+    #
+    #  "standard"
+    #   Enables networking features which auto configuration
+    #   determines are safe and supported on this system.
+    #
+    #  "minimal" (default)
+    #   Resolves all "auto" options to their most conservative
+    #   values.  This will reduce networking performance and is
+    #   a worst case backup.
+    #
+    #   If you suspect an error is caused by Firedancer's auto
+    #   configuration, try setting this to "minimal" to see if
+    #   the issue resolves. If you need "minimal" to make
+    #   your validator work, please report your issue with "standard"
+    #   as a bug at https://github.com/firedancer-io/firedancer/issues
+    #   with the prefix "auto config: ", alongside your log file.
+    auto_level = "minimal"
+
     # The provider determines which Linux networking stack is used by
     # Firedancer.  Possible values for the option are:
     #
@@ -1041,7 +1063,10 @@ telemetry = true
         # This option selects the XDP provider.  Possible values for
         # this option are:
         #
-        # "skb" (default)
+        # "auto" (default)
+        #   Firedancer auto selects based on what your system is safely capable of.
+        #
+        # "skb"
         #   XDP provided by the kernel's generic network code.  This is
         #   the slowest mode, but it is well tested and compatible with
         #   all Linux network devices and drivers.
@@ -1050,18 +1075,12 @@ telemetry = true
         #   XDP provided by the device driver.  This mode is much faster
         #   than "skb" but only works for certain hardware.  May require
         #   very recent Linux versions.  Can be less stable than "skb"
-        #   mode.  Tested extensively with ConnectX NICs (mlx5), Intel
-        #   X710 (i40e), and Intel E810 (ice).
-        #   Full list of network drivers supporting XDP:
-        #   https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#xdp
+        #   mode.  Tested extensively with ConnectX NICs (mlx5).
         #
-        # "default"
-        #   Selects "skb" or "drv" automatically.
-        #
-        # If the kernel/hardware does not support driver mode, then
-        # `firedancer run` will fail to start up with "operation not
+        # With "drv" mode chosen on kernel/hardware which does not support driver
+        # mode, then `firedancer run` will fail to start up with "operation not
         # supported".
-        xdp_mode = "skb"
+        xdp_mode = "auto"
 
         # This option helps reduce CPU usage when receiving packets.
         # If enabled, the net tile instructs the network device to copy
@@ -1070,38 +1089,52 @@ telemetry = true
         # to 100 Gbps per net tile.
         #
         # Only works when XDP is provided by the network driver (see
-        # the xdp_mode option above).  If the kernel/hardware does not
-        # support zero copy, `firedancer run` will fail to start up with
-        # "operation not supported".
-        xdp_zero_copy = false
+        # the xdp_mode option above).  If set to "true" on kernel/hardware
+        # which does not support zero copy, `firedancer run` will fail to
+        # start up with "operation not supported".
+        #
+        # xdp_zero_copy can be broken even when enabled on drivers/kernels
+        # which supposedly support it.  Support varies wildly by exact Linux
+        # version, with regressions being common.  Therefore we recommend
+        # leaving this option set to "auto".
+        #
+        # If "auto" is in use for xdp_mode or native_bond, do not manually set
+        # xdp_zero_copy to "true", and instead leave as either "auto" or "false".
+        #
+        # Its possible values are:
+        #  "true", "false" or "auto" (default)
+        xdp_zero_copy = "auto"
 
         # The poll_mode option determines how Firedancer polls NAPI (Linux's
         # high perf networking mechanisms).  Its possible values are:
         #
-        #  "softirq" (default)
+        #  "auto" (default)
+        #   Firedancer auto selects based on what your system is safely capable of.
+        #
+        #  "softirq"
         #   Relies significantly more on Linux to manage NAPI through wakeups,
         #   softirqs, and under higher network load, a separate ksoftirqd
         #   thread which Linux schedules onto a separate core.
         #
         #  "prefbusy"
-        #   Experimental option which gives Firedancer significantly more
-        #   control over how and when NAPI is polled.  Reduces networking
-        #   related IRQs and ksoftirqds to near zero on well supported NIC
-        #   drivers, increasing determinism and stability during DoS attacks
-        #   and high net load.
+        #   Option which gives Firedancer significantly more control
+        #   over how and when NAPI is polled.  Reduces networking related
+        #   IRQs and ksoftirqds to near zero on well supported NIC drivers,
+        #   increasing determinism and stability during DoS attacks and
+        #   high net load.
         #
         #   Hardware Support: Currently best supported on mlx5 (Mellanox).
         #   Depending on the driver, XDP Copy Mode can see noticeable throughput
         #   gains (up to 2.4x on mlx5, 1.5x on i40e).  Zero-copy RX throughput
         #   generally remains the same across both poll modes.
         #
-        # Extra info
+        # Extra info:
         #
-        #  Requires a kernel version of at least v5.11 (Feb 2021).
+        #  Prefbusy requires a kernel version of at least v5.11 (Feb 2021).
         #
         #  Prefbusy mode increases tail latency for other applications on
         #  the system sharing the same network interface.
-        poll_mode = "softirq"
+        poll_mode = "auto"
 
         # XDP uses metadata queues shared across the kernel and
         # userspace to relay events about incoming and outgoing packets.
@@ -1143,7 +1176,8 @@ telemetry = true
         #
         # "auto" (default)
         #   Attempts to run in "dedicated" mode but automatically falls
-        #   back to "simple" mode if necessary.
+        #   back to "simple" mode if necessary. Not affected by auto_level
+        #   and is separate from the auto configure system.
         rss_queue_mode = "auto"
 
         # Some specialized networking setups, including DoubleZero,
@@ -1165,14 +1199,13 @@ telemetry = true
 
         # Enable native network bonding support.
         #
-        # If native_bond is set to 'true' and [net.interface] is a
-        # 'bond' type network device, install XDP config at bond slave
+        # If native_bond is set to "true" and [net.interface] is a
+        # bond type network device, install XDP config at bond slave
         # devices instead of the bond device itself.
         #
         # Requires net_tile_count to be divisible by the number of slave
-        # devices.  This causes outgoing traffic to be load balanced
-        # with an arbitrary/opaque hash policy.  Supports up to 16 slave
-        # devices.
+        # devices.  This causes outgoing traffic to be load balanced with
+        # an arbitrary/opaque hash policy.  Supports up to 16 slave devices.
         #
         # Assumes that bond memberships don't change, i.e. running `ip
         # link set dev eth1 master bond0` will crash Firedancer.
@@ -1180,7 +1213,10 @@ telemetry = true
         # or unplug cables for maintenance.  In other words, executing
         # `ip link set dev eth1 down` while Firedancer is running is
         # just fine.
-        native_bond = false
+        #
+        # Its possible values are:
+        #  "true", "false" or "auto" (default)
+        native_bond = "auto"
 
     [net.socket]
         # Sets the socket receive buffer size via SO_RCVBUF.  Raises

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -996,11 +996,11 @@ telemetry = true
     # is optimized. Options set to an explicit value are never
     # modified regardless of auto_level's value.
     #
-    #  "standard"
+    #  "standard" (default)
     #   Enables networking features which auto configuration
     #   determines are safe and supported on this system.
     #
-    #  "minimal" (default)
+    #  "minimal"
     #   Resolves all "auto" options to their most conservative
     #   values.  This will reduce networking performance and is
     #   a worst case backup.
@@ -1011,7 +1011,7 @@ telemetry = true
     #   your validator work, please report your issue with "standard"
     #   as a bug at https://github.com/firedancer-io/firedancer/issues
     #   with the prefix "auto config: ", alongside your log file.
-    auto_level = "minimal"
+    auto_level = "standard"
 
     # The provider determines which Linux networking stack is used by
     # Firedancer.  Possible values for the option are:

--- a/src/app/platform/fd_config_extract.h
+++ b/src/app/platform/fd_config_extract.h
@@ -111,6 +111,31 @@ fdctl_cfg_get_bool( int *                 out,
   return 1;
 }
 
+/* Handles true, false, "true", "false" and "auto" */
+static inline int
+fdctl_cfg_get_boolau( int *                 out,
+                      ulong                 out_sz FD_PARAM_UNUSED,
+                      fd_pod_info_t const * info,
+                      char const *          path ) {
+  if( info->val_type==FD_POD_VAL_TYPE_CSTR ) {
+    char const * info_val = (char const *)info->val;
+    if( !strcmp( info_val, "auto"  ) ) {
+      *out = 2;
+      return 1;
+    } else if( !strcmp( info_val, "true"  ) ) {
+      *out = 1;
+      return 1;
+    } else if( !strcmp( info_val, "false" ) ) {
+      *out = 0;
+      return 1;
+    }
+    FD_LOG_WARNING(( "invalid value of `%s` entered for `%s`, must be true, false or auto. ",
+                     info_val, path ));
+    return 0;
+  }
+  return fdctl_cfg_get_bool( out, out_sz, info, path );
+}
+
 static inline int
 fdctl_cfg_get_float( float *               out,
                      ulong                 out_sz FD_PARAM_UNUSED,

--- a/src/app/shared/Local.mk
+++ b/src/app/shared/Local.mk
@@ -3,11 +3,13 @@ ifdef FD_HAS_LINUX
 
 $(call make-lib,fdctl_shared)
 
-$(call add-objs,fd_config fd_config_parse,fdctl_shared)
 $(call add-objs,fd_bootinfo,fdctl_shared)
+$(call add-objs,fd_config fd_config_parse fd_config_auto,fdctl_shared)
 $(call add-objs,fd_obj_callbacks,fdctl_shared)
 $(call make-unit-test,test_config_parse,test_config_parse,fd_fdctl fdctl_shared fdctl_platform fd_disco fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_config_parse)
+$(call make-unit-test,test_config_auto,test_config_auto,fd_fdctl fdctl_shared fdctl_platform fd_disco fd_ballet fd_tango fd_util)
+$(call run-unit-test,test_config_auto)
 $(call make-fuzz-test,fuzz_fdctl_config,fuzz_fdctl_config,fd_fdctl fdctl_shared fdctl_platform fd_disco fd_ballet fd_tango fd_util)
 
 $(call add-objs,boot/fd_boot,fdctl_shared)

--- a/src/app/shared/boot/fd_boot.c
+++ b/src/app/shared/boot/fd_boot.c
@@ -240,6 +240,10 @@ fd_main_init( int *                      pargc,
   fd_log_level_stderr_set( config->log.level_stderr1 );
   fd_log_level_flush_set( config->log.level_flush1 );
 
+  /* When auto config info/decisions are collected is before when the
+     log file is setup, so the logging of this info must be done separately. */
+  if( !boot_silent ) FD_LOG_INFO(( "%s", config->auto_config_log ));
+
   return config_fd<0;
 }
 

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include "fd_config.h"
+#include "fd_config_auto.h"
 #include "fd_config_private.h"
 
 #include "../platform/fd_net_util.h"
@@ -388,6 +389,8 @@ fd_config_fill( fd_config_t * config,
     fd_config_fillh( config );
   }
 
+  fd_config_auto( config );
+
   if( FD_LIKELY( config->is_live_cluster) ) {
     if( FD_UNLIKELY( !config->development.sandbox ) )                            FD_LOG_ERR(( "trying to join a live cluster, but configuration disables the sandbox which is a development only feature" ));
     if( FD_UNLIKELY( config->development.no_clone ) )                            FD_LOG_ERR(( "trying to join a live cluster, but configuration disables multiprocess which is a development only feature" ));
@@ -530,11 +533,25 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_EMPTY( hugetlbfs.max_page_size );
 
   CFG_HAS_NON_ZERO( net.ingress_buffer_size );
+  if( 0!=strcmp( config->net.auto_level, "standard" ) &&
+      0!=strcmp( config->net.auto_level, "minimal"  ) ) {
+    FD_LOG_ERR(( "invalid `net.auto_level`: \"%s\"; must be \"standard\" or \"minimal\"",
+                 config->net.auto_level ));
+  }
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
-    CFG_HAS_NON_EMPTY( net.xdp.xdp_mode );
+    if( 0!=strcmp( config->net.xdp.xdp_mode, "skb"     ) &&
+        0!=strcmp( config->net.xdp.xdp_mode, "drv"     ) &&
+        0!=strcmp( config->net.xdp.xdp_mode, "auto"    ) &&
+        0!=strcmp( config->net.xdp.xdp_mode, "default" ) ) {
+      FD_LOG_ERR(( "invalid `net.xdp.xdp_mode`: \"%s\"; must be \"skb\", \"drv\", \"auto\" or \"default\"",
+                   config->net.xdp.xdp_mode ));
+    }
 
-    if( 0!=strcmp( config->net.xdp.poll_mode, "prefbusy" ) && 0!=strcmp( config->net.xdp.poll_mode, "softirq" ) ) {
-      FD_LOG_ERR(( "invalid `net.xdp.poll_mode`: must be \"prefbusy\" or \"softirq\"" ));
+    if( 0!=strcmp( config->net.xdp.poll_mode, "prefbusy" ) &&
+        0!=strcmp( config->net.xdp.poll_mode, "softirq"  ) &&
+        0!=strcmp( config->net.xdp.poll_mode, "auto"     ) ) {
+      FD_LOG_ERR(( "invalid `net.xdp.poll_mode`: \"%s\"; must be \"prefbusy\", \"softirq\" or \"auto\"",
+                   config->net.xdp.poll_mode ));
     }
 
     CFG_HAS_POW2     ( net.xdp.xdp_rx_queue_size );
@@ -549,7 +566,8 @@ fd_config_validate( fd_config_t const * config ) {
     CFG_HAS_NON_ZERO( net.socket.receive_buffer_size );
     CFG_HAS_NON_ZERO( net.socket.send_buffer_size );
   } else {
-    FD_LOG_ERR(( "invalid `net.provider`: must be \"xdp\" or \"socket\"" ));
+    FD_LOG_ERR(( "invalid `net.provider`: \"%s\"; must be \"xdp\" or \"socket\"",
+                 config->net.provider ));
   }
 
   CFG_HAS_NON_ZERO( tiles.netlink.max_routes           );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -193,6 +193,8 @@ struct fd_configf {
 typedef struct fd_configf fd_configf_t;
 
 struct fd_config_net {
+  char auto_level[ 12 ]; /* "standard" or "minimal" */
+
   char provider[ 8 ]; /* "xdp" or "socket" */
 
   char interface[ IF_NAMESIZE ];
@@ -203,16 +205,16 @@ struct fd_config_net {
   uint ingress_buffer_size;
 
   struct {
-    char xdp_mode[ 8 ];
-    int  xdp_zero_copy;
-    char poll_mode[ 16 ]; /* "prefbusy" or "softirq" */
+    char xdp_mode[ 8 ]; /* "drv", "skb" or "auto" */
+    int  xdp_zero_copy; /* true/false or "auto" */
+    char poll_mode[ 16 ]; /* "prefbusy", "softirq" or "auto" */
 
     uint xdp_rx_queue_size;
     uint xdp_tx_queue_size;
     uint flush_timeout_micros;
     char rss_queue_mode[ 16 ]; /* "simple", "dedicated", or "auto" */
     int  listen_gre;
-    int  native_bond;
+    int  native_bond; /* true/false or "auto" */
   } xdp;
 
   struct {
@@ -280,6 +282,10 @@ struct fd_config {
        here for easy communication to child processes. */
     int  log_fd;
   } log;
+
+  /* Necessary to output auto config's decisions/observed system info
+     to log file, since auto config runs before the log file is setup. */
+  char auto_config_log[ 512 ];
 
   struct {
     ushort expected_shred_version;

--- a/src/app/shared/fd_config_auto.c
+++ b/src/app/shared/fd_config_auto.c
@@ -1,0 +1,387 @@
+#include "fd_config_auto.h"
+#include "../../disco/net/fd_linux_bond.h"
+#include "../../disco/net/fd_net_tile.h"
+
+#include <stdlib.h> /* strtoul */
+#include <limits.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/utsname.h>
+
+#define PROVIDER_CNT       ( 1UL)
+#define FEAT_CNT_MAX       ( 8UL)
+#define NET_DRIVER_CNT_MAX (16UL)
+
+struct fd_auto_info {
+  /* System */
+  ulong linux_major;
+  ulong linux_minor;
+
+  /* Networking */
+  char driver[ NAME_SZ ];
+  int  is_virtual_if;
+  int  is_bonded_if;
+  uint bonded_if_slave_count;
+};
+typedef struct fd_auto_info fd_auto_info_t;
+
+struct fd_auto_driver_rq {
+  char const * name;
+  ulong        min_linux_major;
+  ulong        min_linux_minor;
+
+  /* 0 = no max linux version */
+  ulong        max_linux_major;
+  ulong        max_linux_minor;
+};
+typedef struct fd_auto_driver_rq fd_auto_driver_rq_t;
+
+struct fd_auto_feat {
+  char const *         name;
+  fd_auto_driver_rq_t  supported_drivers[ NET_DRIVER_CNT_MAX ];
+
+  /* Checks if networking feature is auto and sets the default */
+  int  (*is_feat_auto)( fd_config_t          * config );
+  int  (*check       )( fd_config_t    const * config,
+                        fd_auto_info_t const * info   );
+  void (*apply       )( fd_config_t          * config );
+};
+typedef struct fd_auto_feat fd_auto_feat_t;
+
+struct fd_auto_provider {
+  char const *   name;
+  /* Later features observe earlier features updates to config,
+     so the order is important.  e.g. ZC checks xdp_mode is DRV
+     so DRV needs to come before ZC in the feats ordering. */
+  fd_auto_feat_t feats[ FEAT_CNT_MAX ];
+
+  int (*check)( fd_config_t    const * config,
+                fd_auto_info_t const * info );
+};
+typedef struct fd_auto_provider fd_auto_provider_t;
+
+/* XDP checks/apply */
+
+static int
+check_xdp_auto( fd_config_t    const * config,
+                fd_auto_info_t const * info FD_PARAM_UNUSED ) {
+  if( strcmp( config->net.provider, "xdp" ) ) return 0;
+  return 1;
+}
+
+static int
+is_xdp_native_bond_auto( fd_config_t * config ) {
+  if( 2!=config->net.xdp.native_bond ) return 0;
+  /* Set to default */
+  config->net.xdp.native_bond = 0;
+  return 1;
+}
+
+static int
+xdp_native_bond_check( fd_config_t    const * config,
+                       fd_auto_info_t const * info ) {
+  if( !info->is_bonded_if ) return 0;
+
+  if( 0==info->bonded_if_slave_count || info->bonded_if_slave_count>FD_NET_BOND_SLAVE_MAX ) return 0;
+
+  /* net_tile_count must be a multiple of the bonded interface's slave count */
+  if( 0!=config->layout.net_tile_count%info->bonded_if_slave_count ) return 0;
+
+  return 1;
+}
+
+static void
+xdp_native_bond_apply( fd_config_t * config ) {
+  config->net.xdp.native_bond = 1;
+}
+
+static int
+is_xdp_mode_auto( fd_config_t * config ) {
+  if( strcmp( config->net.xdp.xdp_mode, "auto" ) ) return 0;
+  /* Set to default */
+  fd_memcpy( config->net.xdp.xdp_mode, "skb", 4 );
+  return 1;
+}
+
+static int
+xdp_drv_check( fd_config_t    const * config,
+               fd_auto_info_t const * info ) {
+  if( info->is_virtual_if &&
+      !config->net.xdp.native_bond ) return 0;
+  return 1;
+}
+
+static void
+xdp_drv_apply( fd_config_t * config ) {
+  fd_memcpy( config->net.xdp.xdp_mode, "drv", 4 );
+}
+
+static int
+is_xdp_prefbusy_auto( fd_config_t * config ) {
+  if( strcmp( config->net.xdp.poll_mode, "auto" ) ) return 0;
+  /* Set to default */
+  fd_memcpy( config->net.xdp.poll_mode, "softirq", 8 );
+  return 1;
+}
+
+static int
+xdp_prefbusy_check( fd_config_t    const * config,
+                    fd_auto_info_t const * info FD_PARAM_UNUSED ) {
+  if( strcmp( config->net.xdp.xdp_mode, "drv") ) return 0;
+  return 1;
+}
+
+static void
+xdp_prefbusy_apply( fd_config_t * config ) {
+  fd_memcpy( config->net.xdp.poll_mode, "prefbusy", 9 );
+}
+
+static int
+is_xdp_zc_auto( fd_config_t * config ) {
+  if( 2!=config->net.xdp.xdp_zero_copy ) return 0;
+  /* Set to default */
+  config->net.xdp.xdp_zero_copy = 0;
+  return 1;
+}
+
+static int
+xdp_zc_check( fd_config_t    const * config FD_PARAM_UNUSED,
+              fd_auto_info_t const * info   FD_PARAM_UNUSED ) {
+  /* zc turned off for initial config auto rollout just to
+     be safe. */
+  return 0;
+}
+
+static void
+xdp_zc_apply( fd_config_t * config ) {
+  config->net.xdp.xdp_zero_copy = 1;
+}
+
+/* Each feature's supported Linux version matrix per driver decided
+   based on fd-linux-version-testbed test results. */
+static const fd_auto_provider_t NET_PROVIDERS[] = {
+  {
+    .name  = "XDP",
+    .check = check_xdp_auto,
+    .feats = {
+      {
+        .name              = "Native Bond",
+        .supported_drivers = { { "mlx5_core", 5, 15, 0, 0} },
+        .is_feat_auto      = is_xdp_native_bond_auto,
+        .check             = xdp_native_bond_check,
+        .apply             = xdp_native_bond_apply
+      },
+      {
+        .name              = "DRV",
+        .supported_drivers = {
+          { "mlx5_core", 5, 15, 6, 3 },
+          { "mlx5_core", 6,  5, 0, 0 },
+        },
+        .is_feat_auto      = is_xdp_mode_auto,
+        .check             = xdp_drv_check,
+        .apply             = xdp_drv_apply,
+      },
+      {
+        .name              = "Prefbusy",
+        .supported_drivers = { { "mlx5_core", 5, 15, 0, 0 } },
+        .is_feat_auto      = is_xdp_prefbusy_auto,
+        .check             = xdp_prefbusy_check,
+        .apply             = xdp_prefbusy_apply
+      },
+      {
+        .name              = "Zero Copy",
+        .supported_drivers = { { "mlx5_core", 6, 1, 0, 0  } },
+        .is_feat_auto      = is_xdp_zc_auto,
+        .check             = xdp_zc_check,
+        .apply             = xdp_zc_apply
+      }
+    }
+  }
+};
+
+static void
+scrape_system( fd_auto_info_t * info ) {
+  struct utsname utsname;
+  if( FD_UNLIKELY( -1==uname( &utsname ) ) ) {
+    FD_LOG_WARNING(( "uname() failed (%i-%s), auto config skipping kernel version detection",
+                     errno, fd_io_strerror( errno ) ));
+    return;
+  }
+
+  /* utsname.release is typically "major.minor.patch-distrojunk",
+     e.g. "6.8.0-45-generic" or "5.14.0-362.8.1.el9_3.x86_64".  We
+     only care about major.minor.  A missing ".minor" is treated as
+     minor 0.  An unparseable release leaves {0,0}, which fails all
+     version requirements (fail-soft). */
+
+  char const * cur = utsname.release;
+  char *       end = NULL;
+
+  ulong major = strtoul( cur, &end, 10 );
+  if( FD_UNLIKELY( end==cur ) ) {
+    FD_LOG_WARNING(( "unrecognized kernel release `%s`, auto config skipping kernel version detection",
+                     utsname.release ));
+    return;
+  }
+
+  ulong minor = 0UL;
+  if( FD_LIKELY( end[0]=='.' ) ) {
+    cur   = end+1;
+    minor = strtoul( cur, &end, 10 );
+    if( FD_UNLIKELY( end==cur ) ) minor = 0UL; /* tolerate "6." */
+  }
+
+  info->linux_major = major;
+  info->linux_minor = minor;
+}
+
+static void
+scrape_driver( char       * driver,
+               char const * if_name ) {
+  char path[ PATH_MAX ], target[ PATH_MAX ];
+  driver[0] = '\0';
+  FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/device/driver", if_name ) );
+
+  long n = readlink( path, target, PATH_MAX-1 );
+  if( FD_UNLIKELY( n<0L ) ) return;
+  target[ n ] = '\0';  /* readlink does not NUL-terminate */
+
+  char const * base = strrchr( target, '/' );
+  fd_cstr_ncpy( driver, base ? base+1 : target, NAME_SZ );
+}
+
+static void
+scrape_networking( fd_auto_info_t * info,
+                   char const     * if_name ) {
+  /* Check for virtual interface */
+  char path[ PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/device", if_name ) );
+  info->is_virtual_if = ( -1==access( path, F_OK ) );
+
+  /* Check for bond */
+  info->is_bonded_if = fd_bonding_is_master( if_name );
+  if( info->is_bonded_if ) info->bonded_if_slave_count = (uint)fd_bonding_slave_cnt( if_name );
+
+  /* Get driver name.  A bond master reports "n/a" so no driver specific
+     config is applied. If all slaves share a driver name then reports
+     that instead. */
+  if( info->is_bonded_if ) {
+    fd_bonding_slave_iter_t iter_[1];
+    for( fd_bonding_slave_iter_t * iter = fd_bonding_slave_iter_init( iter_, if_name );
+         !fd_bonding_slave_iter_done( iter );
+         fd_bonding_slave_iter_next ( iter ) ) {
+
+      char slave_driver[ NAME_SZ ];
+      scrape_driver( slave_driver, fd_bonding_slave_iter_ele( iter ) );
+      if( FD_UNLIKELY( !slave_driver[0] ||
+                     ( info->driver[0]  && strcmp( info->driver, slave_driver ) ) ) ) {
+        fd_memcpy( info->driver, "n/a", 4 );
+        break;
+      }
+      fd_cstr_ncpy( info->driver, slave_driver, NAME_SZ );
+    }
+  } else {
+    scrape_driver( info->driver, if_name );
+  }
+}
+
+static fd_auto_info_t
+fd_auto_scrape_info( fd_config_t const * config ) {
+  fd_auto_info_t info = {0};
+
+  scrape_system    ( &info                        );
+  scrape_networking( &info, config->net.interface );
+
+  return info;
+}
+
+static int
+fd_auto_check_driver( fd_auto_info_t      const * info,
+                      fd_auto_driver_rq_t const * supported_drivers ) {
+  /* Check for driver requirements. */
+  if( !supported_drivers[0].name ) return 1;
+
+  for( ulong i=0UL; i<NET_DRIVER_CNT_MAX; i++ ) {
+    fd_auto_driver_rq_t const * req = &supported_drivers[ i ];
+    if( !req->name ) return 0;
+
+    if( 0==strcmp( info->driver, req->name ) ) {
+      /* Check system linux version is within bounds of min and max
+         of what this driver req requires. */
+      if( req->max_linux_major > 0UL ) {
+        if( info->linux_major>req->max_linux_major ||
+          ( info->linux_major==req->max_linux_major &&
+            info->linux_minor>req->max_linux_minor ) ) continue;
+      }
+
+
+      if( info->linux_major>req->min_linux_major ||
+        ( info->linux_major==req->min_linux_major &&
+          info->linux_minor>=req->min_linux_minor ) ) return 1;
+    }
+  }
+
+  return 0;
+}
+
+/* fd_auto_net resolves any "auto" fields in the networking
+configuration. The resulting configuration is optimized for the system
+but won't always maximally optimize, this is to reduce risk of failures. */
+static void
+fd_auto_net( fd_config_t          * config,
+             fd_auto_info_t const * info ) {
+  /* Providers are in order of priority with first being the highest */
+  int is_provider_set = 0;
+  for( ulong p=0UL; p<PROVIDER_CNT; p++ ) {
+    fd_auto_provider_t const * provider = &NET_PROVIDERS[p];
+
+    /* Check provider requirements */
+    int is_chosen_provider = !is_provider_set && ( !provider->check || provider->check( config, info ) );
+    if( is_chosen_provider ) is_provider_set = 1;
+
+    for( ulong f=0UL; f<FEAT_CNT_MAX; f++ ) {
+      fd_auto_feat_t const * feat = &provider->feats[f];
+      if( !feat->name ) break;
+
+      /* Checks feature is set to "auto", if so replaces "auto" with
+         default and goes onto the next checks */
+      if( !feat->is_feat_auto( config ) ) continue;
+
+      if( !is_chosen_provider ||
+          !strcmp( config->net.auto_level, "minimal" ) ) continue;
+
+      /* Feature's driver/Linux version requirements */
+      if( !fd_auto_check_driver( info, feat->supported_drivers ) ) continue;
+
+      /* Feature's other requirements */
+      if( feat->check && !feat->check( config, info ) ) continue;
+
+      if( FD_UNLIKELY( !feat->apply ) ) {
+        FD_LOG_ERR(( "Applying auto configure net feature %s failed since no apply function was found.", feat->name ));
+      }
+      feat->apply( config );
+    }
+  }
+}
+
+void
+fd_config_auto( fd_config_t * config ) {
+  fd_auto_info_t info = fd_auto_scrape_info( config );
+  fd_auto_net( config, &info );
+
+  fd_cstr_printf( config->auto_config_log, sizeof(config->auto_config_log), NULL,
+      "network auto configure level=%s, provider=%s xdp_mode=%s poll_mode=%s zero_copy=%d native_bond=%d (driver=%s kernel=%lu.%lu virtual_if=%d bonded_if=%d slaves=%u, net_tile_cnt=%u)",
+      config->net.auto_level,
+      config->net.provider,
+      config->net.xdp.xdp_mode,
+      config->net.xdp.poll_mode,
+      config->net.xdp.xdp_zero_copy,
+      config->net.xdp.native_bond,
+      info.driver[0] ? info.driver : "unknown",
+      info.linux_major, info.linux_minor,
+      info.is_virtual_if,
+      info.is_bonded_if,
+      info.bonded_if_slave_count,
+      config->layout.net_tile_count );
+}

--- a/src/app/shared/fd_config_auto.h
+++ b/src/app/shared/fd_config_auto.h
@@ -1,0 +1,13 @@
+#ifndef HEADER_fd_src_app_shared_fd_config_auto_h
+#define HEADER_fd_src_app_shared_fd_config_auto_h
+
+#include "fd_config.h"
+
+FD_PROTOTYPES_BEGIN
+
+void
+fd_config_auto( fd_config_t * config );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_app_shared_fd_config_auto_h */

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -183,17 +183,18 @@ fd_config_extract_pod( uchar *       pod,
 
   CFG_POP      ( cstr,   net.interface                                    );
   CFG_POP      ( cstr,   net.bind_address                                 );
+  CFG_POP      ( cstr,   net.auto_level                                   );
   CFG_POP      ( cstr,   net.provider                                     );
   CFG_POP      ( uint,   net.ingress_buffer_size                          );
   CFG_POP      ( cstr,   net.xdp.xdp_mode                                 );
-  CFG_POP      ( bool,   net.xdp.xdp_zero_copy                            );
+  CFG_POP      ( boolau, net.xdp.xdp_zero_copy                            );
   CFG_POP      ( cstr,   net.xdp.poll_mode                                );
   CFG_POP      ( uint,   net.xdp.xdp_rx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.xdp_tx_queue_size                        );
   CFG_POP      ( uint,   net.xdp.flush_timeout_micros                     );
   CFG_POP      ( cstr,   net.xdp.rss_queue_mode                           );
   CFG_POP      ( bool,   net.xdp.listen_gre                               );
-  CFG_POP      ( bool,   net.xdp.native_bond                              );
+  CFG_POP      ( boolau, net.xdp.native_bond                              );
   CFG_POP      ( uint,   net.socket.receive_buffer_size                   );
   CFG_POP      ( uint,   net.socket.send_buffer_size                      );
 

--- a/src/app/shared/test_config_auto.c
+++ b/src/app/shared/test_config_auto.c
@@ -1,0 +1,79 @@
+#include "fd_config_auto.c" /* fd_auto_net is static */
+
+/* Test the auto config resolution policy with hand built system
+   info.  The scrape functions (uname, sysfs, bonding) are not
+   covered here. */
+
+static fd_config_t config[1];
+
+static void
+reset_auto( uint net_tile_cnt ) {
+  memset( config, 0, sizeof(fd_config_t) );
+  strcpy( config->net.provider,      "xdp"  );
+  strcpy( config->net.xdp.xdp_mode,  "auto" );
+  strcpy( config->net.xdp.poll_mode, "auto" );
+  config->net.xdp.xdp_zero_copy = 2;
+  config->net.xdp.native_bond   = 2;
+  config->layout.net_tile_count = net_tile_cnt;
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* Supported NIC on a recent kernel */
+
+  reset_auto( 1U );
+  fd_auto_info_t info1 = { .linux_major=7, .linux_minor=0, .driver="mlx5_core" };
+  fd_auto_net( config, &info1 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode,  "drv"      ) );
+  FD_TEST( 0==strcmp( config->net.xdp.poll_mode, "prefbusy" ) );
+  FD_TEST( config->net.xdp.xdp_zero_copy==0 ); /* zc is not auto enabled for now */
+  FD_TEST( config->net.xdp.native_bond  ==0 );
+
+  /* Unsupported NIC falls back to safe defaults */
+
+  reset_auto( 1U );
+  fd_auto_info_t info2 = { .linux_major=7, .linux_minor=0, .driver="ixgbe" };
+  fd_auto_net( config, &info2 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode,  "skb"     ) );
+  FD_TEST( 0==strcmp( config->net.xdp.poll_mode, "softirq" ) );
+  FD_TEST( config->net.xdp.xdp_zero_copy==0 );
+  FD_TEST( config->net.xdp.native_bond  ==0 );
+
+  /* Supported NIC on an old kernel falls back to safe defaults */
+
+  reset_auto( 4U );
+  fd_auto_info_t info3 = { .linux_major=1, .linux_minor=0, .driver="mlx5_core",
+                           .is_virtual_if=1, .is_bonded_if=1, .bonded_if_slave_count=2U };
+  fd_auto_net( config, &info3 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode,  "skb"     ) );
+  FD_TEST( 0==strcmp( config->net.xdp.poll_mode, "softirq" ) );
+  FD_TEST( config->net.xdp.xdp_zero_copy==0 );
+  FD_TEST( config->net.xdp.native_bond  ==0 );
+
+  /* Bonded mlx5 on a recent kernel enables native bond and drv */
+
+  reset_auto( 4U );
+  fd_auto_info_t info4 = info3;
+  info4.linux_major = 7;
+  info4.linux_minor = 0;
+  fd_auto_net( config, &info4 );
+  FD_TEST( config->net.xdp.native_bond==1 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode, "drv" ) );
+  FD_TEST( config->net.xdp.xdp_zero_copy==0 );
+
+  /* Non XDP provider still collapses "auto" fields to defaults */
+
+  reset_auto( 1U );
+  strcpy( config->net.provider, "socket" );
+  fd_auto_net( config, &info1 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode,  "skb"     ) );
+  FD_TEST( 0==strcmp( config->net.xdp.poll_mode, "softirq" ) );
+  FD_TEST( config->net.xdp.xdp_zero_copy==0 );
+  FD_TEST( config->net.xdp.native_bond  ==0 );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+}

--- a/src/app/shared/test_config_parse.c
+++ b/src/app/shared/test_config_parse.c
@@ -8,6 +8,12 @@ static char const cfg_str_1[] =
 static char const cfg_str_2[] =
   "wumbo = \"mini\"";
 
+/* Auto config specific */
+static char const cfg_str_3[] =
+  "[net.xdp]\n  xdp_zero_copy = \"auto\"\n  native_bond = \"auto\"";
+static char const cfg_str_4[] =
+  "[net.xdp]\n  xdp_zero_copy = \"something wrong\"";
+
 extern uchar const fdctl_default_config[];
 extern ulong const fdctl_default_config_sz;
 
@@ -57,6 +63,19 @@ main( int     argc,
   FD_TEST( config->gossip.entrypoints_cnt == 1 );
   FD_TEST( 0==strcmp( config->gossip.entrypoints[0], "208.91.106.45:8080" ) );
   FD_TEST( config->gossip.port == 9191 );  /* unchanged */
+
+  /* Test passing "auto" leads to 2 for auto configure fields */
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_3, sizeof(cfg_str_3)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
+  FD_TEST( fd_config_extract_pod( pod, config ) == config );
+  FD_TEST( config->net.xdp.xdp_zero_copy == 2 );
+  FD_TEST( config->net.xdp.native_bond   == 2 );
+
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_4, sizeof(cfg_str_4)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
## Overview
Many (possibly most) validators use the default configuration provided by the default.toml for the networking subsystem. In these cases large amounts of performance are being left on the table since the defaults are designed to be as safe as possible.

Many validators enable features like zero copy on drivers/kernels that are supposed to support it but have a broken driver implementation. This creates unnecessary support burden in Discord when they report issues that are not Firedancer's fault, as well as making the operator have a less smooth experience using Firedancer.

## Info used
This PR lets Firedancer decide on behalf of the user which networking features to enable based on their system's:
- Linux kernel version
- NIC driver
- Whether the networking interface is a bond
- Whether the networking interface is a virtual interface
- How many slaves there are of the bond (if it is a bond)

## Testing
What is deemed safe was mostly decided using the results of fd-linux-version-testbed, (results cannot be attached at this time due to an infosec issue on my mac).

This is not a 100% foolproof way to test as it does not take into account every edge case e.g. each individual Linux minor release revision, however I believe the risk of these edge cases being the reason for a failure to be low (although not 0).