### PR TITLE
util: using SIMD acceleration on hashing

### DIFF
--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -24,7 +24,6 @@ fd_hash( ulong        seed,
   uchar const * stop = p + sz;
   /* Sharing this values between 2 conditional
   compilation blocks */
-  __m256i state_vec; (void)state_vec;
   __m256i c1_vec;       (void)c1_vec;
   __m256i c2_vec;       (void)c2_vec;
   ulong h;
@@ -47,11 +46,11 @@ fd_hash( ulong        seed,
        Provides the intention clearly to the compiler.
        Same goes for other arrays used in #IF FD_HAS_AVX512 blocks. */
       FD_ALIGNED ulong arr[4] = { w, x, y, z };
-      state_vec =  _mm256_loadu_si256(( const wv_t*)arr   );
-      input_vec = _mm256_mullo_epi64( input_vec, c2_vec   );
-      state_vec =  wl_add( state_vec, input_vec           );
-      state_vec =  wv_rol( state_vec, 31                  );
-      state_vec = _mm256_mullo_epi64( state_vec, c1_vec   );
+      wv_t state_vec =  _mm256_loadu_si256(( const wv_t*)arr   );
+      input_vec =      _mm256_mullo_epi64( input_vec, c2_vec   );
+      state_vec =       wl_add( state_vec, input_vec           );
+      state_vec =       wv_rol( state_vec, 31                  );
+      state_vec =      _mm256_mullo_epi64( state_vec, c1_vec   );
       FD_ALIGNED ulong results[4];
       _mm256_storeu_si256(( wv_t*)results, state_vec );
       w = results[0]; x = results[1]; y = results[2]; z = results[3];
@@ -66,11 +65,12 @@ fd_hash( ulong        seed,
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
     #if FD_HAS_AVX512
+    /* state_vec shouldn't kept between upper conditional compilation block and this one because it creates much register preassure, since it puts both w x y z and state_vec at registers at the same time. */
     FD_ALIGNED ulong arr[4] = { w, x, y, z };
-    state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
-    state_vec = _mm256_mullo_epi64( state_vec, c2_vec );
-    state_vec =                 wv_rol( state_vec, 31 );
-    state_vec = _mm256_mullo_epi64( state_vec, c1_vec );
+    wv_t state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
+    state_vec =      _mm256_mullo_epi64( state_vec, c2_vec );
+    state_vec =                      wv_rol( state_vec, 31 );
+    state_vec =      _mm256_mullo_epi64( state_vec, c1_vec );
     FD_ALIGNED ulong results[4];
        _mm256_storeu_si256(( wv_t*)results, state_vec );
     w = results[0]; x = results[1]; y = results[2]; z = results[3];

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -118,7 +118,7 @@ fd_hash_avx512dq( ulong        seed,
     h ^= z; h = h*C1 + C4;
   }
 
-  h += ((ulong)sz);
+  h += sz;
 
   while( (p+8)<=stop ) { /* Last 1 to 3 complete ulong's */
     ulong w = FD_LOAD( ulong, p );

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -66,8 +66,6 @@ fd_hash( ulong        seed,
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
     #if FD_HAS_AVX512
-    FD_ALIGNED ulong arr[4] = { w, x, y, z };
-    state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
     state_vec = _mm256_mullo_epi64( state_vec, c2_vec );
     state_vec =                 wv_rol( state_vec, 31 );
     state_vec = _mm256_mullo_epi64( state_vec, c1_vec );

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -2,6 +2,11 @@
 #include "bits/fd_bits.h"
 
 /* A cleaner implementation of xxhash-r39 (Open Source BSD licensed). */
+#if FD_HAS_AVX512
+#include "simd/fd_avx.h"
+#else
+#include <immintrin.h>
+#endif
 
 #define ROTATE_LEFT(x,r) (((x)<<(r)) | ((x)>>(64-(r))))
 #define C1 (11400714785074694791UL)
@@ -16,7 +21,12 @@ fd_hash( ulong        seed,
          ulong        sz ) {
   uchar const * p    = ((uchar const *)buf);
   uchar const * stop = p + sz;
-
+  __m256i state_vec;
+  __m256i c1_vec;
+  __m256i c2_vec;
+  (void)state_vec;
+  (void)c1_vec;
+  (void)c2_vec;
   ulong h;
 
   if( sz<32 ) h = seed + C5;
@@ -28,19 +38,46 @@ fd_hash( ulong        seed,
     ulong z = seed - C1;
 
     do { /* All complete blocks of 32 */
+
+      #if FD_HAS_AVX512
+      c1_vec = _mm256_set1_epi64x((long long)C1);
+      c2_vec = _mm256_set1_epi64x((long long)C2);
+      wv_t input_vec = _mm256_loadu_si256((const __m256i*)p);
+      alignas(64) ulong arr[4] = { w, x, y, z };
+      state_vec = _mm256_loadu_si256((const __m256i*)arr);
+      input_vec = _mm256_mullo_epi64(input_vec, c2_vec);
+      state_vec = wl_add(state_vec, input_vec);
+      state_vec = wv_rol(state_vec, 31);
+      state_vec = _mm256_mullo_epi64(state_vec, c1_vec);
+      alignas(64) ulong results[4];
+      _mm256_storeu_si256((__m256i*)results, state_vec);
+      w = results[0]; x = results[1]; y = results[2]; z = results[3];
+      #else
       w += FD_LOAD( ulong, p    )*C2; w = ROTATE_LEFT( w, 31 ); w *= C1;
       x += FD_LOAD( ulong, p+ 8 )*C2; x = ROTATE_LEFT( x, 31 ); x *= C1;
       y += FD_LOAD( ulong, p+16 )*C2; y = ROTATE_LEFT( y, 31 ); y *= C1;
       z += FD_LOAD( ulong, p+24 )*C2; z = ROTATE_LEFT( z, 31 ); z *= C1;
+      #endif
       p += 32;
     } while( p<=stop32 );
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
-
+    #if FD_HAS_AVX512
+    alignas(64) ulong arr[4] = { w, x, y, z };
+    state_vec = _mm256_loadu_si256((const __m256i*)arr);
+    state_vec = _mm256_mullo_epi64(state_vec, c2_vec);
+    state_vec = wv_rol(state_vec, 31);
+    state_vec = _mm256_mullo_epi64(state_vec, c1_vec);
+    alignas(64) ulong results[4];
+    _mm256_storeu_si256((__m256i*)results, state_vec);
+    w = results[0]; x = results[1]; y = results[2]; z = results[3];
+    h ^= w; h = h*C1 + C4; h ^= x; h= h*C1 +C4; h ^= y; h = h*C1 + C4; h ^= z; h = h*C1 + C4;
+    #else
     w *= C2; w = ROTATE_LEFT( w, 31 ); w *= C1; h ^= w; h = h*C1 + C4;
     x *= C2; x = ROTATE_LEFT( x, 31 ); x *= C1; h ^= x; h = h*C1 + C4;
     y *= C2; y = ROTATE_LEFT( y, 31 ); y *= C1; h ^= y; h = h*C1 + C4;
     z *= C2; z = ROTATE_LEFT( z, 31 ); z *= C1; h ^= z; h = h*C1 + C4;
+    #endif
   }
 
   h += ((ulong)sz);

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -1,5 +1,6 @@
 #include "fd_util_base.h"
 #include "bits/fd_bits.h"
+#include "../ballet/fd_ballet_base.h"
 
 /* A cleaner implementation of xxhash-r39 (Open Source BSD licensed). */
 #if FD_HAS_AVX512
@@ -21,12 +22,11 @@ fd_hash( ulong        seed,
          ulong        sz ) {
   uchar const * p    = ((uchar const *)buf);
   uchar const * stop = p + sz;
-  __m256i state_vec;
-  __m256i c1_vec;
-  __m256i c2_vec;
-  (void)state_vec;
-  (void)c1_vec;
-  (void)c2_vec;
+  /* Sharing this values between 2 conditional
+  compilation blocks */
+  __m256i state_vec; (void)state_vec;
+  __m256i c1_vec;       (void)c1_vec;
+  __m256i c2_vec;       (void)c2_vec;
   ulong h;
 
   if( sz<32 ) h = seed + C5;
@@ -40,17 +40,20 @@ fd_hash( ulong        seed,
     do { /* All complete blocks of 32 */
 
       #if FD_HAS_AVX512
-      c1_vec = _mm256_set1_epi64x((long long)C1);
-      c2_vec = _mm256_set1_epi64x((long long)C2);
-      wv_t input_vec = _mm256_loadu_si256((const __m256i*)p);
-      alignas(64) ulong arr[4] = { w, x, y, z };
-      state_vec = _mm256_loadu_si256((const __m256i*)arr);
-      input_vec = _mm256_mullo_epi64(input_vec, c2_vec);
-      state_vec = wl_add(state_vec, input_vec);
-      state_vec = wv_rol(state_vec, 31);
-      state_vec = _mm256_mullo_epi64(state_vec, c1_vec);
-      alignas(64) ulong results[4];
-      _mm256_storeu_si256((__m256i*)results, state_vec);
+      c1_vec =         _mm256_set1_epi64x(( long long)C1  );
+      c2_vec =         _mm256_set1_epi64x(( long long)C2  );
+      wv_t input_vec = _mm256_loadu_si256(( const wv_t*)p );
+      /* Temporary array, eliminated by compiler already.
+       Provides the intention clearly to the compiler.
+       Same goes for other arrays used in #IF FD_HAS_AVX512 blocks. */
+      FD_ALIGNED ulong arr[4] = { w, x, y, z };
+      state_vec =  _mm256_loadu_si256(( const wv_t*)arr   );
+      input_vec = _mm256_mullo_epi64( input_vec, c2_vec   );
+      state_vec =  wl_add( state_vec, input_vec           );
+      state_vec =  wv_rol( state_vec, 31                  );
+      state_vec = _mm256_mullo_epi64( state_vec, c1_vec   );
+      FD_ALIGNED ulong results[4];
+      _mm256_storeu_si256(( wv_t*)results, state_vec );
       w = results[0]; x = results[1]; y = results[2]; z = results[3];
       #else
       w += FD_LOAD( ulong, p    )*C2; w = ROTATE_LEFT( w, 31 ); w *= C1;
@@ -63,15 +66,18 @@ fd_hash( ulong        seed,
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
     #if FD_HAS_AVX512
-    alignas(64) ulong arr[4] = { w, x, y, z };
-    state_vec = _mm256_loadu_si256((const __m256i*)arr);
-    state_vec = _mm256_mullo_epi64(state_vec, c2_vec);
-    state_vec = wv_rol(state_vec, 31);
-    state_vec = _mm256_mullo_epi64(state_vec, c1_vec);
-    alignas(64) ulong results[4];
-    _mm256_storeu_si256((__m256i*)results, state_vec);
+    FD_ALIGNED ulong arr[4] = { w, x, y, z };
+    state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
+    state_vec = _mm256_mullo_epi64( state_vec, c2_vec );
+    state_vec =                 wv_rol( state_vec, 31 );
+    state_vec = _mm256_mullo_epi64( state_vec, c1_vec );
+    FD_ALIGNED ulong results[4];
+       _mm256_storeu_si256(( wv_t*)results, state_vec );
     w = results[0]; x = results[1]; y = results[2]; z = results[3];
-    h ^= w; h = h*C1 + C4; h ^= x; h= h*C1 +C4; h ^= y; h = h*C1 + C4; h ^= z; h = h*C1 + C4;
+    h ^= w; h = h*C1 + C4;
+    h ^= x; h = h*C1 + C4;
+    h ^= y; h = h*C1 + C4;
+    h ^= z; h = h*C1 + C4;
     #else
     w *= C2; w = ROTATE_LEFT( w, 31 ); w *= C1; h ^= w; h = h*C1 + C4;
     x *= C2; x = ROTATE_LEFT( x, 31 ); x *= C1; h ^= x; h = h*C1 + C4;

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -1,12 +1,9 @@
 #include "fd_util_base.h"
 #include "bits/fd_bits.h"
-#include "../ballet/fd_ballet_base.h"
 
 /* A cleaner implementation of xxhash-r39 (Open Source BSD licensed). */
-#if FD_HAS_AVX512
+#if defined(__AVX512DQ__) && defined(__AVX512VL__)
 #include "simd/fd_avx.h"
-#else
-#include <immintrin.h>
 #endif
 
 #define ROTATE_LEFT(x,r) (((x)<<(r)) | ((x)>>(64-(r))))
@@ -16,16 +13,13 @@
 #define C4 ( 9650029242287828579UL)
 #define C5 ( 2870177450012600261UL)
 
-ulong
-fd_hash( ulong        seed,
-         void const * buf,
-         ulong        sz ) {
+static inline FD_FN_UNUSED FD_FN_PURE ulong
+fd_hash_generic( ulong        seed,
+                 void const * buf,
+                 ulong        sz ) {
   uchar const * p    = ((uchar const *)buf);
   uchar const * stop = p + sz;
-  /* Sharing this values between 2 conditional
-  compilation blocks */
-  __m256i c1_vec;       (void)c1_vec;
-  __m256i c2_vec;       (void)c2_vec;
+
   ulong h;
 
   if( sz<32 ) h = seed + C5;
@@ -37,53 +31,19 @@ fd_hash( ulong        seed,
     ulong z = seed - C1;
 
     do { /* All complete blocks of 32 */
-
-      #if FD_HAS_AVX512
-      c1_vec =         _mm256_set1_epi64x(( long long)C1  );
-      c2_vec =         _mm256_set1_epi64x(( long long)C2  );
-      wv_t input_vec = _mm256_loadu_si256(( const wv_t*)p );
-      /* Temporary array, eliminated by compiler already.
-       Provides the intention clearly to the compiler.
-       Same goes for other arrays used in #IF FD_HAS_AVX512 blocks. */
-      FD_ALIGNED ulong arr[4] = { w, x, y, z };
-      wv_t state_vec =  _mm256_loadu_si256(( const wv_t*)arr   );
-      input_vec =      _mm256_mullo_epi64( input_vec, c2_vec   );
-      state_vec =       wl_add( state_vec, input_vec           );
-      state_vec =       wv_rol( state_vec, 31                  );
-      state_vec =      _mm256_mullo_epi64( state_vec, c1_vec   );
-      FD_ALIGNED ulong results[4];
-      _mm256_storeu_si256(( wv_t*)results, state_vec );
-      w = results[0]; x = results[1]; y = results[2]; z = results[3];
-      #else
       w += FD_LOAD( ulong, p    )*C2; w = ROTATE_LEFT( w, 31 ); w *= C1;
       x += FD_LOAD( ulong, p+ 8 )*C2; x = ROTATE_LEFT( x, 31 ); x *= C1;
       y += FD_LOAD( ulong, p+16 )*C2; y = ROTATE_LEFT( y, 31 ); y *= C1;
       z += FD_LOAD( ulong, p+24 )*C2; z = ROTATE_LEFT( z, 31 ); z *= C1;
-      #endif
       p += 32;
     } while( p<=stop32 );
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
-    #if FD_HAS_AVX512
-    /* state_vec shouldn't kept between upper conditional compilation block and this one because it creates much register preassure, since it puts both w x y z and state_vec at registers at the same time. */
-    FD_ALIGNED ulong arr[4] = { w, x, y, z };
-    wv_t state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
-    state_vec =      _mm256_mullo_epi64( state_vec, c2_vec );
-    state_vec =                      wv_rol( state_vec, 31 );
-    state_vec =      _mm256_mullo_epi64( state_vec, c1_vec );
-    FD_ALIGNED ulong results[4];
-       _mm256_storeu_si256(( wv_t*)results, state_vec );
-    w = results[0]; x = results[1]; y = results[2]; z = results[3];
-    h ^= w; h = h*C1 + C4;
-    h ^= x; h = h*C1 + C4;
-    h ^= y; h = h*C1 + C4;
-    h ^= z; h = h*C1 + C4;
-    #else
+
     w *= C2; w = ROTATE_LEFT( w, 31 ); w *= C1; h ^= w; h = h*C1 + C4;
     x *= C2; x = ROTATE_LEFT( x, 31 ); x *= C1; h ^= x; h = h*C1 + C4;
     y *= C2; y = ROTATE_LEFT( y, 31 ); y *= C1; h ^= y; h = h*C1 + C4;
     z *= C2; z = ROTATE_LEFT( z, 31 ); z *= C1; h ^= z; h = h*C1 + C4;
-    #endif
   }
 
   h += ((ulong)sz);
@@ -114,6 +74,90 @@ fd_hash( ulong        seed,
   h ^= h >> 32;
 
   return h;
+}
+
+#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+static inline FD_FN_UNUSED FD_FN_PURE ulong
+fd_hash_avx512dq( ulong        seed,
+                  void const * buf,
+                  ulong        sz ) {
+  uchar const * p    = ((uchar const *)buf);
+  uchar const * stop = p + sz;
+  ulong h;
+
+  if( sz<32 ) h = seed + C5;
+  else {
+    uchar const * stop32 = stop - 32;
+    ulong w, x, y, z;
+    wv_t state_vec = wv_add( wv_bcast( seed ), wv( C1 + C2, C2, 0UL, 0UL - C1 ) );
+    wv_t c1_vec = wv_bcast( C1 );
+    wv_t c2_vec = wv_bcast( C2 );
+    do { /* All complete blocks of 32 */
+      wv_t input_vec = wv_ldu( p );
+      input_vec = wv_mul( input_vec, c2_vec );
+      state_vec = wv_add( state_vec, input_vec );
+      state_vec = wv_rol( state_vec, 31 );
+      state_vec = wv_mul( state_vec, c1_vec );
+      p += 32;
+    } while( p<=stop32 );
+    wv_t h_vec = wv_rol_vector( state_vec, wv( 1UL, 7UL, 12UL, 18UL ) );
+    h = wv_extract( h_vec, 0 )
+      + wv_extract( h_vec, 1 )
+      + wv_extract( h_vec, 2 )
+      + wv_extract( h_vec, 3 );
+    state_vec = wv_mul( state_vec, c2_vec );
+    state_vec = wv_rol( state_vec, 31 );
+    state_vec = wv_mul( state_vec, c1_vec );
+    w = wv_extract( state_vec, 0 );
+    x = wv_extract( state_vec, 1 );
+    y = wv_extract( state_vec, 2 );
+    z = wv_extract( state_vec, 3 );
+    h ^= w; h = h*C1 + C4;
+    h ^= x; h = h*C1 + C4;
+    h ^= y; h = h*C1 + C4;
+    h ^= z; h = h*C1 + C4;
+  }
+
+  h += ((ulong)sz);
+
+  while( (p+8)<=stop ) { /* Last 1 to 3 complete ulong's */
+    ulong w = FD_LOAD( ulong, p );
+    w *= C2; w = ROTATE_LEFT( w, 31 ); w *= C1; h ^= w; h = ROTATE_LEFT( h, 27 )*C1 + C4;
+    p += 8;
+  }
+
+  if( (p+4)<=stop ) { /* Last complete uint */
+    ulong w = ((ulong)FD_LOAD( uint, p ));
+    w *= C1; h ^= w; h = ROTATE_LEFT( h, 23 )*C2 + C3;
+    p += 4;
+  }
+
+  while( p<stop ) { /* Last 1 to 3 uchar's */
+    ulong w = ((ulong)(p[0]));
+    w *= C5; h ^= w; h = ROTATE_LEFT( h, 11 )*C1;
+    p++;
+  }
+
+  /* Final avalanche */
+  h ^= h >> 33;
+  h *= C2;
+  h ^= h >> 29;
+  h *= C3;
+  h ^= h >> 32;
+
+  return h;
+}
+#endif
+
+ulong
+fd_hash( ulong        seed,
+         void const * buf,
+         ulong        sz ) {
+#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+  return fd_hash_avx512dq( seed, buf, sz );
+#else
+  return fd_hash_generic( seed, buf, sz );
+#endif
 }
 
 ulong

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -66,6 +66,8 @@ fd_hash( ulong        seed,
 
     h = ROTATE_LEFT( w, 1 ) + ROTATE_LEFT( x, 7 ) + ROTATE_LEFT( y, 12 ) + ROTATE_LEFT( z, 18 );
     #if FD_HAS_AVX512
+    FD_ALIGNED ulong arr[4] = { w, x, y, z };
+    state_vec =  _mm256_loadu_si256(( const wv_t*)arr );
     state_vec = _mm256_mullo_epi64( state_vec, c2_vec );
     state_vec =                 wv_rol( state_vec, 31 );
     state_vec = _mm256_mullo_epi64( state_vec, c1_vec );

--- a/src/util/fd_hash.c
+++ b/src/util/fd_hash.c
@@ -2,7 +2,7 @@
 #include "bits/fd_bits.h"
 
 /* A cleaner implementation of xxhash-r39 (Open Source BSD licensed). */
-#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512DQ__) && defined(__AVX512VL__)
 #include "simd/fd_avx.h"
 #endif
 
@@ -76,7 +76,7 @@ fd_hash_generic( ulong        seed,
   return h;
 }
 
-#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512DQ__) && defined(__AVX512VL__)
 static inline FD_FN_UNUSED FD_FN_PURE ulong
 fd_hash_avx512dq( ulong        seed,
                   void const * buf,
@@ -153,7 +153,7 @@ ulong
 fd_hash( ulong        seed,
          void const * buf,
          ulong        sz ) {
-#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512DQ__) && defined(__AVX512VL__)
   return fd_hash_avx512dq( seed, buf, sz );
 #else
   return fd_hash_generic( seed, buf, sz );

--- a/src/util/simd/fd_avx_wv.h
+++ b/src/util/simd/fd_avx_wv.h
@@ -125,15 +125,16 @@ wv_insert_variable( wv_t a, int n, ulong v ) {
 /* Note: _mm256_{min,max}_epu64 are missing pre AVX-512.  We emulate
    these on pre AVX-512 targets below (and use the AVX-512 versions if
    possible).  Likewise, there is no _mm256_mullo_epi64 pre AVX-512.
-   Since this is not cheap to emulate, we do not provide a wv_mul for
-   the time being (we could consider exposing it on AVX-512 targets
-   though).  There is a 64L*64L->64 multiply (where the lower 32-bits of
+   Since this is not cheap to emulate, we only provide wv_mul if it can
+   run natively.  There is a 64L*64L->64 multiply (where the lower 32-bits of
    the inputs will be zero extended to 64-bits beforehand) though and
    that is very useful.  So we do provide that. */
 
 #define wv_add(a,b)    _mm256_add_epi64(   (a), (b) ) /* [ a0 +b0     a1 +b1     ... a3 +b3     ] */
 #define wv_sub(a,b)    _mm256_sub_epi64(   (a), (b) ) /* [ a0 -b0     a1 -b1     ... a3 -b3     ] */
-//#define wv_mul(a,b)  _mm256_mullo_epi64( (a), (b) ) /* [ a0 *b0     a1 *b1     ... a3 *b3     ] */
+#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#define wv_mul(a,b)    _mm256_mullo_epi64( (a), (b) ) /* [ a0 *b0     a1 *b1     ... a3 *b3     ] */
+#endif
 #define wv_mul_ll(a,b) _mm256_mul_epu32(   (a), (b) ) /* [ a0l*b0l    a1l*b1l    ... a3l *b3l   ] */
 
 /* Binary operations */
@@ -173,6 +174,10 @@ static inline wv_t wv_ror( wv_t a, int imm ) { return wv_or( wv_shr( a, imm & 63
 static inline wv_t wv_rol_variable( wv_t a, int n ) { return wv_or( wv_shl_variable( a, n&63 ), wv_shr_variable( a, (-n)&63 ) ); }
 static inline wv_t wv_ror_variable( wv_t a, int n ) { return wv_or( wv_shr_variable( a, n&63 ), wv_shl_variable( a, (-n)&63 ) ); }
 
+#if defined(__AVX512VL__)
+#define wv_rol_vector(a,b) _mm256_rolv_epi64( (a), (b) )
+#define wv_ror_vector(a,b) _mm256_rorv_epi64( (a), (b) )
+#else
 static inline wv_t wv_rol_vector( wv_t a, wl_t b ) {
   wl_t m = wl_bcast( 63L );
   return wv_or( wv_shl_vector( a, wl_and( b, m ) ), wv_shr_vector( a, wl_and( wl_neg( b ), m ) ) );
@@ -182,6 +187,7 @@ static inline wv_t wv_ror_vector( wv_t a, wl_t b ) {
   wl_t m = wl_bcast( 63L );
   return wv_or( wv_shr_vector( a, wl_and( b, m ) ), wv_shl_vector( a, wl_and( wl_neg( b ), m ) ) );
 }
+#endif
 
 #define wv_bswap(a) wu_to_wv_raw( wu_bswap( wv_to_wu_raw( wv_rol( (a), 32 ) ) ) )
 

--- a/src/util/simd/fd_avx_wv.h
+++ b/src/util/simd/fd_avx_wv.h
@@ -132,7 +132,7 @@ wv_insert_variable( wv_t a, int n, ulong v ) {
 
 #define wv_add(a,b)    _mm256_add_epi64(   (a), (b) ) /* [ a0 +b0     a1 +b1     ... a3 +b3     ] */
 #define wv_sub(a,b)    _mm256_sub_epi64(   (a), (b) ) /* [ a0 -b0     a1 -b1     ... a3 -b3     ] */
-#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512DQ__) && defined(__AVX512VL__)
 #define wv_mul(a,b)    _mm256_mullo_epi64( (a), (b) ) /* [ a0 *b0     a1 *b1     ... a3 *b3     ] */
 #endif
 #define wv_mul_ll(a,b) _mm256_mul_epu32(   (a), (b) ) /* [ a0l*b0l    a1l*b1l    ... a3l *b3l   ] */
@@ -174,7 +174,7 @@ static inline wv_t wv_ror( wv_t a, int imm ) { return wv_or( wv_shr( a, imm & 63
 static inline wv_t wv_rol_variable( wv_t a, int n ) { return wv_or( wv_shl_variable( a, n&63 ), wv_shr_variable( a, (-n)&63 ) ); }
 static inline wv_t wv_ror_variable( wv_t a, int n ) { return wv_or( wv_shr_variable( a, n&63 ), wv_shl_variable( a, (-n)&63 ) ); }
 
-#if defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512VL__)
 #define wv_rol_vector(a,b) _mm256_rolv_epi64( (a), (b) )
 #define wv_ror_vector(a,b) _mm256_rorv_epi64( (a), (b) )
 #else

--- a/src/util/simd/test_avx_4x64.c
+++ b/src/util/simd/test_avx_4x64.c
@@ -375,7 +375,7 @@ main( int     argc,
     FD_TEST( wv_test( wv_max( x, y ), fd_ulong_max(x0,y0), fd_ulong_max(x1,y1), fd_ulong_max(x2,y2), fd_ulong_max(x3,y3) ) );
     FD_TEST( wv_test( wv_add( x, y ), x0+y0, x1+y1, x2+y2, x3+y3 ) );
     FD_TEST( wv_test( wv_sub( x, y ), x0-y0, x1-y1, x2-y2, x3-y3 ) );
-#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+#if FD_HAS_AVX512 && defined(__AVX512DQ__) && defined(__AVX512VL__)
     FD_TEST( wv_test( wv_mul( x, y ), x0*y0, x1*y1, x2*y2, x3*y3 ) );
 #endif
 

--- a/src/util/simd/test_avx_4x64.c
+++ b/src/util/simd/test_avx_4x64.c
@@ -375,7 +375,9 @@ main( int     argc,
     FD_TEST( wv_test( wv_max( x, y ), fd_ulong_max(x0,y0), fd_ulong_max(x1,y1), fd_ulong_max(x2,y2), fd_ulong_max(x3,y3) ) );
     FD_TEST( wv_test( wv_add( x, y ), x0+y0, x1+y1, x2+y2, x3+y3 ) );
     FD_TEST( wv_test( wv_sub( x, y ), x0-y0, x1-y1, x2-y2, x3-y3 ) );
-  //FD_TEST( wv_test( wv_mul( x, y ), x0*y0, x1*y1, x2*y2, x3*y3 ) );
+#if defined(__AVX512DQ__) && defined(__AVX512VL__)
+    FD_TEST( wv_test( wv_mul( x, y ), x0*y0, x1*y1, x2*y2, x3*y3 ) );
+#endif
 
 #   define SE_LO(x) ((ulong)(uint)(x))
     FD_TEST( wv_test( wv_mul_ll( x, y ), SE_LO(x0)*SE_LO(y0), SE_LO(x1)*SE_LO(y1), SE_LO(x2)*SE_LO(y2), SE_LO(x3)*SE_LO(y3) ) );


### PR DESCRIPTION
# Abstract 
This pr introduces an AVX-512VL/DQ implementation for fd_hash, but I have several questions and need feedback for several ideas.
This code is tested on the ns/byte tests I sent as pr, at https://github.com/firedancer-io/firedancer/pull/10575.
## Performance impact:
<img width="768" height="480" alt="avx512" src="https://github.com/user-attachments/assets/21cbe4e5-2a6a-44a3-b333-da5fbcd4b440" />
fd_hash is often called with 32, 64, rarely with values like 36, which is all compile time known, and with rarely with variable strlen. Not a multiple of 32(1232) workload shows the affect of executing the unchanged paths as well, even if it's not practically used.
Static check shows that the fd_hash is often called with compile time known values at 32-64 :  

```cli
rg 'fd_hash\s*\([^,]+,[^,]+,\s*([^)]+)' -o -r '$1' src/ --no-filename --no-line-number --glob '!*test*' --glob '!*bench*' | sed 's/^[ \t]*//;s/[ \t]*$//' | sort | uniq -c | sort -nr
     13 sizeof(fd_pubkey_t
      7 sizeof(fd_hash_t
      6 32UL
      3 64UL
 ``` 
Not included values lower than 3 calls. 

# Benchmark env.
To get variance-reduced performance results, I used 
```grub
processor.max_cstate=1 isolcpus=managed_irq,domain,0 nohz_full=0 rcu_nocbs=0 transparent_hugepage=never mitigations=off no_timer_check
```
on AWS  m8azn.metal-12xl instance, AMD EPYC 9R05 64-Core Processor, used taskset to 0. Tests were never run concurrently because they can affect each other at shared resources, such as l3 cache. 
Also the profiling itself is warming up inside test to make it variance-reduced, which can  be checked at the pr 10575. 
# Questions  
1) Needed to use some Intrinsics directly from immintrin, for example, 
"src/util/simd/fd_avx_wv.h Likewise, there is no _mm256_mullo_epi64 pre AVX-512." 
this is not added to avx because it is surely not avx, but also not added to avx 512. So,what to do? we may add it to avx512 library or, I don't know. To be more clear;
### Where does firedancer want wrappers for 256 bit instructions which requires avx 512? 
2) This code works on zen 4 and newer, but not sure about intel part. with the e-p core thing, they are removing avx512 support from cpus that is newer than the ones which supporting avx512.
I think that code may return illegal instruction if that situation is not handled properly, but if config/machine is making sure we can execute all the instructions here if FD_HAS_AVX512, it is not a problem.
### edit: 3. is deprecated after checking calling patterns more in depth and found out it doesn't have much practical usage. Everything after avx512 acceleration at power of 32 path at fd_hash is diminishing returns for maintaining a hand-written Intrinsics code.
3) Since we are processing data at while( p<=stop32 ) line 256 bit at once, I cannot %100 leveraged avx512, and this code is somewhere between avx and avx512. If I add a function that uses the same formula, but calculates 2 hash provided with 2 different seeds, I can fully leverage it. Thinking of something like;
foo(seed_1, seed_2, buf_1, buf_2, size_1, size_2) returning hash_1,and hash_2, and wanted to get a feedback at this pr. 