### PR TITLE
Revert "runtime: skip writing untouched accounts (#10631)"

### DIFF
--- a/contrib/test/run_solcap_tests.sh
+++ b/contrib/test/run_solcap_tests.sh
@@ -7,7 +7,7 @@ DUMP=${DUMP:="./dump"}
 OBJDIR=${OBJDIR:-build/native/gcc}
 SKIP_INGEST=${SKIP_INGEST:-0}
 
-LEDGER="mainnet-424669000-solcap-v4.2.0-beta.1-vat-untouched"
+LEDGER="mainnet-424669000-solcap-v4.2.0-beta.1-vat"
 REDOWNLOAD=1
 
 WATCH=( )

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -2490,7 +2490,6 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
       out_accs[ i ].prior_data = NULL;
       out_accs[ i ].commit = 0;
       out_accs[ i ].pd_write = 0;
-      out_accs[ i ].touched = 0;
       out_accs[ i ]._writable = 0;
       out_accs[ i ]._original_size_class = ULONG_MAX;
       out_accs[ i ]._original_cache_idx = ULONG_MAX;
@@ -2520,7 +2519,6 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
 
     out_accs[ i ].commit = 0;
     out_accs[ i ].pd_write = 0;
-    out_accs[ i ].touched = 0;
     out_accs[ i ]._writable = writable[ i ];
     if( FD_UNLIKELY( writable[ i ] && accmetas[ i ] ) ) out_accs[ i ]._overwrite = accdb->fork_pool[ fork_id.val ].shmem->generation==accmetas[ i ]->key.generation;
     else                                            out_accs[ i ]._overwrite = 0;

--- a/src/flamenco/accdb/fd_accdb.h
+++ b/src/flamenco/accdb/fd_accdb.h
@@ -41,8 +41,6 @@ struct fd_accdb_entry {
   int     commit;
   int     pd_write;
 
-  int     touched;
-
   int     _writable;
   int     _overwrite;
 

--- a/src/flamenco/runtime/fd_borrowed_account.c
+++ b/src/flamenco/runtime/fd_borrowed_account.c
@@ -13,9 +13,6 @@ fd_borrowed_account_get_data_mut( fd_borrowed_account_t * borrowed_acct,
     return err;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
-
   if ( data_out != NULL )
     *data_out = borrowed_acct->acc->data;
   if ( dlen_out != NULL )
@@ -52,8 +49,7 @@ fd_borrowed_account_set_owner( fd_borrowed_account_t * borrowed_acct,
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
+  /* Agave self.touch() is a no-op */
 
   /* Copy into owner
      https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L761 */
@@ -86,8 +82,7 @@ fd_borrowed_account_set_lamports( fd_borrowed_account_t * borrowed_acct,
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
+  /* Agave self.touch() is a no-op */
 
   borrowed_acct->acc->lamports = lamports;
   return FD_EXECUTOR_INSTR_SUCCESS;
@@ -104,8 +99,7 @@ fd_borrowed_account_set_data_from_slice( fd_borrowed_account_t * borrowed_acct,
     return err;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
+  /* Agave self.touch() is a no-op */
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L868 */
   if( FD_UNLIKELY( !fd_borrowed_account_update_accounts_resize_delta( borrowed_acct, data_sz, &err ) ) ) {
@@ -137,8 +131,7 @@ fd_borrowed_account_set_data_length( fd_borrowed_account_t * borrowed_acct,
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
+  /* Agave self.touch() is a no-op */
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L890 */
   if( FD_UNLIKELY( !fd_borrowed_account_update_accounts_resize_delta( borrowed_acct, new_len, &err ) ) ) {
@@ -182,8 +175,7 @@ fd_borrowed_account_set_executable( fd_borrowed_account_t * borrowed_acct,
     return FD_EXECUTOR_INSTR_SUCCESS;
   }
 
-  /* Agave self.touch() */
-  borrowed_acct->acc->touched = 1;
+  /* Agave self.touch() is a no-op */
 
   /* https://github.com/anza-xyz/agave/blob/v2.1.14/sdk/src/transaction_context.rs#L1027 */
   borrowed_acct->acc->executable = !!is_executable;

--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1550,11 +1550,6 @@ fd_executor_txn_check( fd_bank_t *    bank,
     else if( !memcmp( acc->owner, &fd_solana_vote_program_id,  sizeof(fd_pubkey_t) ) ) txn_out->accounts.vote_update[ i ] = 1;
   }
 
-  /* The fee payer (account index 0) is debited during loading, outside
-     the VM, so it carries no touch flag but must still be written back.
-     https://github.com/anza-xyz/agave/blob/v4.2.0-beta.0/svm/src/transaction_processor.rs#L1116-L1120 */
-  txn_out->accounts.account[ 0 ]->touched = 1;
-
   /* https://github.com/anza-xyz/agave/blob/v4.2.0-beta.0/svm/src/transaction_processor.rs#L1126-L1132 */
   if( FD_UNLIKELY( ending_lamports_l!=starting_lamports_l || ending_lamports_h!=starting_lamports_h ) ) {
     return FD_RUNTIME_TXN_ERR_UNBALANCED_TRANSACTION;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1105,9 +1105,6 @@ fd_runtime_commit_txn( fd_runtime_t *      runtime,
          payer account. */
       if( FD_UNLIKELY( !txn_out->accounts.is_writable[ i ] ) ) continue;
 
-      /* https://github.com/anza-xyz/agave/blob/v4.2.0-beta.1/runtime/src/account_saver.rs#L120-L122 */
-      if( FD_UNLIKELY( !txn_out->accounts.account[ i ]->touched ) ) continue;
-
       fd_pubkey_t const * pubkey = &txn_out->accounts.keys[ i ];
 
       /* new_vote/rm_vote feed an ordered op-log (fd_new_votes), not a

--- a/src/flamenco/runtime/test_bundle_exec.c
+++ b/src/flamenco/runtime/test_bundle_exec.c
@@ -367,7 +367,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[0].accounts.is_writable[1] == 1 );
   FD_TEST( env->txn_out[0].accounts.account[1]->lamports == 1000000UL );
   env->txn_out[0].accounts.account[1]->lamports = 2000000UL;
-  env->txn_out[0].accounts.account[1]->touched = 1;
 
   env->txn_in.txn                     = &bundle_txns[1];
   env->txn_in.bundle.is_bundle        = 1;
@@ -410,7 +409,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[0].err.is_committable );
   FD_TEST( env->txn_out[0].accounts.is_writable[1] == 1 );
   env->txn_out[0].accounts.account[1]->lamports = 2000001UL;
-  env->txn_out[0].accounts.account[1]->touched = 1;
 
   /* tx1: account becomes readonly */
   serialize_bundle_txn( &txn_p, account_keys, 2UL, 1UL );
@@ -433,7 +431,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[2].accounts.is_writable[1] == 1 );
   FD_TEST( env->txn_out[2].accounts.account[1]->lamports == 2000001UL );
   env->txn_out[2].accounts.account[1]->lamports = 2000011UL;
-  env->txn_out[2].accounts.account[1]->touched = 1;
 
   /* tx3: readonly again */
   serialize_bundle_txn( &txn_p, account_keys, 2UL, 1UL );
@@ -470,7 +467,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[0].err.is_committable );
   FD_TEST( env->txn_out[0].accounts.account[1]->lamports == 1000000UL );
   env->txn_out[0].accounts.account[1]->lamports = 2000021UL;
-  env->txn_out[0].accounts.account[1]->touched = 1;
   /* Single acquire for the bundle; release once via fini_bundle. */
   env->txn_out[0].err.is_committable = 0;
   fd_runtime_fini_bundle( env->runtime );
@@ -492,7 +488,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[0].err.is_committable );
   FD_TEST( env->txn_out[0].accounts.account[1]->lamports == 1000000UL );
   env->txn_out[0].accounts.account[1]->lamports = 2000021UL;
-  env->txn_out[0].accounts.account[1]->touched = 1;
 
   serialize_bundle_txn( &txn_p, account_keys, 2UL, 0UL );
   env->txn_in.txn                     = &txn_p;
@@ -502,7 +497,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[1].err.is_committable );
   FD_TEST( env->txn_out[1].accounts.account[1]->lamports == 2000021UL );
   env->txn_out[1].accounts.account[1]->lamports = 2000031UL;
-  env->txn_out[1].accounts.account[1]->touched = 1;
 
   serialize_bundle_txn( &txn_p, account_keys, 2UL, 0UL );
   env->txn_in.txn                     = &txn_p;
@@ -512,7 +506,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   FD_TEST( env->txn_out[2].err.is_committable );
   FD_TEST( env->txn_out[2].accounts.account[1]->lamports == 2000031UL );
   env->txn_out[2].accounts.account[1]->lamports = 2000041UL;
-  env->txn_out[2].accounts.account[1]->touched = 1;
 
   /* tx3: readonly */
   serialize_bundle_txn( &txn_p, account_keys, 2UL, 1UL );
@@ -583,7 +576,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     FD_TEST( env->txn_out[1].accounts.is_writable[1] == 1 );
     FD_TEST( env->txn_out[1].accounts.account[1] == env->txn_out[0].accounts.account[1] ); /* reused */
     env->txn_out[1].accounts.account[1]->lamports = 4000000UL;
-    env->txn_out[1].accounts.account[1]->touched = 1;
 
     /* Ownership of the accdb ref must transfer to the writable reuser:
        the writer now owns+commits the final state, while is_writable on
@@ -640,7 +632,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
 
   /* Simulate SBF program draining lamports to 0. */
   env->txn_out[0].accounts.account[1]->lamports = 0UL;
-  env->txn_out[0].accounts.account[1]->touched = 1;
 
   serialize_bundle_txn( &txn_p, reclaim_keys, 2UL, 0UL );
   env->txn_in.txn                     = &txn_p;
@@ -747,7 +738,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     env->txn_out[0].accounts.account[1]->lamports   = 0UL;
     env->txn_out[0].accounts.account[1]->data_len   = 0UL;
     env->txn_out[0].accounts.account[1]->executable = 0;
-    env->txn_out[0].accounts.account[1]->touched = 1;
     fd_memset( env->txn_out[0].accounts.account[1]->owner, 0, 32UL );
 
     serialize_bundle_txn( &txn_p, stake_keys, 2UL, 0UL );
@@ -866,7 +856,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     upgraded.inner.program_data.has_upgrade_authority_address = 1;
     ulong out_sz = 0UL;
     FD_TEST( !fd_bpf_state_encode( &upgraded, pd_out_data, PROGRAMDATA_METADATA_SIZE, &out_sz ) );
-    env->txn_out[0].accounts.account[ pd_idx ]->touched = 1;
   }
 
   env->txn_in.txn                     = &coherency_txn[1];
@@ -1088,7 +1077,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
                             env->txn_out[0].accounts.account[1]->data_len,
                             &nonce_fee_payer,
                             &bundle_nonce );
-    env->txn_out[0].accounts.account[1]->touched = 1;
 
     /* tx1: durable nonce txn whose recent blockhash matches only the
        staged bundle nonce. */
@@ -1156,9 +1144,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   env->txn_out[0].accounts.new_vote[1] = 1;
   env->txn_out[1].accounts.rm_vote [1] = 1;
   env->txn_out[2].accounts.new_vote[1] = 1;
-  env->txn_out[2].accounts.account[1]->touched = 1;
-  env->txn_out[1].accounts.account[1]->touched = 1;
-  env->txn_out[0].accounts.account[1]->touched = 1;
 
   fd_runtime_commit_txn( env->runtime, env->bank, NULL, &env->txn_out[0], 0 );
   fd_runtime_commit_txn( env->runtime, env->bank, NULL, &env->txn_out[1], 0 );
@@ -1221,7 +1206,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     /* tx0 closes the vote account; tx1 reuses it writable (taking
        ownership of the accdb ref) but does not touch vote state. */
     env->txn_out[0].accounts.rm_vote[1] = 1;
-    env->txn_out[0].accounts.account[1]->touched = 1;
 
     /* Ownership must have moved to tx1, leaving tx0 a non-owner. */
     FD_TEST( env->txn_out[0].accounts.account_acquired[1] == 0 );
@@ -1291,7 +1275,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
     FD_TEST( env->txn_out[1].accounts.stake_update[1] );      /* carried onto new owner */
     env->txn_out[1].accounts.account[1]->lamports   = 0UL;
     env->txn_out[1].accounts.account[1]->data_len   = 0UL;
-    env->txn_out[1].accounts.account[1]->touched = 1;
     fd_memset( env->txn_out[1].accounts.account[1]->owner, 0, 32UL );
 
     fd_runtime_commit_txn( env->runtime, env->bank, NULL, &env->txn_out[0], 0 );
@@ -1473,55 +1456,6 @@ test_execute_bundles( fd_svm_mini_t * mini ) {
   }
 
   FD_LOG_NOTICE(( "test bundle cancelled vote op not applied... ok" ));
-
-  /* ==========================================================================
-     Test: commit skips write-locked accounts left untouched
-     ========================================================================== */
-
-  {
-    fd_pubkey_t gate_key = { .ul[0] = 0xF00DUL };
-    create_test_account( env->mini->runtime->accdb, env->fork_id, &gate_key, 7000000UL, 0UL, NULL, &system );
-    fd_pubkey_t gate_keys[2] = { pubkey1, gate_key };
-
-    serialize_bundle_txn( &txn_p, gate_keys, 2UL, 0UL );
-    env->txn_in.txn                 = &txn_p;
-    env->txn_in.bundle.is_bundle    = 0;
-    env->txn_in.bundle.prev_txn_cnt = 0;
-    fd_runtime_prepare_and_execute_txn( env->runtime, env->bank, &env->txn_in, &env->txn_out[0] );
-    FD_TEST( env->txn_out[0].err.is_committable );
-    FD_TEST( env->txn_out[0].err.txn_err==FD_RUNTIME_EXECUTE_SUCCESS );
-    FD_TEST( env->txn_out[0].accounts.is_writable[1]==1 );
-    FD_TEST( env->txn_out[0].accounts.account[1]->lamports==7000000UL );
-    FD_TEST( env->txn_out[0].accounts.account[1]->touched==0 );
-
-    /* Simulate state that changed without any mutable access: commit
-       must not publish a new version of the untouched account. */
-    env->txn_out[0].accounts.account[1]->lamports = 8000000UL;
-    fd_runtime_commit_txn( env->runtime, env->bank, NULL, &env->txn_out[0], 0 );
-
-    serialize_bundle_txn( &txn_p, gate_keys, 2UL, 0UL );
-    env->txn_in.txn                 = &txn_p;
-    env->txn_in.bundle.is_bundle    = 0;
-    fd_runtime_prepare_and_execute_txn( env->runtime, env->bank, &env->txn_in, &env->txn_out[1] );
-    FD_TEST( env->txn_out[1].err.is_committable );
-    FD_TEST( env->txn_out[1].accounts.account[1]->lamports==7000000UL ); /* prior version retained */
-
-    /* Touched counterpart: the same mutation marked touched must publish. */
-    env->txn_out[1].accounts.account[1]->lamports = 8000000UL;
-    env->txn_out[1].accounts.account[1]->touched  = 1;
-    fd_runtime_commit_txn( env->runtime, env->bank, NULL, &env->txn_out[1], 0 );
-
-    serialize_bundle_txn( &txn_p, gate_keys, 2UL, 0UL );
-    env->txn_in.txn                 = &txn_p;
-    env->txn_in.bundle.is_bundle    = 0;
-    fd_runtime_prepare_and_execute_txn( env->runtime, env->bank, &env->txn_in, &env->txn_out[2] );
-    FD_TEST( env->txn_out[2].err.is_committable );
-    FD_TEST( env->txn_out[2].accounts.account[1]->lamports==8000000UL ); /* new version published */
-    env->txn_out[2].err.is_committable = 0;
-    fd_runtime_cancel_txn( env->runtime, NULL, NULL, &env->txn_out[2], 0 );
-
-    FD_LOG_NOTICE(( "test untouched account commit skipped... ok" ));
-  }
 }
 
 int

--- a/src/flamenco/vm/fd_vm_private.h
+++ b/src/flamenco/vm/fd_vm_private.h
@@ -387,8 +387,6 @@ fd_vm_handle_input_mem_region_oob( fd_vm_t const * vm,
       ulong memset_sz = fd_ulong_sat_sub( new_region_sz, vm->acc_region_metas[ region->acc_region_meta_idx ].acc->data_len );
       fd_memset( vm->acc_region_metas[ region->acc_region_meta_idx ].acc->data+vm->acc_region_metas[ region->acc_region_meta_idx ].acc->data_len, 0, memset_sz );
       vm->acc_region_metas[ region->acc_region_meta_idx ].acc->data_len = new_region_sz;
-      /* https://github.com/anza-xyz/agave/blob/v4.2.0-beta.1/transaction-context/src/transaction.rs#L546 */
-      vm->acc_region_metas[ region->acc_region_meta_idx ].acc->touched = 1;
       region->region_sz = (uint)new_region_sz;
     }
   }
@@ -436,13 +434,6 @@ fd_vm_find_input_mem_region( fd_vm_t const * vm,
 
   if( FD_UNLIKELY( write && vm->input_mem_regions[ region_idx ].is_writable==0U ) ) {
     return sentinel; /* Illegal write */
-  }
-
-  /* https://github.com/anza-xyz/agave/blob/v4.2.0-beta.1/transaction-context/src/transaction.rs#L546 */
-  if( FD_UNLIKELY( write && vm->acc_region_metas &&
-                   vm->input_mem_regions[ region_idx ].acc_region_meta_idx!=ULONG_MAX ) ) {
-    fd_acc_t * touched_acc = vm->acc_region_metas[ vm->input_mem_regions[ region_idx ].acc_region_meta_idx ].acc;
-    if( FD_LIKELY( touched_acc ) ) touched_acc->touched = 1;
   }
 
   ulong start_region_idx = region_idx;


### PR DESCRIPTION
This reverts commit 00acfda860d1f2b6e5910b93592fd55cc1f6e639.