### PR TITLE
disco: trim FD_TPU_RESOLVED_MTU, saves 572 MiB

### DIFF
--- a/src/ballet/txn/fd_txn.h
+++ b/src/ballet/txn/fd_txn.h
@@ -310,8 +310,8 @@ struct fd_txn {
 
   /* addr_table_adtl_cnt: The total number of account addresses summed across
      all the address lookup tables. addr_table_adtl_cnt in
-     [0, FD_TXN_ADDT_ADDR_MAX - acct_addr_cnt]. Since acct_addr_cnt > 0,
-     addr_table_adtl_cnt < 256. */
+     [0, FD_TXN_ACCT_ADDR_MAX - acct_addr_cnt]. Since acct_addr_cnt > 0,
+     addr_table_adtl_cnt < 64. */
   uchar      addr_table_adtl_cnt;
 
   uchar      _padding_reserved_1; /* explicit padding the compiler would have

--- a/src/disco/fd_txn_m.h
+++ b/src/disco/fd_txn_m.h
@@ -147,14 +147,14 @@ fd_txn_m_realized_footprint( fd_txn_m_t const * txnm,
                               +FD_TXN_MAX_SZ,                   \
                               alignof(fd_txn_m_t) )
 
-#define FD_TPU_RESOLVED_MTU FD_ULONG_ALIGN_UP(                     \
-                              FD_ULONG_ALIGN_UP(                   \
-                                 FD_ULONG_ALIGN_UP(                \
-                                    sizeof(fd_txn_m_t)+FD_TPU_MTU, \
-                                    alignof(fd_txn_t) )            \
-                                 +FD_TXN_MAX_SZ,                   \
-                                 alignof(fd_acct_addr_t) )         \
-                              +256UL*sizeof(fd_acct_addr_t),       \
+#define FD_TPU_RESOLVED_MTU FD_ULONG_ALIGN_UP(                              \
+                              FD_ULONG_ALIGN_UP(                            \
+                                 FD_ULONG_ALIGN_UP(                         \
+                                    sizeof(fd_txn_m_t)+FD_TPU_MTU,          \
+                                    alignof(fd_txn_t) )                     \
+                                 +FD_TXN_MAX_SZ,                            \
+                                 alignof(fd_acct_addr_t) )                  \
+                              +FD_TXN_ACCT_ADDR_MAX*sizeof(fd_acct_addr_t), \
                               alignof(fd_txn_m_t) )
 
 #endif /* HEADER_fd_src_disco_fd_txn_m_h */


### PR DESCRIPTION
This bound was oversized - the number of accounts in a transaction is limited to 64