### PR TITLE
util: define FUTEX2_SIZE_U32 missing in older linux version

### DIFF
--- a/src/util/io_uring/fd_io_uring_sys.h
+++ b/src/util/io_uring/fd_io_uring_sys.h
@@ -99,6 +99,10 @@
 #define IORING_RECVSEND_FIXED_BUF (1U<<2)
 #endif
 
+#ifndef FUTEX2_SIZE_U32
+#define FUTEX2_SIZE_U32 0x02
+#endif
+
 struct fd_io_uring_restriction {
   ushort opcode;
   union {


### PR DESCRIPTION
`FUTEX2_SIZE_U32` was added to linux/futex.h in newer kernels but is missing on older versions.