### PR TITLE
waltz: harden gRPC stream send state

### DIFF
--- a/src/waltz/grpc/fd_grpc_client.c
+++ b/src/waltz/grpc/fd_grpc_client.c
@@ -418,10 +418,10 @@ fd_grpc_client_request_continue1( fd_grpc_client_t * client ) {
   fd_h2_stream_t *      h2_stream = &stream->s;
   fd_h2_tx_op_copy( client->conn, h2_stream, client->frame_tx, client->request_tx_op );
   if( FD_UNLIKELY( client->request_tx_op->chunk_sz ) ) return 0;
+  client->request_stream = NULL;
   if( FD_UNLIKELY( h2_stream->state != FD_H2_STREAM_STATE_CLOSING_TX ) ) return 0;
   client->metrics->stream_chunks_tx_cnt++;
   /* Request finished */
-  client->request_stream = NULL;
   client->callbacks->tx_complete( client->ctx, stream->request_ctx );
   return 1;
 }
@@ -455,7 +455,7 @@ fd_grpc_client_request_is_blocked( fd_grpc_client_t * client ) {
 
 int
 fd_grpc_client_request_stream_busy( fd_grpc_client_t * client ) {
-  return client->request_stream != NULL;
+  return client->request_stream && client->request_tx_op->chunk_sz;
 }
 
 fd_grpc_h2_stream_t *
@@ -638,6 +638,8 @@ fd_grpc_client_stream_send_msg(
   if( FD_UNLIKELY( !fd_h2_rbuf_is_empty( client->frame_tx ) ) ) return 0;
   if( FD_UNLIKELY( client->request_tx_op->chunk_sz > 0UL ) ) return 0;
   if( FD_UNLIKELY( client->request_stream != NULL && client->request_stream != stream ) ) return 0; /* Another stream has a request in progress */
+  if( FD_UNLIKELY( stream->s.state!=FD_H2_STREAM_STATE_OPEN &&
+                   stream->s.state!=FD_H2_STREAM_STATE_CLOSING_RX ) ) return 0;
 
   /* Encode message */
   FD_TEST( client->nanopb_tx_max > sizeof(fd_grpc_hdr_t) );
@@ -679,6 +681,8 @@ fd_grpc_client_stream_send_msg1(
   if( FD_UNLIKELY( !fd_h2_rbuf_is_empty( client->frame_tx ) ) ) return 0;
   if( FD_UNLIKELY( client->request_tx_op->chunk_sz > 0UL ) ) return 0;
   if( FD_UNLIKELY( client->request_stream != NULL && client->request_stream != stream ) ) return 0; /* Another stream has a request in progress */
+  if( FD_UNLIKELY( stream->s.state!=FD_H2_STREAM_STATE_OPEN &&
+                   stream->s.state!=FD_H2_STREAM_STATE_CLOSING_RX ) ) return 0;
 
   /* Validate protobuf size */
   FD_TEST( client->nanopb_tx_max > sizeof(fd_grpc_hdr_t) );
@@ -719,8 +723,11 @@ fd_grpc_client_stream_close(
   if( FD_UNLIKELY( client->conn->flags & FD_H2_CONN_FLAGS_DEAD ) ) return 0;
   if( FD_UNLIKELY( !fd_h2_rbuf_is_empty( client->frame_tx ) ) ) return 0;
   if( FD_UNLIKELY( client->request_stream != NULL ) ) return 0; /* Another request in progress */
+  if( FD_UNLIKELY( stream->s.state!=FD_H2_STREAM_STATE_OPEN &&
+                   stream->s.state!=FD_H2_STREAM_STATE_CLOSING_RX ) ) return 0;
 
   /* Send empty DATA frame with END_STREAM flag to close the stream */
+  fd_h2_stream_close_tx( &stream->s, client->conn );
   fd_h2_tx_prepare( client->conn, client->frame_tx, FD_H2_FRAME_TYPE_DATA, FD_H2_FLAG_END_STREAM, stream->s.stream_id );
   fd_h2_tx_commit( client->conn, client->frame_tx );
 

--- a/src/waltz/grpc/fd_grpc_client.h
+++ b/src/waltz/grpc/fd_grpc_client.h
@@ -231,7 +231,7 @@ fd_grpc_client_rxtx_ossl( fd_grpc_client_t * client,
    (recvmsg(2) and sendmsg(2)).  Uses MSG_NOSIGNAL|MSG_DONTWAIT flags.
 
    Returns -1 if an error was encountered, and errno will be set.
-   Otherwise, returns 0. */
+   Returns 1 if send would block with EAGAIN.  Otherwise, returns 0. */
 
 int
 fd_grpc_client_rxtx_socket( fd_grpc_client_t * client,

--- a/src/waltz/grpc/test_grpc_client.c
+++ b/src/waltz/grpc/test_grpc_client.c
@@ -16,6 +16,15 @@ main( int     argc,
 #include "fd_grpc_client_private.h"
 #include "../../util/tmpl/fd_unit_test.c"
 
+typedef struct {
+  uchar unused;
+} test_empty_msg_t;
+
+#define test_Empty_FIELDLIST(X, a)
+#define test_Empty_CALLBACK NULL
+#define test_Empty_DEFAULT  NULL
+PB_BIND( test_Empty, test_empty_msg_t, AUTO )
+
 static fd_grpc_client_t * client;
 
 /* test_grpc_client_mock_conn injects a fake connection state into the
@@ -168,6 +177,63 @@ FD_UNIT_TEST( stream_release ) {
   FD_TEST( client->stream_ids[ 0 ]==stream3->s.stream_id );
   fd_grpc_client_stream_release( client, stream3 );
   FD_TEST( client->stream_cnt==0 );
+}
+
+FD_UNIT_TEST( stream_send_state ) {
+  fd_grpc_client_reset( client );
+  test_grpc_client_mock_conn( client );
+
+  fd_grpc_h2_stream_t * stream = fd_grpc_client_stream_acquire( client, 0UL );
+  FD_TEST( !fd_grpc_client_request_stream_busy( client ) );
+
+  uchar payload = 0U;
+  fd_h2_tx_op_init( client->request_tx_op, &payload, sizeof(payload), 0U );
+  FD_TEST( fd_grpc_client_request_stream_busy( client ) );
+  *client->request_tx_op = (fd_h2_tx_op_t){0};
+
+  fd_h2_stream_reset( &stream->s, client->conn );
+  test_empty_msg_t msg = {0};
+  FD_TEST( !fd_grpc_client_stream_send_msg ( client, stream, &test_empty_msg_t_msg, &msg ) );
+  FD_TEST( !fd_grpc_client_stream_send_msg1( client, stream, &payload, sizeof(payload) ) );
+
+  stream->s.state = FD_H2_STREAM_STATE_CLOSING_TX;
+  FD_TEST( !fd_grpc_client_stream_send_msg ( client, stream, &test_empty_msg_t_msg, &msg ) );
+  FD_TEST( !fd_grpc_client_stream_send_msg1( client, stream, &payload, sizeof(payload) ) );
+
+  FD_TEST( fd_h2_rbuf_is_empty( client->frame_tx ) );
+  FD_TEST( !client->request_tx_op->chunk_sz );
+
+  fd_grpc_client_stream_release( client, stream );
+}
+
+FD_UNIT_TEST( stream_close_state ) {
+  fd_grpc_client_reset( client );
+  test_grpc_client_mock_conn( client );
+
+  fd_grpc_h2_stream_t * stream = fd_grpc_client_request_start1(
+      client, "/test", 5UL, 0UL, NULL, 0UL, NULL, 0UL, 1 );
+  FD_TEST( stream );
+  FD_TEST( stream->s.state==FD_H2_STREAM_STATE_OPEN );
+  FD_TEST( client->conn->stream_active_cnt[1]==1U );
+  fd_h2_rbuf_skip( client->frame_tx, fd_h2_rbuf_used_sz( client->frame_tx ) );
+
+  uchar payload = 0U;
+  FD_TEST( fd_grpc_client_stream_send_msg1( client, stream, &payload, sizeof(payload) ) );
+  FD_TEST( !client->request_stream );
+  FD_TEST( !client->request_tx_op->chunk_sz );
+  fd_h2_rbuf_skip( client->frame_tx, fd_h2_rbuf_used_sz( client->frame_tx ) );
+
+  FD_TEST( fd_grpc_client_stream_close( client, stream ) );
+  FD_TEST( stream->s.state==FD_H2_STREAM_STATE_CLOSING_TX );
+  fd_h2_rbuf_skip( client->frame_tx, fd_h2_rbuf_used_sz( client->frame_tx ) );
+
+  FD_TEST( !fd_grpc_client_stream_send_msg1( client, stream, &payload, sizeof(payload) ) );
+  FD_TEST( !fd_grpc_client_stream_close( client, stream ) );
+
+  fd_h2_stream_rx_data( &stream->s, client->conn, FD_H2_FLAG_END_STREAM );
+  FD_TEST( stream->s.state==FD_H2_STREAM_STATE_CLOSED );
+  FD_TEST( client->conn->stream_active_cnt[1]==0U );
+  fd_grpc_client_stream_release( client, stream );
 }
 
 FD_UNIT_TEST( rx_headers ) {


### PR DESCRIPTION
Streaming requests could retain a stream pointer after the queued payload drained, and send calls accepted HTTP/2 states that cannot carry DATA.

Report busy only while bytes remain queued, allow streaming DATA only in `OPEN` or `CLOSING_RX`, and document the socket I/O `EAGAIN` result.

The [gRPC over HTTP/2 protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) carries length-prefixed request messages in DATA frames and signals request EOS with `END_STREAM` on the final DATA frame. [RFC 9113 §§5.1 and 6.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-6.1) permit DATA only in open or half-closed (remote), which map to Firedancer's `OPEN` and `CLOSING_RX` states.

Tested with `make -j4 test_grpc_client` and `build/native/gcc/unit-test/test_grpc_client`.
