### PR TITLE
waltz: reject malformed URL ports

### DIFF
--- a/src/waltz/http/fd_url.c
+++ b/src/waltz/http/fd_url.c
@@ -27,10 +27,13 @@ fd_url_parse_cstr( fd_url_t *   const url,
 
   char const * const authority = scheme+scheme_len;
 
-  /* Find beginning of path */
+  /* Find end of authority */
   char const * authority_end;
   for( authority_end = authority;
-       authority_end < url_end && *authority_end!='/';
+       authority_end < url_end &&
+       *authority_end != '/'   &&
+       *authority_end != '?'   &&
+       *authority_end != '#';
        authority_end++ ) {
     if( FD_UNLIKELY( *authority_end=='@' ) ) {
       *opt_err = FD_URL_ERR_USERINFO;
@@ -105,22 +108,24 @@ fd_url_parse_endpoint( fd_url_t *   url_,
   *is_ssl = ( url->scheme_len==8UL );
 
   *tcp_port = *is_ssl ? 443 : 80;
-  if( url->port_len ) {
-    if( FD_UNLIKELY( url->port_len > 5 ) ) {
-    invalid_port:
-      FD_LOG_WARNING(( "Invalid %s `%.*s`: invalid port number", ctx, (int)url_str_len, url_str ));
-      return -1;
-    }
+  if( FD_LIKELY( !url->port ) ) return 0;
+  if( FD_UNLIKELY( !url->port_len || url->port_len>5UL ) ) goto invalid_port;
 
-    char port_cstr[6];
-    fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( port_cstr ), url->port, url->port_len ) );
-    ulong port_no = fd_cstr_to_ulong( port_cstr );
-    if( FD_UNLIKELY( !port_no || port_no>USHORT_MAX ) ) goto invalid_port;
-
-    *tcp_port = (ushort)port_no;
+  ulong port_no = 0UL;
+  for( ulong i=0UL; i<url->port_len; i++ ) {
+    uchar c = (uchar)url->port[ i ];
+    if( FD_UNLIKELY( c<(uchar)'0' || c>(uchar)'9' ) ) goto invalid_port;
+    port_no = 10UL*port_no + (ulong)(c-(uchar)'0');
   }
+  if( FD_UNLIKELY( !port_no || port_no>USHORT_MAX ) ) goto invalid_port;
+
+  *tcp_port = (ushort)port_no;
 
   return 0;
+
+invalid_port:
+  FD_LOG_WARNING(( "Invalid %s `%.*s`: invalid port number", ctx, (int)url_str_len, url_str ));
+  return -1;
 }
 
 

--- a/src/waltz/http/test_url.c
+++ b/src/waltz/http/test_url.c
@@ -155,6 +155,39 @@ test_url_parse( void ) {
   FD_LOG_NOTICE(( "test_url_parse: pass" ));
 }
 
+static void
+test_url_parse_endpoint( void ) {
+  fd_url_t url;
+  ushort   port;
+  _Bool    is_ssl;
+
+  FD_TEST( !fd_url_parse_endpoint( &url, "http://example.com:8080", 23UL, &port, &is_ssl, "test URL" ) );
+  FD_TEST( port==8080U && !is_ssl );
+
+  FD_TEST( !fd_url_parse_endpoint( &url, "https://example.com", 19UL, &port, &is_ssl, "test URL" ) );
+  FD_TEST( port==443U && is_ssl );
+
+  FD_TEST( !fd_url_parse_endpoint( &url, "https://example.com:443?token=x", 31UL, &port, &is_ssl, "test URL" ) );
+  FD_TEST( port==443U && is_ssl && url.tail_len==8UL && !memcmp( url.tail, "?token=x", 8UL ) );
+
+  FD_TEST( !fd_url_parse_endpoint( &url, "http://example.com:80#frag", 26UL, &port, &is_ssl, "test URL" ) );
+  FD_TEST( port==80U && !is_ssl && url.tail_len==5UL && !memcmp( url.tail, "#frag", 5UL ) );
+
+  char const * invalid[] = {
+    "http://example.com:",
+    "http://example.com:0",
+    "http://example.com:0x80",
+    "http://example.com:123x",
+    "http://example.com:65536",
+    "http://example.com:123456"
+  };
+  for( ulong i=0UL; i<sizeof(invalid)/sizeof(invalid[0]); i++ ) {
+    FD_TEST( fd_url_parse_endpoint( &url, invalid[ i ], strlen( invalid[ i ] ), &port, &is_ssl, "test URL" )==-1 );
+  }
+
+  FD_LOG_NOTICE(( "test_url_parse_endpoint: pass" ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -162,6 +195,7 @@ main( int     argc,
 
   test_url_unescape();
   test_url_parse();
+  test_url_parse_endpoint();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();


### PR DESCRIPTION
Malformed URL ports such as `0x80` and `123x` were partially parsed as valid numbers.

Require decimal digits only and keep the accepted range at 1–65535. Add endpoint parsing coverage for valid defaults, explicit ports, and malformed values.

Tested with `make -j4 test_url` and `build/native/gcc/unit-test/test_url --log-path /dev/null`.
