### PR TITLE
ci: bind backtest/hugepages inputs via env before shell

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -41,8 +41,10 @@ runs:
     - name: Set extras key value
       shell: bash
       id: extras_trimmed
+      env:
+        EXTRAS: ${{ inputs.extras }}
       run: |
-        key=$(echo "${{ inputs.extras }}" | sed 's/[[:space:]]//g')
+        key=$(echo "$EXTRAS" | sed 's/[[:space:]]//g')
         echo "extras_key=$key" >> $GITHUB_OUTPUT
 
     - name: apt-get update
@@ -52,7 +54,9 @@ runs:
 
     - id: deps-sh-hash
       shell: bash
-      run: cat /etc/os-release '${{ inputs.deps-script-path }}' | sha256sum | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"
+      env:
+        DEPS_SCRIPT_PATH: ${{ inputs.deps-script-path }}
+      run: cat /etc/os-release "$DEPS_SCRIPT_PATH" | sha256sum | awk '{print "HASH=" $1}' >> "$GITHUB_OUTPUT"
 
     - id: deps-sh-cache
       uses: corca-ai/local-cache@v2
@@ -64,7 +68,9 @@ runs:
 
     - name: Install system level dependencies
       shell: bash
-      run: FD_AUTO_INSTALL_PACKAGES=1 '${{ inputs.deps-script-path }}' check
+      env:
+        DEPS_SCRIPT_PATH: ${{ inputs.deps-script-path }}
+      run: FD_AUTO_INSTALL_PACKAGES=1 "$DEPS_SCRIPT_PATH" check
 
     - name: Install dependencies from cache
       shell: bash
@@ -73,13 +79,20 @@ runs:
 
     - name: Install dependencies from scratch
       shell: bash
+      env:
+        COMPILER: ${{ inputs.compiler }}
+        COMPILER_VERSION: ${{ inputs.compiler-version }}
+        CXX: ${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}
+        DEPS_SCRIPT_PATH: ${{ inputs.deps-script-path }}
+        DEPS_BUNDLE_PATH: ${{ inputs.deps-bundle-path }}
+        EXTRAS: ${{ inputs.extras }}
       run: |
-        if [[ "${{ inputs.compiler-version }}" != "system" ]]; then
-          source /opt/${{ inputs.compiler }}/${{ inputs.compiler }}-${{ inputs.compiler-version }}/activate
+        if [[ "$COMPILER_VERSION" != "system" ]]; then
+          source /opt/${COMPILER}/${COMPILER}-${COMPILER_VERSION}/activate
         fi
-        CC='${{ inputs.compiler }}' \
-        CXX='${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}' \
+        CC="$COMPILER" \
+        CXX="$CXX" \
         FD_AUTO_INSTALL_PACKAGES=1 \
-        '${{ inputs.deps-script-path }}' ${{ inputs.extras }} fetch install
-        '${{ inputs.deps-bundle-path }}'
+        "$DEPS_SCRIPT_PATH" $EXTRAS fetch install
+        "$DEPS_BUNDLE_PATH"
       if: steps.deps-sh-cache.outputs.cache-hit != 'true'

--- a/.github/actions/hugepages/action.yml
+++ b/.github/actions/hugepages/action.yml
@@ -14,6 +14,9 @@ runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        COUNT_GIGANTIC: ${{ inputs.count_gigantic }}
+        COUNT_HUGE: ${{ inputs.count_huge }}
       run: |
         set -x
 
@@ -28,9 +31,9 @@ runs:
            findmnt -t hugetlbfs /mnt/.fd/.huge     >/dev/null 2>&1 && \
            ! has_min_size "$gigantic_opts" && \
            ! has_min_size "$huge_opts" && \
-           [ "$gigantic_have" -ge '${{ inputs.count_gigantic }}' ] && \
-           [ "$huge_have"     -ge '${{ inputs.count_huge }}'     ]; then
-          echo "hugepages: mounts present (no min_size) and >= ${{ inputs.count_gigantic }} gigantic / ${{ inputs.count_huge }} huge pages already reserved; nothing to do"
+           [ "$gigantic_have" -ge "$COUNT_GIGANTIC" ] && \
+           [ "$huge_have"     -ge "$COUNT_HUGE"     ]; then
+          echo "hugepages: mounts present (no min_size) and >= $COUNT_GIGANTIC gigantic / $COUNT_HUGE huge pages already reserved; nothing to do"
           sudo chown -R $USER:$USER /mnt/.fd || true
           exit 0
         fi
@@ -41,8 +44,8 @@ runs:
         findmnt -t hugetlbfs -n -o TARGET | xargs -r sudo umount || true
         sudo src/util/shmem/fd_shmem_cfg reset || true
         sudo src/util/shmem/fd_shmem_cfg init 0775 $USER "" || true
-        [ "$gigantic_have" -lt '${{ inputs.count_gigantic }}' ] && \
-          sudo src/util/shmem/fd_shmem_cfg alloc '${{ inputs.count_gigantic }}' gigantic 0
-        [ "$huge_have" -lt '${{ inputs.count_huge }}' ] && \
-          sudo src/util/shmem/fd_shmem_cfg alloc '${{ inputs.count_huge }}' huge 0
+        [ "$gigantic_have" -lt "$COUNT_GIGANTIC" ] && \
+          sudo src/util/shmem/fd_shmem_cfg alloc "$COUNT_GIGANTIC" gigantic 0
+        [ "$huge_have" -lt "$COUNT_HUGE" ] && \
+          sudo src/util/shmem/fd_shmem_cfg alloc "$COUNT_HUGE" huge 0
         sudo chown -R $USER:$USER /mnt/.fd

--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -70,16 +70,20 @@ jobs:
 
       - name: download ledgers
         timeout-minutes: 45
+        env:
+          SCRIPT: ${{ inputs.script }}
         run: |
-          DUMP_DIR=../dump DOWNLOAD_ONLY=true ${{ inputs.script }}
+          DUMP_DIR=../dump DOWNLOAD_ONLY=true $SCRIPT
 
       - name: run backtest
         timeout-minutes: 45
+        env:
+          SCRIPT: ${{ inputs.script }}
         run: |
           sudo prlimit --pid=$$ --nofile=1048576
           sudo prlimit --pid=$$ --memlock=unlimited
           sudo $OBJDIR/bin/firedancer-dev configure fini all || true
-          DUMP_DIR=../dump ${{ inputs.script }}
+          DUMP_DIR=../dump $SCRIPT
 
       - name: fini
         if: always()

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -141,39 +141,48 @@ jobs:
           extras: +dev
 
       - name: Build command line args
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          CHECK_RUN: ${{ inputs.check_run }}
+          EXIT_ON_ERR: ${{ inputs.exit_on_err }}
+          MACHINE: ${{ inputs.machine }}
+          GCC: ${{ inputs.gcc }}
+          NO_OPTIMIZATION: ${{ inputs.no_optimization }}
+          VERBOSE: ${{ inputs.verbose }}
+          GCC_EXCEPTIONS: ${{ inputs.gcc_exceptions }}
         run: |
           ARGS=""
           # dry-run
-          if [ "${{ inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             ARGS="$ARGS --dry-run"
           fi
           # check-run
-          if [ "${{ inputs.check_run }}" == "true" ]; then
+          if [ "$CHECK_RUN" == "true" ]; then
             ARGS="$ARGS --check-run --no-deps"
           fi
           # exit-on-err
-          if [ "${{ inputs.exit_on_err }}" == "true" ]; then
+          if [ "$EXIT_ON_ERR" == "true" ]; then
             ARGS="$ARGS --exit-on-err"
           fi
           # machine
-          if [ ! -z "${{ inputs.machine }}" ] && [ "${{ inputs.machine }}" != "all" ]; then
-            ARGS="$ARGS --machines ${{ inputs.machine }}"
+          if [ ! -z "$MACHINE" ] && [ "$MACHINE" != "all" ]; then
+            ARGS="$ARGS --machines $MACHINE"
           fi
           # gcc
-          if [ ! -z "${{ inputs.gcc }}" ] && [ "${{ inputs.gcc }}" != "all" ]; then
-            ARGS="$ARGS --gcc-versions ${{ inputs.gcc }}"
+          if [ ! -z "$GCC" ] && [ "$GCC" != "all" ]; then
+            ARGS="$ARGS --gcc-versions $GCC"
           fi
           # no-optimization
-          if [ "${{ inputs.no_optimization }}" == "true" ]; then
+          if [ "$NO_OPTIMIZATION" == "true" ]; then
             ARGS="$ARGS --no-optimization"
           fi
           # verbose
-          if [ "${{ inputs.verbose }}" == "true" ]; then
+          if [ "$VERBOSE" == "true" ]; then
             ARGS="$ARGS --verbose"
           fi
           # exceptions
-          if [ ! -z "${{ inputs.gcc_exceptions }}" ] && [ "${{ inputs.gcc_exceptions }}" != "none" ]; then
-            no_spaces=$(tr -d '[:space:]' <<< "${{ inputs.gcc_exceptions }}")
+          if [ ! -z "$GCC_EXCEPTIONS" ] && [ "$GCC_EXCEPTIONS" != "none" ]; then
+            no_spaces=$(tr -d '[:space:]' <<< "$GCC_EXCEPTIONS")
             IFS=';' read -r -a exceptions <<< "$no_spaces"
             for exception in ${exceptions[@]}; do
               ARGS="$ARGS --gcc-except $exception"
@@ -204,39 +213,48 @@ jobs:
           extras: +dev
 
       - name: Build command line args
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          CHECK_RUN: ${{ inputs.check_run }}
+          EXIT_ON_ERR: ${{ inputs.exit_on_err }}
+          MACHINE: ${{ inputs.machine }}
+          CLANG: ${{ inputs.clang }}
+          NO_OPTIMIZATION: ${{ inputs.no_optimization }}
+          VERBOSE: ${{ inputs.verbose }}
+          CLANG_EXCEPTIONS: ${{ inputs.clang_exceptions }}
         run: |
           ARGS=""
           # dry-run
-          if [ "${{ inputs.dry_run }}" == "true" ]; then
+          if [ "$DRY_RUN" == "true" ]; then
             ARGS="$ARGS --dry-run"
           fi
           # check-run
-          if [ "${{ inputs.check_run }}" == "true" ]; then
+          if [ "$CHECK_RUN" == "true" ]; then
             ARGS="$ARGS --check-run --no-deps"
           fi
           # exit-on-err
-          if [ "${{ inputs.exit_on_err }}" == "true" ]; then
+          if [ "$EXIT_ON_ERR" == "true" ]; then
             ARGS="$ARGS --exit-on-err"
           fi
           # machine
-          if [ ! -z "${{ inputs.machine }}" ] && [ "${{ inputs.machine }}" != "all" ]; then
-            ARGS="$ARGS --machines ${{ inputs.machine }}"
+          if [ ! -z "$MACHINE" ] && [ "$MACHINE" != "all" ]; then
+            ARGS="$ARGS --machines $MACHINE"
           fi
           # clang
-          if [ ! -z "${{ inputs.clang }}" ] && [ "${{ inputs.clang }}" != "all" ]; then
-            ARGS="$ARGS --clang-versions ${{ inputs.clang }}"
+          if [ ! -z "$CLANG" ] && [ "$CLANG" != "all" ]; then
+            ARGS="$ARGS --clang-versions $CLANG"
           fi
           # no-optimization
-          if [ "${{ inputs.no_optimization }}" == "true" ]; then
+          if [ "$NO_OPTIMIZATION" == "true" ]; then
             ARGS="$ARGS --no-optimization"
           fi
           # verbose
-          if [ "${{ inputs.verbose }}" == "true" ]; then
+          if [ "$VERBOSE" == "true" ]; then
             ARGS="$ARGS --verbose"
           fi
           # exceptions
-          if [ ! -z "${{ inputs.clang_exceptions }}" ] && [ "${{ inputs.clang_exceptions }}" != "none" ]; then
-            no_spaces=$(tr -d '[:space:]' <<< "${{ inputs.clang_exceptions }}")
+          if [ ! -z "$CLANG_EXCEPTIONS" ] && [ "$CLANG_EXCEPTIONS" != "none" ]; then
+            no_spaces=$(tr -d '[:space:]' <<< "$CLANG_EXCEPTIONS")
             IFS=';' read -r -a exceptions <<< "$no_spaces"
             for exception in ${exceptions[@]}; do
               ARGS="$ARGS --clang-except $exception"


### PR DESCRIPTION
## Summary
Binds workflow / composite inputs into step `env:` before shell use across Firedancer CI:

- `.github/workflows/backtest.yml` — script path + args
- `.github/actions/hugepages/action.yml` — hugepage counts
- `.github/workflows/builds.yml` — workflow_call build args (gcc + clang jobs)
- `.github/actions/deps/action.yml` — deps script paths, compiler, extras

## Context
GitHub Actions expands `${{ inputs.* }}` before the shell runs. Binding through `env:` keeps values out of the script text (script-injection hardening for `workflow_call` / composite inputs).

## Test plan
- [ ] Confirm affected workflow/action YAML still validates
- [ ] Existing backtest / builds / deps callers behave the same with identical inputs