### PR TITLE
backup: permit purging while producing a snapshot

### DIFF
--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1166,6 +1166,14 @@ fd_topo_initialize( config_t * config ) {
     fd_topob_tile_uses( topo, accdb_tile,  fseq_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
     FD_TEST( fd_pod_insertf_ulong( topo->props, fseq_obj->id, "accdb_epoch.snapzp.%lu", i ) );
   }
+  if( snapmk_enabled ) {
+    fd_topo_obj_t * fseq_obj = fd_topob_obj( topo, "fseq", "metric" );
+    fd_topo_tile_t * snapmk_tile = &topo->tiles[ fd_topo_find_tile( topo, "snapmk", 0UL ) ];
+    fd_topo_tile_t * accdb_tile  = &topo->tiles[ fd_topo_find_tile( topo, "accdb",  0UL ) ];
+    fd_topob_tile_uses( topo, snapmk_tile, fseq_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
+    fd_topob_tile_uses( topo, accdb_tile,  fseq_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
+    FD_TEST( fd_pod_insert_ulong( topo->props, "accdb_epoch.snapmk", fseq_obj->id ) );
+  }
 
   fd_pod_insert_int( topo->props, "sandbox", config->development.sandbox ? 1 : 0 );
 
@@ -1479,6 +1487,8 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
       FD_TEST( tile->accdb.resolv_epoch_obj_ids[ i ]!=ULONG_MAX );
     }
 
+    tile->accdb.snapmk_epoch_obj_id = fd_pod_query_ulong( config->topo.props, "accdb_epoch.snapmk", ULONG_MAX );
+
     tile->accdb.snapzp_epoch_obj_cnt = config->firedancer.layout.enable_snapshot_production
                                        ? config->firedancer.layout.snapzp_tile_count : 0UL;
     FD_TEST( tile->accdb.snapzp_epoch_obj_cnt<=sizeof(tile->accdb.snapzp_epoch_obj_ids)/sizeof(tile->accdb.snapzp_epoch_obj_ids[0]) );
@@ -1693,6 +1703,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
   } else if( FD_UNLIKELY( !strcmp( tile->name, "snapmk" ) ) ) {
 
     tile->snapmk.accdb_obj_id       = fd_pod_query_ulong( config->topo.props, "accdb",              ULONG_MAX ); FD_TEST( tile->snapmk.accdb_obj_id!=ULONG_MAX );
+    tile->snapmk.accdb_epoch_obj_id = fd_pod_query_ulong( config->topo.props, "accdb_epoch.snapmk", ULONG_MAX ); FD_TEST( tile->snapmk.accdb_epoch_obj_id!=ULONG_MAX );
     tile->snapmk.visited_set_obj_id = fd_pod_query_ulong( config->topo.props, "backup.vis",         ULONG_MAX ); FD_TEST( tile->snapmk.visited_set_obj_id!=ULONG_MAX );
     tile->snapmk.banks_obj_id       = fd_pod_query_ulong( config->topo.props, "banks",              ULONG_MAX ); FD_TEST( tile->snapmk.banks_obj_id!=ULONG_MAX );
     tile->snapmk.zp_fseq_id         = fd_pod_query_ulong( config->topo.props, "snapzp.fseq",        ULONG_MAX ); FD_TEST( tile->snapmk.zp_fseq_id!=ULONG_MAX );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -586,6 +586,7 @@ struct fd_topo_tile {
       ulong rpc_epoch_obj_id;
       ulong resolv_epoch_obj_ids[ 16 ];
       ulong resolv_epoch_obj_cnt;
+      ulong snapmk_epoch_obj_id;
       ulong snapzp_epoch_obj_ids[ 64 ];
       ulong snapzp_epoch_obj_cnt;
     } accdb;
@@ -695,6 +696,7 @@ struct fd_topo_tile {
 
     struct {
       ulong accdb_obj_id;
+      ulong accdb_epoch_obj_id;
       ulong visited_set_obj_id;
       ulong banks_obj_id;
       ulong zp_fseq_id;

--- a/src/discof/backup/fd_backup_cache.c
+++ b/src/discof/backup/fd_backup_cache.c
@@ -9,17 +9,24 @@ fd_backup_cache_init( fd_backup_cache_t *        backup,
                       fd_accdb_accmeta_t const * acc_pool,
                       ulong                      max_accounts,
                       ulong                      acc_map_seed,
-                      ulong                      chain_mask ) {
+                      ulong                      chain_mask,
+                      ulong *                    epoch_slot,
+                      ulong const *              epoch ) {
+  FD_TEST( epoch_slot );
+  FD_TEST( epoch      );
   *backup = (fd_backup_cache_t) {
     .acc_map            = acc_map,
     .acc_pool           = acc_pool,
     .max_accounts       = max_accounts,
     .acc_map_seed       = acc_map_seed,
     .chain_mask         = (uint)chain_mask,
+    .epoch_slot         = epoch_slot,
+    .epoch              = epoch,
     .cache_class        = 0UL,
     .cache_idx          = 0UL,
     .root_generation    = 0
   };
+  FD_VOLATILE( *epoch_slot ) = ULONG_MAX; /* idle until first section */
   for( ulong i=0UL; i<FD_ACCDB_CACHE_CLASS_CNT; i++ ) {
     backup->cache    [ i ] = cache    [ i ];
     backup->cache_max[ i ] = cache_max[ i ];
@@ -29,7 +36,8 @@ fd_backup_cache_init( fd_backup_cache_t *        backup,
 
 fd_backup_cache_t *
 fd_backup_cache_join( fd_backup_cache_t * backup,
-                      fd_accdb_shmem_t *  accdb ) {
+                      fd_accdb_shmem_t *  accdb,
+                      ulong *             epoch_fseq ) {
   ulong max_live_slots = accdb->max_live_slots;
   ulong max_accounts   = accdb->max_accounts;
 
@@ -54,7 +62,9 @@ fd_backup_cache_join( fd_backup_cache_t * backup,
       _acc_map,
       _acc_pool_ele,  max_accounts,
       accdb->seed,
-      chain_cnt-1UL
+      chain_cnt-1UL,
+      epoch_fseq,
+      &accdb->epoch
   );
   return backup;
 }
@@ -169,6 +179,10 @@ fd_backup_cache_scan( fd_backup_cache_t * backup,
     return NULL;
   }
 
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *backup->epoch_slot ) = FD_VOLATILE_CONST( *backup->epoch );
+  FD_HW_MFENCE();
+
   /* Scan through cache lines (sequentially)
      This discovers any cached account (rooted or not), therefore may
      produce account indices that become invalid.  These are filtered
@@ -218,6 +232,9 @@ fd_backup_cache_scan( fd_backup_cache_t * backup,
   /* Filter out freed/invisible and non-rooted accounts */
 
   filter_batch( backup, frag );
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *backup->epoch_slot ) = ULONG_MAX;
   return frag;
 }
 
@@ -229,6 +246,8 @@ fd_backup_cache_read( fd_backup_cache_t * ctx,
                       ulong *             out_sz,
                       ulong               out_max ) {
   FD_TEST( pubkey );
+
+  FD_DCHECK_CRIT( FD_VOLATILE_CONST( *ctx->epoch_slot )!=ULONG_MAX, "caller must publish epoch" );
 
   if( FD_UNLIKELY( (ulong)acc_idx>=ctx->max_accounts ) ) {
     return FD_BACKUP_CACHE_ERR_MISS;

--- a/src/discof/backup/fd_backup_cache.h
+++ b/src/discof/backup/fd_backup_cache.h
@@ -43,6 +43,9 @@ struct fd_backup_cache {
   ulong                      acc_map_seed; /* map hash function */
   uint                       chain_mask;   /* map chain count - 1 */
 
+  ulong *       epoch_slot;
+  ulong const * epoch;
+
   uint root_generation;
 
   ulong cache_class;
@@ -81,7 +84,9 @@ fd_backup_cache_init( fd_backup_cache_t *           backup,
                       fd_accdb_accmeta_t const *    acc_pool,
                       ulong                         max_accounts,
                       ulong                         acc_map_seed,
-                      ulong                         chain_mask );
+                      ulong                         chain_mask,
+                      ulong *                       epoch_slot,
+                      ulong const *                 epoch );
 
 /* fd_backup_cache_join is a convenience API for joining an accdb_shmem.
    epoch_fseq is the tile-owned external epoch slot that accdb scans
@@ -89,7 +94,8 @@ fd_backup_cache_init( fd_backup_cache_t *           backup,
 
 fd_backup_cache_t *
 fd_backup_cache_join( fd_backup_cache_t * backup,
-                      fd_accdb_shmem_t *  accdb_shmem );
+                      fd_accdb_shmem_t *  accdb_shmem,
+                      ulong *             epoch_fseq );
 
 /* fd_backup_cache_scan yields a batch of rooted accounts found in
    cache.  Returns NULL once the scan completes. */

--- a/src/discof/backup/fd_backup_disk.h
+++ b/src/discof/backup/fd_backup_disk.h
@@ -52,6 +52,9 @@ struct fd_snapmk_accparse {
   ulong                      acc_map_seed; /* map hash function */
   uint                       chain_mask;   /* map chain count - 1 */
 
+  ulong *       epoch_slot;
+  ulong const * epoch;
+
   visited_set_t *            visited_set;
 
   uint root_generation;
@@ -65,7 +68,7 @@ struct fd_snapmk_accparse {
   /* deslop this shit */
   uint        ps_cnt;
   ulong       ps_base_gaddr;
-  uint        ps_head    [ FD_BACKUP_DISK_PARA ];
+  ulong       ps_hash    [ FD_BACKUP_DISK_PARA ];
   uint        ps_frag_off[ FD_BACKUP_DISK_PARA ];
   ulong       ps_file_off[ FD_BACKUP_DISK_PARA ];
   fd_pubkey_t ps_pubkey  [ FD_BACKUP_DISK_PARA ];
@@ -106,7 +109,7 @@ fd_snapmk_accparse_pop( fd_snapmk_accparse_t * parse,
    otherwise. */
 
 static inline int
-fd_snapmk_accparse_keep( fd_snapmk_accparse_t * parse ) {
+fd_snapmk_accparse_keep_inner( fd_snapmk_accparse_t * parse ) {
   uint const root_generation    = parse->root_generation;
   uint const min_generation     = 0;
   int const  include_tombstones = 0;
@@ -152,6 +155,21 @@ next:
   }
 
   return 0;
+}
+
+static inline int
+fd_snapmk_accparse_keep( fd_snapmk_accparse_t * parse ) {
+  ulong *       epoch_slot = parse->epoch_slot;
+  ulong const * epoch      = parse->epoch;
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *epoch_slot ) = FD_VOLATILE_CONST( *epoch );
+  FD_HW_MFENCE();
+
+  int keep = fd_snapmk_accparse_keep_inner( parse );
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
+  return keep;
 }
 
 static inline void
@@ -301,7 +319,7 @@ fd_snapmk_accparse_prestage( fd_snapmk_accparse_t * parse ) {
   if( FD_UNLIKELY( parse->pub_pending || parse->acc_active || parse->meta_sz ) ) return;
 
   ulong const meta_sz = sizeof(fd_accdb_disk_meta_t);
-  ulong hash[ FD_BACKUP_DISK_PARA ];
+  ulong * hash     = parse->ps_hash;
   ulong seed       = parse->acc_map_seed;
   uint  chain_mask = parse->chain_mask;
   uint const *               acc_map  = parse->acc_map;
@@ -345,7 +363,6 @@ fd_snapmk_accparse_prestage( fd_snapmk_accparse_t * parse ) {
     uint head = FD_VOLATILE_CONST( acc_map[ hash[ i ] ] );
     uint live = ( head!=UINT_MAX ) & ( (ulong)head<max_accounts );
     __builtin_prefetch( &acc_pool[ head & ( 0U-live ) ], 0, 0 );
-    parse->ps_head[ i ] = head;
   }
 
   parse->ps_cnt        = (uint)n;
@@ -358,9 +375,10 @@ fd_snapmk_accparse_prestage( fd_snapmk_accparse_t * parse ) {
 static void
 fd_snapmk_accparse_keep_batch( fd_snapmk_accparse_t * parse,
                                ulong const *          file_off,
-                               uint const *           head,
+                               ulong const *          hash,
                                uint *                 acc_idx,
                                ulong                  cnt ) {
+  uint const *               acc_map      = parse->acc_map;
   fd_accdb_accmeta_t const * acc_pool     = parse->acc_pool;
   ulong                      max_accounts = parse->max_accounts;
   uint                       root_gen     = parse->root_generation;
@@ -370,6 +388,12 @@ fd_snapmk_accparse_keep_batch( fd_snapmk_accparse_t * parse,
   uint matched[ FD_BACKUP_DISK_PARA ];
   for( ulong n=0UL; n<FD_BACKUP_DISK_PARA; n++ ) matched[ n ] = UINT_MAX;
 
+  ulong *       epoch_slot = parse->epoch_slot;
+  ulong const * epoch      = parse->epoch;
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *epoch_slot ) = FD_VOLATILE_CONST( *epoch );
+  FD_HW_MFENCE();
+
   /* lane[i]/cur[i]: compacted live-lane list, lane index and the chain
      node it sits on.  head[] was loaded (and prefetched) when the
      batch was prestaged, a full batch resolve ago. */
@@ -378,7 +402,7 @@ fd_snapmk_accparse_keep_batch( fd_snapmk_accparse_t * parse,
 
   ulong active_cnt = 0UL;
   for( ulong n=0UL; n<cnt; n++ ) {
-    uint h    = head[ n ];
+    uint h    = FD_VOLATILE_CONST( acc_map[ hash[ n ] ] );
     uint live = ( h!=UINT_MAX ) & ( (ulong)h<max_accounts );
     lane[ active_cnt ] = (uint)n;
     cur [ active_cnt ] = h;
@@ -414,6 +438,9 @@ fd_snapmk_accparse_keep_batch( fd_snapmk_accparse_t * parse,
     active_cnt = next_cnt;
   }
 
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
+
   for( ulong n=0UL; n<FD_BACKUP_DISK_PARA; n++ ) {
     uint  idx  = matched[ n ];
     uint  have = idx!=UINT_MAX;
@@ -435,9 +462,9 @@ fd_snapmk_accparse_publish_batch( fd_snapmk_accparse_t *       parse,
 
   /* Move batch N out of the prestage buffer, then stage N+1 before
      resolving N so N+1's prefetches overlap N's chain walk below. */
-  uint  head    [ FD_BACKUP_DISK_PARA ];
+  ulong hash    [ FD_BACKUP_DISK_PARA ];
   ulong file_off[ FD_BACKUP_DISK_PARA ];
-  memcpy( head,            parse->ps_head,     n*sizeof(uint)        );
+  memcpy( hash,            parse->ps_hash,     n*sizeof(ulong)       );
   memcpy( file_off,        parse->ps_file_off, n*sizeof(ulong)       );
   memcpy( batch->frag_off, parse->ps_frag_off, n*sizeof(uint)        );
   memcpy( batch->pubkey,   parse->ps_pubkey,   n*sizeof(fd_pubkey_t) );
@@ -446,7 +473,7 @@ fd_snapmk_accparse_publish_batch( fd_snapmk_accparse_t *       parse,
 
   fd_snapmk_accparse_prestage( parse );
 
-  fd_snapmk_accparse_keep_batch( parse, file_off, head, batch->acc_idx, n );
+  fd_snapmk_accparse_keep_batch( parse, file_off, hash, batch->acc_idx, n );
   for( ulong i=n; i<FD_BACKUP_DISK_PARA; i++ ) batch->acc_idx[ i ] = UINT_MAX;
 
   return n;

--- a/src/discof/backup/fd_snapmk_tile.c
+++ b/src/discof/backup/fd_snapmk_tile.c
@@ -379,7 +379,9 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_TEST( accdb_shmem_ro );
   ctx->accdb_shmem = accdb_shmem_ro;
   ctx->accdb_snapshot_sync = &accdb_shmem_ro->snapshot_sync;
-  fd_backup_cache_join( ctx->acc_cache, accdb_shmem_ro );
+  ulong * epoch_fseq = fd_fseq_join( fd_topo_obj_laddr( topo, tile->snapmk.accdb_epoch_obj_id ) );
+  FD_TEST( epoch_fseq );
+  fd_backup_cache_join( ctx->acc_cache, accdb_shmem_ro, epoch_fseq );
   {
     FD_SCRATCH_ALLOC_INIT( l, accdb_shmem_ro );
     FD_SCRATCH_ALLOC_APPEND( l, FD_ACCDB_SHMEM_ALIGN, sizeof(fd_accdb_shmem_t) );
@@ -1591,6 +1593,8 @@ snap_start( fd_snapmk_t *                  ctx,
     .max_accounts       = ctx->acc_cache->max_accounts,
     .acc_map_seed       = ctx->acc_cache->acc_map_seed,
     .chain_mask         = ctx->acc_cache->chain_mask,
+    .epoch_slot         = ctx->acc_cache->epoch_slot,
+    .epoch              = ctx->acc_cache->epoch,
     .root_generation    = (uint)root_generation
   };
 

--- a/src/discof/backup/fd_snapzp_tile.c
+++ b/src/discof/backup/fd_snapzp_tile.c
@@ -200,7 +200,7 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_TEST( epoch_fseq );
   ctx->accdb = fd_accdb_join_readonly( _accdb, accdb_shmem_ro, epoch_fseq, FD_ACCDB_FD_RO );
   FD_TEST( ctx->accdb );
-  FD_TEST( fd_backup_cache_join( ctx->acc_cache, accdb_shmem_ro ) );
+  FD_TEST( fd_backup_cache_join( ctx->acc_cache, accdb_shmem_ro, epoch_fseq ) );
   ctx->visited_set = visited_set_join( fd_topo_obj_laddr( topo, tile->snapzp.visited_set_obj_id ) );
   FD_TEST( ctx->visited_set );
 
@@ -394,17 +394,27 @@ zip_flush( fd_snapzp_t * ctx ) {
    fallback to disk reads when a cache read is torn by eviction. */
 
 static void
-accmeta_await_evict( fd_snapzp_t *       ctx,
-                     fd_pubkey_t const * pubkey,
-                     uint                acc_idx ) {
-  (void)pubkey;
+accmeta_await_evict( fd_snapzp_t * ctx,
+                     uint          acc_idx ) {
   FD_CHECK_CRIT( acc_idx < ctx->acc_cache->max_accounts, "invalid account index" );
 
+  ulong *       epoch_slot = ctx->acc_cache->epoch_slot;
+  ulong const * epoch      = ctx->acc_cache->epoch;
+
   fd_accdb_accmeta_t const * acc = &ctx->acc_cache->acc_pool[ acc_idx ];
-  ulong off_packed = FD_VOLATILE_CONST( acc->offset_fork );
-  while( FD_UNLIKELY( (off_packed & FD_ACCDB_OFF_MASK)==FD_ACCDB_OFF_INVAL ) ) {
+  for(;;) {
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE( *epoch_slot ) = FD_VOLATILE_CONST( *epoch );
+    FD_HW_MFENCE();
+
+    ulong off_packed = FD_VOLATILE_CONST( acc->offset_fork );
+    int   done       = ( off_packed & FD_ACCDB_OFF_MASK )!=FD_ACCDB_OFF_INVAL;
+
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
+
+    if( FD_LIKELY( done ) ) break;
     FD_SPIN_PAUSE(); /* FIXME yield to OS instead? */
-    off_packed = FD_VOLATILE_CONST( acc->offset_fork );
   }
 
   FD_COMPILER_MFENCE();
@@ -421,29 +431,51 @@ msg_acc_cache( fd_snapzp_t *                 ctx,
                fd_backup_cache_msg_t const * batch ) {
   FD_CHECK_CRIT( ctx->snap_fd>=0, "invalid snapshot file descriptor" );
 
+  ulong *       epoch_slot = ctx->acc_cache->epoch_slot;
+  ulong const * epoch      = ctx->acc_cache->epoch;
+  int           in_epoch   = 0;
+
   ZSTD_inBuffer * buf = &ctx->raw_buf;
   for( ulong i=0UL; i<FD_BACKUP_CACHE_PARA; i++ ) {
     fd_pubkey_t const * pubkey  = &batch->pubkey [ i ];
     uint                acc_idx =  batch->acc_idx[ i ];
     if( acc_idx==UINT_MAX ) continue;
-    /* copy cached account into snapshot stream */
-    int err = fd_backup_cache_read( ctx->acc_cache, pubkey, acc_idx, ctx->raw, &buf->size, RAW_BUF_SZ );
-    if( err==FD_BACKUP_CACHE_ERR_MISS ) {
-      accmeta_await_evict( ctx, pubkey, acc_idx );
-      continue;
+
+    if( FD_UNLIKELY( !in_epoch ) ) {
+      FD_COMPILER_MFENCE();
+      FD_VOLATILE( *epoch_slot ) = FD_VOLATILE_CONST( *epoch );
+      /* a lock prefix is an expensive CPU pipeline hazard, therefore
+         we hold onto our epoch for multiple accounts */
+      FD_HW_MFENCE();
+      in_epoch = 1;
     }
+
+    int err = fd_backup_cache_read( ctx->acc_cache, pubkey, acc_idx, ctx->raw, &buf->size, RAW_BUF_SZ );
     if( FD_UNLIKELY( err==FD_BACKUP_CACHE_ERR_SPACE ) ) {
-      /* not enough buffer space, flush and retry */
+      FD_COMPILER_MFENCE();
+      FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
       zip_flush( ctx );
+      FD_COMPILER_MFENCE();
+      FD_VOLATILE( *epoch_slot ) = FD_VOLATILE_CONST( *epoch );
+      FD_HW_MFENCE();
       err = fd_backup_cache_read( ctx->acc_cache, pubkey, acc_idx, ctx->raw, &buf->size, RAW_BUF_SZ );
-      if( err==FD_BACKUP_CACHE_ERR_MISS ) {
-        accmeta_await_evict( ctx, pubkey, acc_idx );
-        continue;
-      }
       FD_CHECK_ERR( err!=FD_BACKUP_CACHE_ERR_SPACE, "Zstandard buffer too small" );
+    }
+
+    if( FD_UNLIKELY( err==FD_BACKUP_CACHE_ERR_MISS ) ) {
+      FD_COMPILER_MFENCE();
+      FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
+      in_epoch = 0;
+      accmeta_await_evict( ctx, acc_idx );
+      continue;
     }
     FD_CHECK_ERR( err==FD_BACKUP_CACHE_SUCCESS, "unexpected cache error code" );
     ctx->metrics.accounts_compressed++;
+  }
+
+  if( FD_LIKELY( in_epoch ) ) {
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE( *epoch_slot ) = ULONG_MAX;
   }
 }
 

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -1474,6 +1474,8 @@ background_advance_root( fd_accdb_t *       accdb,
 void
 fd_accdb_advance_root( fd_accdb_t *       accdb,
                        fd_accdb_fork_id_t fork_id ) {
+  FD_CHECK_CRIT( fd_accdb_snapshot_sync_state( &accdb->shmem->snapshot_sync )!=FD_ACCDB_SNAPSHOT_SYNC_RUNNING,
+                 "fd_accdb_advance_root called during snapshot production" );
   wait_cmd( accdb );
   submit_cmd( accdb, FD_ACCDB_CMD_ADVANCE_ROOT, fork_id.val );
 }
@@ -4218,44 +4220,9 @@ fd_accdb_background( fd_accdb_t * accdb,
                      int *        charge_busy ) {
   fd_accdb_shmem_t * shmem = accdb->shmem;
 
-  /* process snapshot requests first */
-  ulong * snap_sync_p = &accdb->shmem->snapshot_sync;
+  ulong * snap_sync_p = &shmem->snapshot_sync;
   ulong   snap_sync   = fd_accdb_snapshot_sync_state( snap_sync_p );
-  if( FD_UNLIKELY( snap_sync!=FD_ACCDB_SNAPSHOT_SYNC_IDLE ) ) {
-    switch( snap_sync ) {
-    case FD_ACCDB_SNAPSHOT_SYNC_RUNNING:
-      /* while producing a snapshot, limit background tasks to cache
-         pre-eviction, but pause all other tasks (like advance_root,
-         purge, and compaction) */
-      background_preevict( accdb, charge_busy, 0 );
-      return;
-    case FD_ACCDB_SNAPSHOT_SYNC_DONE:
-      fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_IDLE );
-      break;
-    case FD_ACCDB_SNAPSHOT_SYNC_START_FULL:
-      delta_reset( accdb );
-      fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
-      *charge_busy = 1;
-      return;
-    case FD_ACCDB_SNAPSHOT_SYNC_START_INCR:
-      if( delta_is_valid( accdb->shmem ) ) {
-        fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
-      } else {
-        /* cannot produce incrementals because delta ran out of space,
-           therefore don't know which accounts changed */
-        fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_FAIL );
-      }
-      *charge_busy = 1;
-      return;
-    case FD_ACCDB_SNAPSHOT_SYNC_FAIL:
-      /* wait for client to acknowledge */
-      break;
-    default:
-      FD_LOG_CRIT(( "corrupt snapshot_sync state %lu", snap_sync ));
-    }
-  }
 
-  /* process cnc requests */
   uint op = FD_VOLATILE_CONST( shmem->cmd_op );
   if( FD_UNLIKELY( op!=FD_ACCDB_CMD_IDLE ) ) {
     fd_accdb_fork_id_t fork_id = { .val = FD_VOLATILE_CONST( shmem->cmd_fork_id ) };
@@ -4288,6 +4255,38 @@ fd_accdb_background( fd_accdb_t * accdb,
     FD_VOLATILE( shmem->cmd_op ) = FD_ACCDB_CMD_IDLE;
     *charge_busy = 1;
     return;
+  }
+
+  if( FD_UNLIKELY( snap_sync!=FD_ACCDB_SNAPSHOT_SYNC_IDLE ) ) {
+    switch( snap_sync ) {
+    case FD_ACCDB_SNAPSHOT_SYNC_RUNNING:
+      /* while producing a snapshot, don't do compaction work */
+      background_preevict( accdb, charge_busy, 0 );
+      return;
+    case FD_ACCDB_SNAPSHOT_SYNC_DONE:
+      fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_IDLE );
+      break;
+    case FD_ACCDB_SNAPSHOT_SYNC_START_FULL:
+      delta_reset( accdb );
+      fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
+      *charge_busy = 1;
+      return;
+    case FD_ACCDB_SNAPSHOT_SYNC_START_INCR:
+      if( delta_is_valid( accdb->shmem ) ) {
+        fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
+      } else {
+        /* cannot produce incrementals because delta ran out of space,
+           therefore don't know which accounts changed */
+        fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_FAIL );
+      }
+      *charge_busy = 1;
+      return;
+    case FD_ACCDB_SNAPSHOT_SYNC_FAIL:
+      /* wait for client to acknowledge */
+      break;
+    default:
+      FD_LOG_CRIT(( "corrupt snapshot_sync state %lu", snap_sync ));
+    }
   }
 
   background_preevict( accdb, charge_busy, 0 );

--- a/src/flamenco/accdb/fd_accdb_tile.c
+++ b/src/flamenco/accdb/fd_accdb_tile.c
@@ -15,7 +15,8 @@
 
 /* Maximum number of read-only accdb consumer fseqs the accdb tile can
    bind external_epoch_slots[] to.  Bumped as new RO consumers are
-   added.  Today: snapzp tiles, rpc tile (optional). */
+   added.  Today: resolv tiles, rpc tile (optional), snapmk/zp tiles
+   (optional). */
 #define FD_ACCDB_TILE_MAX_EXTERNAL_EPOCHS (128UL)
 
 struct fd_accdb_tile_ctx {
@@ -130,6 +131,12 @@ unprivileged_init( fd_topo_t const *      topo,
   }
   for( ulong i=0UL; i<tile->accdb.resolv_epoch_obj_cnt; i++ ) {
     ulong * fseq = fd_fseq_join( fd_topo_obj_laddr( topo, tile->accdb.resolv_epoch_obj_ids[ i ] ) );
+    FD_TEST( fseq );
+    FD_TEST( external_epoch_cnt<FD_ACCDB_TILE_MAX_EXTERNAL_EPOCHS );
+    external_epoch_slots[ external_epoch_cnt++ ] = fseq;
+  }
+  if( FD_UNLIKELY( tile->accdb.snapmk_epoch_obj_id!=ULONG_MAX ) ) {
+    ulong * fseq = fd_fseq_join( fd_topo_obj_laddr( topo, tile->accdb.snapmk_epoch_obj_id ) );
     FD_TEST( fseq );
     FD_TEST( external_epoch_cnt<FD_ACCDB_TILE_MAX_EXTERNAL_EPOCHS );
     external_epoch_slots[ external_epoch_cnt++ ] = fseq;


### PR DESCRIPTION
Fixes a replay stall during snapshot production when purging a
dead fork.
