### PR TITLE
backup: make snap producer tiles floating

### DIFF
--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -382,6 +382,9 @@ static char const * FLOATING[] = {
   "ipecho", /* FIREDANCER ONLY */
   "admin",  /* FIREDANCER ONLY */
   "snapsv", /* FIREDANCER ONLY */
+  "snapmk", /* FIREDANCER ONLY */
+  "snapzp", /* FIREDANCER ONLY */
+  "snaprd", /* FIREDANCER ONLY */
   NULL
 };
 
@@ -406,9 +409,6 @@ static char const * POST_START[] = {
   "execrp", /* FIREDANCER only */
   "txsend", /* FIREDANCER only */
   "solcap", /* FIREDANCER only */
-  "snapmk", /* FIREDANCER ONLY */
-  "snapzp", /* FIREDANCER ONLY */
-  "snaprd", /* FIREDANCER ONLY */
   NULL
 };
 


### PR DESCRIPTION
Reduces CPU count requirements
