### PR TITLE
watch: support topologies without node_info

### DIFF
--- a/src/app/shared/commands/watch/watch.c
+++ b/src/app/shared/commands/watch/watch.c
@@ -1459,6 +1459,7 @@ write_node_info( config_t const *       config,
   }
 
   ulong replay_idx = fd_topo_find_tile( &config->topo, "replay", 0UL );
+  if( FD_UNLIKELY( replay_idx==ULONG_MAX ) ) return 0U;
   ulong const * replay_metrics = &cur_tile[ replay_idx*FD_METRICS_TOTAL_SZ ];
   ulong identity_balance = replay_metrics[ MIDX( GAUGE, REPLAY, IDENTITY_BALANCE_LAMPORTS     ) ];
   ulong stake_amount     = replay_metrics[ MIDX( GAUGE, REPLAY, ACTIVE_STAKE_LAMPORTS         ) ];

--- a/src/app/shared/commands/watch/watch.c
+++ b/src/app/shared/commands/watch/watch.c
@@ -1602,7 +1602,7 @@ run( config_t const * config,
 
   ulong node_info_obj_id = fd_pod_query_ulong( config->topo.props, "node_info", ULONG_MAX );
   fd_node_info_box_t * node_info = node_info_obj_id==ULONG_MAX ? NULL :
-                                   fd_node_info_box_join( fd_topo_obj_laddr( &config->topo, node_info_obj_id ) );
+  fd_node_info_box_join( fd_topo_obj_laddr( &config->topo, node_info_obj_id ) );
   FD_TEST( node_info_obj_id==ULONG_MAX || node_info );
 
   ulong tile_cnt = config->topo.tile_cnt;

--- a/src/app/shared/commands/watch/watch.c
+++ b/src/app/shared/commands/watch/watch.c
@@ -1528,7 +1528,8 @@ write_summary( config_t const *           config,
   if( FD_UNLIKELY( !snap_shutdown_time && shutdown  ) ) snap_shutdown_time = 2L; /* Was shutdown on boot */
   if( FD_UNLIKELY( snap_shutdown_time==1L && shutdown  ) ) snap_shutdown_time = fd_log_wallclock();
 
-  fd_node_info_t node_info[1]; fd_node_info_read( node_info, shinfo );
+  fd_node_info_t node_info[1] = {0};
+  if( FD_LIKELY( shinfo ) ) fd_node_info_read( node_info, shinfo );
   lines_printed += write_node_info( config, cur_tile, node_info );
 
   if( FD_UNLIKELY( write_bench( config, cur_tile, prev_tile ) ) ) lines_printed++;
@@ -1599,9 +1600,9 @@ run( config_t const * config,
   (void)drain_output_fd;
 
   ulong node_info_obj_id = fd_pod_query_ulong( config->topo.props, "node_info", ULONG_MAX );
-  FD_TEST( node_info_obj_id!=ULONG_MAX );
-  fd_node_info_box_t * node_info = fd_node_info_box_join( fd_topo_obj_laddr( &config->topo, node_info_obj_id ) );
-  FD_TEST( node_info );
+  fd_node_info_box_t * node_info = node_info_obj_id==ULONG_MAX ? NULL :
+                                   fd_node_info_box_join( fd_topo_obj_laddr( &config->topo, node_info_obj_id ) );
+  FD_TEST( node_info_obj_id==ULONG_MAX || node_info );
 
   ulong tile_cnt = config->topo.tile_cnt;
 


### PR DESCRIPTION
## Issue

`fddev` uses the hybrid Firedancer/Agave topology, which does not create the `node_info` object expected by the shared watcher.

## Original Error
```text
validator@validator-host:~/firedancer$ sudo rm -rf /solana/accounts/* /solana/ledger/* ~/.firedancer && make -j fddev && sudo -E build/native/gcc/bin/fddev dev --config mainnet.toml
cd ./agave && env --unset=LDFLAGS RUSTFLAGS="-C force-frame-pointers=yes -C target-cpu=native" CXXFLAGS="" ./cargo build --profile=release-with-debug --lib -p agave-validator
+ exec cargo +1.96.1 build --profile=release-with-debug --lib -p agave-validator
    Finished `release-with-debug` profile [optimized + debuginfo] target(s) in 0.90s
Log at "/tmp/fd-1.32868.40201_2480649_validator_validator-host_2026_08_06_16_32_13_949177729_GMT+00"
NOTICE  08-06 16:32:13.957512 main      configure.c(103): kill ... configuring
NOTICE  08-06 16:32:13.970336 main      configure.c(86): keys ... unconfigured ...  identity.json, vote-account.json, faucet.json, or stake-account.json does not exist
NOTICE  08-06 16:32:13.970344 main      configure.c(103): keys ... configuring
NOTICE  08-06 16:32:13.970482 main      keys.c(126): successfully created keypair in /home/validator/.firedancer/fd1/faucet.json
NOTICE  08-06 16:32:13.970525 main      keys.c(126): successfully created keypair in /home/validator/.firedancer/fd1/stake-account.json
NOTICE  08-06 16:32:13.970540 main      configure.c(86): blockstore ... unconfigured ... rocksdb directory does not exist at `/solana/ledger`
NOTICE  08-06 16:32:13.970544 main      configure.c(103): blockstore ... configuring
ERR     08-06 16:32:14.123643 main      dev.c(203): firedancer exited unexpectedly with code 1
ERR     08-06 16:32:14.123794 main      watch.c(1436): FAIL: node_info_obj_id!=ULONG_MAX
validator@validator-host:~/firedancer$
```

Tested on v1.1 branch