### PR TITLE
http: set correct poll events

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -197,8 +197,8 @@ fd_http_server_new( void *                     shmem,
   ws_conn_treap_seed( http->ws_conns, params.max_ws_connection_cnt, 42UL );
 
   for( ulong i=0UL; i<params.max_connection_cnt; i++ ) {
-    http->pollfds[ i ].fd = -1;
-    http->pollfds[ i ].events = POLLIN | POLLOUT;
+    http->pollfds[ i ].fd     = -1;
+    http->pollfds[ i ].events = POLLIN;
     http->conns[ i ] = (struct fd_http_server_connection){
       .request_bytes = _request_bytes+i*params.max_request_len,
       .parent = http->conns[ i ].parent,
@@ -206,8 +206,8 @@ fd_http_server_new( void *                     shmem,
   }
 
   for( ulong i=0UL; i<params.max_ws_connection_cnt; i++ ) {
-    http->pollfds[ params.max_connection_cnt+i ].fd = -1;
-    http->pollfds[ params.max_connection_cnt+i ].events = POLLIN | POLLOUT;
+    http->pollfds[ params.max_connection_cnt+i ].fd     = -1;
+    http->pollfds[ params.max_connection_cnt+i ].events = POLLIN;
     http->ws_conns[ i ] = (struct fd_http_server_ws_connection){
       .recv_bytes = _ws_recv_bytes+i*params.max_ws_recv_frame_len,
       .send_frames = _ws_send_frames+i*params.max_ws_send_frame_cnt,
@@ -216,7 +216,7 @@ fd_http_server_new( void *                     shmem,
   }
 
   http->pollfds[ params.max_connection_cnt+params.max_ws_connection_cnt ].fd     = -1;
-  http->pollfds[ params.max_connection_cnt+params.max_ws_connection_cnt ].events = POLLIN | POLLOUT;
+  http->pollfds[ params.max_connection_cnt+params.max_ws_connection_cnt ].events = POLLIN;
 
   memset( &http->metrics, 0, sizeof( http->metrics ) );
 
@@ -371,7 +371,8 @@ close_conn( fd_http_server_t * http,
 
   if( FD_UNLIKELY( -1==close( http->pollfds[ conn_idx ].fd ) ) ) FD_LOG_ERR(( "close failed (%i-%s)", errno, strerror( errno ) ));
 
-  http->pollfds[ conn_idx ].fd = -1;
+  http->pollfds[ conn_idx ].fd     = -1;
+  http->pollfds[ conn_idx ].events = POLLIN;
   if( FD_LIKELY( conn_idx<http->max_conns ) ) {
     if( FD_LIKELY( http->callbacks.close    ) ) http->callbacks.close( conn_idx, reason, http->callback_ctx );
   } else {
@@ -459,7 +460,8 @@ accept_conns( fd_http_server_t * http ) {
 
     ulong conn_id = conn_pool_idx_acquire( http->conns );
 
-    http->pollfds[ conn_id ].fd = fd;
+    http->pollfds[ conn_id ].fd     = fd;
+    http->pollfds[ conn_id ].events = POLLIN;
     http->conns[ conn_id ].state                  = FD_HTTP_SERVER_CONNECTION_STATE_READING;
     http->conns[ conn_id ].request_bytes_read     = 0UL;
     http->conns[ conn_id ].response_bytes_written = 0UL;
@@ -715,6 +717,7 @@ read_conn_http( fd_http_server_t * http,
   fd_http_server_response_t response = http->callbacks.request( &request );
   if( FD_LIKELY( http->pollfds[ conn_idx ].fd==-1 ) ) return; /* Connection was closed by callback */
   conn->response = response;
+  http->pollfds[ conn_idx ].events = POLLOUT | (response.upgrade_websocket ? POLLIN : 0);
 
 #if FD_HTTP_SERVER_DEBUG
   FD_LOG_NOTICE(( "Received %s request \"%s\" from %lu (fd=%d) response code %lu", fd_http_server_method_str( method_enum ), path_nul_terminated, conn_idx, http->pollfds[ conn_idx ].fd, conn->response.status ));
@@ -812,6 +815,7 @@ again:
     if( FD_LIKELY( conn->pong_state!=FD_HTTP_SERVER_PONG_STATE_WAITING ) ) {
       conn->pong_state    = FD_HTTP_SERVER_PONG_STATE_WAITING;
       conn->pong_data_len = payload_len;
+      http->pollfds[ conn_idx ].events |= POLLOUT;
       FD_TEST( payload_len<=125UL );
       memcpy( conn->pong_data, conn->recv_bytes+conn->recv_bytes_parsed, payload_len );
     }
@@ -1043,7 +1047,8 @@ write_conn_http( fd_http_server_t * http,
           }
 
           int fd = http->pollfds[ conn_idx ].fd;
-          http->pollfds[ conn_idx ].fd = -1;
+          http->pollfds[ conn_idx ].fd     = -1;
+          http->pollfds[ conn_idx ].events = POLLIN;
 
           struct fd_http_server_connection * conn = &http->conns[ conn_idx ];
 
@@ -1066,7 +1071,8 @@ write_conn_http( fd_http_server_t * http,
           }
 
           ulong ws_conn_id = ws_conn_pool_idx_acquire( http->ws_conns );
-          http->pollfds[ http->max_conns+ws_conn_id ].fd = fd;
+          http->pollfds[ http->max_conns+ws_conn_id ].fd     = fd;
+          http->pollfds[ http->max_conns+ws_conn_id ].events = POLLIN;
 
           http->ws_conns[ ws_conn_id ].pong_state               = FD_HTTP_SERVER_PONG_STATE_NONE;
           http->ws_conns[ ws_conn_id ].send_frame_cnt           = 0UL;
@@ -1149,7 +1155,10 @@ write_conn_ws( fd_http_server_t * http,
   struct fd_http_server_ws_connection * conn = &http->ws_conns[ conn_idx-http->max_conns ];
 
   if( FD_UNLIKELY( maybe_write_pong( http, conn_idx ) ) ) return;
-  if( FD_UNLIKELY( !conn->send_frame_cnt ) ) return;
+  if( FD_UNLIKELY( !conn->send_frame_cnt ) ) {
+    http->pollfds[ conn_idx ].events = POLLIN;
+    return;
+  }
 
   struct iovec iovecs[ 512UL*2UL ];
   uchar        headers[ 512UL ][ 10UL ];
@@ -1234,6 +1243,9 @@ write_conn_ws( fd_http_server_t * http,
       break;
     }
   }
+
+  if( FD_LIKELY( !conn->send_frame_cnt && conn->pong_state==FD_HTTP_SERVER_PONG_STATE_NONE ) )
+    http->pollfds[ conn_idx ].events = POLLIN;
 }
 
 static void
@@ -1452,6 +1464,7 @@ fd_http_server_ws_send( fd_http_server_t * http,
 
   conn->send_frames[ (conn->send_frame_idx+conn->send_frame_cnt) % http->max_ws_send_frame_cnt ] = frame;
   conn->send_frame_cnt++;
+  http->pollfds[ http->max_conns+ws_conn_id ].events |= POLLOUT;
 
   if( FD_LIKELY( conn->send_frame_cnt==1UL ) ) {
     ws_conn_treap_ele_insert( http->ws_conn_treap, conn, http->ws_conns );
@@ -1492,6 +1505,7 @@ fd_http_server_ws_broadcast( fd_http_server_t * http ) {
 
     conn->send_frames[ (conn->send_frame_idx+conn->send_frame_cnt) % http->max_ws_send_frame_cnt ] = frame;
     conn->send_frame_cnt++;
+    http->pollfds[ http->max_conns+i ].events |= POLLOUT;
 
     if( FD_LIKELY( conn->send_frame_cnt==1UL ) ) {
       ws_conn_treap_ele_insert( http->ws_conn_treap, conn, http->ws_conns );

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -4,6 +4,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <poll.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -44,6 +45,25 @@ request_redirect( fd_http_server_request_t const * request ) {
     .location     = { prefix, request->path_raw },
     .location_len = { sizeof(prefix)-1UL, request->path_len },
   };
+}
+
+static fd_http_server_response_t
+request_websocket( fd_http_server_request_t const * request ) {
+  return (fd_http_server_response_t) {
+    .status            = 200UL,
+    .upgrade_websocket = request->headers.upgrade_websocket,
+  };
+}
+
+static void
+ws_message_noop( ulong         ws_conn_id,
+                 uchar const * data,
+                 ulong         data_sz,
+                 void *        ctx ) {
+  (void)ws_conn_id;
+  (void)data;
+  (void)data_sz;
+  (void)ctx;
 }
 
 static void
@@ -402,6 +422,76 @@ default_test_params( void ) {
   return params;
 }
 
+static void
+test_poll_interest( void ) {
+  fd_http_server_params_t params = default_test_params();
+  fd_http_server_callbacks_t callbacks = {
+    .request    = request_websocket,
+    .ws_message = ws_message_noop,
+  };
+
+  ulong footprint = fd_ulong_align_up( fd_http_server_footprint( params ), 128UL );
+  uchar * scratch = aligned_alloc( 128UL, footprint );
+  FD_TEST( scratch );
+
+  fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, NULL ) );
+  FD_TEST( http );
+  FD_TEST( fd_http_server_listen( http, 0U, 0U ) );
+
+  struct sockaddr_in server_addr = {0};
+  socklen_t server_addr_sz = sizeof(server_addr);
+  FD_TEST( !getsockname( fd_http_server_fd( http ), fd_type_pun( &server_addr ), &server_addr_sz ) );
+
+  struct sockaddr_in connect_addr = {
+    .sin_family      = AF_INET,
+    .sin_port        = server_addr.sin_port,
+    .sin_addr.s_addr = htonl( INADDR_LOOPBACK ),
+  };
+  int client_fd = socket( AF_INET, SOCK_STREAM, 0 );
+  FD_TEST( client_fd>=0 );
+  FD_TEST( !connect( client_fd, fd_type_pun( &connect_addr ), sizeof(connect_addr) ) );
+
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->metrics.connection_cnt==1UL );
+  FD_TEST( http->pollfds[ 0 ].events==POLLIN );
+  FD_TEST( !fd_http_server_poll( http, 1, ULONG_MAX ) );
+
+  char const upgrade[] =
+      "GET / HTTP/1.1\r\n"
+      "Host: localhost\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+      "Sec-WebSocket-Version: 13\r\n"
+      "\r\n";
+  send_all( client_fd, upgrade, sizeof(upgrade)-1UL );
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->pollfds[ 0 ].events==(POLLIN|POLLOUT) );
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->metrics.ws_connection_cnt==1UL );
+  FD_TEST( http->pollfds[ http->max_conns ].events==POLLIN );
+  FD_TEST( !fd_http_server_poll( http, 1, ULONG_MAX ) );
+
+  fd_http_server_printf( http, "test" );
+  FD_TEST( !fd_http_server_ws_send( http, 0UL ) );
+  FD_TEST( http->pollfds[ http->max_conns ].events==(POLLIN|POLLOUT) );
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->pollfds[ http->max_conns ].events==POLLIN );
+  FD_TEST( !fd_http_server_poll( http, 1, ULONG_MAX ) );
+
+  uchar ping[] = { 0x89U, 0x80U, 0U, 0U, 0U, 0U };
+  FD_TEST( send( client_fd, ping, sizeof(ping), 0 )==(long)sizeof(ping) );
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->pollfds[ http->max_conns ].events==(POLLIN|POLLOUT) );
+  FD_TEST( fd_http_server_poll( http, 1, ULONG_MAX ) );
+  FD_TEST( http->pollfds[ http->max_conns ].events==POLLIN );
+
+  FD_TEST( !close( client_fd ) );
+  FD_TEST( !close( fd_http_server_fd( http ) ) );
+  fd_http_server_delete( fd_http_server_leave( http ) );
+  free( scratch );
+}
+
 void
 test_transfer_encoding_close( void ) {
   FD_LOG_NOTICE(( "Testing Transfer-Encoding rejection" ));
@@ -474,6 +564,7 @@ main( int     argc,
   test_oring();
   test_content_length_overflow_close();
   test_poll_conn_max();
+  test_poll_interest();
   test_location_raw_path();
   test_transfer_encoding_close();
   test_duplicate_content_length_different_close();


### PR DESCRIPTION
Fixes issue where tiles that don't separately throttle http polling (e.g. ipecho, metric) spin to 100% cpu utilization when 1+ connections are open (even if the connection is not being written/read to/from).