### PR TITLE
pktgen: reduce boot requirements

### DIFF
--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -264,7 +264,6 @@ render_status( ulong volatile const * net_metrics[ FD_TOPO_MAX_TILES ],
 void
 pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
                config_t * config ) {
-  pktgen_topo( config );
   fd_topo_t *      topo         = &config->topo;
   ulong            net_tile_cnt = config->layout.net_tile_count;
   if( FD_UNLIKELY( net_tile_cnt>FD_TOPO_MAX_TILES ) ) {
@@ -375,6 +374,7 @@ pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
 
 action_t fd_action_pktgen = {
   .name        = "pktgen",
+  .topo        = pktgen_topo,
   .args        = pktgen_cmd_args,
   .fn          = pktgen_cmd_fn,
   .perm        = dev_cmd_perm,


### PR DESCRIPTION
Pktgen only needs 3 tiles + the chosen #net tiles, but currently during boot a full validator topology is constructed before going down to just the pktgen topology so much more cores/RAM are required to run pktgen than should be.