### PR TITLE
backup: serialize stake delegations

### DIFF
--- a/src/discof/backup/fd_snapmk_tile.c
+++ b/src/discof/backup/fd_snapmk_tile.c
@@ -1505,6 +1505,14 @@ snap_start( fd_snapmk_t *                  ctx,
   }
   ctx->incremental = incremental;
 
+  fd_stake_delegations_t const * stake_delegations = fd_bank_stake_delegations_modify( bank );
+  if( FD_UNLIKELY( fd_stake_delegations_pubkey_fallback( stake_delegations ) ) ) {
+    FD_LOG_WARNING(( "cannot create snapshot, too many stake accounts (%lu exceeds capacity %lu)",
+                     fd_stake_delegations_pubkey_cnt( stake_delegations ), FD_RUNTIME_MAX_STAKE_ACCOUNTS ));
+    ctx->state = SNAPMK_STATE_FAIL;
+    return -1;
+  }
+
   /* wait for accdb root to match published root */
   fd_accdb_fork_id_t root_fork_id = bank->accdb_fork_id;
   FD_TEST( root_fork_id.val!=USHORT_MAX );

--- a/src/discof/backup/fd_ssmanifest_encoder.c
+++ b/src/discof/backup/fd_ssmanifest_encoder.c
@@ -107,15 +107,49 @@ ENCODE_FN {
     break;
   }
   case STATE_VOTE_ACCOUNTS: {
-    PUSH_VAL( ulong, 0UL ); /* zero vote_accounts */
-    PUSH_VAL( ulong, 0UL ); /* zero stake delegations */
-    PUSH_VAL( ulong, 0UL ); /* unused */
+    fd_stake_delegations_t const * sd = fd_bank_stake_delegations_modify( enc->bank );
+    FD_CHECK_ERR( !fd_stake_delegations_pubkey_fallback( sd ),
+                  "stake delegations are in pubkey fallback mode" );
+    ulong delegation_cnt = fd_stake_delegations_base_cnt( sd );
+    PUSH_VAL( ulong, 0UL             ); /* zero vote_accounts */
+    PUSH_VAL( ulong, delegation_cnt  );
+    fd_stake_delegations_iter_init( enc->stake_delegation_iter, sd,
+                                    NULL, (fd_accdb_fork_id_t){ .val=USHORT_MAX },
+                                    bank->f.epoch, NULL );
+    enc->stake_delegation_rem = delegation_cnt;
+    enc->state = delegation_cnt ? STATE_STAKE_DELEGATION : STATE_STAKE_EPOCH;
+    break;
+  }
+  case STATE_STAKE_DELEGATION: {
+    ulong batch = fd_ulong_min( enc->stake_delegation_rem, STAKE_DELEGATIONS_PER_CHUNK );
+    for( ulong i=0UL; i<batch; i++ ) {
+      fd_stake_delegation_t const * d = fd_stake_delegations_iter_ele( enc->stake_delegation_iter );
+      FD_TEST( d );
+      /* USHORT_MAX is the compressed form of the ULONG_MAX sentinel
+         meaning bootstrap activation or not deactivating. */
+      ulong activation_epoch   = d->activation_epoch  ==(ushort)USHORT_MAX ? ULONG_MAX : (ulong)d->activation_epoch;
+      ulong deactivation_epoch = d->deactivation_epoch==(ushort)USHORT_MAX ? ULONG_MAX : (ulong)d->deactivation_epoch;
+      PUSH_VAL( fd_pubkey_t, d->stake_account    );
+      PUSH_VAL( fd_pubkey_t, d->vote_account     );
+      PUSH_VAL( ulong,       d->stake            );
+      PUSH_VAL( ulong,       activation_epoch    );
+      PUSH_VAL( ulong,       deactivation_epoch  );
+      PUSH_VAL( double,      fd_stake_delegations_warmup_cooldown_rate_to_double( d->warmup_cooldown_rate ) );
+      fd_stake_delegations_iter_next( enc->stake_delegation_iter );
+    }
+    enc->stake_delegation_rem -= batch;
+    if( !enc->stake_delegation_rem ) {
+      FD_TEST( fd_stake_delegations_iter_done( enc->stake_delegation_iter ) );
+      enc->state = STATE_STAKE_EPOCH;
+    }
+    break;
+  }
+  case STATE_STAKE_EPOCH: {
+    PUSH_VAL( ulong, 0UL           ); /* unused */
     PUSH_VAL( ulong, bank->f.epoch );
     enc->state = STATE_STAKE_HISTORY;
     break;
   }
-  case STATE_STAKE_DELEGATION: { FD_LOG_ERR(( "TODO")); }
-  case STATE_STAKE_EPOCH: { FD_LOG_ERR(( "TODO")); }
   case STATE_STAKE_HISTORY: {
     PUSH_VAL( ulong, 0UL ); /* zero stake history entries */
     enc->state = STATE_BANK_TRAILER;

--- a/src/discof/backup/fd_ssmanifest_writer.c
+++ b/src/discof/backup/fd_ssmanifest_writer.c
@@ -24,6 +24,9 @@
 #define STATE_DONE                  21
 #define STATE_INIT STATE_BLOCKHASH_QUEUE
 
+#define STAKE_DELEGATIONS_PER_CHUNK (128UL*1024UL)
+FD_STATIC_ASSERT( STAKE_DELEGATIONS_PER_CHUNK*96UL<=FD_SSMANIFEST_BUF_MIN, buffer );
+
 fd_ssmanifest_writer_t *
 fd_ssmanifest_writer_init( fd_ssmanifest_writer_t * enc,
                            fd_bank_t *              bank ) {
@@ -34,6 +37,7 @@ fd_ssmanifest_writer_init( fd_ssmanifest_writer_t * enc,
   enc->vote_cnt    = 0;
   enc->vote_idx    = 0;
   enc->total_stake = 0UL;
+  enc->stake_delegation_rem = 0UL;
   return enc;
 }
 

--- a/src/discof/backup/fd_ssmanifest_writer.h
+++ b/src/discof/backup/fd_ssmanifest_writer.h
@@ -14,6 +14,8 @@ struct fd_ssmanifest_writer {
   uint        vote_cnt;
   uint        vote_idx;
   ulong       total_stake;
+  ulong       stake_delegation_rem;
+  fd_stake_delegations_iter_t stake_delegation_iter[1];
   uchar       top_votes_iter_mem[ FD_TOP_VOTES_ITER_FOOTPRINT ] __attribute__((aligned(FD_TOP_VOTES_ITER_ALIGN)));
 };
 

--- a/src/discof/backup/test_snap_roundtrip.c
+++ b/src/discof/backup/test_snap_roundtrip.c
@@ -56,6 +56,65 @@ check_epoch_credits( fd_bank_t *                                bank,
   }
 }
 
+#define EXTRA_DELEGATION_CNT 2UL
+
+static void
+seed_stake_delegations( fd_bank_t * bank,
+                        fd_pubkey_t stake_keys[ EXTRA_DELEGATION_CNT ],
+                        fd_pubkey_t vote_keys [ EXTRA_DELEGATION_CNT ] ) {
+  fd_stake_delegations_t * sd = fd_bank_stake_delegations_modify( bank );
+  FD_TEST( fd_stake_delegations_base_cnt( sd )==VALIDATOR_CNT );
+  for( ulong i=0UL; i<EXTRA_DELEGATION_CNT; i++ ) {
+    stake_keys[i] = (fd_pubkey_t){ .ul = { 0xD0D0D0D0UL, i+1UL, 0UL, 0UL } };
+    vote_keys [i] = (fd_pubkey_t){ .ul = { 0xE0E0E0E0UL, i+1UL, 0UL, 0UL } };
+    fd_stake_delegations_root_update( sd,
+                                      &stake_keys[i], &vote_keys[i],
+                                      7000000000UL + i,
+                                      i+1UL,   /* activation_epoch   */
+                                      i+9UL,   /* deactivation_epoch */
+                                      0UL,     /* credits_observed   */
+                                      0UL,     /* lamports, not serialized */
+                                      0U,      /* acc_dlen, not serialized */
+                                      FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_009 );
+  }
+}
+
+static void
+check_stake_delegations( fd_snapshot_manifest_t const * manifest,
+                         fd_pubkey_t const              stake_keys[ EXTRA_DELEGATION_CNT ],
+                         fd_pubkey_t const              vote_keys [ EXTRA_DELEGATION_CNT ] ) {
+  FD_TEST( manifest->stake_delegations_len==VALIDATOR_CNT+EXTRA_DELEGATION_CNT );
+
+  ulong bootstrap_cnt = 0UL;
+  ulong extra_cnt     = 0UL;
+  for( ulong i=0UL; i<manifest->stake_delegations_len; i++ ) {
+    fd_snapshot_manifest_stake_delegation_t const * d = &manifest->stake_delegations[i];
+
+    ulong j;
+    for( j=0UL; j<EXTRA_DELEGATION_CNT; j++ ) {
+      if( !memcmp( d->stake_pubkey, &stake_keys[j], 32UL ) ) break;
+    }
+    if( j==EXTRA_DELEGATION_CNT ) {
+      /* One of svm_mini's bootstrap delegations. */
+      FD_TEST( d->activation_epoch    ==ULONG_MAX );
+      FD_TEST( d->deactivation_epoch  ==ULONG_MAX );
+      FD_TEST( d->stake_delegation    ==1000000000UL );
+      FD_TEST( d->warmup_cooldown_rate==FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_025 );
+      bootstrap_cnt++;
+      continue;
+    }
+
+    FD_TEST( !memcmp( d->vote_pubkey, &vote_keys[j], 32UL ) );
+    FD_TEST( d->stake_delegation    ==7000000000UL+j );
+    FD_TEST( d->activation_epoch    ==j+1UL );
+    FD_TEST( d->deactivation_epoch  ==j+9UL );
+    FD_TEST( d->warmup_cooldown_rate==FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_009 );
+    extra_cnt++;
+  }
+  FD_TEST( bootstrap_cnt==VALIDATOR_CNT );
+  FD_TEST( extra_cnt==EXTRA_DELEGATION_CNT );
+}
+
 typedef struct {
   fd_txncache_t * tc;
   void *          shmem;
@@ -177,6 +236,10 @@ test_manifest_roundtrip( fd_bank_t * bank ) {
 
   seed_epoch_credits( bank );
 
+  fd_pubkey_t extra_stake_keys[ EXTRA_DELEGATION_CNT ];
+  fd_pubkey_t extra_vote_keys [ EXTRA_DELEGATION_CNT ];
+  seed_stake_delegations( bank, extra_stake_keys, extra_vote_keys );
+
   ulong manifest_sz = fd_snap_manifest_serialized_sz( bank );
   FD_TEST( manifest_sz>0UL );
   FD_LOG_NOTICE(( "manifest serialized size: %lu", manifest_sz ));
@@ -222,6 +285,8 @@ test_manifest_roundtrip( fd_bank_t * bank ) {
   FD_TEST( manifest->rent_params.burn_percent==bank->f.rent.burn_percent );
   FD_TEST( manifest->has_block_id );
   FD_TEST( !memcmp( manifest->block_id, block_id.uc, sizeof(fd_hash_t) ) );
+
+  check_stake_delegations( manifest, extra_stake_keys, extra_vote_keys );
 
   /* Collector round-trip: the encoder tags t_1 entries (epoch_stakes
      key epoch+1) with the epoch override tag and t_2 entries (key
@@ -388,6 +453,32 @@ test_txncache_roundtrip( void ) {
   free( test_tc.shmem );
 }
 
+static void
+test_stake_delegations_fallback( fd_bank_t * bank,
+                                 ulong       max_stake_accounts ) {
+  FD_LOG_NOTICE(( "test_stake_delegations_fallback" ));
+
+  fd_stake_delegations_t * sd = fd_bank_stake_delegations_modify( bank );
+  FD_TEST( !fd_stake_delegations_pubkey_fallback( sd ) );
+
+  ulong overflow = max_stake_accounts + 16UL;
+  for( ulong i=0UL; i<overflow; i++ ) {
+    fd_pubkey_t stake_key = { .ul = { 0xF0F0F0F0UL, i, 0UL, 0UL } };
+    fd_pubkey_t vote_key  = { .ul = { 0xF1F1F1F1UL, i, 0UL, 0UL } };
+    fd_stake_delegations_root_update( sd, &stake_key, &vote_key,
+                                      1000UL, ULONG_MAX, ULONG_MAX, 0UL, 0UL, 0U,
+                                      FD_STAKE_DELEGATIONS_WARMUP_COOLDOWN_RATE_ENUM_025 );
+  }
+
+  FD_TEST( fd_stake_delegations_pubkey_fallback( sd ) );
+
+  ulong base_cnt   = fd_stake_delegations_base_cnt( sd );
+  ulong pubkey_cnt = fd_stake_delegations_pubkey_cnt( sd );
+  FD_TEST( base_cnt==max_stake_accounts );
+  FD_TEST( base_cnt<pubkey_cnt );
+  FD_LOG_INFO(( "fallback mode: %lu of %lu stake accounts in the root map", base_cnt, pubkey_cnt ));
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -411,6 +502,7 @@ main( int     argc,
 
   test_manifest_roundtrip( bank );
   test_txncache_roundtrip();
+  test_stake_delegations_fallback( bank, limits->max_stake_accounts );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_svm_test_halt( mini );


### PR DESCRIPTION
Technically, serializing stake delegations into the snapshot
manifest is pointless.  All state can be recovered from accounts
instead.  However, this is what Agave expects, so Firedancer has
to output delegations or Agave will crash.
