### PR TITLE
config: refuse to build on GCC 15.2.0

### DIFF
--- a/config/machine/native.mk
+++ b/config/machine/native.mk
@@ -18,6 +18,13 @@ ifeq ($(FD_IS_GNU),1)
     endif
 endif
 
+# Ban broken compilers
+ifdef FD_USING_GCC
+ifeq ($(FD_COMPILER_VERSION),15.2.0)
+$(error Your compiler GCC 15.2.0 is broken (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123002). Please upgrade GCC or recompile with make CC=clang)
+endif
+endif
+
 ifdef FD_USING_GCC
   LD?=$(CC)
   include config/base.mk

--- a/config/machine/native_config.sh
+++ b/config/machine/native_config.sh
@@ -32,9 +32,11 @@ printf '\n' | "$@" -march=native -E -dM - | awk '
     if( "__clang__" in define ) {
       print "FD_COMPILER_MAJOR_VERSION:=" define["__clang_major__"]
       print "CC_MAJOR_VERSION:=" define["__clang_major__"]
+      print "FD_COMPILER_VERSION:=" define["__clang_major__"] "." define["__clang_minor__"] "." define["__clang_patchlevel__"]
     } else if( "__GNUC__" in define ) {
       print "FD_COMPILER_MAJOR_VERSION:=" define["__GNUC__"]
       print "CC_MAJOR_VERSION:=" define["__GNUC__"]
+      print "FD_COMPILER_VERSION:=" define["__GNUC__"] "." define["__GNUC_MINOR__"] "." define["__GNUC_PATCHLEVEL__"]
     }
 
     emit_feature( "FD_HAS_SHANI",   "__SHA__" )


### PR DESCRIPTION
```
ubuntu@devbox:~/firedancer$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 26.04 LTS
Release:	26.04
Codename:	resolute
ubuntu@devbox:~/firedancer$ make -j 
config/machine/native.mk:24: *** Your compiler GCC 15.2.0 is broken (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123002). Please upgrade GCC or recompile with make CC=clang.  Stop.
```