### PR TITLE
fdctl: fix --no-clone CPU starvation

### DIFF
--- a/src/app/fdctl/commands/run_agave.c
+++ b/src/app/fdctl/commands/run_agave.c
@@ -262,5 +262,6 @@ action_t fd_action_run_agave = {
   .args        = NULL,
   .fn          = run_agave_cmd_fn,
   .perm        = NULL,
+  .is_multi_process = 1,
   .description = "Start up the Agave side of a Firedancer validator",
 };

--- a/src/app/fddev/commands/dev.c
+++ b/src/app/fddev/commands/dev.c
@@ -33,5 +33,6 @@ action_t fd_action_dev = {
   .fn               = fddev_dev_cmd_fn,
   .perm             = dev_cmd_perm,
   .is_local_cluster = 1,
+  .is_multi_process = 1,
   .description      = "Start up a development validator"
 };

--- a/src/app/fddev/dev1.c
+++ b/src/app/fddev/dev1.c
@@ -121,6 +121,7 @@ action_t fd_action_dev1 = {
   .fn               = dev1_cmd_fn,
   .perm             = dev_cmd_perm,
   .is_local_cluster = 1,
+  .is_multi_process = 1,
   .description      = "Start up a single tile",
   .args_help        = dev1_args_help,
 };

--- a/src/app/firedancer-dev/commands/dev.c
+++ b/src/app/firedancer-dev/commands/dev.c
@@ -12,5 +12,6 @@ action_t fd_action_dev = {
   .fn               = firedancer_dev_dev_cmd_fn,
   .perm             = dev_cmd_perm,
   .is_local_cluster = 1,
+  .is_multi_process = 1,
   .description      = "Start up a development validator"
 };

--- a/src/app/shared/commands/configure/configure.c
+++ b/src/app/shared/commands/configure/configure.c
@@ -282,6 +282,7 @@ action_t fd_action_configure = {
   .args           = configure_cmd_args,
   .fn             = configure_cmd_fn,
   .perm           = configure_cmd_perm,
+  .is_multi_process = 1,
   .description    = "Configure the local host so it can run Firedancer correctly",
   .detail         = "Performs the privileged, host-level setup Firedancer needs before it can run,\n"
                     "organized into stages (such as mounting huge page filesystems and tuning\n"

--- a/src/app/shared/commands/configure/cpuset.c
+++ b/src/app/shared/commands/configure/cpuset.c
@@ -132,6 +132,14 @@ init( config_t const * config ) {
 
   char cgroup[ PATH_MAX ]; cgroup_path( cgroup, config, NULL );
 
+  /* cgroups are process-wide, so not compatible with --no-clone,
+     as fixed and floating tiles need different CPU masks */
+  if( FD_UNLIKELY( config->development.no_clone ) ) {
+    FD_LOG_INFO(( "[development.no_clone] is enabled; not creating `%s` as floating tiles "
+                  "cannot be isolated from fixed tiles within a single process", cgroup ));
+    return;
+  }
+
   if( FD_UNLIKELY( !fd_cpuset_cnt( part_cpus ) ) ) {
     FD_LOG_WARNING(( "no fixed tile CPUs in topology; not creating `%s`", cgroup ));
     return;
@@ -212,11 +220,18 @@ check( config_t const * config,
        int              check_type ) {
   (void)check_type;
 
+  char cgroup[ PATH_MAX ]; cgroup_path( cgroup, config, NULL );
+
+  if( FD_UNLIKELY( config->development.no_clone ) ) {
+    if( FD_UNLIKELY( !access( cgroup, F_OK ) ) )
+      PARTIALLY_CONFIGURED( "`%s` exists but [development.no_clone] is enabled", cgroup );
+    CONFIGURE_OK();
+  }
+
   FD_CPUSET_DECL( part_cpus );
   fd_cpu_isolation_partition_cpus( part_cpus, &config->topo );
   if( FD_UNLIKELY( !fd_cpuset_cnt( part_cpus ) ) ) CONFIGURE_OK();
 
-  char cgroup[ PATH_MAX ]; cgroup_path( cgroup, config, NULL );
   if( FD_UNLIKELY( access( cgroup, F_OK ) ) )
     NOT_CONFIGURED( "`%s` does not exist", cgroup );
 

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -1345,6 +1345,7 @@ action_t fd_action_run1 = {
   .args        = run1_cmd_args,
   .fn          = run1_cmd_fn,
   .perm        = NULL,
+  .is_multi_process = 1,
   .description = "Start up a single Firedancer tile",
   .detail      = "Runs one tile of the validator topology in the current process.  A tile is a\n"
                  "single thread pinned to a CPU core that performs one part of the validator's\n"
@@ -1360,6 +1361,7 @@ action_t fd_action_run = {
   .fn             = run_cmd_fn,
   .require_config = 1,
   .perm           = run_cmd_perm,
+  .is_multi_process = 1,
   .description    = "Start up a Firedancer validator",
   .detail         = "Boots and runs the full validator described by the configuration file.  This\n"
                     "is the main command operators use to run Firedancer.  It must be started with\n"

--- a/src/app/shared/fd_action.h
+++ b/src/app/shared/fd_action.h
@@ -245,6 +245,7 @@ struct fd_action {
   int          is_local_cluster; /* If a command is one which runs a local cluster, certain information in
                                     the configuration file will be changed. */
   uchar        is_diagnostic;  /* 1 implies action should be allowed for prod debugging */
+  int          is_multi_process;
 
   void       (*args)( int * pargc, char *** pargv, args_t * args );
   void       (*topo)( config_t * config );

--- a/src/app/shared_dev/boot/fd_dev_boot.c
+++ b/src/app/shared_dev/boot/fd_dev_boot.c
@@ -150,7 +150,7 @@ fd_dev_main( int                        argc,
   int load_topo = fd_main_init( &argc, &argv, &config, opt_user_config_path, is_firedancer, action->is_local_cluster, log_path, configs, 1 /* dev */ );
   if( FD_LIKELY( load_topo ) ) fd_cstr_ncpy( config.action, action->name, sizeof( config.action ) );
 
-  config.development.no_clone = config.development.no_clone || no_clone;
+  config.development.no_clone = config.development.no_clone || no_clone || !action->is_multi_process;
   config.development.sandbox = config.development.sandbox && !no_sandbox && !config.development.no_clone;
 
   /* Frankendancer has a separate production binary (fdctl); for

--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -303,33 +303,12 @@ run_tile_thread( fd_topo_t *         topo,
   if( FD_UNLIKELY( err ) ) FD_LOG_ERR(( "pthread_create() failed (%i-%s)", err, fd_io_strerror( err ) ));
 }
 
-static void
-join_isolation_cgroup( char const * app_name ) {
-  char path[ PATH_MAX ];
-  FD_TEST( fd_cstr_printf_check( path, sizeof(path), NULL, "/sys/fs/cgroup/%s/cgroup.procs", app_name ) );
-
-  int fd = open( path, O_WRONLY );
-  if( FD_UNLIKELY( fd<0 ) ) {
-    if( FD_LIKELY( errno==ENOENT ) ) return; /* cpuset stage not configured */
-    FD_LOG_ERR(( "open(%s) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-  }
-
-  char pid[ 32 ];
-  ulong pid_len;
-  FD_TEST( fd_cstr_printf_check( pid, sizeof(pid), &pid_len, "%ld", (long)getpid() ) );
-  if( FD_UNLIKELY( write( fd, pid, pid_len )!=(long)pid_len ) )
-    FD_LOG_ERR(( "write(%s,\"%s\") failed (%i-%s)", path, pid, errno, fd_io_strerror( errno ) ));
-  if( FD_UNLIKELY( close( fd ) ) ) FD_LOG_ERR(( "close(%s) failed (%i-%s)", path, errno, fd_io_strerror( errno ) ));
-}
-
 void
 fd_topo_run_single_process( fd_topo_t *       topo,
                             int               agave,
                             uint              uid,
                             uint              gid,
                             fd_topo_run_tile_t (* tile_run )( fd_topo_tile_t const * tile ) ) {
-  join_isolation_cgroup( topo->app_name );
-
   /* Save the current affinity, it will be restored after creating any child tiles */
   FD_CPUSET_DECL( floating_cpu_set );
   if( FD_UNLIKELY( fd_cpuset_getaffinity( 0, floating_cpu_set ) ) )


### PR DESCRIPTION
Fixes a bug where floating tiles inherited the fixed tile CPU
cgroup, which restricted them to a set of CPUs that was already
hogged by nice -19 (fixed) tile CPUs.

Closes #10727
