### PR TITLE
[v26.08] flamenco: fix bpf loader input region footprint (#10729)

### DIFF
--- a/src/flamenco/runtime/fd_runtime_const.h
+++ b/src/flamenco/runtime/fd_runtime_const.h
@@ -176,56 +176,6 @@ FD_PROTOTYPES_BEGIN
                                                sizeof(ulong))              /* rent_epoch        */
 #define FD_BPF_LOADER_DUPLICATE_ACCOUNT_FOOTPRINT (8UL) /* 1 dup byte + 7 bytes for padding */
 
-/* FD_BPF_LOADER_INPUT_REGION_FOOTPRINT bounds the bytes a single
-   instruction can serialize into one input region.
-
-   The account data bodies are NOT bounded by account_lock_limit *
-   FD_RUNTIME_ACC_SZ_MAX (64 * 10 MiB = 640 MiB): a transaction is
-   rejected before execution (and therefore before serialization) if the
-   sum of its loaded account data exceeds
-   FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT (see
-   fd_executor_load_transaction_accounts ->
-   fd_increase_calculated_data_size, called from
-   fd_runtime_pre_execute_check before fd_execute_txn).  An instruction
-   serializes a subset of the transaction's (<= account_lock_limit
-   unique) accounts, each unique account's data copied at most once (dups
-   cost 8 bytes).
-
-   However, a program may GROW account data during execution before a
-   later instruction (or CPI) re-serializes it.  Total account-data
-   growth across a transaction is itself capped, at
-   FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN (== fd_borrowed_account.h's
-   MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN, which fd_borrowed_account.c
-   enforces by rejecting any resize that pushes accounts_resize_delta
-   over the cap).  So the worst-case account-data body serialized by any
-   one instruction is bounded by
-
-     FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT          (initial loaded data)
-   + FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN         (max growth this txn)
-
-   i.e. 64 MiB + 20 MiB = 84 MiB.  We charge the data bodies once at the
-   region level with that combined bound, plus the fixed per-account
-   overhead (metadata + per-account realloc headroom + alignment).
-
-   When direct_mapping is enabled the data body is mapped rather than
-   copied, so it costs nothing in this buffer at all. */
-#define FD_BPF_LOADER_INPUT_REGION_FOOTPRINT(account_lock_limit, direct_mapping)                                                                          \
-                                              (FD_ULONG_ALIGN_UP( (sizeof(ulong)                      /* acct_cnt       */                          +     \
-                                                                   account_lock_limit*FD_BPF_LOADER_UNIQUE_ACCOUNT_FIXED_FOOTPRINT                  +     \
-                                                                   ((direct_mapping) ? 0UL : ((ulong)FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT +              \
-                                                                                              (ulong)FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN))       +     \
-                                                                   (FD_TXN_INSTR_ACCT_MAX-account_lock_limit)*FD_BPF_LOADER_DUPLICATE_ACCOUNT_FOOTPRINT + \
-                                                                   sizeof(ulong)                      /* instr data len */                          +     \
-                                                                   FD_RUNTIME_CPI_MAX_INSTR_DATA_LEN  /* instr data  */                             +     \
-                                                                   sizeof(fd_pubkey_t)                /* program id     */                          +     \
-                                                                   (FD_BPF_ALIGN_OF_U128-1UL) +                                                           \
-                                                                   FD_TXN_INSTR_ACCT_MAX*sizeof(ulong) /* direct_account_pointers_in_program_input */),   \
-                                                                   FD_RUNTIME_EBPF_HOST_ALIGN ))
-
-
-
-#define BPF_LOADER_SERIALIZATION_FOOTPRINT (FD_BPF_LOADER_INPUT_REGION_FOOTPRINT(64UL, 0))
-
 /* FD_SYSVAR_INSTRUCTIONS_FOOTPRINT bounds the worst-case serialized
    size of the sysvar instructions account.  See
    fd_sysvar_instructions.c for the format.
@@ -258,6 +208,59 @@ FD_PROTOTYPES_BEGIN
      - 2 bytes tail (current_instr_idx)
    Total: 78084 bytes, rounded up to 81920. */
 #define FD_SYSVAR_INSTRUCTIONS_FOOTPRINT (81920UL)
+
+/* FD_BPF_LOADER_INPUT_REGION_FOOTPRINT bounds the bytes a single
+   instruction can serialize into one input region.
+
+   The account data bodies are NOT bounded by account_lock_limit *
+   FD_RUNTIME_ACC_SZ_MAX (64 * 10 MiB = 640 MiB): a transaction is
+   rejected before execution (and therefore before serialization) if the
+   sum of its loaded account data exceeds
+   FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT (see
+   fd_executor_load_transaction_accounts ->
+   fd_increase_calculated_data_size, called from
+   fd_runtime_pre_execute_check before fd_execute_txn).  Note that this
+   does not include the instructions sysvar, as this is not counted
+   towards the loaded accounts data size limit.  An instruction
+   serializes a subset of the transaction's (<= account_lock_limit
+   unique) accounts, each unique account's data copied at most once (dups
+   cost 8 bytes).
+
+   However, a program may GROW account data during execution before a
+   later instruction (or CPI) re-serializes it.  Total account-data
+   growth across a transaction is itself capped, at
+   FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN (== fd_borrowed_account.h's
+   MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN, which fd_borrowed_account.c
+   enforces by rejecting any resize that pushes accounts_resize_delta
+   over the cap).  So the worst-case account-data body serialized by any
+   one instruction is bounded by
+
+     FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT          (initial loaded data)
+   + FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN         (max growth this txn)
+
+   i.e. 64 MiB + 20 MiB = 84 MiB.  We charge the data bodies once at the
+   region level with that combined bound, plus the fixed per-account
+   overhead (metadata + per-account realloc headroom + alignment).
+
+   When direct_mapping is enabled the data body is mapped rather than
+   copied, so it costs nothing in this buffer at all. */
+#define FD_BPF_LOADER_INPUT_REGION_FOOTPRINT(account_lock_limit, direct_mapping)                                                                          \
+                                              (FD_ULONG_ALIGN_UP( (sizeof(ulong)                      /* acct_cnt       */                          +     \
+                                                                   account_lock_limit*FD_BPF_LOADER_UNIQUE_ACCOUNT_FIXED_FOOTPRINT                  +     \
+                                                                   ((direct_mapping) ? 0UL : ((ulong)FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT +              \
+                                                                                              (ulong)FD_RUNTIME_ACC_DATA_GROWTH_MAX_PER_TXN))       +     \
+                                                                   FD_SYSVAR_INSTRUCTIONS_FOOTPRINT                                                 +     \
+                                                                   (FD_TXN_INSTR_ACCT_MAX-account_lock_limit)*FD_BPF_LOADER_DUPLICATE_ACCOUNT_FOOTPRINT + \
+                                                                   sizeof(ulong)                      /* instr data len */                          +     \
+                                                                   FD_RUNTIME_CPI_MAX_INSTR_DATA_LEN  /* instr data  */                             +     \
+                                                                   sizeof(fd_pubkey_t)                /* program id     */                          +     \
+                                                                   (FD_BPF_ALIGN_OF_U128-1UL) +                                                           \
+                                                                   FD_TXN_INSTR_ACCT_MAX*sizeof(ulong) /* direct_account_pointers_in_program_input */),   \
+                                                                   FD_RUNTIME_EBPF_HOST_ALIGN ))
+
+
+
+#define BPF_LOADER_SERIALIZATION_FOOTPRINT (FD_BPF_LOADER_INPUT_REGION_FOOTPRINT(64UL, 0))
 
 #define FD_HARD_FORKS_MAX (64UL)
 


### PR DESCRIPTION
backport of https://github.com/firedancer-io/firedancer/commit/ac6aea478d85881882d290cf2adae09abea6d625