### PR TITLE
runtime: support scheduled restarts

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -736,6 +736,15 @@ telemetry = true
         # is not recommended to change this setting.
         mean_cache_entry_size = 131072
 
+    # Options used for a coordinated cluster restart (e.g. testnet downgrade)
+    [runtime.restart]
+        # Causes the validator to create a hard fork at this slot.
+        # A value of zero disables restart hard fork creation.
+        restart_slot = 0
+
+        # The restart attempt number, starting at one.
+        restart_attempt = 0
+
 # CPU cores in Firedancer are carefully managed.  Where a typical
 # program lets the operating system scheduler determine which threads to
 # run on which cores and for how long, Firedancer overrides most of this

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -1417,6 +1417,9 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     tile->replay.full_snapshot_interval_slots        = config->firedancer.snapshots.full_snapshot_interval_slots;
     tile->replay.incremental_snapshot_interval_slots = config->firedancer.snapshots.incremental_snapshot_interval_slots;
 
+    tile->replay.restart_slot    = config->firedancer.runtime.restart.restart_slot;
+    tile->replay.restart_attempt = config->firedancer.runtime.restart.restart_attempt;
+
     fd_cstr_ncpy( tile->replay.genesis_path, config->paths.genesis, sizeof(tile->replay.genesis_path) );
 
     tile->replay.larger_max_cost_per_block = config->development.bench.larger_max_cost_per_block;

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -436,6 +436,10 @@ fd_config_fill( fd_config_t * config,
     FD_LOG_ERR(( "Config option [consensus.wait_for_supermajority_with_bank_hash] requires consensus.expected_shred_version!=0 and consensus.wait_for_vote_to_start_leader==false." ));
   }
 
+  if( FD_UNLIKELY( config->is_firedancer && (!config->firedancer.runtime.restart.restart_slot)!=(!config->firedancer.runtime.restart.restart_attempt) ) ) {
+    FD_LOG_ERR(( "Invalid [runtime.restart] configuration. If restart_slot is set, restart_attempt should be greater than zero." ));
+  }
+
 }
 
 #define CFG_HAS_NON_EMPTY( key ) do {                  \

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -124,6 +124,11 @@ struct fd_configf {
       ulong heap_size_mib;
       ulong mean_cache_entry_size;
     } program_cache;
+
+    struct {
+      ulong restart_slot;
+      ulong restart_attempt;
+    } restart;
   } runtime;
 
   struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -104,6 +104,9 @@ fd_config_extract_podf( uchar *        pod,
   CFG_POP      ( ulong,  runtime.program_cache.heap_size_mib                 );
   CFG_POP      ( ulong,  runtime.program_cache.mean_cache_entry_size         );
 
+  CFG_POP      ( ulong,  runtime.restart.restart_slot                        );
+  CFG_POP      ( ulong,  runtime.restart.restart_attempt                     );
+
   CFG_POP      ( cstr,   consensus.wait_for_supermajority_with_bank_hash     );
 
   CFG_POP      ( uint,   snapshots.sources.max_local_full_effective_age      );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -456,6 +456,9 @@ struct fd_topo_tile {
       ulong full_snapshot_interval_slots;
       ulong incremental_snapshot_interval_slots;
 
+      ulong restart_slot;
+      ulong restart_attempt;
+
       /* not specified in TOML */
 
       long boot_timestamp_nanos;

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -40,6 +40,7 @@
 #include "../../flamenco/runtime/sysvar/fd_sysvar_cache.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_stake_history.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_rent.h"
 #include "../../flamenco/runtime/program/fd_precompiles.h"
 #include "../../flamenco/runtime/program/vote/fd_vote_state_versioned.h"
@@ -1085,6 +1086,11 @@ boot_genesis( fd_replay_tile_t *        ctx,
 
   ctx->caught_up = 1;
 
+  if( FD_UNLIKELY( ctx->restart_slot ) ) {
+    FD_LOG_ERR(( "[runtime.restart] is only supported when booting from a snapshot, but this validator is "
+                 "bootstrapping a new cluster from genesis" ));
+  }
+
   uchar const * genesis_blob = (uchar const *)( meta+1 );
   FD_TEST( meta->bootstrap && meta->has_lthash );
   FD_TEST( fd_genesis_parse( ctx->genesis, genesis_blob, meta->blob_sz ) );
@@ -1217,6 +1223,9 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
     }
 
     ulong snapshot_slot = bank->f.slot;
+    if( FD_UNLIKELY( ctx->restart_slot==snapshot_slot && ctx->restart_slot ) ) {
+      fd_sysvar_last_restart_slot_update( bank, ctx->accdb, ctx->capture_ctx );
+    }
 
     fd_hash_t bank_hash = bank->f.bank_hash;
     if( FD_UNLIKELY( ctx->wfs_enabled && memcmp( ctx->expected_bank_hash.uc, bank_hash.uc, sizeof(fd_hash_t) ) ) ) {
@@ -1319,19 +1328,18 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
       if( FD_UNLIKELY( fd_ssload_recover( fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk ),
                                           ctx->banks,
                                           fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ ),
-                                          ctx->blockhash_seed ) ) ) {
+                                          ctx->blockhash_seed,
+                                          ctx->restart_slot,
+                                          ctx->restart_attempt ) ) ) {
         FD_LOG_ERR(( "Snapshot manifest recovery failed, aborting." ));
       }
 
+      fd_bank_t * boot_bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ );
       ctx->has_cluster_type = 1;
-      ctx->cluster_type     = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ )->f.cluster_type;
+      ctx->cluster_type     = boot_bank->f.cluster_type;
 
       fd_snapshot_manifest_t const * manifest = fd_chunk_to_laddr( ctx->in[ in_idx ].mem, chunk );
-      /* hard_fork_cnt already validated by fd_ssload_recover. */
-      ctx->hard_fork_cnt = manifest->hard_fork_cnt;
-      for( ulong i=0UL; i<manifest->hard_fork_cnt; i++ ) {
-        ctx->hard_forks[ i ] = manifest->hard_forks[ i ];
-      }
+      ctx->hard_forks_known = 1;
       ctx->has_expected_genesis_timestamp = 1;
       ctx->expected_genesis_timestamp     = manifest->creation_time_seconds;
       ctx->has_manifest_block_id          = manifest->has_block_id;
@@ -2440,10 +2448,13 @@ maybe_verify_shred_version( fd_replay_tile_t * ctx ) {
      snapshot's hard fork list until wait-for-supermajority completes. */
   if( FD_UNLIKELY( ctx->wfs_enabled && !ctx->wfs_complete && ctx->expected_shred_version ) ) return;
 
-  if( FD_LIKELY( ctx->has_genesis_hash && ctx->hard_fork_cnt!=ULONG_MAX && (ctx->expected_shred_version || ctx->ipecho_shred_version) ) ) {
+  if( FD_LIKELY( ctx->has_genesis_hash && ctx->hard_forks_known && (ctx->expected_shred_version || ctx->ipecho_shred_version) ) ) {
     ushort expected_shred_version = ctx->expected_shred_version ? ctx->expected_shred_version : ctx->ipecho_shred_version;
 
-    ushort actual_shred_version = compute_shred_version( ctx->genesis_hash->uc, ctx->hard_forks, ctx->hard_fork_cnt );
+    fd_bank_t const * boot_bank = fd_banks_bank_query( ctx->banks, FD_REPLAY_BOOT_BANK_SEQ );
+    FD_CHECK_ERR( boot_bank, "boot bank is not yet available (this is a bug)" );
+
+    ushort actual_shred_version = compute_shred_version( ctx->genesis_hash->uc, boot_bank->f.hard_forks, boot_bank->f.hard_fork_cnt );
 
     if( FD_UNLIKELY( expected_shred_version!=actual_shred_version ) ) {
       FD_BASE58_ENCODE_32_BYTES( ctx->genesis_hash->uc, genesis_hash_b58 );
@@ -3005,9 +3016,12 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->has_cluster_type = 0;
   ctx->has_genesis_timestamp          = 0;
   ctx->has_expected_genesis_timestamp = 0;
+  ctx->hard_forks_known               = 0;
   ctx->cluster_type = FD_CLUSTER_UNKNOWN;
-  ctx->hard_fork_cnt = ULONG_MAX;
   ctx->has_manifest_block_id = 0;
+
+  ctx->restart_slot    = tile->replay.restart_slot;
+  ctx->restart_attempt = tile->replay.restart_attempt;
 
   if( FD_UNLIKELY( ctx->bundle.enabled ) ) {
     if( FD_UNLIKELY( !fd_bundle_crank_gen_init( ctx->bundle.gen,

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -1223,7 +1223,18 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
     }
 
     ulong snapshot_slot = bank->f.slot;
-    if( FD_UNLIKELY( ctx->restart_slot==snapshot_slot && ctx->restart_slot ) ) {
+
+    /* ssload derived the bank hash of the snapshot slot from the hard
+       fork instead of the runtime folding it in during replay.  Nothing
+       else checks a derived hash, so require the cluster's. */
+    int restart_derived_bank_hash = ctx->restart_slot && ctx->restart_slot==snapshot_slot;
+    if( FD_UNLIKELY( restart_derived_bank_hash ) ) {
+      if( FD_UNLIKELY( !ctx->wfs_enabled ) ) {
+        FD_LOG_ERR(( "[runtime.restart.restart_slot] is %lu, the slot this validator boots from, so the bank hash of "
+                     "that slot was derived from the scheduled hard fork rather than replayed.  Set "
+                     "[consensus.wait_for_supermajority_with_bank_hash] to the bank hash the cluster published for "
+                     "the restart slot, so that the derived bank hash is verified against it.", snapshot_slot ));
+      }
       fd_sysvar_last_restart_slot_update( bank, ctx->accdb, ctx->capture_ctx );
     }
 
@@ -1232,8 +1243,11 @@ on_snapshot_message( fd_replay_tile_t *  ctx,
       FD_BASE58_ENCODE_32_BYTES( ctx->expected_bank_hash.uc, expected_bank_hash_cstr );
       FD_BASE58_ENCODE_32_BYTES( bank_hash.uc,                 actual_bank_hash_cstr );
       FD_LOG_ERR(( "[consensus.wait_for_supermajority_with_bank_hash] expected_bank_hash=%s does not match snapshot slot"
-                   "=%lu bank_hash=%s. If you are loading a snapshot from the network, check that the slot matches the "
-                   "cluster restart slot. ", expected_bank_hash_cstr, snapshot_slot, actual_bank_hash_cstr ));
+                   "=%lu bank_hash=%s.%s If you are loading a snapshot from the network, check that the slot matches the "
+                   "cluster restart slot. ", expected_bank_hash_cstr, snapshot_slot, actual_bank_hash_cstr,
+                   restart_derived_bank_hash ?
+                     " That bank hash was derived from the hard fork scheduled at [runtime.restart], so check that "
+                     "[runtime.restart.restart_attempt] is the attempt the cluster restarted with." : "" ));
     }
     if( FD_UNLIKELY( ctx->wfs_enabled ) ) {
       FD_LOG_NOTICE(( "waiting for supermajority at snapshot slot %lu", snapshot_slot ));

--- a/src/discof/replay/fd_replay_tile_private.h
+++ b/src/discof/replay/fd_replay_tile_private.h
@@ -112,6 +112,7 @@ struct fd_replay_tile {
   uint has_cluster_type:1;
   uint has_genesis_timestamp:1;
   uint has_expected_genesis_timestamp:1;
+  uint hard_forks_known:1;
 
   char         genesis_path[ PATH_MAX ];
   fd_hash_t    genesis_hash[1];
@@ -120,8 +121,8 @@ struct fd_replay_tile {
   ulong        genesis_timestamp;
   ulong        expected_genesis_timestamp;
 
-  ulong          hard_fork_cnt;
-  fd_hard_fork_t hard_forks[ FD_HARD_FORKS_MAX ];
+  ulong restart_slot;
+  ulong restart_attempt;
 
   ushort expected_shred_version;
   ushort ipecho_shred_version;

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -547,6 +547,10 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
   root->parent_accdb_fork_id = root->accdb_fork_id;
   root->f.slot = 100UL;
   ctx->restart_slot = root->f.slot;
+  /* A restart at the snapshot slot requires the cluster's bank hash, as
+     the bank hash of that slot was derived rather than replayed. */
+  ctx->wfs_enabled        = 1;
+  ctx->expected_bank_hash = root->f.bank_hash;
   ctx->has_expected_genesis_timestamp = 1;
   mock_accdb_fork_id_next = 0U;
   static ulong test_metrics[ FD_METRICS_TOTAL_SZ/sizeof(ulong) ];
@@ -562,6 +566,7 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
   FD_TEST( mock_last_restart_slot_update_cnt==1UL );
   root->f.slot = 0UL;
   ctx->restart_slot = 0UL;
+  ctx->wfs_enabled  = 0;
   root->refcnt = 0UL;
 
   fd_bank_t * child = fd_banks_new_bank( ctx->banks, root->idx, 0L, 0 );

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -22,6 +22,8 @@
 #include "../../flamenco/runtime/fd_runtime_helpers.h" /* IWYU pragma: keep */
 #include "../../flamenco/runtime/sysvar/fd_sysvar_rent.h" /* IWYU pragma: keep */
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
+#include "../../flamenco/runtime/sysvar/fd_sysvar_last_restart_slot.h"
+#include "../../flamenco/runtime/fd_hashes.h"
 #include "../../flamenco/leaders/fd_multi_epoch_leaders.h"
 #include "../../flamenco/progcache/fd_progcache_admin.h" /* IWYU pragma: keep */
 #include "../../flamenco/rewards/fd_rewards.h" /* IWYU pragma: keep */
@@ -99,6 +101,7 @@ static ulong mock_epoch_boundary_fork_cnt;
 static ulong mock_epoch_boundary_fork_max;
 static int   mock_epoch_boundary_overflow;
 static int   mock_snapshot_boot;
+static ulong mock_last_restart_slot_update_cnt;
 
 ulong
 mock_multi_epoch_leaders_next_slot_fn( fd_multi_epoch_leaders_t const * mleaders FD_PARAM_UNUSED,
@@ -172,6 +175,10 @@ mock_runtime_block_execute_prepare_fn( fd_banks_t *         banks FD_PARAM_UNUSE
 #define fd_vote_stakes_refresh(v,f,a,i)              do { if( !mock_snapshot_boot ) (fd_vote_stakes_refresh)(v,f,a,i); } while(0)
 #define fd_rewards_recalculate_partitioned_rewards(b,k,a,s,c) do { if( !mock_snapshot_boot ) (fd_rewards_recalculate_partitioned_rewards)(b,k,a,s,c); } while(0)
 #define fd_accdb_lamports(a,i,p) (mock_snapshot_boot ? 0UL : (fd_accdb_lamports)(a,i,p))
+#define fd_sysvar_last_restart_slot_update(bank,accdb,capture) do {                        \
+    if( mock_snapshot_boot ) mock_last_restart_slot_update_cnt++;                         \
+    else (fd_sysvar_last_restart_slot_update)(bank,accdb,capture);                        \
+  } while(0)
 #define fd_runtime_block_execute_prepare     mock_runtime_block_execute_prepare_fn
 
 /* ---- Include the tile under test ---- */
@@ -538,6 +545,8 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
 
   root->accdb_fork_id        = (fd_accdb_fork_id_t){ .val=37U };
   root->parent_accdb_fork_id = root->accdb_fork_id;
+  root->f.slot = 100UL;
+  ctx->restart_slot = root->f.slot;
   ctx->has_expected_genesis_timestamp = 1;
   mock_accdb_fork_id_next = 0U;
   static ulong test_metrics[ FD_METRICS_TOTAL_SZ/sizeof(ulong) ];
@@ -550,6 +559,9 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
   FD_TEST( root->accdb_fork_id.val==37U );
   FD_TEST( root->parent_accdb_fork_id.val==37U );
   FD_TEST( mock_accdb_fork_id_next==0U );
+  FD_TEST( mock_last_restart_slot_update_cnt==1UL );
+  root->f.slot = 0UL;
+  ctx->restart_slot = 0UL;
   root->refcnt = 0UL;
 
   fd_bank_t * child = fd_banks_new_bank( ctx->banks, root->idx, 0L, 0 );

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -1,6 +1,7 @@
 #include "fd_ssload.h"
 
 #include "../../../disco/genesis/fd_genesis_cluster.h"
+#include "../../../flamenco/runtime/fd_hashes.h"
 #include "../../../flamenco/runtime/fd_runtime_const.h"
 #include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "fd_ssmsg.h"
@@ -310,11 +311,98 @@ fd_ssload_recover_validate( fd_snapshot_manifest_t const * manifest,
   return fd_ssload_manifest_validate( manifest, banks->max_vote_accounts, banks->max_stake_accounts );
 }
 
+/* register_restart_slot adds a hard fork for the restart slot
+   (as configured in [runtime.restart]). */
+
+static int
+register_restart_slot( fd_bank_t * bank,
+                       ulong       restart_slot,
+                       ulong       restart_attempt ) {
+  if( FD_LIKELY( !restart_slot ) ) return 0;
+
+  ulong            cnt        = bank->f.hard_fork_cnt;
+  fd_hard_fork_t * hard_forks = bank->f.hard_forks;
+
+  /* The hard fork list is sorted ascending by slot, so only the last
+     entry can conflict with the scheduled hard fork. */
+
+  fd_hard_fork_t * last = cnt ? &hard_forks[ cnt-1UL ] : NULL;
+
+  if( FD_UNLIKELY( last && last->slot>restart_slot ) ) {
+    FD_LOG_WARNING(( "[runtime.restart.restart_slot] is %lu but the snapshot already contains a hard fork at the "
+                     "later slot %lu", restart_slot, last->slot ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( last && last->slot==restart_slot ) ) {
+    if( FD_UNLIKELY( restart_attempt<=last->cnt ) ) {
+      FD_LOG_WARNING(( "[runtime.restart.restart_attempt] is %lu but the snapshot already contains attempt %lu of "
+                       "the hard fork at slot %lu", restart_attempt, last->cnt, restart_slot ));
+      return -1;
+    }
+
+    if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
+      FD_LOG_WARNING(( "[runtime.restart.restart_attempt] is %lu but attempt %lu of the hard fork at slot %lu is "
+                       "already part of the bank hash of snapshot slot %lu, so the attempt cannot be changed",
+                       restart_attempt, last->cnt, restart_slot, bank->f.slot ));
+      return -1;
+    }
+
+    last->cnt = restart_attempt;
+    return 0;
+  }
+
+  if( FD_UNLIKELY( cnt>=FD_HARD_FORKS_MAX ) ) {
+    FD_LOG_WARNING(( "Cannot register the hard fork configured at [runtime.restart.restart_slot] because the hard "
+                     "fork list is full (%lu entries)", cnt ));
+    return -1;
+  }
+
+  if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
+    if( FD_UNLIKELY( restart_slot<=bank->f.parent_slot ) ) {
+      FD_LOG_WARNING(( "[runtime.restart].restart_slot is %lu but the snapshot at slot %lu is already past it "
+                       "(parent slot %lu). not applying hard forks",
+                       restart_slot, bank->f.slot, bank->f.parent_slot ));
+      return -1;
+    }
+
+    /* Combining two hard forks in one bank hash requires the sum of
+       their attempts, but the snapshot bank hash already folded in the
+       entry the snapshot came with. */
+    if( FD_UNLIKELY( last && last->slot>bank->f.parent_slot ) ) {
+      FD_LOG_WARNING(( "[runtime.restart.restart_slot] is %lu but the bank hash of snapshot slot %lu already "
+                       "contains the hard fork at slot %lu", restart_slot, bank->f.slot, last->slot ));
+      return -1;
+    }
+  }
+
+  hard_forks[ cnt ].slot = restart_slot;
+  hard_forks[ cnt ].cnt  = restart_attempt;
+  bank->f.hard_fork_cnt  = cnt+1UL;
+
+  if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
+    fd_hashes_apply_hard_forks( &bank->f.bank_hash,
+                                bank->f.slot,
+                                bank->f.parent_slot,
+                                &hard_forks[ cnt ],
+                                1UL );
+    FD_BASE58_ENCODE_32_BYTES( bank->f.bank_hash.uc, bank_hash_b58 );
+    FD_LOG_NOTICE(( "applied hard fork at restart slot %lu (attempt %lu) to snapshot slot %lu, bank hash is now %s",
+                    restart_slot, restart_attempt, bank->f.slot, bank_hash_b58 ));
+  } else {
+    FD_LOG_NOTICE(( "scheduled hard fork at restart slot %lu (attempt %lu)", restart_slot, restart_attempt ));
+  }
+
+  return 0;
+}
+
 int
 fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
                          fd_banks_t *             banks,
                          fd_bank_t *              bank,
-                         ulong                    blockhash_seed ) {
+                         ulong                    blockhash_seed,
+                         ulong                    restart_slot,
+                         ulong                    restart_attempt ) {
 
   /* Slot */
 
@@ -440,6 +528,8 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
       }
     }
   }
+
+  if( FD_UNLIKELY( register_restart_slot( bank, restart_slot, restart_attempt ) ) ) return -1;
 
   /* snapin populates the root stake delegation cache directly from the
      account stream.  The manifest's primary stake delegations are
@@ -582,12 +672,14 @@ int
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_banks_t *             banks,
                    fd_bank_t *              bank,
-                   ulong                    blockhash_seed ) {
+                   ulong                    blockhash_seed,
+                   ulong                    restart_slot,
+                   ulong                    restart_attempt ) {
 
   if( FD_UNLIKELY( fd_ssload_recover_validate( manifest, banks ) ) ) {
     FD_LOG_WARNING(( "snapshot manifest validation failed" ));
     return -1;
   }
 
-  return fd_ssload_recover_apply( manifest, banks, bank, blockhash_seed );
+  return fd_ssload_recover_apply( manifest, banks, bank, blockhash_seed, restart_slot, restart_attempt );
 }

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -27,6 +27,15 @@ fd_ssload_manifest_validate( fd_snapshot_manifest_t const * manifest,
     return -1;
   }
 
+  /* Only the genesis bank is its own parent. */
+
+  int genesis = !manifest->slot && !manifest->parent_slot;
+  if( FD_UNLIKELY( !genesis && manifest->parent_slot>=manifest->slot ) ) {
+    FD_LOG_WARNING(( "corrupt snapshot: parent slot %lu is after snapshot slot %lu",
+                     manifest->parent_slot, manifest->slot ));
+    return -1;
+  }
+
   /* slots_per_epoch must be at least FD_EPOCH_LEN_MIN, so that
      fd_slot_to_epoch and related functions produce valid data.
      This check must come before any epoch computation. */
@@ -311,6 +320,26 @@ fd_ssload_recover_validate( fd_snapshot_manifest_t const * manifest,
   return fd_ssload_manifest_validate( manifest, banks->max_vote_accounts, banks->max_stake_accounts );
 }
 
+/* hash_bank derives the bank hash of the recovered bank from the
+   manifest, as the runtime would have computed it when freezing the
+   slot with the given hard fork list. */
+
+static void
+hash_bank( fd_bank_t *            bank,
+           fd_hard_fork_t const * hard_forks,
+           ulong                  hard_fork_cnt,
+           fd_hash_t *            out ) {
+  fd_lthash_value_t const * lthash = fd_bank_lthash_locking_query( bank );
+  fd_hashes_hash_bank( lthash,
+                       &bank->f.prev_bank_hash,
+                       (fd_hash_t const *)bank->f.poh.hash,
+                       bank->f.signature_count,
+                       out );
+  fd_bank_lthash_end_locking_query( bank );
+
+  fd_hashes_apply_hard_forks( out, bank->f.slot, bank->f.parent_slot, hard_forks, hard_fork_cnt );
+}
+
 /* register_restart_slot adds a hard fork for the restart slot
    (as configured in [runtime.restart]). */
 
@@ -323,10 +352,17 @@ register_restart_slot( fd_bank_t * bank,
   ulong            cnt        = bank->f.hard_fork_cnt;
   fd_hard_fork_t * hard_forks = bank->f.hard_forks;
 
+  if( FD_UNLIKELY( restart_slot<bank->f.slot ) ) {
+    FD_LOG_WARNING(( "[runtime.restart.restart_slot] is %lu but the snapshot is already at slot %lu",
+                     restart_slot, bank->f.slot ));
+    return -1;
+  }
+
   /* The hard fork list is sorted ascending by slot, so only the last
      entry can conflict with the scheduled hard fork. */
 
-  fd_hard_fork_t * last = cnt ? &hard_forks[ cnt-1UL ] : NULL;
+  fd_hard_fork_t * last    = cnt ? &hard_forks[ cnt-1UL ] : NULL;
+  int              replace = last && last->slot==restart_slot;
 
   if( FD_UNLIKELY( last && last->slot>restart_slot ) ) {
     FD_LOG_WARNING(( "[runtime.restart.restart_slot] is %lu but the snapshot already contains a hard fork at the "
@@ -334,63 +370,50 @@ register_restart_slot( fd_bank_t * bank,
     return -1;
   }
 
-  if( FD_UNLIKELY( last && last->slot==restart_slot ) ) {
-    if( FD_UNLIKELY( restart_attempt<=last->cnt ) ) {
-      FD_LOG_WARNING(( "[runtime.restart.restart_attempt] is %lu but the snapshot already contains attempt %lu of "
-                       "the hard fork at slot %lu", restart_attempt, last->cnt, restart_slot ));
-      return -1;
-    }
-
-    if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
-      FD_LOG_WARNING(( "[runtime.restart.restart_attempt] is %lu but attempt %lu of the hard fork at slot %lu is "
-                       "already part of the bank hash of snapshot slot %lu, so the attempt cannot be changed",
-                       restart_attempt, last->cnt, restart_slot, bank->f.slot ));
-      return -1;
-    }
-
-    last->cnt = restart_attempt;
-    return 0;
+  if( FD_UNLIKELY( replace && restart_attempt<=last->cnt ) ) {
+    FD_LOG_WARNING(( "[runtime.restart.restart_attempt] is %lu but the snapshot already contains attempt %lu "
+                     "at slot %lu", restart_attempt, last->cnt, restart_slot ));
+    return -1;
   }
 
-  if( FD_UNLIKELY( cnt>=FD_HARD_FORKS_MAX ) ) {
+  if( FD_UNLIKELY( !replace && cnt>=FD_HARD_FORKS_MAX ) ) {
     FD_LOG_WARNING(( "Cannot register the hard fork configured at [runtime.restart.restart_slot] because the hard "
                      "fork list is full (%lu entries)", cnt ));
     return -1;
   }
 
-  if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
-    if( FD_UNLIKELY( restart_slot<=bank->f.parent_slot ) ) {
-      FD_LOG_WARNING(( "[runtime.restart].restart_slot is %lu but the snapshot at slot %lu is already past it "
-                       "(parent slot %lu). not applying hard forks",
-                       restart_slot, bank->f.slot, bank->f.parent_slot ));
-      return -1;
-    }
-
-    /* Combining two hard forks in one bank hash requires the sum of
-       their attempts, but the snapshot bank hash already folded in the
-       entry the snapshot came with. */
-    if( FD_UNLIKELY( last && last->slot>bank->f.parent_slot ) ) {
-      FD_LOG_WARNING(( "[runtime.restart.restart_slot] is %lu but the bank hash of snapshot slot %lu already "
-                       "contains the hard fork at slot %lu", restart_slot, bank->f.slot, last->slot ));
-      return -1;
-    }
+  if( FD_LIKELY( replace ) ) {
+    last->cnt = restart_attempt;
+  } else {
+    hard_forks[ cnt ].slot = restart_slot;
+    hard_forks[ cnt ].cnt  = restart_attempt;
+    bank->f.hard_fork_cnt  = cnt+1UL;
   }
 
-  hard_forks[ cnt ].slot = restart_slot;
-  hard_forks[ cnt ].cnt  = restart_attempt;
-  bank->f.hard_fork_cnt  = cnt+1UL;
-
-  if( FD_UNLIKELY( restart_slot<=bank->f.slot ) ) {
-    fd_hashes_apply_hard_forks( &bank->f.bank_hash,
-                                bank->f.slot,
-                                bank->f.parent_slot,
-                                &hard_forks[ cnt ],
-                                1UL );
-    FD_BASE58_ENCODE_32_BYTES( bank->f.bank_hash.uc, bank_hash_b58 );
-    FD_LOG_NOTICE(( "applied hard fork at restart slot %lu (attempt %lu) to snapshot slot %lu, bank hash is now %s",
-                    restart_slot, restart_attempt, bank->f.slot, bank_hash_b58 ));
-  } else {
+  if( FD_UNLIKELY( restart_slot!=bank->f.slot ) ) {
     FD_LOG_NOTICE(( "scheduled hard fork at restart slot %lu (attempt %lu)", restart_slot, restart_attempt ));
+    return 0;
+  }
+
+  /* A hard fork is part of the bank hash of the slot it is scheduled
+     at, which the runtime folds in when it freezes that slot.  The
+     restart slot is the snapshot slot here, so it is never replayed
+     and the bank hash is derived from the manifest instead.  The
+     result deliberately differs from the bank hash the snapshot
+     carries, which is the one the slot had under the hard fork list
+     the snapshot came with.  Deriving rather than extending that hash
+     is what lets an earlier attempt be replaced, as its fold cannot be
+     inverted. */
+
+  fd_hash_t snapshot_bank_hash = bank->f.bank_hash;
+  hash_bank( bank, hard_forks, bank->f.hard_fork_cnt, &bank->f.bank_hash );
+
+  if( FD_LIKELY( memcmp( snapshot_bank_hash.uc, bank->f.bank_hash.uc, sizeof(fd_hash_t) ) ) ) {
+    FD_BASE58_ENCODE_32_BYTES( snapshot_bank_hash.uc, snapshot_bank_hash_b58 );
+    FD_BASE58_ENCODE_32_BYTES( bank->f.bank_hash.uc,  bank_hash_b58          );
+    FD_LOG_NOTICE(( "applied hard fork at restart slot %lu (attempt %lu), bank hash of snapshot slot %lu is %s, "
+                    "was %s before the hard fork",
+                    restart_slot, restart_attempt, bank->f.slot, bank_hash_b58, snapshot_bank_hash_b58 ));
   }
 
   return 0;
@@ -526,6 +549,7 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
       if( FD_LIKELY( slot<=manifest->slot ) ) {
         break;
       }
+      FD_LOG_WARNING(( "snapshot contains hard fork at future slot %lu", slot ));
     }
   }
 

--- a/src/discof/restore/utils/fd_ssload.h
+++ b/src/discof/restore/utils/fd_ssload.h
@@ -42,12 +42,16 @@ fd_ssload_recover_validate( fd_snapshot_manifest_t const * manifest,
    unconditionally reset before repopulation.  Returns 0 on success,
    -1 on failure.  On failure, bank and associated structures may be
    left partially mutated; caller must treat this as unrecoverable.
-   blockhash_seed seeds the internal blockhash hash map. */
+   blockhash_seed seeds the internal blockhash hash map.
+
+   restart_slot and restart_attempt insert a hard fork (0->no-op). */
 int
 fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
                          fd_banks_t *             banks,
                          fd_bank_t *              bank,
-                         ulong                    blockhash_seed );
+                         ulong                    blockhash_seed,
+                         ulong                    restart_slot,
+                         ulong                    restart_attempt );
 
 /* fd_ssload_recover validates the manifest and applies it to bank.
    Equivalent to fd_ssload_recover_validate followed by
@@ -56,12 +60,15 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
    left unmodified.  If failure occurs after mutation begins, bank and
    associated structures may be left partially mutated.  Caller must
    treat such failures as unrecoverable (e.g. abort or discard the
-   bank).  blockhash_seed seeds the internal blockhash hash map. */
+   bank).  blockhash_seed seeds the internal blockhash hash map.
+   restart_slot and restart_attempt are as in fd_ssload_recover_apply. */
 int
 fd_ssload_recover( fd_snapshot_manifest_t * manifest,
                    fd_banks_t *             banks,
                    fd_bank_t *              bank,
-                   ulong                    blockhash_seed );
+                   ulong                    blockhash_seed,
+                   ulong                    restart_slot,
+                   ulong                    restart_attempt );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -285,6 +285,35 @@ test_blockhash_queue( fd_snapshot_manifest_t * manifest ) {
 }
 
 static void
+test_parent_slot( fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing parent slot" ));
+
+  /* Only the genesis bank is its own parent. */
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->slot        = 100UL;
+  manifest->parent_slot =  99UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
+
+  manifest->parent_slot = 100UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  manifest->parent_slot = 101UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->parent_slot = 1UL;
+  FD_TEST( VALIDATE_MANIFEST( manifest )==-1 );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+static void
 test_hard_forks( fd_snapshot_manifest_t * manifest ) {
   FD_LOG_NOTICE(( "testing hard forks" ));
 
@@ -624,8 +653,31 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
   FD_LOG_NOTICE(( "... pass" ));
 }
 
+/* Derives the bank hash of the snapshot slot the way the validator that
+   produced the snapshot would have computed it. */
+
+static fd_hash_t
+restart_manifest_bank_hash( fd_snapshot_manifest_t const * manifest ) {
+  fd_lthash_value_t lthash[ 1 ];
+  fd_memcpy( lthash, manifest->accounts_lthash, sizeof(fd_lthash_value_t) );
+
+  fd_hash_t parent_bank_hash[ 1 ];
+  fd_memcpy( parent_bank_hash, manifest->parent_bank_hash, sizeof(fd_hash_t) );
+
+  fd_hash_t last_blockhash[ 1 ];
+  fd_memcpy( last_blockhash, manifest->blockhashes[ manifest->blockhashes_len-1UL ].hash, sizeof(fd_hash_t) );
+
+  fd_hash_t hash[ 1 ];
+  fd_hashes_hash_bank( lthash, parent_bank_hash, last_blockhash, manifest->signature_count, hash );
+  fd_hashes_apply_hard_forks( hash, manifest->slot, manifest->parent_slot,
+                              manifest->hard_forks, manifest->hard_fork_cnt );
+  return *hash;
+}
+
 /* Sets up a manifest describing a snapshot at slot 100, carrying the
-   hard fork list passed in. */
+   hard fork list passed in.  The bank hash is the one the snapshot
+   producer would have arrived at with that list, which is what lets
+   ssload rederive it. */
 
 static void
 setup_restart_manifest( fd_snapshot_manifest_t * manifest,
@@ -633,11 +685,18 @@ setup_restart_manifest( fd_snapshot_manifest_t * manifest,
                         ulong                    hard_fork_cnt ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
-  manifest->slot        = 100UL;
-  manifest->parent_slot =  99UL;
-  fd_memset( manifest->bank_hash, 0x5A, 32UL );
+  manifest->slot            = 100UL;
+  manifest->parent_slot     =  99UL;
+  manifest->signature_count =   7UL;
+  manifest->has_accounts_lthash = 1;
+  fd_memset( manifest->accounts_lthash,  0x33, sizeof(manifest->accounts_lthash) );
+  fd_memset( manifest->parent_bank_hash, 0x22, 32UL );
+  fd_memset( manifest->blockhashes[0].hash, 0x11, 32UL );
   manifest->hard_fork_cnt = hard_fork_cnt;
   for( ulong i=0UL; i<hard_fork_cnt; i++ ) manifest->hard_forks[ i ] = hard_forks[ i ];
+
+  fd_hash_t bank_hash = restart_manifest_bank_hash( manifest );
+  fd_memcpy( manifest->bank_hash, bank_hash.uc, 32UL );
 }
 
 static void
@@ -699,16 +758,37 @@ test_recover_restart_slot( fd_wksp_t * wksp, fd_snapshot_manifest_t * manifest )
   FD_TEST( !memcmp( &bank->f.bank_hash, &snapshot_hash, sizeof(fd_hash_t) ) );
 
   /* A restart slot the snapshot is already at is folded into the
-     recovered bank hash, since that slot is never replayed. */
+     recovered bank hash, since that slot is never replayed.  The
+     resulting hash is the one a validator that replayed the slot with
+     the hard fork registered would have computed. */
 
+  fd_hard_fork_t const at_slot[ 2 ] = {{ .slot = 10UL, .cnt = 1UL }, { .slot = 100UL, .cnt = 1UL }};
   setup_restart_manifest( manifest, one, 1UL );
   FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 100UL, 1UL )==0 );
   FD_TEST( bank->f.hard_fork_cnt     ==2UL   );
   FD_TEST( bank->f.hard_forks[1].slot==100UL );
   FD_TEST( bank->f.hard_forks[1].cnt ==  1UL );
 
-  fd_hash_t expected = snapshot_hash;
-  fd_hashes_apply_hard_forks( &expected, 100UL, 99UL, &bank->f.hard_forks[1], 1UL );
+  setup_restart_manifest( manifest, at_slot, 2UL );
+  fd_hash_t expected = restart_manifest_bank_hash( manifest );
+  FD_TEST( memcmp( &expected, &snapshot_hash, sizeof(fd_hash_t) ) );
+  FD_TEST( !memcmp( &bank->f.bank_hash, &expected, sizeof(fd_hash_t) ) );
+
+  /* A failed restart is retried at the same slot with a higher attempt.
+     A snapshot taken during the previous attempt carries that attempt,
+     which the configured one replaces, bank hash included. */
+
+  fd_hard_fork_t const attempt_2[ 2 ] = {{ .slot = 10UL, .cnt = 1UL }, { .slot = 100UL, .cnt = 2UL }};
+  fd_hard_fork_t const attempt_3[ 2 ] = {{ .slot = 10UL, .cnt = 1UL }, { .slot = 100UL, .cnt = 3UL }};
+
+  setup_restart_manifest( manifest, attempt_2, 2UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 100UL, 3UL )==0 );
+  FD_TEST( bank->f.hard_fork_cnt     ==2UL   );
+  FD_TEST( bank->f.hard_forks[1].slot==100UL );
+  FD_TEST( bank->f.hard_forks[1].cnt ==  3UL );
+
+  setup_restart_manifest( manifest, attempt_3, 2UL );
+  expected = restart_manifest_bank_hash( manifest );
   FD_TEST( !memcmp( &bank->f.bank_hash, &expected, sizeof(fd_hash_t) ) );
 
   /* A hard fork the snapshot already carries at a later slot is a
@@ -726,18 +806,10 @@ test_recover_restart_slot( fd_wksp_t * wksp, fd_snapshot_manifest_t * manifest )
   setup_restart_manifest( manifest, same, 1UL );
   FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 1UL )==-1 );
 
-  /* A restart slot the snapshot's parent is already past cannot be
-     applied to any bank hash. */
+  /* So is a restart slot the snapshot is already past. */
 
   setup_restart_manifest( manifest, one, 1UL );
   FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 99UL, 1UL )==-1 );
-
-  /* Neither can a restart slot on a snapshot whose bank hash already
-     folded in a different hard fork. */
-
-  fd_hard_fork_t const applied[ 1 ] = {{ .slot = 100UL, .cnt = 1UL }};
-  setup_restart_manifest( manifest, applied, 1UL );
-  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 100UL, 2UL )==-1 );
 
   fd_wksp_free_laddr( banks_mem );
 
@@ -763,6 +835,7 @@ main( int     argc,
   test_capacity_mismatch( manifest );
   test_epoch_schedule( manifest );
   test_blockhash_queue( manifest );
+  test_parent_slot( manifest );
   test_hard_forks( manifest );
   test_stake_delegations( manifest );
   test_vote_accounts( manifest );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -1,6 +1,7 @@
 #include "fd_ssload.h"
 #include "../../../util/fd_util.h"
 #include "../../../flamenco/runtime/fd_bank.h"
+#include "../../../flamenco/runtime/fd_hashes.h"
 #include "../../../flamenco/runtime/fd_runtime_const.h"
 #include "../../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
 #include "../../../flamenco/stakes/fd_stake_delegations.h"
@@ -555,7 +556,7 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
 
   /* First apply: simulate initial full snapshot load. */
   FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
-  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed )==0 );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 0UL, 0UL )==0 );
   FD_TEST( bank->accdb_fork_id.val==37U );
   FD_TEST( bank->parent_accdb_fork_id.val==37U );
   FD_TEST( bank->txncache_fork_id.val==38U );
@@ -600,7 +601,7 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
 
   /* A second manifest apply must also leave snapin's cache untouched. */
   FD_TEST( VALIDATE_MANIFEST( manifest )==0 );
-  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed )==0 );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 0UL, 0UL )==0 );
   FD_TEST( bank->accdb_fork_id.val==39U );
   FD_TEST( bank->parent_accdb_fork_id.val==39U );
   FD_TEST( bank->txncache_fork_id.val==40U );
@@ -617,6 +618,126 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
   FD_TEST( !fd_vote_stakes_query_t_1( vote_stakes, bank->vote_stakes_fork_id, (fd_pubkey_t *)pubkey_x, NULL, &stake_out, NULL ) );
   FD_TEST(  fd_vote_stakes_query_t_1( vote_stakes, bank->vote_stakes_fork_id, (fd_pubkey_t *)pubkey_y, NULL, &stake_out, NULL ) );
   FD_TEST( stake_out==7000UL );
+
+  fd_wksp_free_laddr( banks_mem );
+
+  FD_LOG_NOTICE(( "... pass" ));
+}
+
+/* Sets up a manifest describing a snapshot at slot 100, carrying the
+   hard fork list passed in. */
+
+static void
+setup_restart_manifest( fd_snapshot_manifest_t * manifest,
+                        fd_hard_fork_t const *   hard_forks,
+                        ulong                    hard_fork_cnt ) {
+  fd_memset( manifest, 0, sizeof(*manifest) );
+  setup_valid_manifest_base( manifest );
+  manifest->slot        = 100UL;
+  manifest->parent_slot =  99UL;
+  fd_memset( manifest->bank_hash, 0x5A, 32UL );
+  manifest->hard_fork_cnt = hard_fork_cnt;
+  for( ulong i=0UL; i<hard_fork_cnt; i++ ) manifest->hard_forks[ i ] = hard_forks[ i ];
+}
+
+static void
+test_recover_restart_slot( fd_wksp_t * wksp, fd_snapshot_manifest_t * manifest ) {
+  FD_LOG_NOTICE(( "testing recover registers the scheduled restart slot" ));
+
+  ulong max_banks          = 16UL;
+  ulong max_forks          =  4UL;
+  ulong max_stake          = 64UL;
+  ulong max_fallback_stake = 1024UL;
+  ulong max_vote           = 64UL;
+  ulong seed               = 42UL;
+
+  ulong banks_footprint = fd_banks_footprint( max_banks, max_forks,
+                                              max_stake, max_fallback_stake, max_vote );
+  void * banks_mem = fd_wksp_alloc_laddr( wksp, fd_banks_align(), banks_footprint, 2UL );
+  FD_TEST( banks_mem );
+
+  fd_banks_t * banks = fd_banks_join( fd_banks_new( banks_mem, max_banks, max_forks,
+                                                    max_stake, max_fallback_stake, max_vote,
+                                                    0 /* larger_max_cost_per_block */, seed ) );
+  FD_TEST( banks );
+
+  fd_bank_t * bank = fd_banks_init_bank( banks );
+  FD_TEST( bank );
+
+  fd_hard_fork_t const one[ 1 ] = {{ .slot = 10UL, .cnt = 1UL }};
+
+  /* A restart slot of zero leaves the manifest's list untouched. */
+
+  setup_restart_manifest( manifest, one, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 0UL, 0UL )==0 );
+  FD_TEST( bank->f.hard_fork_cnt     ==1UL  );
+  FD_TEST( bank->f.hard_forks[0].slot==10UL );
+  FD_TEST( bank->f.hard_forks[0].cnt ==1UL  );
+
+  fd_hash_t snapshot_hash = bank->f.bank_hash;
+
+  /* A restart slot the validator still has to replay is appended, and
+     leaves the snapshot bank hash alone. */
+
+  setup_restart_manifest( manifest, one, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 1UL )==0 );
+  FD_TEST( bank->f.hard_fork_cnt     ==2UL   );
+  FD_TEST( bank->f.hard_forks[0].slot== 10UL );
+  FD_TEST( bank->f.hard_forks[1].slot==200UL );
+  FD_TEST( bank->f.hard_forks[1].cnt ==  1UL );
+  FD_TEST( !memcmp( &bank->f.bank_hash, &snapshot_hash, sizeof(fd_hash_t) ) );
+
+  /* A later attempt at an unreplayed restart slot supersedes the
+     previous one rather than adding an entry. */
+
+  fd_hard_fork_t const future[ 2 ] = {{ .slot = 10UL, .cnt = 1UL }, { .slot = 200UL, .cnt = 1UL }};
+  setup_restart_manifest( manifest, future, 2UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 2UL )==0 );
+  FD_TEST( bank->f.hard_fork_cnt     ==2UL   );
+  FD_TEST( bank->f.hard_forks[1].slot==200UL );
+  FD_TEST( bank->f.hard_forks[1].cnt ==  2UL );
+  FD_TEST( !memcmp( &bank->f.bank_hash, &snapshot_hash, sizeof(fd_hash_t) ) );
+
+  /* A restart slot the snapshot is already at is folded into the
+     recovered bank hash, since that slot is never replayed. */
+
+  setup_restart_manifest( manifest, one, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 100UL, 1UL )==0 );
+  FD_TEST( bank->f.hard_fork_cnt     ==2UL   );
+  FD_TEST( bank->f.hard_forks[1].slot==100UL );
+  FD_TEST( bank->f.hard_forks[1].cnt ==  1UL );
+
+  fd_hash_t expected = snapshot_hash;
+  fd_hashes_apply_hard_forks( &expected, 100UL, 99UL, &bank->f.hard_forks[1], 1UL );
+  FD_TEST( !memcmp( &bank->f.bank_hash, &expected, sizeof(fd_hash_t) ) );
+
+  /* A hard fork the snapshot already carries at a later slot is a
+     configuration error. */
+
+  fd_hard_fork_t const later[ 1 ] = {{ .slot = 300UL, .cnt = 1UL }};
+  setup_restart_manifest( manifest, later, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 1UL )==-1 );
+
+  /* So is an attempt the snapshot is already at or past. */
+
+  fd_hard_fork_t const same[ 1 ] = {{ .slot = 200UL, .cnt = 2UL }};
+  setup_restart_manifest( manifest, same, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 2UL )==-1 );
+  setup_restart_manifest( manifest, same, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 200UL, 1UL )==-1 );
+
+  /* A restart slot the snapshot's parent is already past cannot be
+     applied to any bank hash. */
+
+  setup_restart_manifest( manifest, one, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 99UL, 1UL )==-1 );
+
+  /* Neither can a restart slot on a snapshot whose bank hash already
+     folded in a different hard fork. */
+
+  fd_hard_fork_t const applied[ 1 ] = {{ .slot = 100UL, .cnt = 1UL }};
+  setup_restart_manifest( manifest, applied, 1UL );
+  FD_TEST( fd_ssload_recover_apply( manifest, banks, bank, seed, 100UL, 2UL )==-1 );
 
   fd_wksp_free_laddr( banks_mem );
 
@@ -647,6 +768,7 @@ main( int     argc,
   test_vote_accounts( manifest );
   test_epoch_credits_downcasting( manifest );
   test_recover_preserves_snapin_stake_delegations( wksp, manifest );
+  test_recover_restart_slot( wksp, manifest );
 
   fd_wksp_free_laddr( manifest );
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -842,6 +842,13 @@ fd_runtime_update_bank_hash( fd_bank_t *        bank,
       bank->f.signature_count,
       new_bank_hash );
 
+  fd_hashes_apply_hard_forks(
+      new_bank_hash,
+      bank->f.slot,
+      bank->f.parent_slot,
+      bank->f.hard_forks,
+      bank->f.hard_fork_cnt );
+
   /* Update the bank hash */
   bank->f.bank_hash = *new_bank_hash;
 


### PR DESCRIPTION
Previously, Firedancer depended on Agave for cluster restarts
because a snapshot was needed with 'hard forks' updated.

This commit allows users to schedule a hard fork entry via
[runtime.restart] configuration, allowing for a cluster restart
off existing snapshots, with just a config change.  (Snapshot
production before restart is no longer necessary.)
