### PR TITLE
Ballet: make scalar byte-buffer access unaligned-safe

### DIFF
--- a/src/ballet/ed25519/fd_curve25519_scalar.c
+++ b/src/ballet/ed25519/fd_curve25519_scalar.c
@@ -102,10 +102,10 @@ fd_curve25519_scalar_reduce( uchar       out[ 32 ],
 
   /* Pack the results into out */
 
-  *(ulong *) out     = (((ulong)s0 )   ) | (((ulong)s1 )<<21) | (((ulong)s2 )<<42) | (((ulong)s3 )<<63);
-  *(ulong *)(out+ 8) = (((ulong)s3 )>>1) | (((ulong)s4 )<<20) | (((ulong)s5 )<<41) | (((ulong)s6 )<<62);
-  *(ulong *)(out+16) = (((ulong)s6 )>>2) | (((ulong)s7 )<<19) | (((ulong)s8 )<<40) | (((ulong)s9 )<<61);
-  *(ulong *)(out+24) = (((ulong)s9 )>>3) | (((ulong)s10)<<18) | (((ulong)s11)<<39);
+  FD_STORE( ulong, out,    (((ulong)s0 )   ) | (((ulong)s1 )<<21) | (((ulong)s2 )<<42) | (((ulong)s3 )<<63) );
+  FD_STORE( ulong, out+ 8, (((ulong)s3 )>>1) | (((ulong)s4 )<<20) | (((ulong)s5 )<<41) | (((ulong)s6 )<<62) );
+  FD_STORE( ulong, out+16, (((ulong)s6 )>>2) | (((ulong)s7 )<<19) | (((ulong)s8 )<<40) | (((ulong)s9 )<<61) );
+  FD_STORE( ulong, out+24, (((ulong)s9 )>>3) | (((ulong)s10)<<18) | (((ulong)s11)<<39) );
   return out;
 }
 
@@ -267,10 +267,10 @@ fd_curve25519_scalar_muladd( uchar       s[ 32 ],
 
   /* Pack the results into s */
 
-  *(ulong *) s     = (((ulong)s0 )   ) | (((ulong)s1 )<<21) | (((ulong)s2 )<<42) | (((ulong)s3 )<<63);
-  *(ulong *)(s+ 8) = (((ulong)s3 )>>1) | (((ulong)s4 )<<20) | (((ulong)s5 )<<41) | (((ulong)s6 )<<62);
-  *(ulong *)(s+16) = (((ulong)s6 )>>2) | (((ulong)s7 )<<19) | (((ulong)s8 )<<40) | (((ulong)s9 )<<61);
-  *(ulong *)(s+24) = (((ulong)s9 )>>3) | (((ulong)s10)<<18) | (((ulong)s11)<<39);
+  FD_STORE( ulong, s,    (((ulong)s0 )   ) | (((ulong)s1 )<<21) | (((ulong)s2 )<<42) | (((ulong)s3 )<<63) );
+  FD_STORE( ulong, s+ 8, (((ulong)s3 )>>1) | (((ulong)s4 )<<20) | (((ulong)s5 )<<41) | (((ulong)s6 )<<62) );
+  FD_STORE( ulong, s+16, (((ulong)s6 )>>2) | (((ulong)s7 )<<19) | (((ulong)s8 )<<40) | (((ulong)s9 )<<61) );
+  FD_STORE( ulong, s+24, (((ulong)s9 )>>3) | (((ulong)s10)<<18) | (((ulong)s11)<<39) );
   return s;
 }
 

--- a/src/ballet/ed25519/fd_curve25519_scalar.h
+++ b/src/ballet/ed25519/fd_curve25519_scalar.h
@@ -72,10 +72,10 @@ fd_curve25519_scalar_validate( uchar const s[ 32 ] ) {
     ulong s1 = fd_ulong_load_8_fast( s +  8 );
     ulong s2 = fd_ulong_load_8_fast( s + 16 );
     ulong s3 = fd_ulong_load_8_fast( s + 24 );
-    ulong l0 = *(ulong *)(&fd_curve25519_scalar_minus_one[  0 ]);
-    ulong l1 = *(ulong *)(&fd_curve25519_scalar_minus_one[  8 ]);
-    ulong l2 = *(ulong *)(&fd_curve25519_scalar_minus_one[ 16 ]);
-    ulong l3 = *(ulong *)(&fd_curve25519_scalar_minus_one[ 24 ]);
+    ulong l0 = FD_LOAD( ulong, &fd_curve25519_scalar_minus_one[  0 ] );
+    ulong l1 = FD_LOAD( ulong, &fd_curve25519_scalar_minus_one[  8 ] );
+    ulong l2 = FD_LOAD( ulong, &fd_curve25519_scalar_minus_one[ 16 ] );
+    ulong l3 = FD_LOAD( ulong, &fd_curve25519_scalar_minus_one[ 24 ] );
     ulong r; int b;
     fd_ulong_sub_borrow( &r, &b, s0, l0, 1 );
     fd_ulong_sub_borrow( &r, &b, s1, l1, b );
@@ -145,7 +145,7 @@ static inline uchar *
 fd_curve25519_scalar_from_u64( uchar *     s,
                                ulong const x ) {
   fd_memset( s, 0, 32 );
-  *((ulong *)s) = x;
+  FD_STORE( ulong, s, x );
   return s;
 }
 

--- a/src/ballet/ed25519/test_ed25519.c
+++ b/src/ballet/ed25519/test_ed25519.c
@@ -858,6 +858,32 @@ test_sc_muladd( fd_rng_t * rng ) {
 }
 
 void
+test_sc_unaligned_output( fd_rng_t * rng ) {
+  uchar in[64];
+  uchar a[32];
+  uchar b[32];
+  uchar c[32];
+  uchar expected[32];
+  uchar _actual[33] __attribute__((aligned(8)));
+  uchar * actual = _actual+1;
+
+  fd_rng_b512( rng, in );
+  fd_curve25519_scalar_reduce( expected, in );
+  FD_TEST( fd_curve25519_scalar_reduce( actual, in )==actual );
+  FD_TEST( fd_memeq( actual, expected, 32UL ) );
+
+  fd_rng_b256( rng, a );
+  fd_rng_b256( rng, b );
+  fd_rng_b256( rng, c );
+  fd_curve25519_scalar_muladd( expected, a, b, c );
+  FD_TEST( fd_curve25519_scalar_muladd( actual, a, b, c )==actual );
+  FD_TEST( fd_memeq( actual, expected, 32UL ) );
+
+  FD_TEST( fd_curve25519_scalar_from_u64( actual, 1UL )==actual );
+  FD_TEST( fd_memeq( actual, fd_curve25519_scalar_one, 32UL ) );
+}
+
+void
 test_public_from_private( fd_rng_t *    rng,
                           fd_sha512_t * sha ) {
   uchar _prv[32]; uchar * prv = _prv;
@@ -1185,6 +1211,7 @@ main( int     argc,
   test_sc_validate  ( rng );
   test_sc_reduce    ( rng );
   test_sc_muladd    ( rng );
+  test_sc_unaligned_output( rng );
 
   test_public_from_private( rng, sha );
   test_sign               ( rng, sha );


### PR DESCRIPTION
## Summary

Curve25519 scalar APIs accept byte-buffer outputs without an alignment requirement, but `reduce`, `muladd`, and `from_u64` wrote through `ulong *`. Use `FD_STORE` for those outputs, use `FD_LOAD` for the byte-array constant, and cover deliberately misaligned outputs in `test_ed25519`.

## Reproduction

On parent revision `aff1567911`, add this before the existing tests in `test_ed25519.c:main`:

```c
uchar in[64] = {0};
uchar a[32] = {0};
uchar b[32] = {0};
uchar c[32] = {0};
uchar _out[33] __attribute__((aligned(8)));
uchar * out = _out+1;

fd_curve25519_scalar_reduce( out, in );
fd_curve25519_scalar_muladd( out, a, b, c );
fd_curve25519_scalar_from_u64( out, 1UL );
```

Then run:

```sh
make -j4 BUILDDIR=clang-ubsan CC=clang CXX=clang++ \
  EXTRAS="ubsan" test_ed25519
UBSAN_OPTIONS=halt_on_error=0:print_stacktrace=0 \
  build/clang-ubsan/unit-test/test_ed25519
```

Clang 22 reports misaligned stores at `fd_curve25519_scalar.c:105-108`, `fd_curve25519_scalar.c:270-273`, and `fd_curve25519_scalar.h:148`. The four loads from the declared `uchar[]` constant are also invalid type-punning even when its address happens to be aligned.

## Validation

`test_ed25519` passes with `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1`, including the new misaligned-output regression.
