### PR TITLE
Pack: keep nonce test priority in range

### DIFF
--- a/src/disco/pack/test_pack.c
+++ b/src/disco/pack/test_pack.c
@@ -1603,14 +1603,14 @@ test_bundle_nonce( void ) {
   /* Cannot insert bundle with same nonce, even with higher prio */
   bundle = fd_pack_insert_bundle_init( pack, _bundle, 3UL );
   make_transaction1      ( bundle[0]->txnp, 0UL, 100U, 100U, 5.0, "A", "B", NULL, NULL );
-  make_nonce_transaction1( bundle[1]->txnp, 1UL, 999.0, 5, 0, 'b' );
+  make_nonce_transaction1( bundle[1]->txnp, 1UL, 12.0, 5, 0, 'b' );
   make_transaction1      ( bundle[2]->txnp, 2UL, 100U, 100U, 4.0, "C", "D", NULL, NULL );
   result = fd_pack_insert_bundle_fini( pack, bundle, 3UL, 1000UL, 0, NULL, &_deleted );
   FD_TEST( result==FD_PACK_INSERT_REJECT_NONCE_PRIORITY );
 
   /* Cannot insert transaction with same nonce, even with higher prio */
   fd_txn_e_t * txn = fd_pack_insert_txn_init( pack );
-  make_nonce_transaction1( txn->txnp, 1UL, 999.0, 5, 0, 'b' );
+  make_nonce_transaction1( txn->txnp, 1UL, 12.0, 5, 0, 'b' );
   result = fd_pack_insert_txn_fini( pack, txn, 1000UL, &_deleted );
   FD_TEST( result==FD_PACK_INSERT_REJECT_NONCE_PRIORITY );
   FD_TEST( fd_pack_avail_txn_cnt( pack )==3UL );


### PR DESCRIPTION
## Summary

Keep the nonce-priority test inside the helper's documented `(0, 13.5]` range. `12.0` remains higher than the existing `11.0` bundle while avoiding `pow(5, 999) == inf` and the subsequent undefined conversion to `ulong`.

## Reproduction

No source changes are needed on parent revision `aff1567911`:

```sh
make -j4 BUILDDIR=clang-ubsan CC=clang CXX=clang++ \
  EXTRAS="ubsan" test_pack
UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
  build/clang-ubsan/unit-test/test_pack
```

Clang 22 stops at `test_pack.c:325`:

```text
runtime error: inf is outside the range of representable values of type 'unsigned long'
```

The stack reaches `make_nonce_transaction1` from `test_bundle_nonce`, where the two test transactions use priority `999.0`.

## Validation

The full `test_pack` binary passes with halt-on-error UBSan after changing both values to `12.0`.
