### PR TITLE
Gossip: avoid unaligned Bloom wire access

### DIFF
--- a/src/discof/gossip/fuzz_gossvf_tile.c
+++ b/src/discof/gossip/fuzz_gossvf_tile.c
@@ -506,14 +506,14 @@ build_pull_request( uchar *       payload,
                     ulong         value_sz,
                     ulong         num_bits,
                     uint          mask_bits ) {
-  ulong * keys;
-  ulong * bits;
-  ulong * bits_set;
+  uchar * keys;
+  uchar * bits;
+  uchar * bits_set;
   long sz = fd_gossip_pull_request_init( payload, payload_sz, 1UL, num_bits, 0UL, mask_bits, value_bytes, value_sz, &keys, &bits, &bits_set );
   if( FD_UNLIKELY( sz<0L ) ) return 0UL;
-  keys[0]   = 0x12345678UL;
-  if( FD_LIKELY( bits ) ) bits[0] = 1UL;
-  *bits_set = !!num_bits;
+  FD_STORE( ulong, keys, 0x12345678UL );
+  if( FD_LIKELY( bits ) ) FD_STORE( ulong, bits, 1UL );
+  FD_STORE( ulong, bits_set, (ulong)!!num_bits );
   return (ulong)sz;
 }
 

--- a/src/flamenco/gossip/fd_gossip.c
+++ b/src/flamenco/gossip/fd_gossip.c
@@ -1048,6 +1048,7 @@ tx_pull_request( fd_gossip_t *       gossip,
   FD_TEST( num_bits>=1UL );
   FD_TEST( (num_bits+63UL)/64UL<=max_words ); /* verify bitvec fits */
   FD_TEST( fd_bloom_num_keys( (double)num_bits, max_items )==num_keys ); /* verify convergence */
+  FD_TEST( num_keys<=(ulong)BLOOM_NUM_KEYS );
 
   double _mask_bits     = ceil( log2( (double)num_items / max_items ) );
   uint   mask_bits      = _mask_bits >= 0.0 ? fd_uint_min( (uint)_mask_bits, 63U ) : 0U;
@@ -1055,7 +1056,7 @@ tx_pull_request( fd_gossip_t *       gossip,
 
   uchar payload[ FD_GOSSIP_MTU ] = {0};
 
-  ulong * keys_ptr, * bits_ptr, * bits_set;
+  uchar * keys_ptr, * bits_ptr, * bits_set;
   long payload_sz = fd_gossip_pull_request_init( payload,
                                                  FD_GOSSIP_MTU,
                                                  num_keys,
@@ -1069,8 +1070,13 @@ tx_pull_request( fd_gossip_t *       gossip,
                                                  &bits_set );
   FD_TEST( -1L!=payload_sz );
 
+  /* Bloom filter fields are not naturally aligned in the serialized packet.
+     Build the filter in aligned storage and copy it into the packet. */
+  ulong bloom_keys[ 8UL ];
+  ulong bloom_bits[ (FD_GOSSIP_MTU+sizeof(ulong)-1UL)/sizeof(ulong) ] = {0};
+  ulong bloom_word_cnt = (num_bits+63UL)/64UL;
   fd_bloom_t filter[1];
-  fd_bloom_init_inplace( keys_ptr, bits_ptr, num_keys, num_bits, 0, gossip->rng, BLOOM_FALSE_POSITIVE_RATE, filter );
+  fd_bloom_init_inplace( bloom_keys, bloom_bits, num_keys, num_bits, 0, gossip->rng, BLOOM_FALSE_POSITIVE_RATE, filter );
 
   uchar iter_mem[ 16UL ];
   for( fd_crds_mask_iter_t * it = fd_crds_mask_iter_init( gossip->crds, mask, mask_bits, iter_mem );
@@ -1086,8 +1092,10 @@ tx_pull_request( fd_gossip_t *       gossip,
   }
 
   int num_bits_set = 0;
-  for( ulong i=0UL; i<(num_bits+63)/64UL; i++ ) num_bits_set += fd_ulong_popcnt( bits_ptr[ i ] );
-  *bits_set = (ulong)num_bits_set;
+  for( ulong i=0UL; i<bloom_word_cnt; i++ ) num_bits_set += fd_ulong_popcnt( bloom_bits[ i ] );
+  fd_memcpy( keys_ptr, bloom_keys, num_keys*sizeof(ulong) );
+  fd_memcpy( bits_ptr, bloom_bits, bloom_word_cnt*sizeof(ulong) );
+  FD_STORE( ulong, bits_set, (ulong)num_bits_set );
 
   ulong idx = fd_gossip_wsample_sample_pull_request( gossip->wsample );
   fd_ip4_port_t peer_addr;

--- a/src/flamenco/gossip/fd_gossip_message.c
+++ b/src/flamenco/gossip/fd_gossip_message.c
@@ -918,16 +918,16 @@ fd_gossip_pull_request_init( uchar *       payload,
                              uint          mask_bits,
                              uchar const * contact_info_crds,
                              ulong         contact_info_crds_sz,
-                             ulong **      out_bloom_keys,
-                             ulong **      out_bloom_bits,
-                             ulong **      out_bits_set ) {
+                             uchar **      out_bloom_keys,
+                             uchar **      out_bloom_bits,
+                             uchar **      out_bits_set ) {
   uchar ** out = &payload;
   ulong original_size = payload_sz;
   ulong * out_sz = &payload_sz;
 
   WRITE_U32( FD_GOSSIP_MESSAGE_PULL_REQUEST, out, out_sz );
   WRITE_U64( num_keys, out, out_sz );
-  *out_bloom_keys = fd_type_pun( payload+(payload_sz-*out_sz) );
+  *out_bloom_keys = payload+(payload_sz-*out_sz);
   WRITE_SKIP_BYTES( num_keys*8UL, out, out_sz );
 
   if( FD_LIKELY( !!num_bits ) ) {
@@ -935,14 +935,14 @@ fd_gossip_pull_request_init( uchar *       payload,
     ulong bloom_vec_len = (num_bits+63UL)/64UL;
     WRITE_U8( 1, out, out_sz ); /* has_bits */
     WRITE_U64( bloom_vec_len, out, out_sz );
-    *out_bloom_bits = fd_type_pun( payload+(payload_sz-*out_sz) );
+    *out_bloom_bits = payload+(payload_sz-*out_sz);
     WRITE_SKIP_BYTES( bloom_vec_len*8UL, out, out_sz );
   } else {
     WRITE_U8( 0, out, out_sz ); /* has_bits */
     *out_bloom_bits = NULL;
   }
   WRITE_U64( num_bits, out, out_sz );
-  *out_bits_set = fd_type_pun( payload+(payload_sz-*out_sz) );
+  *out_bits_set = payload+(payload_sz-*out_sz);
   WRITE_SKIP_BYTES( 8UL, out, out_sz );
   WRITE_U64( mask, out, out_sz );
   WRITE_U32( mask_bits, out, out_sz );

--- a/src/flamenco/gossip/fd_gossip_message.h
+++ b/src/flamenco/gossip/fd_gossip_message.h
@@ -440,9 +440,9 @@ fd_gossip_pull_request_init( uchar *       payload,
                              uint          mask_bits,
                              uchar const * contact_info_crds,
                              ulong         contact_info_crds_sz,
-                             ulong **      out_bloom_keys,
-                             ulong **      out_bloom_bits,
-                             ulong **      out_bits_set );
+                             uchar **      out_bloom_keys,
+                             uchar **      out_bloom_bits,
+                             uchar **      out_bits_set );
 
 /* fd_gossip_version_cstr converts gossip version fields to a null
    terminated c-string.  Returns 1 on success and 0 on failure (e.g.

--- a/src/flamenco/gossip/test_bloom.c
+++ b/src/flamenco/gossip/test_bloom.c
@@ -82,6 +82,53 @@ test_empty_contains( void ) {
 }
 
 void
+test_pull_request_serialize_alignment( void ) {
+  uchar payload[256UL] __attribute__((aligned(8))) = {0};
+  uchar contact_info[1UL] = {0};
+  uchar * wire_keys;
+  uchar * wire_bits;
+  uchar * wire_bits_set;
+
+  long payload_sz = fd_gossip_pull_request_init( payload,
+                                                  sizeof(payload),
+                                                  1UL,
+                                                  64UL,
+                                                  0UL,
+                                                  0U,
+                                                  contact_info,
+                                                  sizeof(contact_info),
+                                                  &wire_keys,
+                                                  &wire_bits,
+                                                  &wire_bits_set );
+  FD_TEST( payload_sz>0L );
+  FD_TEST( !fd_ulong_is_aligned( (ulong)wire_keys,     alignof(ulong) ) );
+  FD_TEST( !fd_ulong_is_aligned( (ulong)wire_bits,     alignof(ulong) ) );
+  FD_TEST( !fd_ulong_is_aligned( (ulong)wire_bits_set, alignof(ulong) ) );
+
+  ulong keys[1UL];
+  ulong bits[1UL] = {0};
+  fd_rng_t rng_mem[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
+  FD_TEST( rng );
+
+  fd_bloom_t bloom[1];
+  FD_TEST( !fd_bloom_init_inplace( keys, bits, 1UL, 64UL, 0UL, rng, 0.1, bloom ) );
+  fd_bloom_insert( bloom, (uchar const *)"x", 1UL );
+  ulong bits_set = (ulong)fd_ulong_popcnt( bits[0] );
+  FD_TEST( bits_set );
+
+  fd_memcpy( wire_keys, keys, sizeof(keys) );
+  fd_memcpy( wire_bits, bits, sizeof(bits) );
+  FD_STORE( ulong, wire_bits_set, bits_set );
+
+  FD_TEST( FD_LOAD( ulong, wire_keys     )==keys[0]  );
+  FD_TEST( FD_LOAD( ulong, wire_bits     )==bits[0]  );
+  FD_TEST( FD_LOAD( ulong, wire_bits_set )==bits_set );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+}
+
+void
 test_bitvec_deserialize_case( uchar has_bits,
                               ulong bits_cap,
                               ulong encoded_bits_len,
@@ -217,6 +264,7 @@ main( int     argc,
   test_filters();
   test_add_contains();
   test_empty_contains();
+  test_pull_request_serialize_alignment();
   test_bitvec_deserialize();
   test_epoch_slots_bitvec_deserialize();
   test_keys_oob();


### PR DESCRIPTION
## Summary

Pull-request Bloom fields are byte-serialized at offsets that are not `ulong` aligned. Return byte pointers from the serializer, construct the Bloom filter in aligned local storage, copy it into the packet, and use unaligned-safe stores in the fuzz producer.

For an aligned payload, keys start at offset 12, bit words at `21+8N`, and `bits_set` at `29+8N+8M`; typed access is therefore structurally unsafe.

## Reproduction

On parent revision `aff1567911`, add and call this function from `test_bloom.c`:

```c
static void
reproduce_pull_request_alignment( void ) {
  uchar payload[256] __attribute__((aligned(8))) = {0};
  uchar contact_info[1] = {0};
  ulong * keys;
  ulong * bits;
  ulong * bits_set;

  FD_TEST( fd_gossip_pull_request_init(
      payload, sizeof(payload), 1UL, 64UL, 0UL, 0U,
      contact_info, sizeof(contact_info),
      &keys, &bits, &bits_set )>0L );

  fd_rng_t rng_mem[1];
  fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
  fd_bloom_t bloom[1];
  FD_TEST( !fd_bloom_init_inplace(
      keys, bits, 1UL, 64UL, 0UL, rng, 0.1, bloom ) );
}
```

Then run:

```sh
make -j4 BUILDDIR=clang-ubsan CC=clang CXX=clang++ \
  EXTRAS="ubsan" test_bloom
UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
  build/clang-ubsan/unit-test/test_bloom
```

Clang 22 stops at `fd_bloom.c:171` with `store to misaligned address ... for type 'ulong'`.

## Validation

`test_bloom` passes with halt-on-error UBSan. With the independent Curve25519 alignment fix applied so fuzzing can progress past signing, `fuzz_gossvf_tile -runs=5000` also passes with halt-on-error UBSan.
