### PR TITLE
Gossip: check purged iterator sentinel before lookup

### DIFF
--- a/src/flamenco/gossip/Local.mk
+++ b/src/flamenco/gossip/Local.mk
@@ -16,6 +16,9 @@ $(call run-unit-test,test_ping_tracker)
 $(call make-unit-test,test_gossip_wsample,test_gossip_wsample,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_gossip_wsample)
 
+$(call make-unit-test,test_gossip_purged,test_gossip_purged,fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_gossip_purged)
+
 ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_gossip_message_serialize,fuzz_gossip_message_serialize,fd_flamenco fd_ballet fd_util)
 endif

--- a/src/flamenco/gossip/fd_gossip_purged.c
+++ b/src/flamenco/gossip/fd_gossip_purged.c
@@ -304,8 +304,9 @@ fd_gossip_purged_mask_iter_next( fd_gossip_purged_mask_iter_t * it,
 int
 fd_gossip_purged_mask_iter_done( fd_gossip_purged_mask_iter_t * it,
                                  fd_gossip_purged_t const *     purged ) {
+  if( FD_UNLIKELY( purged_treap_idx_is_null( it->idx ) ) ) return 1;
   fd_crds_purged_t const * val = purged_treap_ele_fast_const( it->idx, purged->pool );
-  return purged_treap_idx_is_null( it->idx ) || (it->end_hash<val->treap.hash_prefix);
+  return it->end_hash<val->treap.hash_prefix;
 }
 
 uchar const *

--- a/src/flamenco/gossip/test_gossip_purged.c
+++ b/src/flamenco/gossip/test_gossip_purged.c
@@ -1,0 +1,33 @@
+#include "../../util/fd_util.h"
+#include "fd_gossip_purged.h"
+
+#include <stdlib.h>
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  ulong footprint = fd_gossip_purged_footprint( 8UL );
+  void * mem = aligned_alloc( fd_gossip_purged_align(), footprint );
+  FD_TEST( mem );
+
+  fd_rng_t rng_mem[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
+  FD_TEST( rng );
+
+  fd_gossip_purged_t * purged = fd_gossip_purged_join( fd_gossip_purged_new( mem, rng, 8UL ) );
+  FD_TEST( purged );
+  FD_TEST( !fd_gossip_purged_len( purged ) );
+
+  uchar iter_mem[16UL] __attribute__((aligned(8)));
+  fd_gossip_purged_mask_iter_t * iter = fd_gossip_purged_mask_iter_init( purged, 0UL, 0U, iter_mem );
+  FD_TEST( fd_gossip_purged_mask_iter_done( iter, purged ) );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  free( mem );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
## Summary

An empty purged treap returns the null index `ULONG_MAX`. Check that sentinel before asking the treap helper for `pool + idx`, and add an empty-iterator regression.

## Reproduction

On parent revision `aff1567911`, include `fd_gossip_purged.h` in `test_bloom.c`, add this function, and call it from `main`:

```c
static void
reproduce_empty_purged_iter( void ) {
  ulong footprint = fd_gossip_purged_footprint( 8UL );
  void * mem = aligned_alloc( fd_gossip_purged_align(), footprint );
  FD_TEST( mem );

  fd_rng_t rng_mem[1];
  fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
  fd_gossip_purged_t * purged = fd_gossip_purged_join(
      fd_gossip_purged_new( mem, rng, 8UL ) );
  FD_TEST( purged );

  uchar iter_mem[16] __attribute__((aligned(8)));
  fd_gossip_purged_mask_iter_t * iter =
      fd_gossip_purged_mask_iter_init( purged, 0UL, 0U, iter_mem );
  FD_TEST( fd_gossip_purged_mask_iter_done( iter, purged ) );
  free( mem );
}
```

Then run with Clang 22:

```sh
make -j4 BUILDDIR=clang-ubsan CC=clang CXX=clang++ \
  EXTRAS="ubsan" test_bloom
UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
  build/clang-ubsan/unit-test/test_bloom
```

UBSan reports pointer overflow in `purged_treap_ele_fast_const`, reached from `fd_gossip_purged_mask_iter_done`. The table is genuinely empty and `iter->idx` is `ULONG_MAX`; the invalid pointer is formed before the old short-circuit check.

## Validation

The new `test_gossip_purged` target passes with halt-on-error UBSan.

Clang 19.1.7, used by the current sanitizer CI job, suppresses pointer-overflow instrumentation when Firedancer's default `-fwrapv` is present. The test is therefore sanitizer-enforced under Clang 22 or a UBSan build without `-fwrapv`; current CI verifies the empty-iterator result but does not detect the invalid intermediate pointer in the negative control.
