### PR TITLE
util: more granular deepasan poisoning, remove unnecessary size rounding

### DIFF
--- a/config/extra/with-deepasan.mk
+++ b/config/extra/with-deepasan.mk
@@ -1,8 +1,7 @@
 FD_HAS_ASAN:=1
 FD_HAS_DEEPASAN:=1
-CPPFLAGS+=-DFD_HAS_ASAN=1
-CFLAGS+=-DFD_HAS_DEEPASAN=1
+CPPFLAGS+=-DFD_HAS_ASAN=1 -DFD_HAS_DEEPASAN=1
 
-CPPFLAGS+=-fsanitize=address,leak  -fno-omit-frame-pointer
+CPPFLAGS+=-fsanitize=address,leak -fno-omit-frame-pointer
 
 LDFLAGS+=-fsanitize=address,leak

--- a/src/flamenco/stakes/test_stake_delegations.c
+++ b/src/flamenco/stakes/test_stake_delegations.c
@@ -123,8 +123,9 @@ int main( int argc, char ** argv ) {
   FD_TEST( new_stake_delegations_mem );
 
   FD_TEST( !fd_stake_delegations_join( NULL ) );
-  void * junk_mem = fd_wksp_alloc_laddr( wksp, 1UL, 1UL, 999UL );
+  void * junk_mem = fd_wksp_alloc_laddr( wksp, fd_stake_delegations_align(), sizeof(fd_stake_delegations_t), 999UL );
   FD_TEST( junk_mem );
+  memset( junk_mem, 0, sizeof(fd_stake_delegations_t) );
   FD_TEST( !fd_stake_delegations_join( junk_mem ) );
 
   fd_stake_delegations_t * stake_delegations = fd_stake_delegations_join( new_stake_delegations_mem );

--- a/src/util/alloc/fd_alloc.h
+++ b/src/util/alloc/fd_alloc.h
@@ -120,6 +120,7 @@
    time to try to bound the amount of pre-allocation for small requests. */
 
 #include "../wksp/fd_wksp.h"
+#include "../sanitize/fd_asan.h"
 
 /* FD_ALLOC_{ALIGN,FOOTPRINT} give the required alignment and footprint
    needed for a wksp allocation to be suitable as a fd_alloc.  ALIGN is
@@ -422,7 +423,13 @@ fd_alloc_malloc( fd_alloc_t * join,
                  ulong        align,
                  ulong        sz ) {
   ulong max[1];
-  return fd_alloc_malloc_at_least( join, align, sz, max );
+  void * laddr = fd_alloc_malloc_at_least( join, align, sz, max );
+
+#if FD_HAS_DEEPASAN
+  if( FD_LIKELY( laddr ) ) fd_asan_poison( (uchar *)laddr + sz, (*max) - sz );
+#endif
+
+  return laddr;
 }
 
 /* FIXME: consider a fd_alloc_avail API that returns the max bytes avail

--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -417,6 +417,25 @@ main( int     argc,
     FD_TEST( fd_alloc_join_cgroup_hint( alloc2 )==(cgroup_hint & FD_ALLOC_JOIN_CGROUP_HINT_MAX) );
   }
 
+# if FD_HAS_DEEPASAN
+  FD_LOG_NOTICE(( "Testing malloc tail poisoning" ));
+
+  do {
+    ulong    sz = 100UL; /* deliberately not a multiple of FD_ASAN_ALIGN */
+    ulong    max;
+    uchar *  mem = (uchar *)fd_alloc_malloc_at_least( alloc, 8UL, sz, &max );
+    FD_TEST( mem && (max>sz)                );
+    FD_TEST( !fd_asan_query( mem, max )     ); /* at_least exposes all max bytes */
+    fd_alloc_free( alloc, mem );
+
+    mem = (uchar *)fd_alloc_malloc( alloc, 8UL, sz );
+    FD_TEST( mem                            );
+    FD_TEST( !fd_asan_query( mem, sz )      ); /* requested bytes are accessible */
+    FD_TEST( fd_asan_test( mem + sz )==1    ); /* first unused byte is poisoned */
+    fd_alloc_free( alloc, mem );
+  } while(0);
+# endif
+
   FD_LOG_NOTICE(( "Testing is_empty" ));
 
   do {

--- a/src/util/scratch/fd_scratch.h
+++ b/src/util/scratch/fd_scratch.h
@@ -414,10 +414,9 @@ fd_scratch_prepare( ulong align ) {
 # endif
 
 # if FD_HAS_DEEPASAN
-  /* At this point the user is able to clobber any bytes in the region. smem is
-     always going to be at least 8 byte aligned. */
-  ulong aligned_sz = fd_ulong_align_up( fd_scratch_private_stop - smem, FD_ASAN_ALIGN );
-  fd_asan_unpoison( (void*)smem, aligned_sz );
+  /* The user can clobber any byte in [smem,stop) and unpoisoning is
+     exact at the end of a region, so unpoison exactly that. */
+  fd_asan_unpoison( (void*)smem, fd_scratch_private_stop - smem );
 # endif
 
   fd_scratch_private_free = smem;

--- a/src/util/spad/fd_spad.c
+++ b/src/util/spad/fd_spad.c
@@ -262,10 +262,14 @@ fd_spad_prepare_sanitizer_impl( fd_spad_t * spad,
   align = fd_ulong_if( align>0UL, fd_ulong_max( align, FD_MSAN_ALIGN ), FD_SPAD_ALLOC_ALIGN_DEFAULT ); /* typically compile time */
 #endif
 
+  /* poison the free region first to cancel any in-progress prepare,
+     including the alignment padding this prepare will consume */
+  fd_asan_poison( fd_spad_private_mem( spad ) + spad->mem_used, spad->mem_max - spad->mem_used );
+
   void * buf = fd_spad_prepare_impl( spad, align, max );
 
-  /* unpoison memory starting at buf, which is guaranteed to be 8 byte aligned */
-  fd_asan_unpoison( buf,  spad->mem_max - spad->mem_used );
+  /* unpoison only the max bytes this prepare promises */
+  fd_asan_unpoison( buf, max );
   return buf;
 }
 

--- a/src/util/spad/test_spad.c
+++ b/src/util/spad/test_spad.c
@@ -72,12 +72,29 @@ test_spad_deepasan( fd_spad_t * spad ) {
     uchar* prepare_then_cancel = (uchar *)fd_spad_prepare( spad, 1, 50 );
     /* test that accessing the byte right before prepare_then_cancel is poisoned */
     FD_TEST( fd_asan_test( (void*)( prepare_then_cancel - 1 ) ) == 1 );
-    /* test that rest of the spad region is unpoisoned */
-    FD_TEST( fd_asan_query( prepare_then_cancel, fd_spad_alloc_max( spad, 1 ) ) == NULL );
+    /* test that the prepared region is unpoisoned */
+    FD_TEST( fd_asan_query( prepare_then_cancel, 50 ) == NULL );
+    /* test the spad past the prepared region stays poisoned, probing the
+       first granule wholly past the request */
+    FD_TEST( fd_asan_test( prepare_then_cancel + fd_ulong_align_up( 50UL, FD_ASAN_ALIGN ) ) == 1 );
 
     /* test that fd_spad_cancel resets the memory region to poisoned */
     fd_spad_cancel( spad );
     FD_TEST( fd_asan_query( fd_spad_frame_hi( spad ), fd_spad_alloc_max( spad, 1 ) ) == fd_spad_frame_hi( spad ) );
+  }
+
+  /* test that a re-prepare re-poisons what the previous prepare exposed,
+     including the alignment padding the new prepare consumes */
+  {
+    fd_spad_push( spad );
+    FD_TEST( fd_spad_alloc( spad, 32, 8UL ) ); /* mem_used is now 8 but not 32 byte aligned */
+    uchar * wide   = (uchar *)fd_spad_prepare( spad,  1, 50 );
+    uchar * narrow = (uchar *)fd_spad_prepare( spad, 32, 10 );
+    FD_TEST( narrow > wide );
+    FD_TEST( fd_asan_test( wide ) == 1 );
+    FD_TEST( fd_asan_query( narrow, 10 ) == NULL );
+    FD_TEST( fd_asan_test( narrow + fd_ulong_align_up( 10UL, FD_ASAN_ALIGN ) ) == 1 );
+    fd_spad_pop( spad );
   }
 
   /* test the prepare then publish API */

--- a/src/util/wksp/fd_wksp_admin.c
+++ b/src/util/wksp/fd_wksp_admin.c
@@ -205,11 +205,7 @@ fd_wksp_new( void *       shmem,
   }
 
   #if FD_HAS_DEEPASAN
-  /* Poison entire workspace except wksp header and the pinfo array. */
-  void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
-  fd_asan_poison( wksp_data, footprint - fd_wksp_private_pinfo_off() );
-  fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
-  fd_asan_unpoison( pinfo, FD_WKSP_PRIVATE_PINFO_FOOTPRINT * part_max );
+  fd_wksp_private_asan_poison_data( wksp );
   #endif
 
   fd_wksp_private_unlock( wksp );

--- a/src/util/wksp/fd_wksp_checkpt_v1.c
+++ b/src/util/wksp/fd_wksp_checkpt_v1.c
@@ -193,6 +193,11 @@ fd_wksp_private_checkpt_v1( fd_tpool_t * tpool,
       fd_wksp_private_checkpt_v1_publish( checkpt, prep );
 
       /* Checkpt partition data */
+#     if FD_HAS_DEEPASAN
+      /* We read the whole partition, so unpoison the holes sub-allocators
+         leave poisoned (permanently discarding that finer poisoning). */
+      fd_asan_unpoison( laddr_lo, sz );
+#     endif
 
       err = fd_wksp_private_checkpt_v1_write( checkpt, laddr_lo, sz ); if( FD_UNLIKELY( err ) ) goto io_err;
     }

--- a/src/util/wksp/fd_wksp_checkpt_v2.c
+++ b/src/util/wksp/fd_wksp_checkpt_v2.c
@@ -458,6 +458,12 @@ fd_wksp_private_checkpt_v2( fd_tpool_t * tpool,
       ulong gaddr_lo = pinfo[ part_idx ].gaddr_lo;
       ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
 
+#     if FD_HAS_DEEPASAN
+      /* We read the whole partition, so unpoison the holes sub-allocators
+         leave poisoned (permanently discarding that finer poisoning). */
+      fd_asan_unpoison( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
+#     endif
+
       CHECKPT_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
 
       part_idx = fd_wksp_private_pinfo_idx( pinfo[ part_idx ].stack_cidx );

--- a/src/util/wksp/fd_wksp_private.h
+++ b/src/util/wksp/fd_wksp_private.h
@@ -230,6 +230,34 @@ fd_wksp_private_pinfo_const( fd_wksp_t const * wksp ) {
   return (fd_wksp_private_pinfo_t const *)(((ulong)wksp) + fd_wksp_private_pinfo_off());
 }
 
+#if FD_HAS_DEEPASAN
+
+/* fd_wksp_private_asan_poison_data poisons everything after wksp's
+   pinfo array, i.e. marks every partition free.  The wksp header and
+   pinfo array are left unpoisoned.  Assumes wksp is a local join. */
+
+static inline void
+fd_wksp_private_asan_poison_data( fd_wksp_t * wksp ) {
+  ulong footprint = fd_wksp_footprint( wksp->part_max, wksp->data_max ); /* includes the trailing guard region */
+  fd_asan_poison( fd_wksp_laddr_fast( wksp, wksp->gaddr_lo ), footprint - wksp->gaddr_lo );
+}
+
+/* fd_wksp_private_asan_sync makes wksp's poison state match its current
+   partitioning, i.e. all free space poisoned and allocated partitions
+   not.  Assumes wksp is a local join with a rebuilt partitioning. */
+
+static inline void
+fd_wksp_private_asan_sync( fd_wksp_t * wksp ) {
+  fd_wksp_private_asan_poison_data( wksp );
+  fd_wksp_private_pinfo_t * pinfo = fd_wksp_private_pinfo( wksp );
+  for( ulong i=0UL; i<wksp->part_max; i++ ) {
+    if( !pinfo[ i ].tag ) continue; /* idle or free */
+    fd_asan_unpoison( fd_wksp_laddr_fast( wksp, pinfo[ i ].gaddr_lo ), pinfo[ i ].gaddr_hi - pinfo[ i ].gaddr_lo );
+  }
+}
+
+#endif
+
 /* fd_wksp_private_pinfo_{cidx,idx} compresses / uncompresses a pinfo index */
 
 static inline uint  fd_wksp_private_pinfo_cidx( ulong idx  ) { return (uint) idx;  }

--- a/src/util/wksp/fd_wksp_restore_v1.c
+++ b/src/util/wksp/fd_wksp_restore_v1.c
@@ -241,16 +241,9 @@ fd_wksp_private_restore_v1( fd_tpool_t * tpool,
     wksp_dirty = 1;
 
     #if FD_HAS_DEEPASAN
-    /* Poison the restored allocations. Potentially under poison to respect
-       manual poisoning alignment requirements. Don't poison if the allocation
-       is smaller than FD_ASAN_ALIGN. */
-    ulong laddr_lo = (ulong)fd_wksp_laddr_fast( wksp, gaddr_lo );
-    ulong laddr_hi = laddr_lo + sz;
-    ulong aligned_laddr_lo = fd_ulong_align_up( laddr_lo, FD_ASAN_ALIGN );
-    ulong aligned_laddr_hi = fd_ulong_align_dn( laddr_hi, FD_ASAN_ALIGN );
-    if( aligned_laddr_lo < aligned_laddr_hi ) {
-      fd_asan_poison( (void*)aligned_laddr_lo, aligned_laddr_hi - aligned_laddr_lo );
-    }
+    /* The destination can be poisoned free space, so unpoison it before
+       restoring into it (the rebuild below syncs the final state). */
+    fd_asan_unpoison( fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
     #endif
 
     err = fd_io_buffered_istream_read( restore, fd_wksp_laddr_fast( wksp, gaddr_lo ), sz );
@@ -277,6 +270,10 @@ fd_wksp_private_restore_v1( fd_tpool_t * tpool,
     goto unlock;
   }
 
+  #if FD_HAS_DEEPASAN
+  fd_wksp_private_asan_sync( wksp ); /* old allocations are gone now */
+  #endif
+
   wksp_dirty = 0;
 
   FD_LOG_INFO(( "Restore successful" ));
@@ -291,6 +288,9 @@ unlock: /* note: wksp locked at this point */
     FD_LOG_WARNING(( "wksp \"%s\" dirty; attempting to reset it and continue", wksp->name ));
     for( ulong i=0UL; i<wksp_part_max; i++ ) wksp_pinfo[ i ].tag = 0UL;
     fd_wksp_rebuild( wksp, new_seed ); /* logs details */
+    #if FD_HAS_DEEPASAN
+    fd_wksp_private_asan_sync( wksp ); /* everything is free now */
+    #endif
     err = FD_WKSP_ERR_CORRUPT;
   }
 

--- a/src/util/wksp/fd_wksp_restore_v2.c
+++ b/src/util/wksp/fd_wksp_restore_v2.c
@@ -354,6 +354,14 @@ fd_wksp_private_restore_v2_cgroup( fd_wksp_t *                      wksp,
     /* Restore the allocation into the wksp data region */
 
     dirty = 1;
+#   if FD_HAS_DEEPASAN
+    /* Unpoison granule aligned as checkpt partitions can share a shadow
+       byte with a neighbor another thread is restoring concurrently.
+       The caller syncs the exact state once the threads have joined. */
+    ulong asan_lo = fd_ulong_align_dn( (ulong)fd_wksp_laddr_fast( wksp, gaddr_lo ), FD_ASAN_ALIGN );
+    ulong asan_hi = fd_ulong_align_up( (ulong)fd_wksp_laddr_fast( wksp, gaddr_hi ), FD_ASAN_ALIGN );
+    fd_asan_unpoison( (void *)asan_lo, asan_hi - asan_lo );
+#   endif
     RESTORE_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
   }
 
@@ -703,6 +711,10 @@ fd_wksp_private_restore_v2_mmio( fd_tpool_t *   tpool,
 
   if( FD_UNLIKELY( fd_wksp_rebuild( wksp, new_seed ) ) ) goto fail; /* logs details */
 
+# if FD_HAS_DEEPASAN
+  fd_wksp_private_asan_sync( wksp ); /* old allocations are gone now */
+# endif
+
   FD_LOG_INFO(( "Unlocking wksp" ));
 
   fd_wksp_private_unlock( wksp );
@@ -867,6 +879,11 @@ fd_wksp_private_restore_v2_stream( fd_wksp_t *    wksp,
         ulong gaddr_hi = pinfo[ part_idx ].gaddr_hi;
 
         dirty = 1;
+#       if FD_HAS_DEEPASAN
+        /* The destination can be poisoned free space, so unpoison it
+           before restoring into it. */
+        fd_asan_unpoison( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
+#       endif
         RESTORE_DATA( fd_wksp_laddr_fast( wksp, gaddr_lo ), gaddr_hi - gaddr_lo );
       }
 
@@ -915,6 +932,10 @@ restore_footer:
   for( ulong part_idx=ftr_alloc_cnt; part_idx<part_max; part_idx++ ) pinfo[ part_idx ].tag = 0UL;
 
   if( FD_UNLIKELY( fd_wksp_rebuild( wksp, new_seed ) ) ) goto fail; /* logs details */
+
+# if FD_HAS_DEEPASAN
+  fd_wksp_private_asan_sync( wksp ); /* old allocations are gone now */
+# endif
 
   FD_LOG_INFO(( "Unlocking wksp" ));
 

--- a/src/util/wksp/fd_wksp_user.c
+++ b/src/util/wksp/fd_wksp_user.c
@@ -237,13 +237,9 @@ fd_wksp_alloc_at_least( fd_wksp_t * wksp,
   if( FD_UNLIKELY( !tag                       ) ) { FD_LOG_WARNING(( "bad tag"     )); goto fail; }
 
 # if FD_HAS_DEEPASAN
-  /* ASan requires 8 byte alignment for poisoning because memory is mapped in
-     8 byte intervals to ASan shadow bytes. Update alignment, sz, and footprint
-     to meet manual poisoning requirements. */
+  /* ASan poisons in 8 byte shadow granules, so bump alignment (and thus
+     footprint) to meet manual poisoning requirements. */
   align = fd_ulong_if( align < FD_ASAN_ALIGN, FD_ASAN_ALIGN, align );
-  if( sz && sz < ULONG_MAX ) {
-    sz = fd_ulong_align_up( sz, FD_ASAN_ALIGN );
-  }
   footprint = sz + align - 1UL;
 # endif
 
@@ -537,12 +533,7 @@ fd_wksp_reset( fd_wksp_t * wksp,
   if( FD_UNLIKELY( !wksp ) ) { FD_LOG_WARNING(( "NULL wksp" )); return; }
 
 # if FD_HAS_DEEPASAN
-  /* Poison entire workspace except wksp header and the pinfo array. */
-  ulong footprint = fd_wksp_footprint( wksp->part_max, wksp->data_max );
-  void * wksp_data = (void*)((ulong)wksp + fd_wksp_private_pinfo_off());
-  fd_asan_poison( wksp_data, footprint - fd_wksp_private_pinfo_off() );
-  fd_wksp_private_pinfo_t * pinfo_arr = fd_wksp_private_pinfo( wksp );
-  fd_asan_unpoison( pinfo_arr, FD_WKSP_PRIVATE_PINFO_FOOTPRINT * wksp->part_max );
+  fd_wksp_private_asan_poison_data( wksp );
 # endif
 
   ulong                     part_max = wksp->part_max;


### PR DESCRIPTION
Deepasan unpoisoned considerably more memory than it should have. `fd_alloc_malloc()` left the whole enclosing size block unpoisoned past the original request, `fd_wksp_alloc_at_least` unnecessarily rounded `sz` up to alignment, `fd_spad_prepare()` unpoisoned everything left in the spad rather than the real max bytes promised by its contract, and `fd_scratch_prepare()` also rounded its size up, marking bytes past the end of the scratch region as accessible. Each is now tightened to the caller's actual request. Unpoisoning needs to be exact at a region's end. A shadow byte records how many leading bytes of its datum are addressable, so the rounding only hurt us by allowing false negatives.

Tightening the rounding immediately uncovered a bonafide OOB access: test_stake_delegations only allocated a single byte and handed it to `fd_stake_delegations_join()` which reads an 8-byte magic.