### PR TITLE
runtime: fix heap overflow in instr harness

### DIFF
--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -66,8 +66,9 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
   fd_txn_p_t * txn            = fd_spad_alloc_check( runner->spad, alignof(fd_txn_p_t), sizeof(fd_txn_p_t) );
   fd_txn_t *   txn_descriptor = TXN( txn );
   if( test_ctx->data ) {
-    memcpy( txn->payload, test_ctx->data->bytes, test_ctx->data->size );
-    txn->payload_sz = test_ctx->data->size;
+    ulong payload_sz = fd_ulong_min( test_ctx->data->size, sizeof(txn->payload) );
+    memcpy( txn->payload, test_ctx->data->bytes, payload_sz );
+    txn->payload_sz = payload_sz;
   } else {
     txn->payload_sz = 0;
   }


### PR DESCRIPTION
txn->payload is a fixed FD_TPU_MTU buffer. test_ctx->data->size is fixture-controlled and can exceed it, so bound the copy to avoid overflowing the buffer (a real transaction can never exceed the MTU anyway). solfuzz fix ups should make this not reachable but nothing stops us from replaying any arbitrary input fixture that can still hit this.