### PR TITLE
pack: raise byte bound now that shreds close batches at two FECs

### DIFF
--- a/src/disco/pack/fd_pack.h
+++ b/src/disco/pack/fd_pack.h
@@ -83,6 +83,11 @@ struct fd_pack_limits {
      would be to kill the block.  To address this, pack limits the size
      of the data it puts into the block to a limit that we can prove
      will never cause the shred tile to produce too many shreds.
+     At runtime this is how many entry bytes fit in max_shred_idx
+     after FEC padding (we close a shred batch when the next
+     microblock would not fit in two FEC sets).  Empty ticks are
+     subtracted.  Large microblocks pad more, so the cap
+     tightens.
 
      This limit includes transaction and microblock headers for
      non-empty microblocks that pack produces. */

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -1170,23 +1170,16 @@ after_frag( fd_pack_ctx_t *     ctx,
 
     ulong base_max_data = ctx->larger_shred_limits_per_block ? LARGER_MAX_DATA_PER_BLOCK : FD_PACK_MAX_DATA_PER_BLOCK;
     if( FD_LIKELY( !ctx->larger_shred_limits_per_block ) ) {
-      /* Compute base_max_data to ensure that we don't overflow
-         slot_max_data_shreds. See FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX in
-         fd_shred_batch.h. Some of the terms are
-         based on the worst-case number of FEC sets in a block, which
-         scales with the slot time reductions:
-         - pad_ohead = per-batch padding (OHEAD_PAD in fd_shred_batch.h)
-         - hdr_ohead = per-batch header (OHEAD_HDR in fd_shred_batch.h)
-         - reg_ohead = only used for the last batch
-                       (OHEAD_REG in fd_shred_batch.h) */
-      ulong fec_set_cnt     = ctx->_became_leader->limits.slot_max_data_shreds/32UL;
-      ulong pad_ohead       = ( fec_set_cnt/2UL )*FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ;
-      ulong hdr_ohead       = fec_set_cnt*8UL;
-      ulong reg_ohead       = 8192UL;
-      FD_TEST( fec_set_cnt >= 2UL ); /* guard against underflow */
-      ulong fec_data        = ( fec_set_cnt - 2UL )*FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ;
-      FD_TEST( fec_data    >= pad_ohead+hdr_ohead+reg_ohead );
-      base_max_data         = fec_data - pad_ohead - hdr_ohead - reg_ohead;
+      /* Cap pack's entry bytes at the worst case: how many entry
+         bytes fit in max_shred_idx given our shredding.  We fill a
+         batch until the next microblock would not fit in two FEC
+         sets, then pad out that batch.  Empty ticks are subtracted
+         below. */
+      ulong shreds            = ctx->_became_leader->limits.slot_max_data_shreds;
+      ulong max_microblock_sz = sizeof(fd_entry_batch_header_t) + EFFECTIVE_TXN_PER_MICROBLOCK*FD_TPU_MTU;
+      ulong shred_safe        = fd_shred_batch_pack_data_max( shreds, max_microblock_sz );
+      FD_TEST( shred_safe );
+      base_max_data = shred_safe;
     }
     /* Reserve some space in the block for ticks */
     ctx->slot_max_data        = base_max_data

--- a/src/disco/shred/Local.mk
+++ b/src/disco/shred/Local.mk
@@ -11,10 +11,12 @@ $(call make-unit-test,test_shred_dest,test_shred_dest,fd_disco fd_flamenco fd_ba
 $(call make-unit-test,test_shred_dest_conformance,test_shred_dest_conformance,fd_disco fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,test_stake_ci,test_stake_ci,fd_disco fd_flamenco fd_ballet fd_util fd_tango fd_reedsol)
 $(call make-unit-test,test_rnonce_ss,test_rnonce_ss,fd_util)
+$(call make-unit-test,test_shred_batch,test_shred_batch,fd_disco fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_shred_dest)
 $(call run-unit-test,test_shred_dest_conformance)
 $(call run-unit-test,test_stake_ci)
 $(call run-unit-test,test_rnonce_ss)
+$(call run-unit-test,test_shred_batch)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_shredder,test_shredder,fd_disco fd_flamenco fd_ballet fd_util fd_reedsol)
 $(call run-unit-test,test_shredder)

--- a/src/disco/shred/fd_shred_batch.h
+++ b/src/disco/shred/fd_shred_batch.h
@@ -101,35 +101,59 @@ FD_STATIC_ASSERT( ( FD_SHRED_BATCH_RAW_BUF_SZ ) >= ( FD_SHRED_BATCH_WMARK_NORMAL
 FD_STATIC_ASSERT( ( FD_SHRED_BATCH_RAW_BUF_SZ ) >= ( FD_SHRED_BATCH_WMARK_CHAINED  + FD_POH_SHRED_MTU ), FD_SHRED_BATCH_RAW_BUF_SZ );
 FD_STATIC_ASSERT( ( FD_SHRED_BATCH_RAW_BUF_SZ ) >= ( FD_SHRED_BATCH_WMARK_RESIGNED + FD_POH_SHRED_MTU + FD_SHRED_BATCH_RESIGNED_WMARK_REGRESSION ), FD_SHRED_BATCH_RAW_BUF_SZ );
 
-/* Each block is limited to 32k parity shreds.  Since each FEC set
-   is now guaranteed to contain 32 data shreds and 32 parity shreds,
-   the maximum number of FEC sets is FEC_SETS_MAX = 1024 (32k/32).
-   We consider the payload capacity of chained FEC sets as the raw
-   capacity (which is smaller than normal FEC sets), that means
-   FEC_SETS_MAX * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ, and then
-   we subtract from there the worst-case overheads from: padding,
-   watermark regression and batch header.
-   - OHEAD_PAD (padding overhead): except for the first and last batch
-   in a block, each batch typically has FD_SHRED_BATCH_FEC_SETS_WMARK
-   FEC sets, but can contain as little as one FEC set.  However, the
-   worst case occurs when each batch has two FEC sets, of which the
-   second one contains a single byte of data and the rest is padding.
-   In that case, OHEAD_PAD is approximately 1/2 of the maximum raw
-   capacity, i.e.
-   (FEC_SETS_MAX / 2) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ.
-   - OHEAD_REG (watermark regression overhead): this is basically
-   FD_SHRED_BATCH_FEC_SETS_MAX * 2048 bytes (the difference in
-   payload size between chained and (chained+)resigned FEC sets).
-   For FD_SHRED_BATCH_FEC_SETS_MAX = 4, the overhead is 8192 bytes.
-   - OHEAD_HDR (batch header overhead): this is 8 bytes per batch,
-   and is maximum when every batch contains 1 FEC set, therefore
-   FEC_SETS_MAX * 8 = 8192 bytes.
-   The calculations below assume FD_SHRED_BATCH_FEC_SETS_MAX = 4. */
+/* FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX is a conservative compile-time
+   bound on entry bytes in a 32k-shred block (1024 chained FEC sets).
+   It subtracts worst-case padding of about half the payload, plus
+   last-batch resigned-size regression and 8-byte batch headers.
+   Pack does not use this as its per-slot cap; that is
+   fd_shred_batch_pack_data_max at become-leader.  This macro is the
+   pre-leader default (FD_PACK_MAX_DATA_PER_BLOCK) and sizes skipped-
+   tick buffers. */
 FD_STATIC_ASSERT( ( FD_SHRED_BATCH_FEC_SETS_MAX ) == ( 4UL ), FD_SHRED_BATCH_FEC_SETS_MAX );
-/* Define and validate total overhead. */
 #define FD_SHRED_BATCH_BLOCK_DATA_OHEAD  (  512UL * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ + 8192UL + 8192UL )
 FD_STATIC_ASSERT( ( FD_SHRED_BATCH_BLOCK_DATA_OHEAD ) < ( 1024UL * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ ), FD_SHRED_BATCH_BLOCK_DATA_OHEAD );
-/* Define FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX. */
 #define FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX ( (1024UL-2UL) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ - FD_SHRED_BATCH_BLOCK_DATA_OHEAD )
+
+/* fd_shred_batch_pack_data_max: how many entry bytes (microblock
+   headers + txn payloads, excluding empty ticks) pack can emit in a
+   slot without producing more than slot_max_data_shreds.
+
+   max_microblock_sz is the largest pack-produced entry: the 48-byte
+   entry header plus (max txns per microblock)*FD_TPU_MTU.
+
+   We shred by filling a batch until the next microblock would not
+   fit in two chained FEC sets (WMARK_CHAINED = 2*C-8 payload bytes),
+   then padding out that batch:
+     - The first microblock of a slot is flushed immediately, using
+       ceil( (8+max_microblock_sz)/C ) FEC sets.
+     - Each later closed batch holds at least
+       WMARK_CHAINED-max_microblock_sz entry bytes and uses 2 FEC sets.
+     - The last batch is the leftover (at most wmark) plus the
+       completing microblock, padded to resigned FEC sets:
+       ceil( (wmark + 8 + max_microblock_sz) / R ).  Production
+       finishes on an empty tick; low-power can finish on a
+       max-size microblock.
+
+   Empty ticks are not included; the caller should subtract
+   48*(ticks_per_slot+skipped_ticks).  Returns 0 if the shred budget
+   cannot cover the reserved FEC sets. */
+FD_FN_CONST static inline ulong
+fd_shred_batch_pack_data_max( ulong slot_max_data_shreds,
+                              ulong max_microblock_sz ) {
+  ulong const C     = FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ;
+  ulong const R     = FD_SHREDDER_RESIGNED_FEC_SET_PAYLOAD_SZ;
+  ulong const wmark = FD_SHRED_BATCH_WMARK_CHAINED; /* 2*C - 8 */
+
+  if( FD_UNLIKELY( max_microblock_sz>=wmark ) ) return 0UL;
+
+  ulong fec_set_cnt          = slot_max_data_shreds / 32UL;
+  ulong first_batch_fec_cnt  = ( 8UL + max_microblock_sz + C - 1UL ) / C;
+  ulong last_batch_fec_cnt   = ( wmark + 8UL + max_microblock_sz + R - 1UL ) / R;
+  if( FD_UNLIKELY( fec_set_cnt<first_batch_fec_cnt+last_batch_fec_cnt ) ) return 0UL;
+
+  ulong middle_batch_fec_cnt = ( fec_set_cnt - first_batch_fec_cnt - last_batch_fec_cnt ) & ~1UL; /* even, 2 FEC per batch */
+  ulong min_batch            = wmark - max_microblock_sz;
+  return ( middle_batch_fec_cnt / 2UL ) * min_batch;
+}
 
 #endif /* HEADER_fd_src_disco_shred_fd_shred_batch_h */

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -734,7 +734,9 @@ during_frag( fd_shred_ctx_t * ctx,
          would exceed the pending_batch_wmark.  If true, then the
          batch is closed now, shredded, and a new batch is started
          with the incoming microblock.  If false, no shredding takes
-         place, and the microblock is added to the current batch. */
+         place, and the microblock is added to the current batch.
+         Pack limits entry bytes so this batching cannot exceed
+         max_shred_idx. */
       int forced_end_batch         = entry_meta->block_complete | new_slot;
       int batch_would_exceed_wmark = ( ctx->pending_batch.pos + entry_sz ) > pending_batch_wmark;
       int include_in_current_batch = forced_end_batch | ( !batch_would_exceed_wmark );

--- a/src/disco/shred/test_shred_batch.c
+++ b/src/disco/shred/test_shred_batch.c
@@ -1,0 +1,56 @@
+#include "fd_shred_batch.h"
+#include "../../flamenco/runtime/fd_slot_params.h"
+#include "../../util/fd_util.h"
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  /* One-txn microblocks (SMALL_MICROBLOCKS): largest shred-tile entry
+     is header + FD_TPU_MTU. */
+  ulong const M = sizeof(fd_entry_batch_header_t) + FD_TPU_MTU;
+  FD_TEST( M==4144UL );
+
+  /* Helper must fail closed on impossible inputs. */
+  FD_TEST( !fd_shred_batch_pack_data_max( 0UL, M ) );
+  FD_TEST( !fd_shred_batch_pack_data_max( 96UL, M ) ); /* 3 FEC, less than first+last reserve */
+  FD_TEST( !fd_shred_batch_pack_data_max( 128UL, 30000UL ) ); /* 4 FEC; last batch needs 4 */
+  FD_TEST( !fd_shred_batch_pack_data_max( 24576UL, FD_SHRED_BATCH_WMARK_CHAINED ) );
+
+  /* Helper is nonzero at every slot-time shred count.  Fewer shreds
+     must yield a strictly smaller byte budget.  shred_safe is below
+     the no-padding payload (every data shred full). */
+  fd_slot_params_t const stages[] = {
+    FD_SLOT_PARAMS_400MS,
+    FD_SLOT_PARAMS_350MS,
+    FD_SLOT_PARAMS_300MS,
+    FD_SLOT_PARAMS_250MS,
+    FD_SLOT_PARAMS_200MS,
+  };
+  ulong prev = ULONG_MAX;
+  for( ulong i=0UL; i<sizeof(stages)/sizeof(stages[0]); i++ ) {
+    ulong shreds                        = stages[i].max_shred_idx;
+    ulong max_stage_data_shred_capacity = ( shreds / 32UL ) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ;
+    ulong shred_safe                    = fd_shred_batch_pack_data_max( shreds, M );
+    FD_TEST( shred_safe );
+    FD_TEST( shred_safe<prev );
+    FD_TEST( shred_safe<max_stage_data_shred_capacity );
+    prev = shred_safe;
+  }
+
+  /* Large microblocks pad more, so the same shred count yields
+     fewer entry bytes.  Last batch can need 3 or 4 resigned FEC
+     sets. */
+  ulong const M_large                       = 30000UL;
+  ulong const shreds_300                    = FD_SLOT_PARAMS_300MS.max_shred_idx;
+  ulong const max_stage_data_shred_capacity = ( shreds_300 / 32UL ) * FD_SHREDDER_CHAINED_FEC_SET_PAYLOAD_SZ;
+  ulong       shred_large                   = fd_shred_batch_pack_data_max( shreds_300, M_large );
+  FD_TEST( shred_large );
+  FD_TEST( shred_large<fd_shred_batch_pack_data_max( shreds_300, M ) );
+  FD_TEST( shred_large<max_stage_data_shred_capacity );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
pack’s leader byte budget assumed some weird worst-case ~50% FEC padding. the shred tile does not do that. it closes a chained batch when the next microblock would not fit in two FEC sets, so padding is at worst case one (worst-case) microblock (minus one byte).

pack now takes the min of that shred-fit entry-byte bound and SIMD-0525 `max_entry_bytes_per_slot`, then subtracts ticks. with one-txn microblocks the protocol cap binds (15.73 MiB at 300 ms, up from 11.75 MiB).

shoutout @KirillLykov for finding this