### PR TITLE
reasm: initialize root xid_next sentinel

### DIFF
--- a/src/discof/reasm/fd_reasm.c
+++ b/src/discof/reasm/fd_reasm.c
@@ -701,6 +701,7 @@ fd_reasm_init( fd_reasm_t *      reasm,
   fec->out.next        = null;
   fec->out.prev        = null;
   fec->in_out          = 0;
+  fec->xid_next        = null;
   fec->subtreel.next   = null;
   fec->subtreel.prev   = null;
 


### PR DESCRIPTION
Prevents XID-list removal from propagating pool index 0 and leaving a stale reference to a released root element. Luckly this was not reachable in prod.