### PR TITLE
backup: quickly skip unrelated accounts

### DIFF
--- a/src/discof/backup/fd_backup_accidx.h
+++ b/src/discof/backup/fd_backup_accidx.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_discof_backup_fd_backup_accidx_h
 
 /* fd_backup_accidx.h provides a read-only view of the accdb in-memory
-   account index for snapshot production. 
+   account index for snapshot production.
 
    The index is a chained hash map keyed by account address.  acc_map is
    an array of (chain_mask+1) chain heads, each an index into acc_pool

--- a/src/discof/backup/fd_backup_disk.h
+++ b/src/discof/backup/fd_backup_disk.h
@@ -153,6 +153,10 @@ fd_snapmk_accparse_lookup( fd_snapmk_accparse_t * parse,
 
 static inline int
 fd_snapmk_accparse_keep( fd_snapmk_accparse_t * parse ) {
+  if( FD_UNLIKELY( parse->meta.generation>parse->idx.root_generation ) ) {
+    parse->acc_idx = UINT_MAX;
+    return 0;
+  }
   ulong chain_idx = fd_backup_accidx_chain( &parse->idx, parse->meta.pubkey );
   fd_snapmk_accparse_lookup( parse, &chain_idx, &parse->acc_file_off, &parse->acc_idx, 1UL );
   return parse->acc_idx!=UINT_MAX;
@@ -193,11 +197,13 @@ fd_snapmk_accparse_prestage( fd_snapmk_accparse_t * parse ) {
     ulong rec      = meta_sz + data_len;
     if( parse->data_sz < rec ) break;     /* account data straddles frag end */
 
-    chain_idx[ n ] = fd_backup_accidx_chain( idx, dm->pubkey );
-    __builtin_prefetch( &acc_map[ chain_idx[ n ] ], 0, 3 );
-    parse->ps_frag_off[ n ] = (uint)( parse->src_gaddr - parse->frag_base_gaddr );
-    parse->ps_file_off[ n ] = parse->src_off;
-    n++;
+    if( FD_LIKELY( dm->generation <= idx->root_generation ) ) {
+      chain_idx[ n ] = fd_backup_accidx_chain( idx, dm->pubkey );
+      __builtin_prefetch( &acc_map[ chain_idx[ n ] ], 0, 3 );
+      parse->ps_frag_off[ n ] = (uint)( parse->src_gaddr - parse->frag_base_gaddr );
+      parse->ps_file_off[ n ] = parse->src_off;
+      n++;
+    }
 
     parse->data      += rec;
     parse->data_sz   -= rec;

--- a/src/discof/backup/test_backup_disk.c
+++ b/src/discof/backup/test_backup_disk.c
@@ -223,6 +223,82 @@ test_keep_derives_chain( void ) {
   FD_TEST( parse->acc_idx==UINT_MAX );
 }
 
+/* A record header above the root generation is dropped without ever
+   reaching the index, so the entry it would have hit stays unclaimed. */
+
+static void
+test_keep_skips_too_new( void ) {
+  env_reset();
+
+  uchar const * pubkey   = pubkey_n( 888UL );
+  ulong         chain    = fd_backup_accidx_chain( &parse->idx, pubkey );
+  ulong         file_off = 0xc000UL;
+  uint          ele      = index_add( 44U, chain, pubkey, 5U, 1000UL, file_off );
+
+  memcpy( parse->meta.pubkey, pubkey, 32UL );
+  parse->acc_file_off   = file_off;
+  parse->acc_idx        = UINT_MAX;
+  parse->meta.generation = ROOT_GEN+1U;
+
+  FD_TEST( fd_snapmk_accparse_keep( parse )==0 );
+  FD_TEST( parse->acc_idx==UINT_MAX );
+
+  /* the skip must not have burned the visited bit */
+  parse->meta.generation = ROOT_GEN;
+  FD_TEST( fd_snapmk_accparse_keep( parse )==1 );
+  FD_TEST( parse->acc_idx==ele );
+}
+
+/* Same skip on the whole-record path: too-new records are consumed off
+   the frag but never staged into the batch. */
+
+static void
+test_prestage_skips_too_new( void ) {
+  env_reset();
+
+  ulong const rec_sz  = sizeof(fd_accdb_disk_meta_t); /* data_len 0 */
+  ulong const off_base = 0x20000UL;
+
+  static fd_accdb_disk_meta_t recs[ 3 ];
+  uint expected[ 3 ];
+  for( ulong i=0UL; i<3UL; i++ ) {
+    uchar const * pubkey = pubkey_n( 200UL+i );
+    ulong chain = fd_backup_accidx_chain( &parse->idx, pubkey );
+    uint  gen   = ( i==1UL ) ? ROOT_GEN+1U : 5U;
+
+    memset( &recs[ i ], 0, sizeof(recs[ i ]) );
+    memcpy( recs[ i ].pubkey, pubkey, 32UL );
+    recs[ i ].size       = 0U;
+    recs[ i ].generation = gen;
+
+    uint ele = index_add( (uint)(50UL+i), chain, pubkey, gen, 1000UL, off_base + i*rec_sz );
+    expected[ i ] = ( gen<=ROOT_GEN ) ? ele : UINT_MAX;
+  }
+
+  parse->data            = (uchar const *)recs;
+  parse->data_sz         = 3UL*rec_sz;
+  parse->src_gaddr       = 0x900000UL;
+  parse->frag_base_gaddr = 0x900000UL;
+  parse->src_off         = off_base;
+  parse->pf_cursor       = NULL;
+  parse->ps_cnt          = 0U;
+  parse->pub_pending     = 0;
+  parse->acc_active      = 0;
+  parse->meta_sz         = 0U;
+
+  fd_backup_disk_batch_msg_t batch[1];
+  ulong n = fd_snapmk_accparse_publish_batch( parse, batch );
+
+  FD_TEST( n==2UL );                                   /* middle one dropped */
+  FD_TEST( batch->acc_idx [ 0 ]==expected[ 0 ] );
+  FD_TEST( batch->frag_off[ 0 ]==0U             );
+  FD_TEST( batch->acc_idx [ 1 ]==expected[ 2 ] );      /* record 2, not 1 */
+  FD_TEST( batch->frag_off[ 1 ]==(uint)(2UL*rec_sz) );
+  for( ulong i=n; i<FD_BACKUP_DISK_PARA; i++ ) FD_TEST( batch->acc_idx[ i ]==UINT_MAX );
+
+  FD_TEST( !parse->data_sz ); /* every record consumed, skipped ones too */
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -255,6 +331,8 @@ main( int     argc,
   test_visited_dedup();
   test_full_batch();
   test_keep_derives_chain();
+  test_keep_skips_too_new();
+  test_prestage_skips_too_new();
 
   /* every lookup must have released its epoch announcement */
   FD_TEST( epoch_slot==ULONG_MAX );

--- a/src/discof/restore/fd_snapwr_tile.c
+++ b/src/discof/restore/fd_snapwr_tile.c
@@ -5,6 +5,7 @@
 
 #include "../../disco/topo/fd_topo.h"
 #include "../../disco/metrics/fd_metrics.h"
+#include "../../flamenco/accdb/fd_accdb_shmem.h"
 
 #include "generated/fd_snapwr_tile_seccomp.h"
 
@@ -154,7 +155,7 @@ process_account_header( fd_snapwr_tile_t *            ctx,
                         fd_ssparse_advance_result_t * result ) {
   /* Ensure header+data does not cross a partition boundary.  If it
      would, pad with zeros so the account starts at the next one. */
-  ulong account_sz    = 68UL + (ulong)result->account_header.data_len;
+  ulong account_sz    = sizeof(fd_accdb_disk_meta_t) + (ulong)result->account_header.data_len;
   ulong cur_boundary  = ctx->accounts_off / ctx->partition_sz;
   ulong end_boundary  = (ctx->accounts_off + account_sz - 1UL) / ctx->partition_sz;
   if( FD_UNLIKELY( cur_boundary!=end_boundary ) ) {
@@ -162,11 +163,12 @@ process_account_header( fd_snapwr_tile_t *            ctx,
     buffer_skip( ctx, next - ctx->accounts_off );
   }
 
-  uchar data[ 68UL ];
-  fd_memcpy( data, result->account_header.pubkey, 32UL );
-  fd_memcpy( data+32UL, &result->account_header.data_len, 4UL );
-  fd_memcpy( data+36UL, result->account_header.owner, 32UL );
-  buffer_write( ctx, data, 68UL );
+  fd_accdb_disk_meta_t meta;
+  fd_memcpy( meta.pubkey, result->account_header.pubkey, 32UL );
+  meta.size       = (uint)result->account_header.data_len;
+  meta.generation = 0U;
+  fd_memcpy( meta.owner, result->account_header.owner, 32UL );
+  buffer_write( ctx, meta.b, sizeof(fd_accdb_disk_meta_t) );
   ctx->metrics.accounts_written++;
 }
 

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -2463,7 +2463,8 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
         total_write_sz += sizeof(fd_accdb_disk_meta_t) + FD_ACCDB_SIZE_DATA( evicted->executable_size );
         FD_TEST( write_meta_cnt<(int)(sizeof(write_metas)/sizeof(write_metas[0])) );
         fd_memcpy( write_metas[ write_meta_cnt ].pubkey, evicted->key.pubkey, 32UL );
-        write_metas[ write_meta_cnt ].size = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+        write_metas[ write_meta_cnt ].size       = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+        write_metas[ write_meta_cnt ].generation = evicted->key.generation;
         fd_memcpy( write_metas[ write_meta_cnt ].owner, destination_cache_lines[ i ][ j ]->owner, 32UL );
         write_ops[ write_ops_cnt++ ] = (struct iovec){ .iov_base = &write_metas[ write_meta_cnt ], .iov_len = sizeof(fd_accdb_disk_meta_t) };
         write_meta_cnt++;
@@ -2477,7 +2478,8 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
         total_write_sz += sizeof(fd_accdb_disk_meta_t) + FD_ACCDB_SIZE_DATA( evicted->executable_size );
         FD_TEST( write_meta_cnt<(int)(sizeof(write_metas)/sizeof(write_metas[0])) );
         fd_memcpy( write_metas[ write_meta_cnt ].pubkey, evicted->key.pubkey, 32UL );
-        write_metas[ write_meta_cnt ].size = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+        write_metas[ write_meta_cnt ].size       = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+        write_metas[ write_meta_cnt ].generation = evicted->key.generation;
         fd_memcpy( write_metas[ write_meta_cnt ].owner, original_cache_line[ i ]->owner, 32UL );
         write_ops[ write_ops_cnt++ ] = (struct iovec){ .iov_base = &write_metas[ write_meta_cnt ], .iov_len = sizeof(fd_accdb_disk_meta_t) };
         write_meta_cnt++;
@@ -2491,7 +2493,8 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
       total_write_sz += sizeof(fd_accdb_disk_meta_t) + FD_ACCDB_SIZE_DATA( evicted->executable_size );
       FD_TEST( write_meta_cnt<(int)(sizeof(write_metas)/sizeof(write_metas[0])) );
       fd_memcpy( write_metas[ write_meta_cnt ].pubkey, evicted->key.pubkey, 32UL );
-      write_metas[ write_meta_cnt ].size = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+      write_metas[ write_meta_cnt ].size       = FD_ACCDB_SIZE_DATA( evicted->executable_size );
+      write_metas[ write_meta_cnt ].generation = evicted->key.generation;
       fd_memcpy( write_metas[ write_meta_cnt ].owner, original_cache_line[ i ]->owner, 32UL );
       write_ops[ write_ops_cnt++ ] = (struct iovec){ .iov_base = &write_metas[ write_meta_cnt ], .iov_len = sizeof(fd_accdb_disk_meta_t) };
       write_meta_cnt++;
@@ -3854,7 +3857,8 @@ background_preevict( fd_accdb_t * accdb,
 
         fd_accdb_disk_meta_t meta;
         fd_memcpy( meta.pubkey, accmeta->key.pubkey, 32UL );
-        meta.size = FD_ACCDB_SIZE_DATA( accmeta->executable_size );
+        meta.size       = FD_ACCDB_SIZE_DATA( accmeta->executable_size );
+        meta.generation = accmeta->key.generation;
         fd_memcpy( meta.owner, line->owner, 32UL );
 
         struct iovec iovs[ 2UL ] = {
@@ -4446,7 +4450,8 @@ fd_accdb_debug_clock_evict_line( fd_accdb_t * accdb,
 
     fd_accdb_disk_meta_t meta;
     fd_memcpy( meta.pubkey, accmeta->key.pubkey, 32UL );
-    meta.size = FD_ACCDB_SIZE_DATA( accmeta->executable_size );
+    meta.size       = FD_ACCDB_SIZE_DATA( accmeta->executable_size );
+    meta.generation = accmeta->key.generation;
     fd_memcpy( meta.owner, line->owner, 32UL );
 
     struct iovec iovs[ 2UL ] = {

--- a/src/flamenco/accdb/fd_accdb_private.h
+++ b/src/flamenco/accdb/fd_accdb_private.h
@@ -27,13 +27,6 @@ spin_lock_release( int * lock ) {
   *lock = 0;
 # endif
 }
-struct __attribute__((packed)) fd_accdb_disk_meta {
-  uchar pubkey[ 32UL ];
-  uint  size;
-  uchar owner[ 32UL ];
-};
-
-typedef struct fd_accdb_disk_meta fd_accdb_disk_meta_t;
 
 struct fd_accdb_txn {
   union {

--- a/src/flamenco/accdb/fd_accdb_shmem.h
+++ b/src/flamenco/accdb/fd_accdb_shmem.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_flamenco_accdb_fd_accdb_shmem_h
 
 #include "fd_accdb_cache.h"
+#include <stddef.h> /* offsetof */
 
 #define FD_ACCDB_SHMEM_ALIGN (128UL)
 
@@ -60,6 +61,23 @@ struct fd_accdb_metrics {
 };
 
 typedef struct fd_accdb_metrics fd_accdb_metrics_t;
+
+/* fd_accdb_disk_meta_t is the on-disk account revision header. */
+
+union fd_accdb_disk_meta {
+  struct __attribute__((packed)) {
+    uchar pubkey[ 32UL ];
+    uint  size;
+    uint  generation;
+    uchar owner[ 32UL ];
+  };
+  uchar b[72];
+};
+
+typedef union fd_accdb_disk_meta fd_accdb_disk_meta_t;
+
+FD_STATIC_ASSERT( sizeof(fd_accdb_disk_meta_t)==72UL, layout );
+FD_STATIC_ASSERT( offsetof(fd_accdb_disk_meta_t,owner)+32UL==sizeof(fd_accdb_disk_meta_t), layout );
 
 FD_PROTOTYPES_BEGIN
 


### PR DESCRIPTION
Greatly reduces the amount of hash chain probing work.
Fixes a vicious cycle where snapshot production excessively slows down the longer it takes. 

- **accdb: store account generation on disk**
- **backup: quickly skip unrelated accounts**

On validators with dm-crypt, this reduces snapshot creation times from 1750 seconds to 160 seconds.