### PR TITLE
watch: fix uptime showing the command's own runtime

### DIFF
--- a/src/app/shared/fd_bootinfo.c
+++ b/src/app/shared/fd_bootinfo.c
@@ -403,7 +403,21 @@ fd_bootinfo_notice( fd_bootinfo_instance_t const * instance ) {
 
 void
 fd_bootinfo_adopt( config_t * config ) {
-  if( FD_LIKELY( config->has_user_config ) ) return; /* fd_bootinfo_check_layout verifies before joining */
+  if( FD_LIKELY( config->has_user_config ) ) {
+    /* config->boot_timestamp_nanos is this command's start time, not
+       the validator's.  Adopt the running validator's, else zero it so
+       consumers report no uptime rather than a wrong one. */
+    char path[ PATH_MAX ];
+    bootinfo_path( config->hugetlbfs.mount_path, config->name, path );
+
+    fd_bootinfo_t info;
+    config->boot_timestamp_nanos = 0L;
+    if( FD_LIKELY( -1!=fd_bootinfo_path_read( path, &info ) && fd_bootinfo_live( &info ) ) ) {
+      config->boot_timestamp_nanos = info.boot_wallclock_nanos;
+    }
+
+    return; /* fd_bootinfo_check_layout verifies before joining */
+  }
 
   fd_bootinfo_instance_t instances[ FD_BOOTINFO_INSTANCE_MAX ];
   ulong cnt = fd_bootinfo_discover( instances, FD_BOOTINFO_INSTANCE_MAX );

--- a/src/app/shared/fd_bootinfo.h
+++ b/src/app/shared/fd_bootinfo.h
@@ -118,8 +118,11 @@ fd_bootinfo_notice( fd_bootinfo_instance_t const * instance );
    topology from the file is used and only the layout is verified.
    Otherwise the running validator is discovered and config is replaced
    with the validator's own published resolved config, so all topology
-   offsets are exactly the ones in use.  Logs an error and exits if no
-   or multiple validators are running, or on a version mismatch. */
+   offsets are exactly the ones in use.  In either case
+   config->boot_timestamp_nanos is replaced with the running
+   validator's boot time, or zero if it cannot be determined.  Logs an
+   error and exits if no or multiple validators are running, or on a
+   version mismatch. */
 
 void
 fd_bootinfo_adopt( config_t * config );


### PR DESCRIPTION
### Problem

`fd_bootinfo_adopt` returns immediately when `--config` was given, so `config->boot_timestamp_nanos` keeps the value `fd_config.c` stamped when this command parsed the config 

watch renders that field as the node's uptime, so it reports how long watch itself has been running, counting up from **0m 0s** on every invocation, rather than the validator's uptime.

standalone watch only - when a development command spawns it internally with the validator's own config the value is already right

### Summary of Changes

- `fd_bootinfo_adopt` now adopts the running validator's `boot_wallclock_nanos` on the `--config` path, so the stamp describes the validator rather than the command
- it resolves the descriptor by mount path and name, via `bootinfo_path / fd_bootinfo_path_read / fd_bootinfo_live` - the identity `fd_bootinfo_check_layout` already uses - instead of scanning every hugetlbfs mount, which would match a same-named instance on another mount
- with no live descriptor the stamp is zeroed, so watch renders '-' instead of a wrong number
- the header contract documents that adopt replaces `boot_timestamp_nanos`