### PR TITLE
ballet: make SipHash input loads unaligned-safe

### DIFF
--- a/src/ballet/siphash13/fd_siphash13.c
+++ b/src/ballet/siphash13/fd_siphash13.c
@@ -161,11 +161,11 @@ fd_siphash13_hash( void const * data,
 
   /* Hash blocks */
 
-  ulong m;
-  ulong const * in    = (ulong const *)data;
-  ulong const * end   = in + data_sz/8UL;
-  for( ; in!=end; in++ ) {
-    m = *in;
+  ulong         m;
+  uchar const * in  = (uchar const *)data;
+  uchar const * end = in + (data_sz & ~7UL);
+  for( ; in!=end; in+=8UL ) {
+    m = FD_LOAD( ulong, in );
     v[ 3 ] ^= m;
     FD_SIPHASH_ROUND( v );
     v[ 0 ] ^= m;
@@ -175,7 +175,7 @@ fd_siphash13_hash( void const * data,
 
   int const     left = data_sz & 7;
   ulong         b    = ((ulong)data_sz) << 56;
-  uchar const * rem  = (uchar const *)in;
+  uchar const * rem  = in;
   switch( left ) {
     case 7: b |= ((ulong)rem[6]) << 48; __attribute__((fallthrough));
     case 6: b |= ((ulong)rem[5]) << 40; __attribute__((fallthrough));

--- a/src/ballet/siphash13/test_siphash13.c
+++ b/src/ballet/siphash13/test_siphash13.c
@@ -82,13 +82,19 @@ main( int     argc,
   fd_siphash13_t  _sip[1];
   fd_siphash13_t * sip = fd_siphash13_init( _sip, k0, k1 );
 
-  uchar buf[ 64 ];
+  uchar buf    [ 64 ];
+  uchar shifted[ 64+7 ] __attribute__((aligned(8)));
   for( ulong i=0UL; i<FD_SIPHASH13_TEST_CNT; i++ ) {
     uchar const * msg   = buf;
     ulong         msgsz = i;
 
     ulong hash = fd_siphash13_hash( msg, msgsz, k0, k1 );
     FD_TEST( hash == fd_siphash13_test_vector[ i ] );
+
+    for( ulong off=0UL; off<8UL; off++ ) {
+      fd_memcpy( shifted+off, msg, msgsz );
+      FD_TEST( fd_siphash13_hash( shifted+off, msgsz, k0, k1 )==hash );
+    }
 
     fd_siphash13_t sip2 = *sip;
     ulong hash2 = fd_siphash13_fini( &sip2 );
@@ -164,4 +170,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-


### PR DESCRIPTION
Reads SipHash words with `FD_LOAD` from the byte-oriented input contract and adds coverage for offsets 0 through 7.

This removes alignment UB reached by HTTP/2 header matching without changing hash results or tail handling.

Tests:
- `test_siphash13`, `test_bundle_client`, `test_bundle_client_wraparound`, `test_event_client`, `test_grpc_client`, and `test_h2` with halt-on-error UBSan
- five alternating pinned-core GCC samples: 19.36 Gbit/s/core patched versus 19.38 baseline