### PR TITLE
choreo: make tower wire decoding unaligned-safe

### DIFF
--- a/src/choreo/tower/fd_tower_serdes.c
+++ b/src/choreo/tower/fd_tower_serdes.c
@@ -3,7 +3,7 @@
 
 #define DE( T, name ) do {                                \
     if( FD_UNLIKELY( buf_sz<sizeof(T) ) ) return -1;      \
-    serde->name = *(T const *)fd_type_pun_const( buf );   \
+    serde->name = FD_LOAD( T, buf );                      \
     buf    += sizeof(T);                                  \
     buf_sz -= sizeof(T);                                  \
 } while(0)

--- a/src/choreo/tower/test_tower_serdes.c
+++ b/src/choreo/tower/test_tower_serdes.c
@@ -76,6 +76,15 @@ test_de_attacker( void ) {
     FD_TEST( 0==fd_compact_tower_sync_de( serde, buf, sz ) );
     FD_TEST( serde->root==42UL );
     FD_TEST( serde->lockouts_cnt==3 );
+
+    uchar shifted[ 1024+7 ] __attribute__((aligned(8)));
+    for( ulong off=0UL; off<8UL; off++ ) {
+      fd_memcpy( shifted+off, buf, sz );
+      FD_TEST( 0==fd_compact_tower_sync_de( serde, shifted+off, sz ) );
+      FD_TEST( serde->root==42UL );
+      FD_TEST( serde->lockouts_cnt==3 );
+      FD_TEST( serde->timestamp==1234567890L );
+    }
   }
 
   /* Sanity: zero lockouts is valid. */


### PR DESCRIPTION
Uses `FD_LOAD` for fixed-width CompactTowerSync fields and tests valid payloads at every byte offset.

The decoder accepts byte buffers, so typed dereferences could fault or trigger undefined behavior on unaligned transaction instruction data.

Test: `test_tower_serdes` with halt-on-error UBSan.
