### PR TITLE
runtime: load vote-state discriminant safely

### DIFF
--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -3,6 +3,7 @@
 #include "../fd_runtime.h"
 #include "../fd_bank.h"
 #include "../fd_system_ids.h"
+#include "fd_vote_program.h"
 #include "../../features/fd_features.h"
 #include "../../../ballet/hex/fd_hex.h"
 #include "vote/fd_vote_codec.h"
@@ -1088,6 +1089,24 @@ test_vote_instruction_footprints( void ) {
   FD_LOG_NOTICE(( "test_vote_instruction_footprints... ok" ));
 }
 
+static void
+test_vote_state_alignment( void ) {
+  uchar storage[ FD_VOTE_STATE_V4_SZ+3UL ] __attribute__((aligned(4)));
+
+  for( ulong off=0UL; off<4UL; off++ ) {
+    uchar * data = storage+off;
+
+    fd_memset( data, 0, FD_VOTE_STATE_V4_SZ );
+    FD_STORE( uint, data, fd_vote_state_versioned_enum_v4 );
+    FD_TEST( fd_vsv_is_correct_size_and_initialized( data, FD_VOTE_STATE_V4_SZ ) );
+    FD_TEST( !fd_vsv_is_correct_size_and_initialized( data, FD_VOTE_STATE_V4_SZ-1UL ) );
+
+    fd_memset( data, 0, FD_VOTE_STATE_V3_SZ );
+    data[ 4 ] = 1U;
+    FD_TEST( fd_vsv_is_correct_size_and_initialized( data, FD_VOTE_STATE_V3_SZ ) );
+  }
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -1114,6 +1133,7 @@ main( int     argc,
   test_landed_votes_footprint();
   test_epoch_credits_footprint();
   test_vote_instruction_footprints();
+  test_vote_state_alignment();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_svm_test_halt( mini );

--- a/src/flamenco/runtime/program/vote/fd_vote_state_versioned.c
+++ b/src/flamenco/runtime/program/vote/fd_vote_state_versioned.c
@@ -738,11 +738,9 @@ fd_vsv_is_uninitialized( fd_vote_state_versioned_t * self ) {
 int
 fd_vsv_is_correct_size_and_initialized( uchar const * data,
                                         ulong         data_len ) {
-  uint const *  disc_ptr = (uint const *)data; // NOT SAFE TO ACCESS YET!
-
   /* VoteStateV4::is_correct_size_and_initialized
      https://github.com/anza-xyz/solana-sdk/blob/vote-interface%40v4.0.4/vote-interface/src/state/vote_state_v4.rs#L207-L210 */
-  if( FD_LIKELY( data_len==FD_VOTE_STATE_V4_SZ && *disc_ptr==fd_vote_state_versioned_enum_v4 ) ) {
+  if( FD_LIKELY( data_len==FD_VOTE_STATE_V4_SZ && FD_LOAD( uint, data )==fd_vote_state_versioned_enum_v4 ) ) {
     return 1;
   }
 


### PR DESCRIPTION
Loads the vote-state discriminant with `FD_LOAD` and covers V3/V4 account data at offsets 0 through 3.

The API accepts a byte pointer and does not guarantee four-byte alignment, but the V4-size path previously used a typed dereference.

Test: `test_vote_program` with halt-on-error UBSan.
