### PR TITLE
shred: make FEC signature keys unaligned-safe

### DIFF
--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -5,10 +5,10 @@
 #include "../metrics/fd_metrics.h"
 #include "fd_fec_resolver.h"
 
-typedef union {
+typedef struct {
   fd_ed25519_sig_t u;
-  ulong            l;
 } wrapped_sig_t;
+FD_STATIC_ASSERT( alignof(wrapped_sig_t)==1UL, wrapped_sig_t_align );
 
 typedef struct __attribute__((packed)) {
   ulong slot;
@@ -68,7 +68,7 @@ typedef struct set_ctx set_ctx_t;
 #define MAP_PREV              map_prev
 #define MAP_ELE_T             set_ctx_t
 #define MAP_KEY_EQ(k0,k1)    (!memcmp( (k0)->u, (k1)->u, FD_ED25519_SIG_SZ ))
-#define MAP_KEY_HASH(key,s)  (fd_ulong_hash( (key)->l ^ (s) ))
+#define MAP_KEY_HASH(key,s)  (fd_ulong_hash( FD_LOAD( ulong, (key)->u ) ^ (s) ))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
 

--- a/src/disco/shred/test_fec_resolver.c
+++ b/src/disco/shred/test_fec_resolver.c
@@ -185,6 +185,13 @@ test_interleaved( void ) {
   fd_fec_set_t * set1 = fd_shredder_next_fec_set( shredder, _set+1UL, chained_merkle_root );
   FD_TEST( fd_shredder_fini_batch( shredder ) );
 
+  int has_misaligned_shred = 0;
+  for( ulong i=0UL; i<FD_FEC_SHRED_CNT; i++ ) {
+    has_misaligned_shred |= !fd_ulong_is_aligned( (ulong)set0->data_shreds[ i ].s, alignof(ulong) );
+    has_misaligned_shred |= !fd_ulong_is_aligned( (ulong)set1->data_shreds[ i ].s, alignof(ulong) );
+  }
+  FD_TEST( has_misaligned_shred );
+
   fd_fec_set_t const * out_fec[1];
   fd_shred_t const   * out_shred[1];
   fd_bmtree_node_t     out_merkle_root[1];


### PR DESCRIPTION
Represents FEC signature keys as alignment-1 byte storage and hashes the first word with `FD_LOAD`.

### Production change

Previously, `wrapped_sig_t` was a union:

```c
typedef union {
  fd_ed25519_sig_t u;  /* 64 signature bytes */
  ulong            l;  /* first 8 bytes for hashing */
} wrapped_sig_t;
```

Including `ulong` gave the union an eight-byte alignment requirement. The resolver then cast `shred->signature` to `wrapped_sig_t const *`, even though `fd_shred_t` is packed and its address is not guaranteed to be eight-byte aligned. Accessing `key->l` could therefore trigger undefined behavior.

The PR changes it to byte-aligned storage:

```c
typedef struct {
  fd_ed25519_sig_t u;
} wrapped_sig_t;

FD_STATIC_ASSERT( alignof(wrapped_sig_t)==1UL, wrapped_sig_t_align );
```

The static assertion ensures that a future field cannot accidentally restore a stronger alignment requirement.

The hash changes from:

```c
fd_ulong_hash( key->l ^ seed )
```

to:

```c
fd_ulong_hash( FD_LOAD( ulong, key->u ) ^ seed )
```
