### PR TITLE
pack: avoid invalid estimator arithmetic

### DIFF
--- a/src/disco/pack/fd_est_tbl.h
+++ b/src/disco/pack/fd_est_tbl.h
@@ -159,7 +159,9 @@ fd_est_tbl_estimate( fd_est_tbl_t const * tbl,
     var  = 0.0;
   } else {
     mean = bin->x / bin->d;
-    var  = (bin->d * bin->x2 - (bin->x*bin->x)) / ( bin->d * bin->d - bin->d2 );
+    double denom = bin->d * bin->d - bin->d2;
+    if( FD_LIKELY( denom>0.0 ) ) var = (bin->d * bin->x2 - (bin->x*bin->x)) / denom;
+    else                         var = 0.0;
   }
   var  = fd_double_if( var>0.0, var, 0.0 );
   if( FD_LIKELY( variance_out ) ) *variance_out = var;
@@ -181,8 +183,9 @@ fd_est_tbl_update( fd_est_tbl_t * tbl,
 #else
   double C = tbl->ema_coeff;
 #endif
-  bin->x  = value       + fd_double_if( C*bin->x >DBL_MIN, C*bin->x , 0.0 );
-  bin->x2 = value*value + fd_double_if( C*bin->x2>DBL_MIN, C*bin->x2, 0.0 );
+  double value_d = (double)value;
+  bin->x  = value_d         + fd_double_if( C*bin->x >DBL_MIN, C*bin->x , 0.0 );
+  bin->x2 = value_d*value_d + fd_double_if( C*bin->x2>DBL_MIN, C*bin->x2, 0.0 );
   bin->d  = 1.0         +   C*bin->d ; /* Can't go denormal */
   bin->d2 = 1.0         + C*C*bin->d2; /* Can't go denormal */
 }

--- a/src/disco/pack/test_est_tbl.c
+++ b/src/disco/pack/test_est_tbl.c
@@ -21,12 +21,20 @@ main( int     argc,
   FD_LOG_NOTICE(( "testing empty query gives default value" )); /* in bin 0 */
   FD_TEST( fd_est_tbl_estimate( tbl, 0UL, &out_var ) == default_val );
   FD_TEST( out_var == 0.0 );
+  fd_est_tbl_update( tbl, 3UL, 0U );
+  FD_TEST( fd_est_tbl_estimate( tbl, 3UL, &out_var )==0.0 );
+  FD_TEST( out_var==0.0 );
   for( uint i=0U; i<9U; i++ ) {
     fd_est_tbl_update( tbl, 0UL, i );
     out_var = 1.0;
     FD_TEST( fd_est_tbl_estimate( tbl, 0UL, &out_var ) < 9.0 );
   }
   FD_TEST( fd_est_tbl_estimate( tbl, 0UL, &out_var ) < 5.0 );
+
+  fd_est_tbl_update( tbl, 4UL, UINT_MAX );
+  FD_TEST( tbl->bins[ 4 ].x2>1.0e18 );
+  FD_TEST( fd_est_tbl_estimate( tbl, 4UL, &out_var )==(double)UINT_MAX );
+  FD_TEST( out_var==0.0 );
 
   FD_LOG_NOTICE(( "testing single entry normal distribution" )); /* in bin 1 */
   for( ulong i=0UL; i<2000UL; i++ ) {
@@ -105,4 +113,3 @@ main( int     argc,
   fd_halt();
   return 0;
 }
-


### PR DESCRIPTION
Skips variance division until the weighted denominator is positive and squares observations after conversion to `double`.

A single observation previously evaluated `0.0/0.0`, while large `uint` observations were squared with 32-bit wraparound before conversion.

Test: `test_est_tbl` with halt-on-error UBSan, including single-sample and `UINT_MAX` coverage.
