### PR TITLE
util: validate clock inputs before arithmetic

### DIFF
--- a/src/util/clock/fd_clock.c
+++ b/src/util/clock/fd_clock.c
@@ -165,7 +165,7 @@ fd_clock_new( void * shmem,
     return NULL;
   }
 
-  if( FD_UNLIKELY( !((1L<=recal_jit) & (recal_jit<=recal_avg) & (recal_avg<=(LONG_MAX-recal_jit))) ) ) {
+  if( FD_UNLIKELY( !((1L<=recal_jit) && (recal_jit<=recal_avg) && (recal_avg<=(LONG_MAX-recal_jit))) ) ) {
     FD_LOG_WARNING(( "bad recal_avg / recal_jit" ));
     return NULL;
   }
@@ -180,8 +180,12 @@ fd_clock_new( void * shmem,
     return NULL;
   }
 
+  if( FD_UNLIKELY( !(init_w>0.) ) ) {
+    FD_LOG_WARNING(( "bad w" ));
+    return NULL;
+  }
   double init_m = 1./init_w;
-  if( FD_UNLIKELY( !((init_w>0.) & (init_m>0.)) ) ) {
+  if( FD_UNLIKELY( !((init_m>0.) && (init_m<=DBL_MAX)) ) ) {
     FD_LOG_WARNING(( "bad w" ));
     return NULL;
   }

--- a/src/util/clock/test_clock.c
+++ b/src/util/clock/test_clock.c
@@ -73,9 +73,13 @@ main( int     argc,
   FD_TEST( !fd_clock_new( shmem,       0L,        recal_jit, recal_hist, recal_frac, init_x0, init_y0, init_w ) );
   FD_TEST( !fd_clock_new( shmem,       recal_avg, -1L,       recal_hist, recal_frac, init_x0, init_y0, init_w ) );
   FD_TEST( !fd_clock_new( shmem,       recal_avg, LONG_MAX,  recal_hist, recal_frac, init_x0, init_y0, init_w ) );
+  FD_TEST( !fd_clock_new( shmem,       LONG_MAX,  1L,        recal_hist, recal_frac, init_x0, init_y0, init_w ) );
   FD_TEST( !fd_clock_new( shmem,       recal_avg, recal_jit, -1.,        recal_frac, init_x0, init_y0, init_w ) );
   FD_TEST( !fd_clock_new( shmem,       recal_avg, recal_jit, recal_hist, -1,         init_x0, init_y0, init_w ) );
   FD_TEST( !fd_clock_new( shmem,       recal_avg, recal_jit, recal_hist, recal_frac, init_x0, init_y0, 0.     ) );
+  FD_TEST( !fd_clock_new( shmem,       recal_avg, recal_jit, recal_hist, recal_frac, init_x0, init_y0, DBL_TRUE_MIN ) );
+
+  FD_TEST( fd_clock_new( shmem, LONG_MAX-1L, 1L, recal_hist, recal_frac, 0L, 0L, init_w )==shmem );
 
   void * shclock = fd_clock_new( shmem, recal_avg, recal_jit, recal_hist, recal_frac, init_x0, init_y0, init_w );
   FD_TEST( shclock==shmem );


### PR DESCRIPTION
Short-circuits clock range validation before subtraction and validates `init_w` before taking its reciprocal.

Invalid inputs previously reached signed overflow or floating division by zero before being rejected.

Test: `test_clock` with halt-on-error UBSan, including the `LONG_MAX` boundary.
