### PR TITLE
util: avoid ctz zero in uint128 LSB helper

### DIFF
--- a/src/util/bits/fd_bits_find_lsb.h
+++ b/src/util/bits/fd_bits_find_lsb.h
@@ -166,11 +166,8 @@ fd_uint128_find_lsb_w_default( uint128 x,
            "cmovz  %3, %0  # if( !xl ) c = 64;\n\t"
            "cmovnz %2, %1  # if(!!xl ) xh = xl;"
            : "+&r" (c), "+&r" (xh) : "r" (xl), "r" (_64) : "cc" );
-  int r = c + fd_ulong_find_lsb( xh );
-  __asm__( "testq  %1, %1  # cc.zf = !xh;\n\t"
-           "cmovz  %2, %0  # if( !xl ) c = d;"
-           : "+&r" (r) : "r" (xh), "r" (d) : "cc" );
-  return r;
+  int r = fd_ulong_find_lsb_w_default( xh, (int)((uint)d - (uint)c) );
+  return (int)((uint)c + (uint)r);
 }
 
 #else /* other architectures */
@@ -180,4 +177,3 @@ FD_FN_CONST static inline int fd_uint128_find_lsb_w_default( uint128 x, int d ) 
 #endif
 
 #endif
-

--- a/src/util/bits/test_bits.c
+++ b/src/util/bits/test_bits.c
@@ -675,7 +675,11 @@ main( int     argc,
     }
     FD_TEST( fd_uint128_popcnt  ( zeros )==0                ); FD_TEST( fd_uint128_popcnt  ( ones  )==w                     );
     FD_TEST( fd_uint128_find_lsb( ones  )==0                ); FD_TEST( fd_uint128_find_msb( ones  )==(w-1)                 );
-    FD_TEST( fd_uint128_find_lsb_w_default( zeros, -1 )==-1 ); FD_TEST( fd_uint128_find_lsb_w_default( ones, -1 )==0        );
+    FD_TEST( fd_uint128_find_lsb_w_default( zeros,      -1 )==     -1 ); FD_TEST( fd_uint128_find_lsb_w_default( ones,  -1 )== 0       );
+    FD_TEST( fd_uint128_find_lsb_w_default( zeros,       0 )==      0 ); FD_TEST( fd_uint128_find_lsb_w_default( zeros, 63 )==63       );
+    FD_TEST( fd_uint128_find_lsb_w_default( zeros,     127 )==    127 );
+    FD_TEST( fd_uint128_find_lsb_w_default( zeros, INT_MIN )==INT_MIN );
+    FD_TEST( fd_uint128_find_lsb_w_default( zeros, INT_MAX )==INT_MAX );
     FD_TEST( fd_uint128_find_msb_w_default( zeros, -1 )==-1 ); FD_TEST( fd_uint128_find_msb_w_default( ones, -1 )==(w-1)    );
     FD_TEST( fd_uint128_pow2_up ( zeros )==(uint128)0       ); FD_TEST( fd_uint128_pow2_up ( ones  )==(uint128)0            );
     FD_TEST( fd_uint128_pow2_dn ( zeros )==(uint128)1       ); FD_TEST( fd_uint128_pow2_dn ( ones  )==(((uint128)1)<<(w-1)) );


### PR DESCRIPTION
Selects the caller-provided default before evaluating the 64-bit least-significant-bit primitive, while preserving branchless code generation on the tested compiler/target combinations.

The zero case previously reached `__builtin_ctzl(0)` on BMI targets before selecting the caller-provided default. The conditional expression now evaluates `fd_ulong_find_lsb` only when the selected half is nonzero, and preserves arbitrary `int` defaults without signed-overflow arithmetic.

In optimized code-generation checks, Clang 22 and GCC 12/16 on generic x86-64 and Icelake emitted `bsf`/`tzcnt` plus conditional moves, with no conditional jump.

Tests:
- `test_bits` with halt-on-error UBSan on Icelake and generic x86-64 builds
- `-O3` assembly inspection with Clang 22 and GCC 12/16 on generic x86-64 and Icelake