### PR TITLE
util: make zero-size memcpy null-safe

### DIFF
--- a/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_cpi_common.c
@@ -65,7 +65,7 @@ VM_SYSCALL_CPI_INSTRUCTION_TO_INSTR_FUNC( fd_vm_t *                         vm,
   out_instr->stack_height = (uchar)( vm->instr_ctx->runtime->instr.stack_sz+1 );
   out_instr->data_sz      = (ushort)VM_SYSCALL_CPI_INSTR_DATA_LEN( cpi_instr );
   out_instr->acct_cnt     = (ushort)VM_SYSCALL_CPI_INSTR_ACCS_LEN( cpi_instr );
-  memcpy( out_instr->data, cpi_instr_data, out_instr->data_sz );
+  fd_memcpy( out_instr->data, cpi_instr_data, out_instr->data_sz );
 
   /* Find the index of the CPI instruction's program account in the transaction */
   ulong program_id_idx = fd_runtime_find_index_of_account( vm->instr_ctx->txn_out, program_id );

--- a/src/flamenco/vm/syscall/test_cpi_semantics.c
+++ b/src/flamenco/vm/syscall/test_cpi_semantics.c
@@ -103,6 +103,8 @@ struct cpi_test_cfg {
   uchar             cpi_meta_writable[ MAX_CFG_ACCTS ];
   uchar             cpi_meta_signer  [ MAX_CFG_ACCTS ];
 
+  int zero_instruction_data;
+
   /* Optional hook: mutate input_buf after env_build but before the CPI
      syscall.  NULL = no mutation. */
   pre_cpi_hook_t    pre_cpi_hook;
@@ -500,6 +502,7 @@ rust_cpi_build( fd_vm_t *              vm,
   ulong data_off = fd_ulong_align_up( h, 8UL );
   vm->heap[ data_off ] = 0;
   instr->data     = (fd_vm_rust_vec_t){ .addr = HEAP_VA( data_off ), .cap = 1, .len = 1 };
+  if( cfg->zero_instruction_data ) instr->data = (fd_vm_rust_vec_t){0};
   memcpy( instr->pubkey, callee_program_pubkey.uc, 32 );
 
   setup_input_region_for_cfg( vm, cfg );
@@ -590,6 +593,10 @@ c_cpi_build( fd_vm_t *              vm,
   vm->heap[ data_off ] = 0;
   instr->data_addr       = HEAP_VA( data_off );
   instr->data_len        = 1UL;
+  if( cfg->zero_instruction_data ) {
+    instr->data_addr = 0UL;
+    instr->data_len  = 0UL;
+  }
 
   setup_input_region_for_cfg( vm, cfg );
 }
@@ -1008,8 +1015,8 @@ test_zero_account_cpi( fd_svm_mini_t * mini ) {
 
 static void
 test_zero_data_cpi( fd_svm_mini_t * mini ) {
-  /* data_len=0 is the default in both ABI builders. */
   cpi_test_cfg_t cfg[1]; simple_writable_cfg( cfg );
+  cfg->zero_instruction_data = 1;
 
   int e[4][2][2]; expect_all( e, FD_VM_SUCCESS );
   run_matrix( mini, cfg, "test_zero_data_cpi", e );

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -1094,7 +1094,10 @@ typedef long (*fd_clock_func_t)( void const * args );
 
 FD_PROTOTYPES_BEGIN
 
-/* fd_memcpy(d,s,sz):  On modern x86 in some circumstances, rep mov will
+/* fd_memcpy(d,s,sz):  If sz is zero, d and s may be NULL.  No memory is
+   accessed and d is returned.
+
+   On modern x86 in some circumstances, rep mov will
    be faster than memcpy under the hood (basically due to RFO /
    read-for-ownership optimizations in the cache protocol under the hood
    that aren't easily done from the ISA ... see Intel docs on enhanced
@@ -1130,6 +1133,7 @@ static inline void *
 fd_memcpy( void       * FD_RESTRICT d,
            void const * FD_RESTRICT s,
            ulong                    sz ) {
+  if( FD_UNLIKELY( !sz ) ) return d;
   return __msan_memcpy( d, s, sz );
 }
 
@@ -1139,9 +1143,7 @@ static inline void *
 fd_memcpy( void       * FD_RESTRICT d,
            void const * FD_RESTRICT s,
            ulong                    sz ) {
-#if defined(CBMC) || FD_HAS_ASAN
-  if( FD_UNLIKELY( !sz ) ) return d; /* Standard says sz 0 is UB, uncomment if target is insane and doesn't treat sz 0 as a nop */
-#endif
+  if( FD_UNLIKELY( !sz ) ) return d;
   return memcpy( d, s, sz );
 }
 

--- a/src/util/test_util.c
+++ b/src/util/test_util.c
@@ -12,10 +12,15 @@ main( int     argc,
   FD_TEST( !strcmp( fd_version_cstr_format( version, sizeof(version), 25UL, 8UL, 1UL ), "25.8.1" ) );
   FD_TEST( !strcmp( fd_version_cstr_format( version, sizeof(version), 26UL, 8UL, 1UL ), "26.08.1" ) );
   FD_TEST( !strcmp( fd_version_cstr_format( version, sizeof(version), 26UL, 10UL, 1UL ), "26.10.1" ) );
+  volatile ulong zero = 0UL;
+  void * volatile null = NULL;
+  uchar byte = 0U;
+  FD_TEST( fd_memcpy( null,  &byte, zero )==NULL  );
+  FD_TEST( fd_memcpy( &byte, null,  zero )==&byte );
+  FD_TEST( fd_memcpy( null,  null,  zero )==NULL  );
   FD_LOG_INFO(( "fd_commit_ref_cstr = %s", fd_commit_ref_cstr ));
   FD_LOG_INFO(( "fd_commit_ref_u32 = 0x%08x", fd_commit_ref_u32 ));
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;
 }
-


### PR DESCRIPTION
Returns before the generic/libc and MSan `fd_memcpy` backends when the size is zero, and routes the nullable CPI instruction-data copy through the wrapper. The x86 `rep movsb` fast path remains branch-free because a zero count performs no access.

`fd_memcpy` now explicitly guarantees that when `sz` is zero, the source and destination may be null, no memory is accessed, and the destination is returned. This makes the null/zero contract consistent across generic, icelake, MSan, ASan, and UBSan configurations.

The CPI semantics fixture now emits address/length zero instruction-data descriptors for both C and Rust ABIs, so the runtime path is covered under halt-on-error UBSan.

Tests:
- `test_util` under icelake UBSan, generic UBSan, and generic ASan+UBSan
- `test_vm_syscall_cpi` under halt-on-error UBSan
- `test_cpi_semantics` under Clang 22 generic x86-64 UBSan with `halt_on_error=1`
