### PR TITLE
discof: initialize resolv tile test context

### DIFF
--- a/src/discof/resolv/test_resolv_tile.c
+++ b/src/discof/resolv/test_resolv_tile.c
@@ -4,6 +4,7 @@
 #include "../../util/tmpl/fd_unit_test.c"
 
 #define TOPO_TAG 2UL
+#define TEST_MAX_LIVE_SLOTS 32UL
 #define TEST_HASH_SEED (0x0123456789abcdefUL)
 
 static fd_svm_mini_t * mini;
@@ -165,11 +166,14 @@ test_env_create( test_env_t * env ) {
     .out_reliable        = env->out_reliable
   };
 
-  env->tile_mem = fd_wksp_alloc_laddr( mini->wksp, scratch_align(), scratch_footprint( NULL ), TOPO_TAG );
+  fd_topo_tile_t tile = {0};
+  tile.resolv.max_live_slots = TEST_MAX_LIVE_SLOTS;
+  env->tile_mem = fd_wksp_alloc_laddr( mini->wksp, scratch_align(), scratch_footprint( &tile ), TOPO_TAG );
   FD_TEST( env->tile_mem );
   FD_SCRATCH_ALLOC_INIT( l, env->tile_mem );
   env->ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_resolv_ctx_t), sizeof(fd_resolv_ctx_t) );
   fd_memset( env->ctx, 0, sizeof(fd_resolv_ctx_t) );
+  env->ctx->startup_gate->started = 1;
 
   env->ctx->completed_slot     = 200UL;
   env->ctx->flush_pool_idx     = ULONG_MAX;
@@ -406,7 +410,7 @@ main( int     argc,
       char ** argv ) {
   fd_svm_mini_limits_t limits[1];
   fd_svm_mini_limits_default( limits );
-  limits->max_live_slots      = 32;
+  limits->max_live_slots      = TEST_MAX_LIVE_SLOTS;
   limits->max_txn_per_slot    = 32;
   limits->max_txn_write_locks = MAX_TX_ACCOUNT_LOCKS;
   limits->wksp_addl_sz        = 5UL<<30;


### PR DESCRIPTION
Fix `test_resolv_tile` after the resolver footprint and startup-gate changes.

`scratch_footprint` now reads `tile->resolv.max_live_slots`, so the standalone test must provide a minimally configured tile rather than passing `NULL`. The configured live-slot limit is shared with the SVM mini limits so the allocated footprint matches the test environment.

The resolver startup gate also begins closed. The standalone fixture marks it ready so the fragment-processing paths under test do not stop at the startup gate.

Tests:
- GCC `test_resolv_tile`
- Clang 22 UBSan `test_resolv_tile` with `halt_on_error=1`