### PR TITLE
util: make SIMD tests UBSan-clean

### DIFF
--- a/src/util/simd/test_avx512_16x32.c
+++ b/src/util/simd/test_avx512_16x32.c
@@ -100,12 +100,18 @@ main( int     argc,
                             fd_int_max(x4,y4), fd_int_max(x5,y5), fd_int_max(x6,y6), fd_int_max(x7,y7),
                             fd_int_max(x8,y8), fd_int_max(x9,y9), fd_int_max(xa,ya), fd_int_max(xb,yb),
                             fd_int_max(xc,yc), fd_int_max(xd,yd), fd_int_max(xe,ye), fd_int_max(xf,yf) );
-    WWI_TEST( wwi_add(x,y), x0+y0, x1+y1, x2+y2, x3+y3, x4+y4, x5+y5, x6+y6, x7+y7,
-                            x8+y8, x9+y9, xa+ya, xb+yb, xc+yc, xd+yd, xe+ye, xf+yf );
-    WWI_TEST( wwi_sub(x,y), x0-y0, x1-y1, x2-y2, x3-y3, x4-y4, x5-y5, x6-y6, x7-y7,
-                            x8-y8, x9-y9, xa-ya, xb-yb, xc-yc, xd-yd, xe-ye, xf-yf );
-    WWI_TEST( wwi_mul(x,y), x0*y0, x1*y1, x2*y2, x3*y3, x4*y4, x5*y5, x6*y6, x7*y7,
-                            x8*y8, x9*y9, xa*ya, xb*yb, xc*yc, xd*yd, xe*ye, xf*yf );
+    WWU_TEST( wwi_to_wwu( wwi_add(x,y) ), (uint)x0+(uint)y0, (uint)x1+(uint)y1, (uint)x2+(uint)y2, (uint)x3+(uint)y3,
+                                          (uint)x4+(uint)y4, (uint)x5+(uint)y5, (uint)x6+(uint)y6, (uint)x7+(uint)y7,
+                                          (uint)x8+(uint)y8, (uint)x9+(uint)y9, (uint)xa+(uint)ya, (uint)xb+(uint)yb,
+                                          (uint)xc+(uint)yc, (uint)xd+(uint)yd, (uint)xe+(uint)ye, (uint)xf+(uint)yf );
+    WWU_TEST( wwi_to_wwu( wwi_sub(x,y) ), (uint)x0-(uint)y0, (uint)x1-(uint)y1, (uint)x2-(uint)y2, (uint)x3-(uint)y3,
+                                          (uint)x4-(uint)y4, (uint)x5-(uint)y5, (uint)x6-(uint)y6, (uint)x7-(uint)y7,
+                                          (uint)x8-(uint)y8, (uint)x9-(uint)y9, (uint)xa-(uint)ya, (uint)xb-(uint)yb,
+                                          (uint)xc-(uint)yc, (uint)xd-(uint)yd, (uint)xe-(uint)ye, (uint)xf-(uint)yf );
+    WWU_TEST( wwi_to_wwu( wwi_mul(x,y) ), (uint)x0*(uint)y0, (uint)x1*(uint)y1, (uint)x2*(uint)y2, (uint)x3*(uint)y3,
+                                          (uint)x4*(uint)y4, (uint)x5*(uint)y5, (uint)x6*(uint)y6, (uint)x7*(uint)y7,
+                                          (uint)x8*(uint)y8, (uint)x9*(uint)y9, (uint)xa*(uint)ya, (uint)xb*(uint)yb,
+                                          (uint)xc*(uint)yc, (uint)xd*(uint)yd, (uint)xe*(uint)ye, (uint)xf*(uint)yf );
 
     /* Test bit ops */
 
@@ -208,16 +214,24 @@ main( int     argc,
               ((c>> 4)&1) ? y4 : z4, ((c>> 5)&1) ? y5 : z5, ((c>> 6)&1) ? y6 : z6, ((c>> 7)&1) ? y7 : z7,
               ((c>> 8)&1) ? y8 : z8, ((c>> 9)&1) ? y9 : z9, ((c>>10)&1) ? ya : za, ((c>>11)&1) ? yb : zb,
               ((c>>12)&1) ? yc : zc, ((c>>13)&1) ? yd : zd, ((c>>14)&1) ? ye : ze, ((c>>15)&1) ? yf : zf );
-    WWI_TEST( wwi_add_if( c, x, y, z ),
-              ((c>> 0)&1) ? (x0+y0) : z0, ((c>> 1)&1) ? (x1+y1) : z1, ((c>> 2)&1) ? (x2+y2) : z2, ((c>> 3)&1) ? (x3+y3) : z3,
-              ((c>> 4)&1) ? (x4+y4) : z4, ((c>> 5)&1) ? (x5+y5) : z5, ((c>> 6)&1) ? (x6+y6) : z6, ((c>> 7)&1) ? (x7+y7) : z7,
-              ((c>> 8)&1) ? (x8+y8) : z8, ((c>> 9)&1) ? (x9+y9) : z9, ((c>>10)&1) ? (xa+ya) : za, ((c>>11)&1) ? (xb+yb) : zb,
-              ((c>>12)&1) ? (xc+yc) : zc, ((c>>13)&1) ? (xd+yd) : zd, ((c>>14)&1) ? (xe+ye) : ze, ((c>>15)&1) ? (xf+yf) : zf );
-    WWI_TEST( wwi_sub_if( c, x, y, z ),
-              ((c>> 0)&1) ? (x0-y0) : z0, ((c>> 1)&1) ? (x1-y1) : z1, ((c>> 2)&1) ? (x2-y2) : z2, ((c>> 3)&1) ? (x3-y3) : z3,
-              ((c>> 4)&1) ? (x4-y4) : z4, ((c>> 5)&1) ? (x5-y5) : z5, ((c>> 6)&1) ? (x6-y6) : z6, ((c>> 7)&1) ? (x7-y7) : z7,
-              ((c>> 8)&1) ? (x8-y8) : z8, ((c>> 9)&1) ? (x9-y9) : z9, ((c>>10)&1) ? (xa-ya) : za, ((c>>11)&1) ? (xb-yb) : zb,
-              ((c>>12)&1) ? (xc-yc) : zc, ((c>>13)&1) ? (xd-yd) : zd, ((c>>14)&1) ? (xe-ye) : ze, ((c>>15)&1) ? (xf-yf) : zf );
+    WWU_TEST( wwi_to_wwu( wwi_add_if( c, x, y, z ) ),
+              ((c>> 0)&1) ? (uint)x0+(uint)y0 : (uint)z0, ((c>> 1)&1) ? (uint)x1+(uint)y1 : (uint)z1,
+              ((c>> 2)&1) ? (uint)x2+(uint)y2 : (uint)z2, ((c>> 3)&1) ? (uint)x3+(uint)y3 : (uint)z3,
+              ((c>> 4)&1) ? (uint)x4+(uint)y4 : (uint)z4, ((c>> 5)&1) ? (uint)x5+(uint)y5 : (uint)z5,
+              ((c>> 6)&1) ? (uint)x6+(uint)y6 : (uint)z6, ((c>> 7)&1) ? (uint)x7+(uint)y7 : (uint)z7,
+              ((c>> 8)&1) ? (uint)x8+(uint)y8 : (uint)z8, ((c>> 9)&1) ? (uint)x9+(uint)y9 : (uint)z9,
+              ((c>>10)&1) ? (uint)xa+(uint)ya : (uint)za, ((c>>11)&1) ? (uint)xb+(uint)yb : (uint)zb,
+              ((c>>12)&1) ? (uint)xc+(uint)yc : (uint)zc, ((c>>13)&1) ? (uint)xd+(uint)yd : (uint)zd,
+              ((c>>14)&1) ? (uint)xe+(uint)ye : (uint)ze, ((c>>15)&1) ? (uint)xf+(uint)yf : (uint)zf );
+    WWU_TEST( wwi_to_wwu( wwi_sub_if( c, x, y, z ) ),
+              ((c>> 0)&1) ? (uint)x0-(uint)y0 : (uint)z0, ((c>> 1)&1) ? (uint)x1-(uint)y1 : (uint)z1,
+              ((c>> 2)&1) ? (uint)x2-(uint)y2 : (uint)z2, ((c>> 3)&1) ? (uint)x3-(uint)y3 : (uint)z3,
+              ((c>> 4)&1) ? (uint)x4-(uint)y4 : (uint)z4, ((c>> 5)&1) ? (uint)x5-(uint)y5 : (uint)z5,
+              ((c>> 6)&1) ? (uint)x6-(uint)y6 : (uint)z6, ((c>> 7)&1) ? (uint)x7-(uint)y7 : (uint)z7,
+              ((c>> 8)&1) ? (uint)x8-(uint)y8 : (uint)z8, ((c>> 9)&1) ? (uint)x9-(uint)y9 : (uint)z9,
+              ((c>>10)&1) ? (uint)xa-(uint)ya : (uint)za, ((c>>11)&1) ? (uint)xb-(uint)yb : (uint)zb,
+              ((c>>12)&1) ? (uint)xc-(uint)yc : (uint)zc, ((c>>13)&1) ? (uint)xd-(uint)yd : (uint)zd,
+              ((c>>14)&1) ? (uint)xe-(uint)ye : (uint)ze, ((c>>15)&1) ? (uint)xf-(uint)yf : (uint)zf );
     WWI_TEST( wwi_and_if( c, x, y, z ),
               ((c>> 0)&1) ? (x0&y0) : z0, ((c>> 1)&1) ? (x1&y1) : z1, ((c>> 2)&1) ? (x2&y2) : z2, ((c>> 3)&1) ? (x3&y3) : z3,
               ((c>> 4)&1) ? (x4&y4) : z4, ((c>> 5)&1) ? (x5&y5) : z5, ((c>> 6)&1) ? (x6&y6) : z6, ((c>> 7)&1) ? (x7&y7) : z7,

--- a/src/util/simd/test_avx512_8x64.c
+++ b/src/util/simd/test_avx512_8x64.c
@@ -77,9 +77,12 @@ main( int     argc,
                                fd_long_min(x4,y4), fd_long_min(x5,y5), fd_long_min(x6,y6), fd_long_min(x7,y7) );
     WWL_TEST( wwl_max(x,y),    fd_long_max(x0,y0), fd_long_max(x1,y1), fd_long_max(x2,y2), fd_long_max(x3,y3),
                                fd_long_max(x4,y4), fd_long_max(x5,y5), fd_long_max(x6,y6), fd_long_max(x7,y7) );
-    WWL_TEST( wwl_add(x,y),    x0+y0, x1+y1, x2+y2, x3+y3, x4+y4, x5+y5, x6+y6, x7+y7 );
-    WWL_TEST( wwl_sub(x,y),    x0-y0, x1-y1, x2-y2, x3-y3, x4-y4, x5-y5, x6-y6, x7-y7 );
-    WWL_TEST( wwl_mul(x,y),    x0*y0, x1*y1, x2*y2, x3*y3, x4*y4, x5*y5, x6*y6, x7*y7 );
+    WWV_TEST( wwl_to_wwv( wwl_add(x,y) ), (ulong)x0+(ulong)y0, (ulong)x1+(ulong)y1, (ulong)x2+(ulong)y2, (ulong)x3+(ulong)y3,
+                                          (ulong)x4+(ulong)y4, (ulong)x5+(ulong)y5, (ulong)x6+(ulong)y6, (ulong)x7+(ulong)y7 );
+    WWV_TEST( wwl_to_wwv( wwl_sub(x,y) ), (ulong)x0-(ulong)y0, (ulong)x1-(ulong)y1, (ulong)x2-(ulong)y2, (ulong)x3-(ulong)y3,
+                                          (ulong)x4-(ulong)y4, (ulong)x5-(ulong)y5, (ulong)x6-(ulong)y6, (ulong)x7-(ulong)y7 );
+    WWV_TEST( wwl_to_wwv( wwl_mul(x,y) ), (ulong)x0*(ulong)y0, (ulong)x1*(ulong)y1, (ulong)x2*(ulong)y2, (ulong)x3*(ulong)y3,
+                                          (ulong)x4*(ulong)y4, (ulong)x5*(ulong)y5, (ulong)x6*(ulong)y6, (ulong)x7*(ulong)y7 );
     WWL_TEST( wwl_mul_ll(x,y), ((long)(int)x0)*((long)(int)y0), ((long)(int)x1)*((long)(int)y1),
                                ((long)(int)x2)*((long)(int)y2), ((long)(int)x3)*((long)(int)y3),
                                ((long)(int)x4)*((long)(int)y4), ((long)(int)x5)*((long)(int)y5),
@@ -159,12 +162,16 @@ main( int     argc,
     WWL_TEST( wwl_if( c, y, z ),
               ((c>>0)&1) ? y0 : z0, ((c>>1)&1) ? y1 : z1, ((c>>2)&1) ? y2 : z2, ((c>>3)&1) ? y3 : z3,
               ((c>>4)&1) ? y4 : z4, ((c>>5)&1) ? y5 : z5, ((c>>6)&1) ? y6 : z6, ((c>>7)&1) ? y7 : z7 );
-    WWL_TEST( wwl_add_if( c, x, y, z ),
-              ((c>>0)&1) ? (x0+y0) : z0, ((c>>1)&1) ? (x1+y1) : z1, ((c>>2)&1) ? (x2+y2) : z2, ((c>>3)&1) ? (x3+y3) : z3,
-              ((c>>4)&1) ? (x4+y4) : z4, ((c>>5)&1) ? (x5+y5) : z5, ((c>>6)&1) ? (x6+y6) : z6, ((c>>7)&1) ? (x7+y7) : z7 );
-    WWL_TEST( wwl_sub_if( c, x, y, z ),
-              ((c>>0)&1) ? (x0-y0) : z0, ((c>>1)&1) ? (x1-y1) : z1, ((c>>2)&1) ? (x2-y2) : z2, ((c>>3)&1) ? (x3-y3) : z3,
-              ((c>>4)&1) ? (x4-y4) : z4, ((c>>5)&1) ? (x5-y5) : z5, ((c>>6)&1) ? (x6-y6) : z6, ((c>>7)&1) ? (x7-y7) : z7 );
+    WWV_TEST( wwl_to_wwv( wwl_add_if( c, x, y, z ) ),
+              ((c>>0)&1) ? (ulong)x0+(ulong)y0 : (ulong)z0, ((c>>1)&1) ? (ulong)x1+(ulong)y1 : (ulong)z1,
+              ((c>>2)&1) ? (ulong)x2+(ulong)y2 : (ulong)z2, ((c>>3)&1) ? (ulong)x3+(ulong)y3 : (ulong)z3,
+              ((c>>4)&1) ? (ulong)x4+(ulong)y4 : (ulong)z4, ((c>>5)&1) ? (ulong)x5+(ulong)y5 : (ulong)z5,
+              ((c>>6)&1) ? (ulong)x6+(ulong)y6 : (ulong)z6, ((c>>7)&1) ? (ulong)x7+(ulong)y7 : (ulong)z7 );
+    WWV_TEST( wwl_to_wwv( wwl_sub_if( c, x, y, z ) ),
+              ((c>>0)&1) ? (ulong)x0-(ulong)y0 : (ulong)z0, ((c>>1)&1) ? (ulong)x1-(ulong)y1 : (ulong)z1,
+              ((c>>2)&1) ? (ulong)x2-(ulong)y2 : (ulong)z2, ((c>>3)&1) ? (ulong)x3-(ulong)y3 : (ulong)z3,
+              ((c>>4)&1) ? (ulong)x4-(ulong)y4 : (ulong)z4, ((c>>5)&1) ? (ulong)x5-(ulong)y5 : (ulong)z5,
+              ((c>>6)&1) ? (ulong)x6-(ulong)y6 : (ulong)z6, ((c>>7)&1) ? (ulong)x7-(ulong)y7 : (ulong)z7 );
     WWL_TEST( wwl_and_if( c, x, y, z ),
               ((c>>0)&1) ? (x0&y0) : z0, ((c>>1)&1) ? (x1&y1) : z1, ((c>>2)&1) ? (x2&y2) : z2, ((c>>3)&1) ? (x3&y3) : z3,
               ((c>>4)&1) ? (x4&y4) : z4, ((c>>5)&1) ? (x5&y5) : z5, ((c>>6)&1) ? (x6&y6) : z6, ((c>>7)&1) ? (x7&y7) : z7 );
@@ -192,14 +199,14 @@ main( int     argc,
     WWL_TEST( wwl_pack_halves( y,1, z,1 ), y4,y5,y6,y7, z4,z5,z6,z7 );
     WWL_TEST( wwl_pack_h0_h1 ( y,   z   ), y0,y1,y2,y3, z4,z5,z6,z7 );
 
-    long const m52 = (1L<<52)-1L;
+    ulong const m52 = (1UL<<52)-1UL;
 
-#   define MADD52LO(x,y,z) ((x) + (((long)((((uint128)((y) & m52))*((uint128)((z) & m52)))    ))&m52))
-#   define MADD52HI(x,y,z) ((x) + (((long)((((uint128)((y) & m52))*((uint128)((z) & m52)))>>52))    ))
-    WWL_TEST( wwl_madd52lo( x, y, z ), MADD52LO(x0,y0,z0), MADD52LO(x1,y1,z1), MADD52LO(x2,y2,z2), MADD52LO(x3,y3,z3),
-                                       MADD52LO(x4,y4,z4), MADD52LO(x5,y5,z5), MADD52LO(x6,y6,z6), MADD52LO(x7,y7,z7) );
-    WWL_TEST( wwl_madd52hi( x, y, z ), MADD52HI(x0,y0,z0), MADD52HI(x1,y1,z1), MADD52HI(x2,y2,z2), MADD52HI(x3,y3,z3),
-                                       MADD52HI(x4,y4,z4), MADD52HI(x5,y5,z5), MADD52HI(x6,y6,z6), MADD52HI(x7,y7,z7) );
+#   define MADD52LO(x,y,z) ((ulong)(x) + ((ulong)(((uint128)((ulong)(y) & m52))*((uint128)((ulong)(z) & m52))) & m52))
+#   define MADD52HI(x,y,z) ((ulong)(x) +  (ulong)((((uint128)((ulong)(y) & m52))*((uint128)((ulong)(z) & m52)))>>52))
+    WWV_TEST( wwl_to_wwv( wwl_madd52lo( x, y, z ) ), MADD52LO(x0,y0,z0), MADD52LO(x1,y1,z1), MADD52LO(x2,y2,z2), MADD52LO(x3,y3,z3),
+                                                        MADD52LO(x4,y4,z4), MADD52LO(x5,y5,z5), MADD52LO(x6,y6,z6), MADD52LO(x7,y7,z7) );
+    WWV_TEST( wwl_to_wwv( wwl_madd52hi( x, y, z ) ), MADD52HI(x0,y0,z0), MADD52HI(x1,y1,z1), MADD52HI(x2,y2,z2), MADD52HI(x3,y3,z3),
+                                                        MADD52HI(x4,y4,z4), MADD52HI(x5,y5,z5), MADD52HI(x6,y6,z6), MADD52HI(x7,y7,z7) );
 #   undef MADD52HI
 #   undef MADD52LO
 

--- a/src/util/simd/test_avx_16x16.c
+++ b/src/util/simd/test_avx_16x16.c
@@ -141,7 +141,7 @@ main( int     argc,
     INIT_HJ( fd_ushort_max( xi[j], yi[j] )               ); FD_TEST( wh_test( wh_max(   x, y ), hj ) );
     INIT_HJ( (ushort)(xi[j]+yi[j])                       ); FD_TEST( wh_test( wh_add(   x, y ), hj ) );
     INIT_HJ( (ushort)(xi[j]-yi[j])                       ); FD_TEST( wh_test( wh_sub(   x, y ), hj ) );
-    INIT_HJ( (ushort)(xi[j]*yi[j])                       ); FD_TEST( wh_test( wh_mul(   x, y ), hj ) );
+    INIT_HJ( (ushort)(((uint)xi[j])*((uint)yi[j]))       ); FD_TEST( wh_test( wh_mul(   x, y ), hj ) );
     /*                                                   */ FD_TEST( wh_test( wh_mullo( x, y ), hj ) );
     INIT_HJ( (ushort)((((uint)xi[j])*((uint)yi[j]))>>16) ); FD_TEST( wh_test( wh_mulhi( x, y ), hj ) );
 

--- a/src/util/simd/test_avx_4x64.c
+++ b/src/util/simd/test_avx_4x64.c
@@ -145,7 +145,8 @@ main( int     argc,
 
     FD_TEST( wl_test( wd_to_wl( x ), (long)x0, (long)x1, (long)x2, (long)x3 ) );
 
-    FD_TEST( wv_test( wd_to_wv( x ), (ulong)x0, (ulong)x1, (ulong)x2, (ulong)x3 ) );
+    /* Exclude negative values from unsigned conversions, as above. */
+    FD_TEST( wv_test( wd_to_wv( wd_abs( x ) ), (ulong)fabs(x0), (ulong)fabs(x1), (ulong)fabs(x2), (ulong)fabs(x3) ) );
 
     /* Reduction operations */
 

--- a/src/util/simd/test_avx_8x32.c
+++ b/src/util/simd/test_avx_8x32.c
@@ -254,8 +254,9 @@ main( int     argc,
     FD_TEST( wl_test( wf_to_wl( x, 0 ), (long)x0, (long)x1, (long)x2, (long)x3 ) );
     FD_TEST( wl_test( wf_to_wl( x, 1 ), (long)x4, (long)x5, (long)x6, (long)x7 ) );
 
-    FD_TEST( wv_test( wf_to_wv( x, 0 ), (ulong)x0, (ulong)x1, (ulong)x2, (ulong)x3 ) );
-    FD_TEST( wv_test( wf_to_wv( x, 1 ), (ulong)x4, (ulong)x5, (ulong)x6, (ulong)x7 ) );
+    /* Exclude negative values from unsigned conversions, as above. */
+    FD_TEST( wv_test( wf_to_wv( wf_abs( x ), 0 ), (ulong)fabsf(x0), (ulong)fabsf(x1), (ulong)fabsf(x2), (ulong)fabsf(x3) ) );
+    FD_TEST( wv_test( wf_to_wv( wf_abs( x ), 1 ), (ulong)fabsf(x4), (ulong)fabsf(x5), (ulong)fabsf(x6), (ulong)fabsf(x7) ) );
 
     /* Reduction operations */
 

--- a/src/util/simd/test_sse_2x64.c
+++ b/src/util/simd/test_sse_2x64.c
@@ -132,7 +132,8 @@ main( int     argc,
 
     FD_TEST( vl_test( vd_to_vl( x ), (long)x0, (long)x1 ) );
 
-    FD_TEST( vv_test( vd_to_vv( x ), (ulong)x0, (ulong)x1 ) );
+    /* Exclude negative values from unsigned conversions, as above. */
+    FD_TEST( vv_test( vd_to_vv( vd_abs( x ) ), (ulong)fabs(x0), (ulong)fabs(x1) ) );
 
     /* Reduction operations */
 

--- a/src/util/simd/test_sse_4x32.c
+++ b/src/util/simd/test_sse_4x32.c
@@ -259,22 +259,23 @@ main( int     argc,
     FD_TEST( vl_test( vf_to_vl( x, 3, 2 ), (long)x3, (long)x2 ) );
     FD_TEST( vl_test( vf_to_vl( x, 3, 3 ), (long)x3, (long)x3 ) );
 
-    FD_TEST( vv_test( vf_to_vv( x, 0, 0 ), (ulong)x0, (ulong)x0 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 0, 1 ), (ulong)x0, (ulong)x1 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 0, 2 ), (ulong)x0, (ulong)x2 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 0, 3 ), (ulong)x0, (ulong)x3 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 1, 0 ), (ulong)x1, (ulong)x0 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 1, 1 ), (ulong)x1, (ulong)x1 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 1, 2 ), (ulong)x1, (ulong)x2 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 1, 3 ), (ulong)x1, (ulong)x3 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 2, 0 ), (ulong)x2, (ulong)x0 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 2, 1 ), (ulong)x2, (ulong)x1 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 2, 2 ), (ulong)x2, (ulong)x2 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 2, 3 ), (ulong)x2, (ulong)x3 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 3, 0 ), (ulong)x3, (ulong)x0 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 3, 1 ), (ulong)x3, (ulong)x1 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 3, 2 ), (ulong)x3, (ulong)x2 ) );
-    FD_TEST( vv_test( vf_to_vv( x, 3, 3 ), (ulong)x3, (ulong)x3 ) );
+    /* Exclude negative values from unsigned conversions, as above. */
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 0, 0 ), (ulong)fabsf(x0), (ulong)fabsf(x0) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 0, 1 ), (ulong)fabsf(x0), (ulong)fabsf(x1) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 0, 2 ), (ulong)fabsf(x0), (ulong)fabsf(x2) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 0, 3 ), (ulong)fabsf(x0), (ulong)fabsf(x3) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 1, 0 ), (ulong)fabsf(x1), (ulong)fabsf(x0) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 1, 1 ), (ulong)fabsf(x1), (ulong)fabsf(x1) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 1, 2 ), (ulong)fabsf(x1), (ulong)fabsf(x2) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 1, 3 ), (ulong)fabsf(x1), (ulong)fabsf(x3) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 2, 0 ), (ulong)fabsf(x2), (ulong)fabsf(x0) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 2, 1 ), (ulong)fabsf(x2), (ulong)fabsf(x1) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 2, 2 ), (ulong)fabsf(x2), (ulong)fabsf(x2) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 2, 3 ), (ulong)fabsf(x2), (ulong)fabsf(x3) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 3, 0 ), (ulong)fabsf(x3), (ulong)fabsf(x0) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 3, 1 ), (ulong)fabsf(x3), (ulong)fabsf(x1) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 3, 2 ), (ulong)fabsf(x3), (ulong)fabsf(x2) ) );
+    FD_TEST( vv_test( vf_to_vv( vf_abs( x ), 3, 3 ), (ulong)fabsf(x3), (ulong)fabsf(x3) ) );
 
     /* Reduction operations */
 


### PR DESCRIPTION
Make the SIMD unit-test oracles clean under Firedancer's explicit UBSan configuration without changing production SIMD helpers.

Firedancer compiles with `-fwrapv`, so signed addition, subtraction, and multiplication wrap rather than being language-level undefined behavior. Clang nevertheless documents that an explicitly enabled `-fsanitize=signed-integer-overflow` check still diagnoses these operations under `-fwrapv`. The tests use full-range random lanes and intentionally exercise modulo-2^N SIMD arithmetic, so their scalar reference expressions are now calculated through unsigned arithmetic and compared as unsigned lanes. This preserves the exact wrapping result while keeping the explicit sanitizer useful for unintended signed overflow elsewhere.

Separately, converting negative floating-point values to unsigned integer types is outside the representable input range and is not affected by `-fwrapv`. As the existing float-to-`uint` tests already do, the float-to-`ulong` cases now use nonnegative inputs.

Clang behavior: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks

Tests:
- All ten SSE, AVX, and AVX-512 unit tests with Clang 22 UBSan and `halt_on_error=1`