### PR TITLE
replay: block marker parsing, populate bls keys vote_stakes

### DIFF
--- a/src/choreo/votor/ag_epoch_info.c
+++ b/src/choreo/votor/ag_epoch_info.c
@@ -43,3 +43,107 @@ FD_FN_PURE int
 ag_epoch_info_is_strong_quorum( ag_epoch_info_t const * self, ulong stake ) {
   return fraction_is_met( stake, self->total_stake, AG_STRONG_QUORUM_THRESHOLD_NUMER, AG_QUORUM_THRESHOLD_DENOM );
 }
+
+#if FD_HAS_BLST
+#include "../../ballet/bls/fd_bls12_381.h"
+#endif
+
+/* Rank-ordering key: stake descending, tie-broken by the compressed BLS
+   pubkey ascending.  bls/id point into the caller's stakes array, which
+   is stable for the duration of the sorts.  pk carries the decompressed
+   voting pubkey from the filter pass so it is decompressed only once. */
+
+struct ei_rank { ulong stake; uchar const * bls; uchar const * id; ulong src; ulong drop; ag_bls_pub_t pk; };
+typedef struct ei_rank ei_rank_t;
+
+#define SORT_NAME        ei_rank_sort
+#define SORT_KEY_T       ei_rank_t
+#define SORT_BEFORE(a,b) ( (a).stake>(b).stake ||                                            \
+                          ( (a).stake==(b).stake &&                                         \
+                            memcmp( (a).bls, (b).bls, AG_BLS_PUB_COMPRESSED_SZ )<0 ) )
+#include "../../util/tmpl/fd_sort.c"
+
+#define SORT_NAME        ei_bls_sort
+#define SORT_KEY_T       ei_rank_t
+#define SORT_BEFORE(a,b) ( memcmp( (a).bls, (b).bls, AG_BLS_PUB_COMPRESSED_SZ )<0 )
+#include "../../util/tmpl/fd_sort.c"
+
+#define SORT_NAME        ei_id_sort
+#define SORT_KEY_T       ei_rank_t
+#define SORT_BEFORE(a,b) ( memcmp( (a).id, (b).id, sizeof(fd_pubkey_t) )<0 )
+#include "../../util/tmpl/fd_sort.c"
+
+FD_STATIC_ASSERT( sizeof(((fd_vote_stake_weight_t *)0)->bls_key)==AG_BLS_PUB_COMPRESSED_SZ, bls_key_sz );
+
+ag_epoch_info_t *
+ag_epoch_info_init( ag_epoch_info_t *              mem,
+                    fd_vote_stake_weight_t const * stakes,
+                    ulong                          stake_cnt ) {
+  /* Drop entries whose compressed BLS voting pubkey is missing or does
+     not decode to a valid G1 point.  The producer already guarantees
+     nonzero stake and VAT admission (fd_stakes_activate_epoch), so
+     those are not re-checked. */
+
+  ei_rank_t rank[ AG_VAT_MAX ]; /* surviving validators, pre-sort */
+  ulong     in_cnt = fd_ulong_min( stake_cnt, AG_VAT_MAX );
+  ulong     m      = 0UL;
+  for( ulong i=0UL; i<in_cnt; i++ ) {
+    if( FD_UNLIKELY( !stakes[i].stake ) ) continue; /* re-check nonzero stake, in case stakes came verbatim from a snapshot */
+    uchar const * bls = stakes[i].bls_key;
+#if FD_HAS_BLST
+    if( FD_UNLIKELY( fd_bls12_381_g1_decompress_syscall( rank[m].pk, bls, 1 ) ) ) continue; /* no / invalid BLS key */
+#else
+    memset( &rank[m].pk, 0, sizeof(ag_bls_pub_t) );
+    fd_memcpy( rank[m].pk, bls, AG_BLS_PUB_COMPRESSED_SZ ); /* stub builds do not verify signatures */
+#endif
+    rank[m].stake = stakes[i].stake;
+    rank[m].bls   = bls;
+    rank[m].id    = stakes[i].id_key.uc;
+    rank[m].src   = i;
+    rank[m].drop  = 0UL;
+    m++;
+  }
+
+  /* ALL copies of a duplicated BLS key or identity are dropped.  Sort
+     by each key so duplicates are adjacent, then mark adjacent-equal
+     runs. */
+
+  ei_bls_sort_inplace( rank, m );
+  for( ulong i=1UL; i<m; i++ ) {
+    if( FD_UNLIKELY( !memcmp( rank[i].bls, rank[i-1UL].bls, AG_BLS_PUB_COMPRESSED_SZ ) ) ) {
+      rank[i].drop = rank[i-1UL].drop = 1UL;
+    }
+  }
+
+  ei_id_sort_inplace( rank, m );
+  for( ulong i=1UL; i<m; i++ ) {
+    if( FD_UNLIKELY( !memcmp( rank[i].id, rank[i-1UL].id, sizeof(fd_pubkey_t) ) ) ) {
+      rank[i].drop = rank[i-1UL].drop = 1UL;
+    }
+  }
+
+  ulong k = 0UL;
+  for( ulong i=0UL; i<m; i++ ) if( FD_LIKELY( !rank[i].drop ) ) rank[k++] = rank[i];
+
+  if( FD_UNLIKELY( !k ) ) { FD_LOG_WARNING(( "no validators survived ranking" )); return NULL; }
+
+  ei_rank_sort_inplace( rank, k );
+
+  ag_epoch_info_t * ei = mem;
+
+  ulong total = 0UL;
+  for( ulong r=0UL; r<k; r++ ) {
+    ulong                 src = rank[r].src;
+    ag_validator_info_t * vi  = ei->validators + r;
+    memset( vi, 0, sizeof(ag_validator_info_t) );
+    vi->id            = r;
+    vi->stake         = stakes[src].stake;
+    vi->pubkey        = stakes[src].id_key;
+    memcpy(vi->voting_pubkey, rank[r].pk, sizeof(ag_bls_pub_t));
+    memcpy(ei->pubkeys[ r ],  rank[r].pk, sizeof(ag_bls_pub_t));
+    total += vi->stake;
+  }
+  ei->validator_cnt = k;
+  ei->total_stake   = total;
+  return mem;
+}

--- a/src/choreo/votor/ag_epoch_info.h
+++ b/src/choreo/votor/ag_epoch_info.h
@@ -3,6 +3,7 @@
 
 #include "ag_votor_base.h"
 #include "ag_bls.h"
+#include "../../flamenco/stakes/fd_stake_weight.h"
 
 struct ag_validator_info {
   ulong        id;
@@ -16,6 +17,7 @@ struct ag_epoch_info {
   ulong               validator_cnt;
   ulong               total_stake;
   ag_validator_info_t validators[ AG_VAT_MAX ]; /* indexed by rank; validator_cnt live */
+  ag_bls_pub_t        pubkeys   [ AG_VAT_MAX ]; /* same validators list, pubkeys continguous for easy cert verification. TODO keep/remove? */
 };
 typedef struct ag_epoch_info ag_epoch_info_t;
 
@@ -53,6 +55,27 @@ FD_FN_PURE int ag_epoch_info_is_weakest_quorum( ag_epoch_info_t const * self, ul
 FD_FN_PURE int ag_epoch_info_is_weak_quorum   ( ag_epoch_info_t const * self, ulong stake );
 FD_FN_PURE int ag_epoch_info_is_quorum        ( ag_epoch_info_t const * self, ulong stake );
 FD_FN_PURE int ag_epoch_info_is_strong_quorum ( ag_epoch_info_t const * self, ulong stake );
+
+/* ag_epoch_info_init formats mem as an ag_epoch_info_t holding the
+   canonical Alpenglow validator ranking derived from the epoch info
+   msg's staked VAT voters.  init drops entries with a missing or
+   undecodable compressed BLS voting pubkey, drop ALL copies of a
+   duplicated BLS key or identity pubkey, then order survivors by stake,
+   tie-broken by compressed BLS pubkey asc.
+
+   See Agave BLSPubkeyToRankMap https://github.com/anza-xyz/agave/blob/19e021d626df202b0ec11b4b39c76c3cfe9b90e4/runtime/src/epoch_stakes.rs#L87
+
+   Zero-stake, vote account balance, and top-2000 VAT admission are
+   already enforced by the producer (fd_stakes_activate_epoch) and are
+   not re-checked here.
+
+   Returns mem on success.  Returns NULL, leaving mem untouched, if mem
+   is no validator survives the filters. */
+
+ag_epoch_info_t *
+ag_epoch_info_init( ag_epoch_info_t              * ei_mem,
+                    fd_vote_stake_weight_t const * stakes,
+                    ulong                          stake_cnt );
 
 FD_PROTOTYPES_END
 

--- a/src/discof/backup/fd_ssmanifest_encoder.c
+++ b/src/discof/backup/fd_ssmanifest_encoder.c
@@ -209,7 +209,7 @@ ENCODE_FN {
     if( entry_type==2U ) {
       fd_vote_stakes_t_1_iter_t * iter = fd_type_pun( enc->vote_stakes_iter_mem );
       FD_TEST( !fd_vote_stakes_t_1_iter_done( vote_stakes, fork_id, iter ) );
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission );
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission, NULL );
       ec = find_epoch_credits( enc->bank, &pubkey );
       FD_TEST( ec );
       ec_cnt = ec->cnt;
@@ -217,7 +217,7 @@ ENCODE_FN {
     } else if( entry_type==1U ) {
       fd_vote_stakes_t_2_iter_t * iter = fd_type_pun( enc->vote_stakes_iter_mem );
       FD_TEST( !fd_vote_stakes_t_2_iter_done( vote_stakes, fork_id, iter ) );
-      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, &commission, NULL );
+      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, &commission, NULL, NULL );
       co_epoch = fd_ulong_sat_sub( bank->f.epoch, 1UL );
     } else {
       /* The bank epoch credits will have the resolved commission for

--- a/src/discof/backup/test_snap_roundtrip.c
+++ b/src/discof/backup/test_snap_roundtrip.c
@@ -165,11 +165,11 @@ test_manifest_roundtrip( fd_bank_t * bank ) {
   fd_vote_stakes_t_1_iter_t * iter = fd_vote_stakes_t_1_iter_init( vote_stakes, fork_id, iter_mem );
   FD_TEST( !fd_vote_stakes_t_1_iter_done( vote_stakes, fork_id, iter ) );
   fd_pubkey_t vote0;
-  fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote0, NULL, NULL, NULL );
+  fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote0, NULL, NULL, NULL, NULL );
   fd_vote_stakes_t_1_iter_next( vote_stakes, fork_id, iter );
   FD_TEST( !fd_vote_stakes_t_1_iter_done( vote_stakes, fork_id, iter ) );
   fd_pubkey_t vote1;
-  fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote1, NULL, NULL, NULL );
+  fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote1, NULL, NULL, NULL, NULL );
 
   fd_pubkey_t infl0 = { .ul = { 0xAA, 1 } };
   fd_pubkey_t blk0  = { .ul = { 0xBB, 2 } };

--- a/src/discof/replay/fd_block_marker.h
+++ b/src/discof/replay/fd_block_marker.h
@@ -1,0 +1,68 @@
+#ifndef HEADER_fd_src_discof_replay_fd_block_marker_h
+#define HEADER_fd_src_discof_replay_fd_block_marker_h
+
+#include "../../util/fd_util_base.h"
+#include "../../flamenco/fd_flamenco_base.h"
+
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L251 */
+struct __attribute__((packed)) fd_block_header {
+   uchar header_version;
+   struct {
+     ulong     parent_slot;
+     fd_hash_t parent_block_id;
+   } v1;
+};
+typedef struct fd_block_header fd_block_header_t;
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L240 */
+struct __attribute__((packed)) fd_block_footer {
+   uchar footer_version;
+   struct {
+     fd_hash_t bank_hash;
+     ulong     block_producer_time_nanos;
+     uchar     block_user_agent_length;
+     /* optional fields... */
+     // uchar   block_user_agent[255];
+     /* uchar   has_final_cert;
+        uchar   final_cert[255];
+
+        uchar   has_skip_reward_cert;
+        uchar   skip_reward_cert[255];
+        uchar   has_notar_reward_cert;
+        uchar notar_reward_cert[255]; */
+   } v1;
+};
+typedef struct fd_block_footer fd_block_footer_t;
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L257 */
+struct __attribute__((packed)) fd_update_parent {
+   uchar     update_parent_version;
+   ulong     new_parent_slot;
+   fd_hash_t new_parent_block_id;
+};
+typedef struct fd_update_parent fd_update_parent_t;
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L381 */
+enum fd_block_marker_variant {
+   FOOTER = 0,
+   HEADER = 1,
+   UPDATE_PARENT = 2,
+   GENESIS_CERTIFICATE = 3, /* ??? */
+};
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L436 */
+struct __attribute__((packed)) fd_block_marker {
+   ulong  marker_flag; /* always 0 */
+   ushort version;     /* block marker header version, currently 1  */
+   uchar  variant;     /* variant of block marker */
+   ushort length;
+   union {
+    fd_block_header_t header;
+    fd_block_footer_t footer;
+    fd_update_parent_t update_parent;
+   } data;
+};
+typedef struct fd_block_marker fd_block_marker_t;
+
+#endif /*HEADER_fd_src_discof_replay_fd_block_marker_h */

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -98,6 +98,7 @@
 #define IN_KIND_GOSSIP_OUT (10)
 #define IN_KIND_SNAPMK     (11)
 #define IN_KIND_ADMIN      (12)
+#define IN_KIND_VOTOR      (13)
 
 #define DEBUG_LOGGING 0
 
@@ -137,6 +138,11 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
 
   if( FD_UNLIKELY( tile->replay.dump_block_to_pb ) ) {
     l = FD_LAYOUT_APPEND( l, fd_block_dump_context_align(), fd_block_dump_context_footprint() );
+  }
+  if( FD_UNLIKELY( tile->replay.alpenglow ) ) {
+    for( ulong i=0UL; i<FD_REPLAY_VTR_EPOCH_WINDOW; i++ ) {
+      l = FD_LAYOUT_APPEND( l, alignof(ag_epoch_info_t), sizeof(ag_epoch_info_t) );
+    }
   }
 
   l = FD_LAYOUT_FINI( l, scratch_align() );
@@ -202,6 +208,22 @@ metrics_write( fd_replay_tile_t * ctx ) {
   FD_ACCDB_METRICS_WRITE( REPLAY, fd_accdb_metrics( ctx->accdb ) );
 }
 
+/* ag_epoch_vtrs_update stores the ranked Alpenglow validator set for
+   the epoch built from outgoing epoch msg. */
+
+static void
+ag_epoch_vtrs_update( fd_replay_tile_t *          ctx,
+                      fd_epoch_info_msg_t const * msg ) {
+  fd_replay_epoch_vtrs_t * s = &ctx->epoch_vtrs[ msg->epoch % FD_REPLAY_VTR_EPOCH_WINDOW ];
+  /* Don't let a stale (older) re-publish evict a newer epoch sharing this
+    ring slot.  Refresh (==) and normal advance (older occupant) proceed. */
+  if( FD_UNLIKELY( s->epoch!=ULONG_MAX && s->epoch>msg->epoch ) ) return;
+  if( FD_UNLIKELY( !ag_epoch_info_init( s->info, fd_epoch_info_msg_stake_weights( msg ), msg->staked_vote_cnt ) ) ) {
+    FD_LOG_CRIT(( "epoch %lu info failed", msg->epoch ));
+  }
+  s->epoch = msg->epoch;
+}
+
 static void
 publish_epoch_info( fd_replay_tile_t *  ctx,
                     fd_stem_context_t * stem,
@@ -233,14 +255,15 @@ publish_epoch_info( fd_replay_tile_t *  ctx,
   fd_stake_weight_t * src_id_weights = next_epoch ? runtime_stack->epoch_weights.next_id_weights : runtime_stack->epoch_weights.id_weights;
   fd_memcpy( id_weights, src_id_weights, epoch_info_msg->staked_id_cnt * sizeof(fd_stake_weight_t) );
 
-  ulong epoch_info_sz = fd_epoch_info_msg_sz( epoch_info_msg->staked_vote_cnt , epoch_info_msg->staked_id_cnt );
-
+  ulong epoch_info_sz = fd_epoch_info_msg_sz( epoch_info_msg->staked_vote_cnt, epoch_info_msg->staked_id_cnt );
   ulong epoch_info_sig = 4UL;
   fd_stem_publish( stem, ctx->epoch_out->idx, epoch_info_sig, ctx->epoch_out->chunk, epoch_info_sz, 0UL, 0UL, fd_frag_meta_ts_comp( fd_tickcount() ) );
   ctx->epoch_out->chunk = fd_dcache_compact_next( ctx->epoch_out->chunk, epoch_info_sz, ctx->epoch_out->chunk0, ctx->epoch_out->wmark );
 
   fd_multi_epoch_leaders_epoch_msg_init( ctx->mleaders, epoch_info_msg );
   fd_multi_epoch_leaders_epoch_msg_fini( ctx->mleaders );
+
+  if( FD_UNLIKELY( ctx->is_alpenglow ) ) ag_epoch_vtrs_update( ctx, epoch_info_msg );
 }
 
 /**********************************************************************/
@@ -311,7 +334,14 @@ replay_block_start( fd_replay_tile_t * ctx,
     FD_LOG_CRIT(( "couldn't compute tick height/max tick height slot %lu ticks_per_slot %lu", slot, parent_bank->f.ticks_per_slot ));
   }
   bank->f.max_tick_height = max_tick_height;
-  if( FD_UNLIKELY( ctx->alpenglow ) ) { FD_TEST( bank->f.max_tick_height > 0 ); bank->f.tick_height = bank->f.max_tick_height - 1UL; }
+  if( FD_UNLIKELY( ctx->is_alpenglow ) ) {
+    /* in alpenglow, we expect only one tick per block.  Instead of
+       adjusting max tick height, we match agave behavior by setting
+       tick height to max tick height - 1. These fields must stay in
+       line with agave behavior. */
+    bank->f.tick_height = bank->f.max_tick_height - 1UL;
+    bank->f.slot_params.hashes_per_tick = 1UL;
+  }
   fd_sched_set_poh_params( ctx->sched, bank->idx, bank->f.tick_height, bank->f.max_tick_height, bank->f.slot_params.hashes_per_tick, &parent_bank->f.poh );
 
   FD_LOG_DEBUG(( "replay_block_start: bank_idx=%lu slot=%lu parent_bank_idx=%lu", bank_idx, slot, parent_bank_idx ));
@@ -687,7 +717,7 @@ publish_slot_completed( fd_replay_tile_t *  ctx,
   /* refcnt should be incremented by 1 for each consumer that uses
      `bank_idx`.  Each consumer should decrement the bank's refcnt once
      they are done using the bank. */
-  bank->refcnt++; /* tower_tile */
+  if( FD_LIKELY( !ctx->is_alpenglow ) ) bank->refcnt++; /* tower_tile */
   if( FD_LIKELY( ctx->rpc_enabled ) ) bank->refcnt++; /* rpc tile */
   slot_info->bank_idx = bank->idx;
   slot_info->bank_seq = bank->bank_seq;
@@ -3525,6 +3555,12 @@ unprivileged_init( fd_topo_t const *      topo,
   if( FD_UNLIKELY( tile->replay.dump_block_to_pb ) ) {
     block_dump_ctx = FD_SCRATCH_ALLOC_APPEND( l, fd_block_dump_context_align(), fd_block_dump_context_footprint() );
   }
+  if( FD_UNLIKELY( tile->replay.alpenglow ) ) {
+    for( ulong i=0UL; i<FD_REPLAY_VTR_EPOCH_WINDOW; i++ ) {
+      ctx->epoch_vtrs[ i ].epoch = ULONG_MAX;
+      ctx->epoch_vtrs[ i ].info  = FD_SCRATCH_ALLOC_APPEND( l, alignof(ag_epoch_info_t), sizeof(ag_epoch_info_t) );
+    }
+  }
 
   ctx->runtime_stack = fd_runtime_stack_join( fd_runtime_stack_new( runtime_stack_mem, FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS, FD_RUNTIME_MAX_STAKED_VOTE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS, ctx->runtime_stack_seed ) );
   FD_TEST( ctx->runtime_stack );
@@ -3655,10 +3691,11 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_TEST( ctx->reception_stats_cnt );
   for( ulong i=0UL; i<ctx->reception_stats_cnt; i++ ) ctx->reception_stats[ i ].slot = ULONG_MAX;
   ctx->reasm_evicted = NULL;
+  ctx->is_alpenglow = tile->replay.alpenglow;
 
   ctx->leader_stats.slot = ULONG_MAX;
 
-  ctx->sched = fd_sched_join( fd_sched_new( sched_mem, ctx->rng, tile->replay.sched_depth, tile->replay.max_live_slots, fd_topo_tile_name_cnt( topo, "execrp" ) ) );
+  ctx->sched = fd_sched_join( fd_sched_new( sched_mem, ctx->rng, tile->replay.sched_depth, tile->replay.max_live_slots, fd_topo_tile_name_cnt( topo, "execrp" ), ctx->is_alpenglow ) );
   FD_TEST( ctx->sched );
 
   ctx->in_cnt          = tile->in_cnt;
@@ -3735,7 +3772,6 @@ unprivileged_init( fd_topo_t const *      topo,
     else if( !strcmp( link->name, "ipecho_out"    ) ) ctx->in_kind[ i ] = IN_KIND_IPECHO;
     else if( !strcmp( link->name, "snapin_manif"  ) ) ctx->in_kind[ i ] = IN_KIND_SNAP;
     else if( !strcmp( link->name, "execrp_replay" ) ) ctx->in_kind[ i ] = IN_KIND_EXECRP;
-    else if( !strcmp( link->name, "tower_out"     ) ) ctx->in_kind[ i ] = IN_KIND_TOWER;
     else if( !strcmp( link->name, "poh_replay"    ) ) ctx->in_kind[ i ] = IN_KIND_POH;
     else if( !strcmp( link->name, "resolv_replay" ) ) ctx->in_kind[ i ] = IN_KIND_RESOLV;
     else if( !strcmp( link->name, "shred_out"     ) ) ctx->in_kind[ i ] = IN_KIND_REPAIR;
@@ -3745,6 +3781,8 @@ unprivileged_init( fd_topo_t const *      topo,
     else if( !strcmp( link->name, "gossip_out"    ) ) ctx->in_kind[ i ] = IN_KIND_GOSSIP_OUT;
     else if( !strcmp( link->name, "snapmk_out"    ) ) ctx->in_kind[ i ] = IN_KIND_SNAPMK;
     else if( !strcmp( link->name, "admin_replay"  ) ) ctx->in_kind[ i ] = IN_KIND_ADMIN;
+    else if( !strcmp( link->name, "tower_out"     ) ) ctx->in_kind[ i ] = IN_KIND_TOWER;
+    else if( !strcmp( link->name, "votor_out"     ) ) ctx->in_kind[ i ] = IN_KIND_VOTOR;
     else FD_LOG_ERR(( "unexpected input link name %s", link->name ));
 
     if( ctx->in_kind[ i ]==IN_KIND_ADMIN ) {

--- a/src/discof/replay/fd_replay_tile_private.h
+++ b/src/discof/replay/fd_replay_tile_private.h
@@ -3,6 +3,7 @@
 
 #include "fd_vote_tracker.h"
 #include "../../disco/fd_clock_tile.h"
+#include "../../choreo/votor/ag_epoch_info.h"
 #include "../../disco/topo/fd_wksp_mon.h"
 #include "../../disco/store/fd_store.h"
 #include "../../disco/bundle/fd_bundle_crank.h"
@@ -40,6 +41,22 @@ struct fd_replay_out_link {
 };
 
 typedef struct fd_replay_out_link fd_replay_out_link_t;
+
+/* fd_replay_epoch_vtrs_t is one epoch's ranked Alpenglow validator set,
+   used to verify the finalization certs embedded in block footers with
+   the exact checks the votor tile / pool run on network certs.  Mirrors
+   the votor tile's epoch window: footer certs only reference the
+   current or an immediately-adjacent epoch. */
+
+#define FD_REPLAY_VTR_EPOCH_WINDOW (4UL)
+
+/* TODO: the following struct is temporary, and should be removed after
+   the centralized BLS verify tile is created. */
+struct fd_replay_epoch_vtrs {
+   ulong             epoch; /* ULONG_MAX marks an empty entry */
+   ag_epoch_info_t * info;  /* ranked epoch info, alloc-ed on init size ag_epoch_info_footprint() */
+ };
+ typedef struct fd_replay_epoch_vtrs fd_replay_epoch_vtrs_t;
 
 /* fd_block_id_map is a simple map of block-ids to bank indices.  The
    map sits on top of an array of fd_block_id_ele_t.  This serves as a
@@ -139,6 +156,15 @@ struct fd_replay_tile {
      wfs_complete will be set to 1. */
   int   wfs_enabled;
   int   wfs_complete;
+
+  /* is_alpenglow is 1 if the validator is booted in alpenglow mode.
+
+     Note: reasm is not used in alpenglow mode. instead frags are delivered
+     replay order directly from repair. */
+  int is_alpenglow;
+  /* ranked per-epoch validator sets for cert verification. temp done
+     in replay tile, may be moved to an external verify tile later. */
+  fd_replay_epoch_vtrs_t epoch_vtrs[ FD_REPLAY_VTR_EPOCH_WINDOW ];
 
   fd_hash_t expected_bank_hash;
 

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -2,6 +2,7 @@
 #include <stdarg.h> /* for va_list */
 
 #include "fd_sched.h"
+#include "fd_block_marker.h"
 #include "fd_execrp.h" /* for poh hash value */
 #include "../../util/math/fd_stat.h" /* for sorted search */
 #include "../../disco/fd_disco_base.h" /* for FD_MAX_TXN_PER_SLOT */
@@ -268,6 +269,7 @@ struct fd_sched {
   ulong                 print_buf_sz;
   fd_chkdup_t           chkdup[ 1 ];
   fd_sched_metrics_t    metrics[ 1 ];
+  int                   is_alpenglow; /* set if alpenglow is enabled. */
   ulong                 canary; /* == FD_SCHED_MAGIC */
   ulong                 depth;         /* Immutable. */
   ulong                 block_cnt_max; /* Immutable. */
@@ -668,7 +670,8 @@ fd_sched_new( void *     mem,
               fd_rng_t * rng,
               ulong      depth,
               ulong      block_cnt_max,
-              ulong      exec_cnt ) {
+              ulong      exec_cnt,
+              int        is_alpenglow ) {
 
   if( FD_UNLIKELY( !mem ) ) {
     FD_LOG_WARNING(( "NULL mem" ));
@@ -736,6 +739,7 @@ fd_sched_new( void *     mem,
   sched->next_ready_last_tick     = LONG_MAX;
   sched->next_ready_last_bank_idx = ULONG_MAX;
 
+  sched->is_alpenglow           = is_alpenglow;
   sched->canary                 = FD_SCHED_MAGIC;
   sched->depth                  = depth;
   sched->block_cnt_max          = block_cnt_max;
@@ -2301,7 +2305,20 @@ fd_sched_parse( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_ctx_
       }
 
       block->fec_sob = 0;
-      if( FD_UNLIKELY( !block->mblks_rem ) ) {
+
+      /* TODO parse alpenglow block markers */
+      if( FD_UNLIKELY( !block->mblks_rem && sched->is_alpenglow ) ) {
+        if( block->fec_buf_sz < sizeof(ulong) + sizeof(ushort) + sizeof(uchar) ) FD_LOG_CRIT(( "unhandled bad block marker - should mark dead"));
+        fd_block_marker_t const * m = (fd_block_marker_t const *)fd_type_pun_const( block->fec_buf );
+        if( m->variant==HEADER ) {
+          // TODO
+        } else if( m->variant==FOOTER ) {
+          // TODO
+        } else if( m->variant==UPDATE_PARENT ) {
+          // TODO
+          FD_LOG_CRIT(( "UNHANDLED alpenglow update parent: slot %lu", block->slot ));
+        }
+      } else if( FD_UNLIKELY( !block->mblks_rem && !sched->is_alpenglow ) ) {
         FD_LOG_INFO(( "bad block: ZERO_MICROBLOCKS, slot %lu, parent slot %lu, mblk_cnt %u (%u ticks)", block->slot, block->parent_slot, block->mblk_cnt, block->mblk_tick_cnt ));
         return FD_SCHED_DEAD_REASON_ZERO_MICROBLOCKS;
       }

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -247,7 +247,8 @@ fd_sched_new( void *     mem,
               fd_rng_t * rng,
               ulong      depth,
               ulong      block_cnt_max,
-              ulong      exec_cnt );
+              ulong      exec_cnt,
+              int        is_alpenglow );
 
 fd_sched_t *
 fd_sched_join( void * mem );

--- a/src/discof/replay/fuzz_sched_rdisp.c
+++ b/src/discof/replay/fuzz_sched_rdisp.c
@@ -761,7 +761,7 @@ build_case( case_t * tc, uchar const * data, ulong data_sz ) {
 
   fd_rng_t rng[1];
   fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  tc->sched = fd_sched_join( fd_sched_new( tc->mem, rng, depth, block_cnt_max, TEST_EXEC_CNT ) );
+  tc->sched = fd_sched_join( fd_sched_new( tc->mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
 
   /* Seed the scheduler with bank 0 as a completed snapshot root.  The
      notify/advance pair is a no-op for the current root, but using the

--- a/src/discof/replay/test_sched.c
+++ b/src/discof/replay/test_sched.c
@@ -80,7 +80,7 @@ run_bad_tick_case( fd_hash_t const * start_poh,
   FD_TEST( mem );
 
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
 
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -182,7 +182,7 @@ run_lane_policy_case( void ) {
   FD_TEST( mem );
 
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
 
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -308,7 +308,7 @@ new_sched( fd_rng_t * rng, void ** mem_out, ulong block_cnt_max ) {
   ulong footprint = fd_sched_footprint( depth, block_cnt_max );
   void * mem      = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
   *mem_out = mem;
   return sched;

--- a/src/discof/restore/utils/fd_ssload.c
+++ b/src/discof/restore/utils/fd_ssload.c
@@ -493,7 +493,7 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
   for( ulong i=0UL; i<manifest->epoch_stakes[t_1_idx].vote_stakes_len; i++ ) {
     fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[t_1_idx].vote_stakes[i];
 
-    fd_vote_stakes_snap_insert_t_1( vote_stakes, vote_stakes_fork_id, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, elem->commission );
+    fd_vote_stakes_snap_insert_t_1( vote_stakes, vote_stakes_fork_id, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, elem->commission, elem->identity_bls );
 
     /* Record SIMD-0232 collector overrides for the t_1 set (tag
        bank->f.epoch). */
@@ -543,8 +543,7 @@ fd_ssload_recover_apply( fd_snapshot_manifest_t * manifest,
   if( has_t_2 ) {
     for( ulong i=0UL; i<manifest->epoch_stakes[t_2_idx].vote_stakes_len; i++ ) {
       fd_snapshot_manifest_vote_stakes_t const * elem = &manifest->epoch_stakes[t_2_idx].vote_stakes[i];
-
-      fd_vote_stakes_snap_insert_t_2( vote_stakes, vote_stakes_fork_id, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, elem->commission );
+      fd_vote_stakes_snap_insert_t_2( vote_stakes, vote_stakes_fork_id, (fd_pubkey_t *)elem->vote, (fd_pubkey_t *)elem->identity, elem->stake, elem->commission, elem->identity_bls );
 
       /* Record SIMD-0232 collector overrides for the t_2 set (tag
          bank->f.epoch-1, the leader schedule source state). */

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -362,6 +362,7 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 2UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
@@ -375,6 +376,7 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = (ulong)USHORT_MAX;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
@@ -385,6 +387,7 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = (ulong)UINT_MAX;
@@ -406,6 +409,7 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = (ulong)UINT_MAX + 1UL;
@@ -430,6 +434,7 @@ test_epoch_credits_downcasting( fd_snapshot_manifest_t * manifest ) {
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = 2UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].epoch        = 1UL;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits[0].credits      = 100UL;
@@ -481,6 +486,7 @@ setup_migration_marker_case( fd_snapshot_manifest_t * manifest,
   fd_memset( manifest, 0, sizeof(*manifest) );
   setup_valid_manifest_base( manifest );
   manifest->epoch_stakes[0].vote_stakes_len = 1UL;
+  manifest->epoch_stakes[0].vote_stakes[0].has_identity_bls = 1;
   manifest->epoch_stakes[0].vote_stakes[0].epoch_credits_history_len = history_len;
 }
 
@@ -602,6 +608,8 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
   fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].identity, ident_x,  32 );
   manifest->epoch_stakes[1].vote_stakes[0].stake      = 5000UL;
   manifest->epoch_stakes[1].vote_stakes[0].commission = 10;
+  manifest->epoch_stakes[1].vote_stakes[0].has_identity_bls = 1;
+  fd_memset( manifest->epoch_stakes[1].vote_stakes[0].identity_bls, 0xB2, sizeof(manifest->epoch_stakes[1].vote_stakes[0].identity_bls) );
   manifest->epoch_stakes[1].total_stake               = 5000UL;
 
   /* First apply: simulate initial full snapshot load. */
@@ -635,6 +643,8 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
   fd_memcpy( manifest->epoch_stakes[1].vote_stakes[0].identity, ident_y,  32 );
   manifest->epoch_stakes[1].vote_stakes[0].stake      = 7000UL;
   manifest->epoch_stakes[1].vote_stakes[0].commission = 5;
+  manifest->epoch_stakes[1].vote_stakes[0].has_identity_bls = 1;
+  fd_memset( manifest->epoch_stakes[1].vote_stakes[0].identity_bls, 0xD2, sizeof(manifest->epoch_stakes[1].vote_stakes[0].identity_bls) );
   manifest->epoch_stakes[1].total_stake               = 7000UL;
 
   /* A second manifest apply must also leave snapin's cache untouched. */

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -894,7 +894,7 @@ query_towers( fd_tower_tile_t *            ctx,
     ulong batch_n = 0UL;
     while( !fd_vote_stakes_t_2_iter_done( vote_stakes, fork_id, iter ) && batch_n<BATCH ) {
       uchar is_valid;
-      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &vote_accs[ batch_n ], NULL, &stakes[ batch_n ], NULL, NULL, NULL, &is_valid );
+      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &vote_accs[ batch_n ], NULL, &stakes[ batch_n ], NULL, NULL, NULL, &is_valid, NULL );
       fd_vote_stakes_t_2_iter_next( vote_stakes, fork_id, iter );
       total_stake += stakes[ batch_n ];
       if( FD_UNLIKELY( !is_valid ) ) continue;
@@ -1194,10 +1194,10 @@ query_epoch_voters( fd_tower_tile_t *      ctx,
     fd_pubkey_t pubkey;
     ulong       stake;
     if( use_t_1 ) {
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, vote_stakes_fork_id, iter, &pubkey, NULL, &stake, NULL );
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, vote_stakes_fork_id, iter, &pubkey, NULL, &stake, NULL, NULL );
       fd_vote_stakes_t_1_iter_next( vote_stakes, vote_stakes_fork_id, iter );
     } else {
-      fd_vote_stakes_t_2_iter_ele( vote_stakes, vote_stakes_fork_id, iter, &pubkey, NULL, &stake, NULL, NULL, NULL, NULL );
+      fd_vote_stakes_t_2_iter_ele( vote_stakes, vote_stakes_fork_id, iter, &pubkey, NULL, &stake, NULL, NULL, NULL, NULL, NULL );
       fd_vote_stakes_t_2_iter_next( vote_stakes, vote_stakes_fork_id, iter );
     }
     total_stake += stake;

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1567,8 +1567,10 @@ fd_runtime_init_bank_from_genesis( fd_banks_t *         banks,
       fd_pubkey_t node_account;
       ulong       stake;
       ushort      commission;
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission );
-      fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &pubkey, &node_account, stake, commission );
+      uchar       bls_key[ FD_BLS_PUBKEY_COMPRESSED_SZ ];
+
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission, bls_key );
+      fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &pubkey, &node_account, stake, commission, bls_key );
     }
     fd_vote_stakes_refresh( vote_stakes, fork_id, accdb, bank->accdb_fork_id );
   }

--- a/src/flamenco/runtime/fd_slot_params.h
+++ b/src/flamenco/runtime/fd_slot_params.h
@@ -48,6 +48,7 @@ struct fd_slot_params {
   ulong  max_shred_idx;
   ulong  max_entry_bytes_per_slot;
   ulong  stake_account_stores_per_block;
+  ulong  vat_to_burn_per_epoch;
 };
 typedef struct fd_slot_params fd_slot_params_t;
 
@@ -63,6 +64,7 @@ typedef struct fd_slot_params fd_slot_params_t;
   .max_shred_idx                      = 32768UL,                                  \
   .max_entry_bytes_per_slot           = FD_DEFAULT_MAX_ENTRY_BYTES_PER_SLOT,      \
   .stake_account_stores_per_block     = 4096UL,                                   \
+  .vat_to_burn_per_epoch              = 1600000000UL,                             \
 })
 
 /* https://github.com/anza-xyz/agave/blob/v4.2/runtime/src/slot_params.rs#L135-L145 */
@@ -77,6 +79,7 @@ typedef struct fd_slot_params fd_slot_params_t;
   .max_shred_idx                      = 28672UL,                                  \
   .max_entry_bytes_per_slot           = 18350080UL,                               \
   .stake_account_stores_per_block     = 3584UL,                                   \
+  .vat_to_burn_per_epoch              = 1400000000UL,                             \
 })
 
 /* https://github.com/anza-xyz/agave/blob/v4.2/runtime/src/slot_params.rs#L147-L157 */
@@ -91,6 +94,7 @@ typedef struct fd_slot_params fd_slot_params_t;
   .max_shred_idx                      = 24576UL,                                  \
   .max_entry_bytes_per_slot           = 15728640UL,                               \
   .stake_account_stores_per_block     = 3072UL,                                   \
+  .vat_to_burn_per_epoch              = 1200000000UL,                             \
 })
 
 /* https://github.com/anza-xyz/agave/blob/v4.2/runtime/src/slot_params.rs#L159-L169 */
@@ -105,6 +109,7 @@ typedef struct fd_slot_params fd_slot_params_t;
   .max_shred_idx                      = 20480UL,                                  \
   .max_entry_bytes_per_slot           = 13107200UL,                               \
   .stake_account_stores_per_block     = 2560UL,                                   \
+  .vat_to_burn_per_epoch              = 1000000000UL,                             \
 })
 
 /* https://github.com/anza-xyz/agave/blob/v4.2/runtime/src/slot_params.rs#L171-L181 */
@@ -119,6 +124,7 @@ typedef struct fd_slot_params fd_slot_params_t;
   .max_shred_idx                      = 16384UL,                                  \
   .max_entry_bytes_per_slot           = 10485760UL,                               \
   .stake_account_stores_per_block     = 2048UL,                                   \
+  .vat_to_burn_per_epoch              = 800000000UL,                              \
 })
 
 FD_PROTOTYPES_BEGIN

--- a/src/flamenco/runtime/program/vote/fd_vote_codec.c
+++ b/src/flamenco/runtime/program/vote/fd_vote_codec.c
@@ -633,6 +633,16 @@ fd_vote_account_is_v4_with_bls_pubkey( uchar const * data,
   return !!data[ WIRE_BLS_OFF_V4 ];
 }
 
+int
+fd_vote_account_bls_pubkey( uchar const * data,
+                            ulong         data_sz,
+                            uchar         out[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
+  if( FD_UNLIKELY( !fd_vote_account_is_v4_with_bls_pubkey( data, data_sz ) )      ) return 1;
+  if( FD_UNLIKELY( data_sz<WIRE_BLS_OFF_V4+1UL+FD_BLS_PUBKEY_COMPRESSED_SZ )      ) return 1;
+  fd_memcpy( out, data+WIRE_BLS_OFF_V4+1UL, FD_BLS_PUBKEY_COMPRESSED_SZ );
+  return 0;
+}
+
 fd_vote_epoch_credits_t const *
 fd_vote_account_epoch_credits( uchar const * data,
                                ulong         data_sz,

--- a/src/flamenco/runtime/program/vote/fd_vote_codec.h
+++ b/src/flamenco/runtime/program/vote/fd_vote_codec.h
@@ -655,6 +655,14 @@ fd_vote_account_node_pubkey( uchar const *  data,
                              ulong          data_sz,
                              fd_pubkey_t *  out );
 
+/* Reads the compressed BLS voting pubkey directly from raw
+   bincode-encoded v4 vote account data. Returns 0 on success, 1 on
+   error (not v4, no bls pubkey set, or truncated). */
+int
+fd_vote_account_bls_pubkey( uchar const * data,
+                            ulong         data_sz,
+                            uchar         out[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] );
+
 /* Returns the commission in basis points.  If commission_rate_in_bps is
    set, returns the v4 commission rate as a raw basis points value.
    Otherwise, returns the v4 commission rate in basis points, rounded

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -132,7 +132,7 @@ accum_vote_stakes( fd_bank_t *          bank,
     ulong       last_vote_slot;
     long        last_vote_timestamp;
     uchar       is_valid;
-    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, &stake_t_2, &last_vote_slot, &last_vote_timestamp, NULL, &is_valid );
+    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, &stake_t_2, &last_vote_slot, &last_vote_timestamp, NULL, &is_valid, NULL );
     if( FD_UNLIKELY( !is_valid ) ) continue;
 
     /* https://github.com/anza-xyz/agave/blob/v3.0.0/runtime/src/bank.rs#L2445 */

--- a/src/flamenco/runtime/test_vat_refresh_vote_accounts.c
+++ b/src/flamenco/runtime/test_vat_refresh_vote_accounts.c
@@ -389,8 +389,12 @@ test_env_create( test_env_t * env, fd_wksp_t * wksp ) {
     put_vote_account_v4( env, &v, &v, commission, VOTE_ACCOUNT_LAMPORTS,
                          voter_has_bls( i ), 0UL, voter_vote_ts( i ) );
     if( voter_has_bls( i ) ) {
-      fd_vote_stakes_snap_insert_t_1( vote_stakes, fork_id, &v, &v, stake, commission );
-      fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &v, &v, stake, commission );
+      /* Match the 0xBB key pattern put_vote_account_v4 writes into the
+         account data. */
+      uchar bls[ FD_BLS_PUBKEY_COMPRESSED_SZ ];
+      fd_memset( bls, 0xBB, sizeof(bls) );
+      fd_vote_stakes_snap_insert_t_1( vote_stakes, fork_id, &v, &v, stake, commission, bls );
+      fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &v, &v, stake, commission, bls );
       fd_vote_stakes_update_state( vote_stakes, fork_id, &v, 0UL, voter_vote_ts( i ), 1 );
     }
     add_delegated_stake_account     ( env, &s, &v, stake );

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -61,8 +61,9 @@ fd_solfuzz_block_update_prev_epoch_stakes( fd_vote_stakes_t *                 vo
       commission = (ushort)( (uchar)( vote_accounts[i].commission_bps / 100U ) * 100U );
     }
 
-    if( use_t_1 ) fd_vote_stakes_snap_insert_t_1( vote_stakes, vote_stakes_fork_id, &vote_pubkey, &node_pubkey, stake, commission );
-    else          fd_vote_stakes_snap_insert_t_2( vote_stakes, vote_stakes_fork_id, &vote_pubkey, &node_pubkey, stake, commission );
+    uchar const no_bls[ FD_BLS_PUBKEY_COMPRESSED_SZ ] = {0};
+    if( use_t_1 ) fd_vote_stakes_snap_insert_t_1( vote_stakes, vote_stakes_fork_id, &vote_pubkey, &node_pubkey, stake, commission, no_bls );
+    else          fd_vote_stakes_snap_insert_t_2( vote_stakes, vote_stakes_fork_id, &vote_pubkey, &node_pubkey, stake, commission, no_bls );
   }
 }
 

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -641,7 +641,7 @@ create_block_context_protobuf_from_block( fd_block_dump_ctx_t * dump_ctx,
     ulong       stake;
     fd_pubkey_t node;
     ushort      commission;
-    fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node, &stake, &commission );
+    fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node, &stake, &commission, NULL );
     add_account_to_dumped_accounts( dumped_accounts, &pubkey );
 
     fd_exec_test_prev_vote_account_t * acc = &va_t1[ va_t1_cnt++ ];
@@ -675,7 +675,7 @@ create_block_context_protobuf_from_block( fd_block_dump_ctx_t * dump_ctx,
     ulong       stake;
     fd_pubkey_t node;
     ushort      commission;
-    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node, &stake, NULL, NULL, &commission, NULL );
+    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node, &stake, NULL, NULL, &commission, NULL, NULL );
     add_account_to_dumped_accounts( dumped_accounts, &pubkey );
 
     fd_exec_test_prev_vote_account_t * acc = &va_t2[ va_t2_cnt++ ];

--- a/src/flamenco/runtime/tests/fd_shred_harness.c
+++ b/src/flamenco/runtime/tests/fd_shred_harness.c
@@ -215,7 +215,7 @@ fd_solfuzz_pb_shred_run( fd_solfuzz_runner_t * runner,
   fd_rng_t rng_mem[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
   void * sched_mem = fd_spad_alloc( runner->spad, fd_sched_align(), fd_sched_footprint( SCHED_DEPTH, SCHED_BLOCK_CNT_MAX ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( sched_mem, rng, SCHED_DEPTH, SCHED_BLOCK_CNT_MAX, SCHED_EXEC_CNT ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( sched_mem, rng, SCHED_DEPTH, SCHED_BLOCK_CNT_MAX, SCHED_EXEC_CNT, 0 ) );
   FD_TEST( sched );
   fd_sched_set_bypass_poh_verify( sched, 1 ); /* skip PoH end_hash compare */
   fd_sched_set_bypass_alut_resolution( sched, 1 ); /* skip ALUT resolution (no accdb) */

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -384,8 +384,9 @@ fd_svm_mini_init_mock_validators( fd_svm_mini_t *              mini,
 
     /* Populate bank structures */
 
-    fd_vote_stakes_snap_insert_t_1( vote_stakes, fork_id, &vote_key, &identity_key, uniform_stake, 1234U );
-    fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &vote_key, &identity_key, uniform_stake, 1234U );
+    uchar const no_bls[ FD_BLS_PUBKEY_COMPRESSED_SZ ] = {0}; /* zeroed means no key is registered */
+    fd_vote_stakes_snap_insert_t_1( vote_stakes, fork_id, &vote_key, &identity_key, uniform_stake, 1234U, no_bls );
+    fd_vote_stakes_snap_insert_t_2( vote_stakes, fork_id, &vote_key, &identity_key, uniform_stake, 1234U, no_bls );
     fd_vote_stakes_update_state( vote_stakes, fork_id, &vote_key, 0UL, 0L, 1 );
 
     fd_epoch_credits_t * epoch_credits = &fd_bank_epoch_credits( bank )[ i ];

--- a/src/flamenco/stakes/fd_stakes.c
+++ b/src/flamenco/stakes/fd_stakes.c
@@ -438,13 +438,14 @@ fd_stake_weights_by_node( fd_vote_stakes_t const * vote_stakes,
       fd_pubkey_t pubkey;
       ulong       stake;
       fd_pubkey_t node_account;
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL );
+      uchar       bls_key[ FD_BLS_PUBKEY_COMPRESSED_SZ ];
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, bls_key );
 
       FD_TEST( weights_cnt<MAX_STAKE_WEIGHTS );
       fd_memcpy( weights[ weights_cnt ].vote_key.uc, &pubkey, sizeof(fd_pubkey_t) );
       fd_memcpy( weights[ weights_cnt ].id_key.uc, &node_account, sizeof(fd_pubkey_t) );
+      fd_memcpy( weights[ weights_cnt ].bls_key, bls_key, sizeof(weights[ weights_cnt ].bls_key) );
       weights[ weights_cnt ].stake = stake;
-      fd_memset( weights[ weights_cnt ].bls_key, 0, sizeof(weights[ weights_cnt ].bls_key) );
       weights_cnt++;
     }
   } else {
@@ -454,13 +455,14 @@ fd_stake_weights_by_node( fd_vote_stakes_t const * vote_stakes,
       fd_pubkey_t pubkey;
       ulong       stake;
       fd_pubkey_t node_account;
-      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, NULL, NULL );
+      uchar       bls_key[ FD_BLS_PUBKEY_COMPRESSED_SZ ];
+      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, NULL, NULL, bls_key );
 
       FD_TEST( weights_cnt<MAX_STAKE_WEIGHTS );
       fd_memcpy( weights[ weights_cnt ].vote_key.uc, &pubkey, sizeof(fd_pubkey_t) );
       fd_memcpy( weights[ weights_cnt ].id_key.uc, &node_account, sizeof(fd_pubkey_t) );
+      fd_memcpy( weights[ weights_cnt ].bls_key, bls_key, sizeof(weights[ weights_cnt ].bls_key) );
       weights[ weights_cnt ].stake = stake;
-      fd_memset( weights[ weights_cnt ].bls_key, 0, sizeof(weights[ weights_cnt ].bls_key) );
       weights_cnt++;
     }
   }
@@ -530,6 +532,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
   ulong total_deactivating         = 0UL;
   ulong staked_accounts            = 0UL;
   int   use_fixed_point_stake_math = FD_FEATURE_ACTIVE_BANK( bank, upgrade_bpf_stake_program_to_v5_1 );
+  int   alpenglow_enabled          = 0; // TODO add feature
 
   fd_stake_accum_t *     stake_accum_pool = runtime_stack->stakes.stake_accum;
   fd_stake_accum_map_t * stake_accum_map  = runtime_stack->stakes.stake_accum_map;
@@ -594,20 +597,23 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
     fd_pubkey_t node_account_t_1 = {0};
     ulong       stake_t_1        = stake_accum->stake;
     ushort      commission_t_1   = 0;
+    uchar       bls_key_t_1[ FD_BLS_PUBKEY_COMPRESSED_SZ ];
 
     if( FD_UNLIKELY( !stake_t_1 ) ) continue;
 
     fd_acc_t acc = fd_accdb_read_one( accdb, bank->accdb_fork_id, stake_accum->pubkey.uc );
     /* Agave's VAT filter also checks lamports against the VoteStateV4
-       rent-exempt minimum. */
+       rent-exempt minimum, plus one epoch's VAT burn once alpenglow is
+       active. */
     if( FD_UNLIKELY( !acc.lamports ) ) {
       fd_accdb_unread_one( accdb, &acc );
       continue;
     }
 
-    ulong vote_account_lamports            = acc.lamports;
-    ulong vote_account_rent_exempt_minimum = fd_rent_exempt_minimum_balance( &bank->f.rent, FD_VOTE_STATE_V4_SZ );
-    if( FD_UNLIKELY( vote_account_lamports < vote_account_rent_exempt_minimum ) ) {
+    ulong vote_account_lamports = acc.lamports;
+    ulong vat_to_burn_per_epoch = alpenglow_enabled ? fd_slot_params_at_slot( bank, bank->f.slot ).vat_to_burn_per_epoch : 0UL;
+    ulong minimum_vote_account_balance = fd_rent_exempt_minimum_balance( &bank->f.rent, FD_VOTE_STATE_V4_SZ ) + vat_to_burn_per_epoch;
+    if( FD_UNLIKELY( vote_account_lamports < minimum_vote_account_balance ) ) {
       fd_accdb_unread_one( accdb, &acc );
       continue;
     }
@@ -619,8 +625,11 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
 
     FD_TEST( !fd_vote_account_commission_bps( acc.data, acc.data_len, FD_FEATURE_ACTIVE_BANK( bank, commission_rate_in_basis_points ), &commission_t_1 ) );
     FD_TEST( !fd_vote_account_node_pubkey( acc.data, acc.data_len, &node_account_t_1 ) );
+    if( FD_LIKELY( fd_vote_account_is_v4_with_bls_pubkey( acc.data, acc.data_len ) ) ) {
+      FD_TEST( !fd_vote_account_bls_pubkey( acc.data, acc.data_len, bls_key_t_1 ) );
+    }
 
-    fd_vote_stakes_insert( vote_stakes, fork_id, &stake_accum->pubkey, &node_account_t_1, stake_t_1, commission_t_1 );
+    fd_vote_stakes_insert( vote_stakes, fork_id, &stake_accum->pubkey, &node_account_t_1, stake_t_1, commission_t_1, bls_key_t_1 );
     fd_accdb_unread_one( accdb, &acc );
   }
 
@@ -636,7 +645,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
          fd_vote_stakes_t_1_iter_next( vote_stakes, fork_id, iter ) ) {
       fd_pubkey_t vote_pubkey;
       fd_pubkey_t node_pubkey;
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote_pubkey, &node_pubkey, NULL, NULL );
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &vote_pubkey, &node_pubkey, NULL, NULL, NULL );
 
       fd_acc_t acc = fd_accdb_read_one( accdb, bank->accdb_fork_id, vote_pubkey.uc );
       fd_pubkey_t inflation_collector;
@@ -672,7 +681,7 @@ fd_refresh_vote_accounts( fd_bank_t *                    bank,
     fd_pubkey_t pubkey;
     ulong       stake;
     ushort      commission_t_1 = 0;
-    fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, &stake, &commission_t_1 );
+    fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, &stake, &commission_t_1, NULL );
 
     ushort commission_t_3 = 0;
     int    exists_t_3     = fd_vote_stakes_query_t_3( vote_stakes, fork_id, &pubkey, NULL, NULL, &commission_t_3 );

--- a/src/flamenco/stakes/fd_vote_stakes.c
+++ b/src/flamenco/stakes/fd_vote_stakes.c
@@ -3,7 +3,6 @@
 #include "../fd_flamenco_base.h"
 #include "../runtime/fd_runtime_const.h"
 #include "../runtime/program/vote/fd_vote_state_versioned.h"
-#include "../runtime/program/vote/fd_vote_codec.h"
 #include "../../util/bits/fd_bits.h"
 #include "../../util/log/fd_log.h"
 
@@ -15,6 +14,7 @@ struct vacc {
   fd_pubkey_t node_account;
   ulong       stake;
   ushort      commission;
+  uchar       bls_key[ FD_BLS_PUBKEY_COMPRESSED_SZ ]; /* zero if unregistered */
   uint        left;
   uint        right;
   uint        next;
@@ -398,7 +398,8 @@ fd_vote_stakes_snap_insert_t_1( fd_vote_stakes_t *  vote_stakes,
                                 fd_pubkey_t const * pubkey,
                                 fd_pubkey_t const * node_account,
                                 ulong               stake,
-                                ushort              commission ) {
+                                ushort              commission,
+                                uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
   if( FD_UNLIKELY( !stake ) ) return;
 
   vacc_t *     pool = t_1_vacc_pool( vote_stakes, fork_id_width_id( fork_id ) );
@@ -409,6 +410,7 @@ fd_vote_stakes_snap_insert_t_1( fd_vote_stakes_t *  vote_stakes,
   vacc->node_account = *node_account;
   vacc->stake        = stake;
   vacc->commission   = commission;
+  memcpy( vacc->bls_key, bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
   FD_TEST( vacc_map_ele_insert( map, vacc, pool ) );
 }
 
@@ -418,7 +420,8 @@ fd_vote_stakes_snap_insert_t_2( fd_vote_stakes_t *  vote_stakes,
                                 fd_pubkey_t const * pubkey,
                                 fd_pubkey_t const * node_account,
                                 ulong               stake,
-                                ushort              commission ) {
+                                ushort              commission,
+                                uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
   if( FD_UNLIKELY( !stake ) ) return;
 
   ulong        epoch_idx = (ulong)fork_id_epoch( fork_id ) & 1UL;
@@ -430,6 +433,7 @@ fd_vote_stakes_snap_insert_t_2( fd_vote_stakes_t *  vote_stakes,
   vacc->node_account = *node_account;
   vacc->stake        = stake;
   vacc->commission   = commission;
+  memcpy( vacc->bls_key, bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
   FD_TEST( vacc_map_ele_insert( map, vacc, pool ) );
 }
 
@@ -439,7 +443,8 @@ fd_vote_stakes_insert( fd_vote_stakes_t *  vote_stakes,
                        fd_pubkey_t const * pubkey,
                        fd_pubkey_t const * node_account,
                        ulong               stake,
-                       ushort              commission ) {
+                       ushort              commission,
+                       uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
   ulong         width_idx = (ulong)fork_id_width_id( fork_id );
   vacc_t *      pool      = t_1_vacc_pool( vote_stakes, width_idx );
   vacc_map_t *  map       = t_1_vacc_map ( vote_stakes, width_idx );
@@ -466,6 +471,7 @@ fd_vote_stakes_insert( fd_vote_stakes_t *  vote_stakes,
   vacc->node_account = *node_account;
   vacc->stake        = stake;
   vacc->commission   = commission;
+  memcpy( vacc->bls_key, bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
   vacc_heap_ele_insert( heap, vacc, pool );
   FD_TEST( vacc_map_ele_insert( map, vacc, pool ) );
 }
@@ -535,6 +541,7 @@ fd_vote_stakes_new_fork( fd_vote_stakes_t * vote_stakes,
         dst->node_account = src->node_account;
         dst->stake        = src->stake;
         dst->commission   = src->commission;
+        memcpy( dst->bls_key, src->bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
         FD_TEST( vacc_map_ele_insert( t_2_map, dst, t_2_pool ) );
       }
       vote_stakes->t_2_epoch[ t_2_idx ] = epoch;
@@ -595,7 +602,7 @@ fd_vote_stakes_refresh( fd_vote_stakes_t * vote_stakes,
        !fd_vote_stakes_t_2_iter_done( vote_stakes, fork_id, iter );
        fd_vote_stakes_t_2_iter_next( vote_stakes, fork_id, iter ) ) {
     fd_pubkey_t pubkey;
-    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, NULL, NULL, NULL, NULL, NULL );
+    fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, NULL, NULL, NULL, NULL, NULL, NULL, NULL );
 
     fd_acc_t acc = fd_accdb_read_one( accdb, accdb_fork_id, pubkey.uc );
     if( FD_UNLIKELY( !acc.lamports || !fd_vsv_is_correct_size_owner_and_init( acc.owner, acc.data, acc.data_len ) ) ) {
@@ -742,7 +749,8 @@ fd_vote_stakes_t_1_iter_ele( fd_vote_stakes_t const *    vote_stakes,
                              fd_pubkey_t *               pubkey_out,
                              fd_pubkey_t *               node_account_out_opt,
                              ulong *                     stake_out_opt,
-                             ushort *                    commission_out_opt ) {
+                             ushort *                    commission_out_opt,
+                             uchar                       bls_key_out_opt[ FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
   ulong          width_idx = (ulong)fork_id_width_id( fork_id );
   vacc_t *       pool      = t_1_vacc_pool( vote_stakes, width_idx );
   vacc_map_t *   map       = t_1_vacc_map ( vote_stakes, width_idx );
@@ -752,6 +760,7 @@ fd_vote_stakes_t_1_iter_ele( fd_vote_stakes_t const *    vote_stakes,
   if( node_account_out_opt ) *node_account_out_opt = vacc->node_account;
   if( stake_out_opt )        *stake_out_opt        = vacc->stake;
   if( commission_out_opt )   *commission_out_opt   = vacc->commission;
+  if( bls_key_out_opt )      memcpy( bls_key_out_opt, vacc->bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
 }
 
 fd_vote_stakes_t_2_iter_t *
@@ -797,7 +806,8 @@ fd_vote_stakes_t_2_iter_ele( fd_vote_stakes_t const *    vote_stakes,
                              ulong *                     last_vote_slot_out_opt,
                              long *                      last_vote_ts_out_opt,
                              ushort *                    commission_out_opt,
-                             uchar *                     is_valid_out_opt ) {
+                             uchar *                     is_valid_out_opt,
+                             uchar                       bls_key_out_opt[ FD_BLS_PUBKEY_COMPRESSED_SZ ] ) {
   ulong                 epoch_idx = (ulong)fork_id_epoch( fork_id ) & 1UL;
   vacc_t *              pool      = t_2_vacc_pool( vote_stakes, epoch_idx );
   vacc_map_t *          map       = t_2_vacc_map ( vote_stakes, epoch_idx );
@@ -812,4 +822,5 @@ fd_vote_stakes_t_2_iter_ele( fd_vote_stakes_t const *    vote_stakes,
   if( last_vote_ts_out_opt )   *last_vote_ts_out_opt   = states->states[ vacc_idx ].last_vote_ts;
   if( commission_out_opt )     *commission_out_opt     = vacc->commission;
   if( is_valid_out_opt )       *is_valid_out_opt       = states->states[ vacc_idx ].is_valid;
+  if( bls_key_out_opt )        memcpy( bls_key_out_opt, vacc->bls_key, FD_BLS_PUBKEY_COMPRESSED_SZ );
 }

--- a/src/flamenco/stakes/fd_vote_stakes.h
+++ b/src/flamenco/stakes/fd_vote_stakes.h
@@ -4,6 +4,7 @@
 #include "../../util/fd_util_base.h"
 #include "../fd_flamenco_base.h"
 #include "../accdb/fd_accdb_base.h"
+#include "../runtime/program/vote/fd_vote_codec.h"
 
 #define FD_VOTE_STAKES_ALIGN (128UL)
 
@@ -88,7 +89,8 @@ fd_vote_stakes_snap_insert_t_1( fd_vote_stakes_t *  vote_stakes,
                                 fd_pubkey_t const * pubkey,
                                 fd_pubkey_t const * node_account,
                                 ulong               stake,
-                                ushort              commission );
+                                ushort              commission,
+                                uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] );
 
 /* fd_vote_stakes_snap_insert_t_2 inserts a new vote account into the
    t-2 set.  This skips over any vote account validation and should
@@ -100,7 +102,8 @@ fd_vote_stakes_snap_insert_t_2( fd_vote_stakes_t *  vote_stakes,
                                 fd_pubkey_t const * pubkey,
                                 fd_pubkey_t const * node_account,
                                 ulong               stake,
-                                ushort              commission );
+                                ushort              commission,
+                                uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] );
 
 /* fd_vote_stakes_insert inserts a new vote account into the t-1 set.
    This can be called repeatedly after a boundary-crossing
@@ -114,7 +117,8 @@ fd_vote_stakes_insert( fd_vote_stakes_t *  vote_stakes,
                        fd_pubkey_t const * pubkey,
                        fd_pubkey_t const * node_account,
                        ulong               stake,
-                       ushort              commission );
+                       ushort              commission,
+                       uchar const         bls_key[ static FD_BLS_PUBKEY_COMPRESSED_SZ ] );
 
 /* fd_vote_stakes_purge_fork removes a t-1 set.  This should be called
    when the banks are evicting a bank or during root advancement. */
@@ -239,7 +243,8 @@ fd_vote_stakes_t_1_iter_ele( fd_vote_stakes_t const *    vote_stakes,
                              fd_pubkey_t *               pubkey_out,
                              fd_pubkey_t *               node_account_out_opt,
                              ulong *                     stake_out_opt,
-                             ushort *                    commission_out_opt );
+                             ushort *                    commission_out_opt,
+                             uchar                       bls_key_out_opt[ FD_BLS_PUBKEY_COMPRESSED_SZ ] );
 
 fd_vote_stakes_t_2_iter_t *
 fd_vote_stakes_t_2_iter_init( fd_vote_stakes_t const * vote_stakes,
@@ -266,7 +271,8 @@ fd_vote_stakes_t_2_iter_ele( fd_vote_stakes_t const *    vote_stakes,
                              ulong *                     last_vote_slot_out_opt,
                              long *                      last_vote_ts_out_opt,
                              ushort *                    commission_out_opt,
-                             uchar *                     is_valid_out_opt );
+                             uchar *                     is_valid_out_opt,
+                             uchar                       bls_key_out_opt[ FD_BLS_PUBKEY_COMPRESSED_SZ ] );
 
 FD_PROTOTYPES_END
 

--- a/src/flamenco/stakes/test_vote_stakes.c
+++ b/src/flamenco/stakes/test_vote_stakes.c
@@ -25,10 +25,13 @@ main( int argc, char ** argv ) {
   fd_pubkey_t node_b = key( 4UL );
   fd_pubkey_t vote_c = key( 5UL );
   fd_pubkey_t node_c = key( 6UL );
+  uchar bls_a[ FD_BLS_PUBKEY_COMPRESSED_SZ ] = { 7UL };
+  uchar bls_b[ FD_BLS_PUBKEY_COMPRESSED_SZ ] = { 8UL };
+  uchar bls_c[ FD_BLS_PUBKEY_COMPRESSED_SZ ] = { 9UL };
 
   ulong root = fd_vote_stakes_init( vote_stakes, 0UL );
-  fd_vote_stakes_snap_insert_t_1( vote_stakes, root, &vote_a, &node_a, 100UL, 10U );
-  fd_vote_stakes_snap_insert_t_2( vote_stakes, root, &vote_b, &node_b, 200UL, 20U );
+  fd_vote_stakes_snap_insert_t_1( vote_stakes, root, &vote_a, &node_a, 100UL, 10U, bls_a );
+  fd_vote_stakes_snap_insert_t_2( vote_stakes, root, &vote_b, &node_b, 200UL, 20U, bls_b );
   fd_vote_stakes_update_state( vote_stakes, root, &vote_b, 7UL, 8L, 1 );
 
   ulong stake;
@@ -45,7 +48,7 @@ main( int argc, char ** argv ) {
   FD_TEST( fd_vote_stakes_query_t_3( vote_stakes, child, &vote_b, NULL, NULL, &commission ) );
   FD_TEST( commission==20U );
 
-  fd_vote_stakes_insert( vote_stakes, child, &vote_c, &node_c, 300UL, 30U );
+  fd_vote_stakes_insert( vote_stakes, child, &vote_c, &node_c, 300UL, 30U, bls_c );
   FD_TEST( fd_vote_stakes_query_t_1( vote_stakes, child, &vote_c, NULL, &stake, &commission ) );
   FD_TEST( stake==300UL && commission==30U );
 
@@ -61,7 +64,7 @@ main( int argc, char ** argv ) {
        !fd_vote_stakes_t_1_iter_done( vote_stakes, sibling, iter );
        fd_vote_stakes_t_1_iter_next( vote_stakes, sibling, iter ) ) {
     fd_pubkey_t pubkey;
-    fd_vote_stakes_t_1_iter_ele( vote_stakes, sibling, iter, &pubkey, NULL, NULL, NULL );
+    fd_vote_stakes_t_1_iter_ele( vote_stakes, sibling, iter, &pubkey, NULL, NULL, NULL, NULL );
     iter_cnt++;
   }
   FD_TEST( iter_cnt==1UL );
@@ -82,21 +85,21 @@ main( int argc, char ** argv ) {
   child = fd_vote_stakes_new_fork( vote_stakes, root, 1UL );
   fd_pubkey_t tie_a = key( 10000UL );
   fd_pubkey_t tie_b = key( 10001UL );
-  fd_vote_stakes_insert( vote_stakes, child, &tie_a, &node_a, 10UL, 1U );
-  fd_vote_stakes_insert( vote_stakes, child, &tie_b, &node_b, 10UL, 1U );
+  fd_vote_stakes_insert( vote_stakes, child, &tie_a, &node_a, 10UL, 1U, bls_a );
+  fd_vote_stakes_insert( vote_stakes, child, &tie_b, &node_b, 10UL, 1U, bls_b );
   for( ulong i=2UL; i<FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS; i++ ) {
     fd_pubkey_t vote = key( 10000UL+i );
-    fd_vote_stakes_insert( vote_stakes, child, &vote, &node_a, 100UL+i, 1U );
+    fd_vote_stakes_insert( vote_stakes, child, &vote, &node_a, 100UL+i, 1U, bls_a );
   }
   fd_pubkey_t tie_candidate = key( 20000UL );
-  fd_vote_stakes_insert( vote_stakes, child, &tie_candidate, &node_a, 10UL, 1U );
+  fd_vote_stakes_insert( vote_stakes, child, &tie_candidate, &node_a, 10UL, 1U, bls_a );
   FD_TEST( !fd_vote_stakes_query_t_1( vote_stakes, child, &tie_a, NULL, NULL, NULL ) );
   FD_TEST( !fd_vote_stakes_query_t_1( vote_stakes, child, &tie_b, NULL, NULL, NULL ) );
   FD_TEST( !fd_vote_stakes_query_t_1( vote_stakes, child, &tie_candidate, NULL, NULL, NULL ) );
   FD_TEST( fd_vote_stakes_cnt_t_1( vote_stakes, child )==FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS-2UL );
 
   fd_pubkey_t above_floor = key( 20001UL );
-  fd_vote_stakes_insert( vote_stakes, child, &above_floor, &node_a, 11UL, 1U );
+  fd_vote_stakes_insert( vote_stakes, child, &above_floor, &node_a, 11UL, 1U, bls_a );
   FD_TEST( fd_vote_stakes_query_t_1( vote_stakes, child, &above_floor, NULL, NULL, NULL ) );
   fd_vote_stakes_purge_fork( vote_stakes, child );
   fd_vote_stakes_purge_fork( vote_stakes, root );


### PR DESCRIPTION
- Allows us to boot + execute on ag cluster
- still using reasm, but publish is not wired through so will OOM
- replay slot metric is populated by tower reset slot, so also need to update metrics for replay slot in order for it to look like we are replaying

TODO BLS key should be validated in snap manifest, but wont pass ci rn