### PR TITLE
gossvf: clear signature cache after stakes change

### DIFF
--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -323,6 +323,10 @@ handle_epoch( fd_gossvf_tile_ctx_t *      ctx,
     stake_map_ele_insert( ctx->stake.map, entry, ctx->stake.pool );
   }
   ctx->stake.count = stake_pool_used( ctx->stake.pool );
+
+  /* A stake update can cause gossip to discard CRDS values that were
+     accepted under the previous stake table. */
+  *ctx->tcache.sync = fd_tcache_reset( ctx->tcache.ring, ctx->tcache.depth, ctx->tcache.map, ctx->tcache.map_cnt );
 }
 
 static int


### PR DESCRIPTION
Fixes 2Gbps+ ingress gossip traffic for several minutes after boot.

What was happening:

1. Before epoch stakes arrive, every CRDS is stored with `stake=0` and a large TTL. The gossip table fills up.

2. Epoch stakes load (after incremental snapshot load), gossip enables the normal 15-second TTL for unstaked entries. Existing entries expire almost immediately.

3. The network sees that the node is missing those values and sends them again, producing the massive ingress bandwidth.

4. Those values cannot repopulate CRDS because gossvf’s signature cache remembers their signatures from the first fill.  Eventually recovers minutes later when the signature cache is fully overwritten with new signatures.