### PR TITLE
runtime: cache BPF syscall tables

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -807,6 +807,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->runtime->accdb                    = ctx->accdb;
   ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = txncache;
+  fd_runtime_bpf_loader_syscalls_init( &ctx->runtime->bpf_loader_program.syscalls );
   memset( &ctx->runtime->log, 0, sizeof(ctx->runtime->log) );
   ctx->runtime->log.log_collector        = ctx->log_collector;
   ctx->runtime->fuzz.enabled             = 0;

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -489,6 +489,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->runtime->accdb                    = ctx->accdb;
   ctx->runtime->progcache                = ctx->progcache;
   ctx->runtime->status_cache             = ctx->txncache;
+  fd_runtime_bpf_loader_syscalls_init( &ctx->runtime->bpf_loader_program.syscalls );
   memset( &ctx->runtime->log, 0, sizeof(ctx->runtime->log) );
   ctx->runtime->log.log_collector        = &ctx->log_collector;
   ctx->runtime->log.dumping_mem          = _dumping;

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -73,6 +73,9 @@ ifdef FD_HAS_ATOMIC
 $(call add-hdrs,fd_runtime.h fd_runtime_err.h fd_runtime_const.h fd_runtime_stack.h fd_runtime_helpers.h)
 $(call add-objs,fd_runtime,fd_flamenco)
 ifdef FD_HAS_HOSTED
+$(call make-unit-test,test_bpf_loader_syscalls,test_bpf_loader_syscalls,fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_bpf_loader_syscalls)
+
 $(call make-unit-test,test_lamports_per_byte_feature_gates,test_lamports_per_byte_feature_gates,fd_flamenco_test fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_lamports_per_byte_feature_gates)
 $(call make-unit-test,test_vat_refresh_vote_accounts,test_vat_refresh_vote_accounts,fd_flamenco fd_ballet fd_util)

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -28,6 +28,33 @@
 
 FD_STATIC_ASSERT( MAX_STAKE_WEIGHTS==FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS, vat_stake_weights );
 
+#define FD_RUNTIME_BPF_SYSCALLS_MAGIC (0xF17EDA2CE5B5C001UL)
+
+void
+fd_runtime_bpf_loader_syscalls_init( fd_runtime_bpf_loader_syscalls_t * syscalls ) {
+  syscalls->magic       = FD_RUNTIME_BPF_SYSCALLS_MAGIC;
+  syscalls->slot_key    = ULONG_MAX;
+  syscalls->rebuild_cnt = 0UL;
+}
+
+fd_sbpf_syscalls_t *
+fd_runtime_bpf_loader_syscalls_get( fd_runtime_bpf_loader_syscalls_t * syscalls,
+                                    fd_bank_t const *                  bank ) {
+  if( FD_UNLIKELY( (!syscalls) | (!bank) ) ) return NULL;
+  if( FD_UNLIKELY( syscalls->magic!=FD_RUNTIME_BPF_SYSCALLS_MAGIC ) ) fd_runtime_bpf_loader_syscalls_init( syscalls );
+
+  ulong slot_key = fd_vm_syscall_slot_key( bank->f.slot, &bank->f.features, 0 );
+  fd_sbpf_syscalls_t * map = fd_sbpf_syscalls_join( syscalls->map );
+
+  if( FD_UNLIKELY( slot_key!=syscalls->slot_key ) ) {
+    if( FD_UNLIKELY( fd_vm_syscall_register_slot( map, bank->f.slot, &bank->f.features, 0 ) ) ) return NULL;
+    syscalls->slot_key = slot_key;
+    syscalls->rebuild_cnt++;
+  }
+
+  return map;
+}
+
 /*
    https://github.com/anza-xyz/agave/blob/v2.1.1/runtime/src/bank.rs#L1254-L1258
    https://github.com/anza-xyz/agave/blob/v2.1.1/runtime/src/bank.rs#L1749

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -71,6 +71,14 @@
    txn_out (not committable) --> fd_runtime_cancel_txn()
 */
 
+struct fd_runtime_bpf_loader_syscalls {
+  ulong              magic;
+  ulong              slot_key;
+  ulong              rebuild_cnt;
+  fd_sbpf_syscalls_t map[ FD_SBPF_SYSCALLS_SLOT_CNT ];
+};
+typedef struct fd_runtime_bpf_loader_syscalls fd_runtime_bpf_loader_syscalls_t;
+
 struct fd_runtime {
   fd_accdb_t *     accdb;
   fd_txncache_t *  status_cache;
@@ -138,9 +146,10 @@ struct fd_runtime {
   } bpf_loader_serialization;
 
   struct {
-    uchar rodata        [ FD_RUNTIME_ACC_SZ_MAX     ] __attribute__((aligned(FD_SBPF_PROG_RODATA_ALIGN)));
-    uchar sbpf_footprint[ FD_SBPF_PROGRAM_FOOTPRINT ] __attribute__((aligned(alignof(fd_sbpf_program_t))));
-    uchar programdata   [ FD_RUNTIME_ACC_SZ_MAX     ] __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
+    uchar                            rodata        [ FD_RUNTIME_ACC_SZ_MAX     ] __attribute__((aligned(FD_SBPF_PROG_RODATA_ALIGN)));
+    uchar                            sbpf_footprint[ FD_SBPF_PROGRAM_FOOTPRINT ] __attribute__((aligned(alignof(fd_sbpf_program_t))));
+    uchar                            programdata   [ FD_RUNTIME_ACC_SZ_MAX     ] __attribute__((aligned(FD_ACCOUNT_REC_ALIGN)));
+    fd_runtime_bpf_loader_syscalls_t syscalls;
   } bpf_loader_program;
 
   union {
@@ -330,6 +339,20 @@ struct fd_txn_out {
 typedef struct fd_txn_out fd_txn_out_t;
 
 FD_PROTOTYPES_BEGIN
+
+/* fd_runtime_bpf_loader_syscalls_init invalidates a runtime-local
+   execution syscall cache.  fd_runtime_bpf_loader_syscalls_get returns
+   the syscall map for bank, rebuilding it only when the effective
+   feature-gated syscall set changes.  A runtime is single-worker state;
+   callers must not change bank's feature set while a VM using the
+   returned map is live. */
+
+void
+fd_runtime_bpf_loader_syscalls_init( fd_runtime_bpf_loader_syscalls_t * syscalls );
+
+fd_sbpf_syscalls_t *
+fd_runtime_bpf_loader_syscalls_get( fd_runtime_bpf_loader_syscalls_t * syscalls,
+                                    fd_bank_t const *                  bank );
 
 /* fd_runtime_block_execute_prepare kicks off the execution of a block.
    After this function is called, transactions can be executed and

--- a/src/flamenco/runtime/program/fd_bpf_loader_program.c
+++ b/src/flamenco/runtime/program/fd_bpf_loader_program.c
@@ -403,17 +403,9 @@ fd_bpf_execute( fd_exec_instr_ctx_t *      instr_ctx,
 
   int err = FD_EXECUTOR_INSTR_SUCCESS;
 
-  uchar syscalls_mem[ FD_SBPF_SYSCALLS_FOOTPRINT ] __attribute__((aligned(FD_SBPF_SYSCALLS_ALIGN)));
-  fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_join( fd_sbpf_syscalls_new( syscalls_mem ) );
-  if( FD_UNLIKELY( !syscalls ) ) {
-    FD_LOG_CRIT(( "Unable to allocate syscalls" ));
-  }
-
-  /* TODO do we really need to re-do this on every instruction? */
-  fd_vm_syscall_register_slot( syscalls,
-                               instr_ctx->bank->f.slot,
-                               &instr_ctx->bank->f.features,
-                               0 );
+  fd_sbpf_syscalls_t * syscalls = fd_runtime_bpf_loader_syscalls_get(
+      &instr_ctx->runtime->bpf_loader_program.syscalls, instr_ctx->bank );
+  if( FD_UNLIKELY( !syscalls ) ) FD_LOG_CRIT(( "Unable to register syscalls" ));
 
   /* https://github.com/anza-xyz/agave/blob/574bae8fefc0ed256b55340b9d87b7689bcdf222/programs/bpf_loader/src/lib.rs#L1362-L1368 */
   ulong                   input_sz                                 = 0UL;

--- a/src/flamenco/runtime/test_bpf_loader_syscalls.c
+++ b/src/flamenco/runtime/test_bpf_loader_syscalls.c
@@ -1,0 +1,135 @@
+#include "fd_runtime.h"
+#include "fd_bank.h"
+#include "../features/fd_features.h"
+
+static int
+has_syscall( fd_sbpf_syscalls_t const * syscalls,
+             char const *              name ) {
+  for( ulong i=0UL; i<FD_SBPF_SYSCALLS_SLOT_CNT; i++ ) {
+    if( fd_sbpf_syscalls_key_inval( syscalls[i].key ) ) continue;
+    if( syscalls[i].name && !strcmp( syscalls[i].name, name ) ) return 1;
+  }
+  return 0;
+}
+
+static fd_sbpf_syscalls_t *
+syscalls_at( fd_runtime_bpf_loader_syscalls_t * syscalls,
+             fd_bank_t *                        bank,
+             ulong                              slot ) {
+  bank->f.slot = slot;
+  fd_sbpf_syscalls_t * map = fd_runtime_bpf_loader_syscalls_get( syscalls, bank );
+  FD_TEST( map );
+  return map;
+}
+
+static void
+test_feature_transitions( void ) {
+  static fd_runtime_bpf_loader_syscalls_t syscalls[1];
+  static fd_bank_t                        bank[1];
+
+  fd_memset( bank, 0, sizeof(bank) );
+  fd_runtime_bpf_loader_syscalls_init( syscalls );
+  fd_features_disable_all( &bank->f.features );
+
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, get_sysvar_syscall_enabled,      101UL );
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, enable_get_epoch_stake_syscall,  102UL );
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, enable_bls12_381_syscall,        103UL );
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, enable_sha512_syscall,           104UL );
+
+  fd_sbpf_syscalls_t * map = syscalls_at( syscalls, bank, 100UL );
+  FD_TEST( map==syscalls->map );
+  FD_TEST( syscalls->rebuild_cnt==1UL );
+  FD_TEST(  has_syscall( map, "sol_log_"            ) );
+  FD_TEST(  has_syscall( map, "sol_alloc_free_"     ) );
+  FD_TEST( !has_syscall( map, "sol_get_sysvar"      ) );
+  FD_TEST( !has_syscall( map, "sol_get_epoch_stake" ) );
+  FD_TEST( !has_syscall( map, "sol_sha512"          ) );
+#if FD_HAS_BLST
+  FD_TEST( !has_syscall( map, "sol_curve_decompress" ) );
+  FD_TEST( !has_syscall( map, "sol_curve_pairing_map" ) );
+#endif
+
+  FD_TEST( syscalls_at( syscalls, bank, 100UL )==map );
+  FD_TEST( syscalls->rebuild_cnt==1UL );
+
+  map = syscalls_at( syscalls, bank, 0UL );
+  FD_TEST( syscalls->rebuild_cnt==2UL );
+  FD_TEST( has_syscall( map, "sol_get_sysvar"      ) );
+  FD_TEST( has_syscall( map, "sol_get_epoch_stake" ) );
+  FD_TEST( has_syscall( map, "sol_sha512"          ) );
+#if FD_HAS_BLST
+  FD_TEST( has_syscall( map, "sol_curve_decompress" ) );
+  FD_TEST( has_syscall( map, "sol_curve_pairing_map" ) );
+#endif
+
+  map = syscalls_at( syscalls, bank, 101UL );
+  FD_TEST( syscalls->rebuild_cnt==3UL );
+  FD_TEST(  has_syscall( map, "sol_get_sysvar"      ) );
+  FD_TEST( !has_syscall( map, "sol_get_epoch_stake" ) );
+  FD_TEST( !has_syscall( map, "sol_sha512"          ) );
+
+  map = syscalls_at( syscalls, bank, 102UL );
+  FD_TEST( syscalls->rebuild_cnt==4UL );
+  FD_TEST( has_syscall( map, "sol_get_sysvar"      ) );
+  FD_TEST( has_syscall( map, "sol_get_epoch_stake" ) );
+  FD_TEST( !has_syscall( map, "sol_sha512"         ) );
+
+  map = syscalls_at( syscalls, bank, 103UL );
+#if FD_HAS_BLST
+  FD_TEST( syscalls->rebuild_cnt==5UL );
+  FD_TEST( has_syscall( map, "sol_curve_decompress" ) );
+  FD_TEST( has_syscall( map, "sol_curve_pairing_map" ) );
+#else
+  FD_TEST( syscalls->rebuild_cnt==4UL );
+#endif
+  FD_TEST( !has_syscall( map, "sol_sha512" ) );
+
+  map = syscalls_at( syscalls, bank, 104UL );
+#if FD_HAS_BLST
+  FD_TEST( syscalls->rebuild_cnt==6UL );
+#else
+  FD_TEST( syscalls->rebuild_cnt==5UL );
+#endif
+  FD_TEST( has_syscall( map, "sol_sha512" ) );
+
+  FD_TEST( syscalls_at( syscalls, bank, 105UL )==map );
+#if FD_HAS_BLST
+  FD_TEST( syscalls->rebuild_cnt==6UL );
+#else
+  FD_TEST( syscalls->rebuild_cnt==5UL );
+#endif
+
+  map = syscalls_at( syscalls, bank, 100UL );
+#if FD_HAS_BLST
+  FD_TEST( syscalls->rebuild_cnt==7UL );
+#else
+  FD_TEST( syscalls->rebuild_cnt==6UL );
+#endif
+  FD_TEST( !has_syscall( map, "sol_get_sysvar"      ) );
+  FD_TEST( !has_syscall( map, "sol_get_epoch_stake" ) );
+  FD_TEST( !has_syscall( map, "sol_sha512"          ) );
+
+  fd_sbpf_syscalls_t deploy_mem[ FD_SBPF_SYSCALLS_SLOT_CNT ];
+  fd_sbpf_syscalls_t * deploy = fd_sbpf_syscalls_join( fd_sbpf_syscalls_new( deploy_mem ) );
+  FD_TEST( !fd_vm_syscall_register_slot( deploy, bank->f.slot, &bank->f.features, 1 ) );
+  FD_TEST( !has_syscall( deploy, "sol_alloc_free_" ) );
+  FD_TEST(  has_syscall( map,    "sol_alloc_free_" ) );
+
+  FD_TEST( !fd_runtime_bpf_loader_syscalls_get( NULL, bank ) );
+  FD_TEST( !fd_runtime_bpf_loader_syscalls_get( syscalls, NULL ) );
+
+  fd_memset( syscalls, 0, sizeof(syscalls) );
+  map = syscalls_at( syscalls, bank, 100UL );
+  FD_TEST( syscalls->rebuild_cnt==1UL );
+  FD_TEST( !has_syscall( map, "sol_get_sysvar" ) );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+  test_feature_transitions();
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/runtime/tests/fd_solfuzz.c
+++ b/src/flamenco/runtime/tests/fd_solfuzz.c
@@ -140,6 +140,7 @@ fd_solfuzz_runner_new( fd_wksp_t *                         wksp,
 
   runner->runtime = fd_wksp_alloc_laddr( wksp, alignof(fd_runtime_t), sizeof(fd_runtime_t), wksp_tag );
   if( FD_UNLIKELY( !runner->runtime ) ) goto bail2;
+  fd_runtime_bpf_loader_syscalls_init( &runner->runtime->bpf_loader_program.syscalls );
   runner->runtime->accounts.executable_cnt = 0UL;
   runner->runtime->accounts.account_cnt    = 0UL;
   runner->runtime_stack = fd_wksp_alloc_laddr( wksp, fd_runtime_stack_align(), fd_runtime_stack_footprint( 2048UL, 2048UL, 2048UL ), wksp_tag );

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -214,6 +214,7 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
   runtime->accdb        = accdb;
   runtime->status_cache = mini->txncache;
   runtime->progcache    = mini->progcache;
+  fd_runtime_bpf_loader_syscalls_init( &runtime->bpf_loader_program.syscalls );
 
   runtime->instr.stack_sz          = 0;
   runtime->instr.trace_length      = 0;

--- a/src/flamenco/vm/fd_vm_base.h
+++ b/src/flamenco/vm/fd_vm_base.h
@@ -758,6 +758,17 @@ fd_vm_syscall_register( fd_sbpf_syscalls_t *   syscalls,
                         char const *           name,
                         fd_sbpf_syscall_func_t func );
 
+/* fd_vm_syscall_slot_key returns an opaque key identifying the exact
+   feature-gated syscall set selected for slot and is_deploy.  Equal
+   keys select the same set.  The return value is never ULONG_MAX.
+   Callers may use this to cache a syscall map across slots where the
+   effective feature set does not change. */
+
+FD_FN_PURE ulong
+fd_vm_syscall_slot_key( ulong                 slot,
+                        fd_features_t const * features,
+                        uchar                 is_deploy );
+
 /* fd_vm_syscall_register_slot unmaps all syscalls in the current map
    (also ending any interest in the corresponding name cstr) and
    registers all syscalls appropriate for the slot.  Returns

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -1,6 +1,38 @@
 #include "fd_vm_syscall.h"
 #include "../../../ballet/murmur3/fd_murmur3.h"
 
+/* Keep these bits synchronized with the feature-gated registrations in
+   fd_vm_syscall_register_slot. */
+#define FD_VM_SYSCALL_KEY_GET_SYSVAR      (1UL<<0)
+#define FD_VM_SYSCALL_KEY_GET_EPOCH_STAKE (1UL<<1)
+#define FD_VM_SYSCALL_KEY_BLS12_381       (1UL<<2)
+#define FD_VM_SYSCALL_KEY_SHA512          (1UL<<3)
+#define FD_VM_SYSCALL_KEY_DEPLOY          (1UL<<4)
+
+FD_FN_PURE ulong
+fd_vm_syscall_slot_key( ulong                 slot,
+                        fd_features_t const * features,
+                        uchar                 is_deploy ) {
+  ulong key = is_deploy ? FD_VM_SYSCALL_KEY_DEPLOY : 0UL;
+  if( FD_UNLIKELY( !slot ) ) {
+    return key |
+           FD_VM_SYSCALL_KEY_GET_SYSVAR |
+           FD_VM_SYSCALL_KEY_GET_EPOCH_STAKE |
+#if FD_HAS_BLST
+           FD_VM_SYSCALL_KEY_BLS12_381 |
+#endif
+           FD_VM_SYSCALL_KEY_SHA512;
+  }
+
+  if( FD_FEATURE_ACTIVE( slot, features, get_sysvar_syscall_enabled      ) ) key |= FD_VM_SYSCALL_KEY_GET_SYSVAR;
+  if( FD_FEATURE_ACTIVE( slot, features, enable_get_epoch_stake_syscall ) ) key |= FD_VM_SYSCALL_KEY_GET_EPOCH_STAKE;
+#if FD_HAS_BLST
+  if( FD_FEATURE_ACTIVE( slot, features, enable_bls12_381_syscall       ) ) key |= FD_VM_SYSCALL_KEY_BLS12_381;
+#endif
+  if( FD_FEATURE_ACTIVE( slot, features, enable_sha512_syscall          ) ) key |= FD_VM_SYSCALL_KEY_SHA512;
+  return key;
+}
+
 int
 fd_vm_syscall_register( fd_sbpf_syscalls_t *   syscalls,
                         char const *           name,
@@ -23,25 +55,11 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *      syscalls,
                              uchar                     is_deploy ) {
   if( FD_UNLIKELY( !syscalls ) ) return FD_VM_ERR_INVAL;
 
-  int enable_get_sysvar_syscall        = 0;
-  int enable_get_epoch_stake_syscall   = 0;
-  int enable_bls12_381_syscall         = 0;
-  int enable_sha512_syscall            = 0;
+  ulong key = fd_vm_syscall_slot_key( slot, features, is_deploy );
 
-  if( slot ) {
-    enable_get_sysvar_syscall        = FD_FEATURE_ACTIVE( slot, features, get_sysvar_syscall_enabled );
-    enable_get_epoch_stake_syscall   = FD_FEATURE_ACTIVE( slot, features, enable_get_epoch_stake_syscall );
-    enable_bls12_381_syscall         = FD_FEATURE_ACTIVE( slot, features, enable_bls12_381_syscall );
-    enable_sha512_syscall            = FD_FEATURE_ACTIVE( slot, features, enable_sha512_syscall );
-
-  } else { /* enable ALL */
-
-    enable_get_sysvar_syscall        = 1;
-    enable_get_epoch_stake_syscall   = 1;
-    enable_bls12_381_syscall         = 1;
-    enable_sha512_syscall            = 1;
-
-  }
+  int enable_get_sysvar_syscall      = !!(key & FD_VM_SYSCALL_KEY_GET_SYSVAR      );
+  int enable_get_epoch_stake_syscall = !!(key & FD_VM_SYSCALL_KEY_GET_EPOCH_STAKE);
+  int enable_sha512_syscall          = !!(key & FD_VM_SYSCALL_KEY_SHA512          );
 
   fd_sbpf_syscalls_clear( syscalls );
 
@@ -63,7 +81,7 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *      syscalls,
      programs can no longer be deployed which use the sol_alloc_free_ syscall.
 
     https://github.com/anza-xyz/agave/blob/d6041c002bbcf1526de4e38bc18fa6e781c380e7/programs/bpf_loader/src/syscalls/mod.rs#L429 */
-  if ( FD_LIKELY( !is_deploy ) ) {
+  if( FD_LIKELY( !(key & FD_VM_SYSCALL_KEY_DEPLOY) ) ) {
     REGISTER( "sol_alloc_free_",                       fd_vm_syscall_sol_alloc_free );
   }
 
@@ -133,12 +151,10 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *      syscalls,
 //REGISTER( "sol_remaining_compute_units",           fd_vm_syscall_sol_remaining_compute_units );
 
 #if FD_HAS_BLST
-  if( enable_bls12_381_syscall ) {
+  if( key & FD_VM_SYSCALL_KEY_BLS12_381 ) {
     REGISTER( "sol_curve_decompress",                fd_vm_syscall_sol_curve_decompress );
     REGISTER( "sol_curve_pairing_map",               fd_vm_syscall_sol_curve_pairing_map );
   }
-#else
-  (void)enable_bls12_381_syscall;
 #endif /* FD_HAS_BLST */
 
 # undef REGISTER


### PR DESCRIPTION
## Summary

- Move the execution-mode SBPF syscall table into runtime-owned state.
- Cache it by the effective feature-gated syscall set and rebuild only when that set changes.
- Keep deployment verification on its separate syscall table.
- Add feature-transition regression coverage.

## Performance

A local targeted measurement, using a benchmark harness that is not included in this PR, measured:

- syscall registration: 396.52 ns/invocation
- cached lookup: 3.49 ns/invocation
- removed setup cost: 393.03 ns/invocation, about 99.1 percent

This isolates syscall-table setup; total transaction impact depends on the BPF workload and invocation count.

## Testing

- GCC and Clang: test_bpf_loader_syscalls
- GCC and Clang: test_bpf_loader_program
- test_programdata_delayvis
- test_cpi_semantics
- test_vm_syscalls --page-sz normal --page-cnt 160000
- git diff --check

## Remaining draft validation

- Run a BPF-heavy microblock replay covering top-level and CPI invocation counts and feature-boundary slots before marking ready.