### PR TITLE
txncache: memory improvements

### DIFF
--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -57,20 +57,30 @@ typedef struct fd_blockhash_entry fd_blockhash_entry_t;
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
 
-/* The most root slots Agave could possibly serve in a snapshot.  The
-   txnpage pool sizing assumes staged entries never exceed this. */
-#define FD_SNAPIN_TXNCACHE_MAX_ENTRIES (FD_TXNCACHE_SNAPSHOT_SLOT_DELTA_MAX*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT)
+/* For a transaction to be valid to be inserted into the txncache, it
+   must reference a blockhash that is in the set of recent blockhashes.
+   This means that only transactions executed in the latest 151 slots
+   can be in the txncache: the remaining entries can be ignored. */
+#define FD_SNAPIN_TXNCACHE_MAX_ENTRIES (FD_TXNCACHE_MAX_SLOT_DELTAS*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT)
 
-FD_STATIC_ASSERT( FD_SLOT_DELTA_MAX_ENTRIES==FD_TXNCACHE_SNAPSHOT_SLOT_DELTA_MAX, slot_delta_max );
+FD_STATIC_ASSERT( FD_TXNCACHE_MAX_SLOT_DELTAS<=FD_SLOT_DELTA_MAX_ENTRIES, txncache_staging_slot_cnt );
 
 struct blockhash_group {
   uchar blockhash[ 32UL ];
+  ulong slot;
   ulong txnhash_offset;
   ulong txncache_entry_idx;
   ulong txncache_entry_cnt;
 };
 
 typedef struct blockhash_group blockhash_group_t;
+
+struct txncache_staging_slot {
+  ulong slot;
+  ulong entry_cnt;
+};
+
+typedef struct txncache_staging_slot txncache_staging_slot_t;
 
 struct fd_snapin_out_link {
   ulong       idx;
@@ -148,8 +158,11 @@ struct fd_snapin_tile {
 
   int alpenglow;
 
-  ulong                  txncache_entries_len;
-  fd_sstxncache_hash_t * txncache_entries;
+  fd_sstxncache_hash_t *  txncache_entries;
+  txncache_staging_slot_t txncache_slots[ FD_TXNCACHE_MAX_SLOT_DELTAS ];
+  ulong                   txncache_slots_len;
+  ulong                   txncache_current_slot_idx;
+  ulong                   txncache_current_slot_entry_cnt;
 
   fd_accdb_fork_id_t accdb_root_fork_id;
   fd_accdb_fork_id_t accdb_incr_fork_id; /* child fork for incremental writes (purge on failure) */
@@ -632,9 +645,8 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
       FD_LOG_WARNING(( "corrupt snapshot: no blockhash offsets found (rooted_slots=%lu)", ss.ele_cnt ));
       return 1;
     }
-    FD_LOG_WARNING(( "status cache has no blockhash offsets (rooted_slots=%lu txn_entries=%lu); "
-                     "proceeding with empty txncache offsets",
-                     ss.ele_cnt, ctx->txncache_entries_len ));
+    FD_LOG_WARNING(( "status cache has no blockhash offsets (rooted_slots=%lu); proceeding with empty txncache offsets",
+                     ss.ele_cnt ));
   }
   for( ulong i=0UL; i<ctx->blockhash_groups_len; i++ ) {
     blockhash_group_t const * group = &ctx->blockhash_groups[ i ];
@@ -663,23 +675,31 @@ populate_txncache( fd_snapin_tile_t *                     ctx,
   /* Now insert all transactions as if they executed at the current
      root, per above. */
 
-  ulong insert_cnt = 0UL;
   for( ulong i=0UL; i<ctx->blockhash_groups_len; i++ ) {
     blockhash_group_t const * group = &ctx->blockhash_groups[ i ];
+    /* Skip if there are no transaction in this group or if the slot is
+       too old. */
+    if( FD_UNLIKELY( group->txncache_entry_idx==ULONG_MAX || !group->txncache_entry_cnt ) ) continue;
+
+    ulong slot_idx = group->txncache_entry_idx/FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT;
+    FD_TEST( slot_idx<ctx->txncache_slots_len );
+    /* Skip groups whose entries correspond to a different slot.  This
+       happens when an older slot is evicted and its storage is reused. */
+    if( FD_UNLIKELY( ctx->txncache_slots[ slot_idx ].slot!=group->slot ) ) continue;
+    ulong slot_entry_idx = group->txncache_entry_idx-slot_idx*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT;
+    FD_TEST( slot_entry_idx<=ctx->txncache_slots[ slot_idx ].entry_cnt );
+    FD_TEST( group->txncache_entry_cnt<=ctx->txncache_slots[ slot_idx ].entry_cnt-slot_entry_idx );
+    fd_sstxncache_hash_t const * entries = &ctx->txncache_entries[ group->txncache_entry_idx ];
+
     fd_hash_t key;
     fd_memcpy( key.uc, group->blockhash, 32UL );
     if( FD_UNLIKELY( !blockhash_map_ele_query_const( blockhash_map, &key, NULL, blockhash_pool ) ) ) continue;
 
-    FD_TEST( group->txncache_entry_idx<=ctx->txncache_entries_len );
-    FD_TEST( group->txncache_entry_cnt<=ctx->txncache_entries_len-group->txncache_entry_idx );
     for( ulong j=0UL; j<group->txncache_entry_cnt; j++ ) {
-      fd_sstxncache_hash_t const * entry = &ctx->txncache_entries[ group->txncache_entry_idx+j ];
+      fd_sstxncache_hash_t const * entry = &entries[ j ];
       fd_txncache_insert( ctx->txncache, banks[ 0UL ].fork_id, group->blockhash, entry->txnhash );
-      insert_cnt++;
     }
   }
-
-  FD_LOG_INFO(( "inserted %lu/%lu transactions into the txncache", insert_cnt, ctx->txncache_entries_len ));
 
   /* Then finalize all the banks (freezing them) and setting the txnhash
      offset so future queries use the correct offset.  If the offset is
@@ -1099,6 +1119,27 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
             FD_LOG_WARNING(( "error while parsing slot deltas in status cache" ));
             transition_malformed( ctx, stem );
             return 0;
+          } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_SLOT ) ) {
+            /* If we're parsing a new slot, add th new slot if we
+               haven't parsed 151 slots yet.  Otherwise ignore or evict
+               slots that are too old.  */
+            ulong candidate_idx;
+            if( FD_LIKELY( ctx->txncache_slots_len<FD_TXNCACHE_MAX_SLOT_DELTAS ) ) {
+              candidate_idx = ctx->txncache_slots_len++;
+            } else {
+              candidate_idx = 0UL;
+              for( ulong i=1UL; i<FD_TXNCACHE_MAX_SLOT_DELTAS; i++ ) {
+                if( ctx->txncache_slots[ i ].slot<ctx->txncache_slots[ candidate_idx ].slot ) candidate_idx = i;
+              }
+              if( FD_UNLIKELY( sd_result->slot<ctx->txncache_slots[ candidate_idx ].slot ) ) candidate_idx = ULONG_MAX;
+            }
+
+            if( FD_LIKELY( candidate_idx!=ULONG_MAX ) ) {
+              ctx->txncache_slots[ candidate_idx ].slot      = sd_result->slot;
+              ctx->txncache_slots[ candidate_idx ].entry_cnt = 0UL;
+            }
+            ctx->txncache_current_slot_idx       = candidate_idx;
+            ctx->txncache_current_slot_entry_cnt = 0UL;
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) ) {
             if( FD_UNLIKELY( ctx->blockhash_groups_len>=FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ) ) {
               FD_LOG_WARNING(( "blockhash groups overflow, max is %lu", FD_SNAPIN_MAX_SLOT_DELTA_GROUPS ));
@@ -1108,18 +1149,46 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
 
             blockhash_group_t * group = &ctx->blockhash_groups[ ctx->blockhash_groups_len++ ];
             memcpy( group->blockhash, sd_result->group.blockhash, 32UL );
+            group->slot               = sd_result->group.slot;
             group->txnhash_offset     = sd_result->group.txnhash_offset;
-            group->txncache_entry_idx = ctx->txncache_entries_len;
             group->txncache_entry_cnt = 0UL;
+
+            /* Ignore the group if its corresponding slot is too old.
+               Otherwise record which entry to start looking at. */
+            ulong slot_idx = ctx->txncache_current_slot_idx;
+            if( FD_UNLIKELY( slot_idx==ULONG_MAX ) ) {
+              group->txncache_entry_idx = ULONG_MAX;
+            } else {
+              FD_TEST( slot_idx<ctx->txncache_slots_len );
+              FD_TEST( ctx->txncache_slots[ slot_idx ].slot==group->slot );
+              group->txncache_entry_idx = slot_idx*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT+ctx->txncache_slots[ slot_idx ].entry_cnt;
+            }
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) ) {
-            if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) {
-              FD_LOG_WARNING(( "txncache entries overflow, max is %lu", FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+            FD_TEST( ctx->blockhash_groups_len );
+            blockhash_group_t * group = &ctx->blockhash_groups[ ctx->blockhash_groups_len-1UL ];
+            FD_TEST( group->slot==sd_result->entry->slot );
+
+            if( FD_UNLIKELY( ctx->txncache_current_slot_entry_cnt>=FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT ) ) {
+              FD_LOG_WARNING(( "txncache entries overflow for slot %lu, max is %lu",
+                               group->slot, FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT ));
               transition_malformed( ctx, stem );
               return 0;
             }
-            FD_TEST( ctx->blockhash_groups_len );
-            memcpy( ctx->txncache_entries[ ctx->txncache_entries_len++ ].txnhash, sd_result->entry->txnhash, sizeof(fd_sstxncache_hash_t) );
-            ctx->blockhash_groups[ ctx->blockhash_groups_len-1UL ].txncache_entry_cnt++;
+            ctx->txncache_current_slot_entry_cnt++;
+
+            /* Record the entry iff it corresponds to a valid slot. */
+            ulong slot_idx = ctx->txncache_current_slot_idx;
+            if( FD_LIKELY( slot_idx!=ULONG_MAX ) ) {
+              FD_TEST( slot_idx<ctx->txncache_slots_len );
+              txncache_staging_slot_t * staging_slot = &ctx->txncache_slots[ slot_idx ];
+              FD_TEST( staging_slot->slot==group->slot );
+              FD_TEST( staging_slot->entry_cnt<FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT );
+              ulong entry_idx = slot_idx*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT+staging_slot->entry_cnt;
+              FD_TEST( entry_idx==group->txncache_entry_idx+group->txncache_entry_cnt );
+              memcpy( ctx->txncache_entries[ entry_idx ].txnhash, sd_result->entry->txnhash, sizeof(fd_sstxncache_hash_t) );
+              staging_slot->entry_cnt++;
+              group->txncache_entry_cnt++;
+            }
           }
 
           bytes_remaining           -= sd_result->bytes_consumed;
@@ -1253,9 +1322,11 @@ handle_control_frag( fd_snapin_tile_t *  ctx,
       ctx->state = FD_SNAPSHOT_STATE_PROCESSING;
       ctx->full = sig==FD_SNAPSHOT_MSG_CTRL_INIT_FULL;
       ctx->in.pos                  = 0UL;
-      ctx->txncache_entries_len    = 0UL;
       ctx->blockhash_groups_len    = 0UL;
       ctx->manifest_capitalization = 0UL;
+
+      ctx->txncache_slots_len = 0UL;
+
       fd_txncache_reset( ctx->txncache );
       fd_ssparse_init( ctx->ssparse );
       fd_ssparse_batch_enable( ctx->ssparse, 1 );
@@ -1566,8 +1637,7 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_TEST( ctx->bank );
   FD_TEST( ctx->bank->idx==0UL );
 
-  ctx->txncache_entries_len = 0UL;
-  ctx->blockhash_groups_len  = 0UL;
+  ctx->blockhash_groups_len = 0UL;
 
   ctx->manifest_parser = fd_ssmanifest_parser_join( fd_ssmanifest_parser_new( _manifest_parser ) );
   FD_TEST( ctx->manifest_parser );

--- a/src/discof/restore/test_snapin_tile.c
+++ b/src/discof/restore/test_snapin_tile.c
@@ -175,6 +175,134 @@ test_txncache_staging_entry_size( void ) {
   FD_TEST( sizeof(ctx->txncache_entries[ 0 ])==20UL );
 }
 
+static ulong
+test_txncache_staging_slot_prepare( fd_snapin_tile_t * ctx,
+                                    ulong               slot ) {
+  ulong candidate_idx;
+  if( ctx->txncache_slots_len<FD_TXNCACHE_MAX_SLOT_DELTAS ) {
+    candidate_idx = ctx->txncache_slots_len++;
+  } else {
+    candidate_idx = 0UL;
+    for( ulong i=1UL; i<FD_TXNCACHE_MAX_SLOT_DELTAS; i++ ) {
+      if( ctx->txncache_slots[ i ].slot<ctx->txncache_slots[ candidate_idx ].slot ) candidate_idx = i;
+    }
+    if( slot<ctx->txncache_slots[ candidate_idx ].slot ) return ULONG_MAX;
+  }
+
+  ctx->txncache_slots[ candidate_idx ].slot      = slot;
+  ctx->txncache_slots[ candidate_idx ].entry_cnt = 0UL;
+  return candidate_idx;
+}
+
+static void
+test_txncache_staging_slot_begin( fd_snapin_tile_t * ctx,
+                                  ulong               slot ) {
+  ctx->txncache_current_slot_idx       = test_txncache_staging_slot_prepare( ctx, slot );
+  ctx->txncache_current_slot_entry_cnt = 0UL;
+}
+
+static void
+test_txncache_staging_evicts_oldest_slot( void ) {
+  fd_snapin_tile_t ctx[ 1 ] = {0};
+  ctx->txncache_current_slot_idx       = ULONG_MAX;
+  ctx->txncache_current_slot_entry_cnt = 0UL;
+  ctx->txncache_slots_len              = 0UL;
+
+  ulong oldest_idx = ULONG_MAX;
+  for( ulong i=0UL; i<FD_TXNCACHE_MAX_SLOT_DELTAS; i++ ) {
+    ulong slot_idx = test_txncache_staging_slot_prepare( ctx, 1000UL+i );
+    FD_TEST( slot_idx!=ULONG_MAX );
+    if( FD_UNLIKELY( !i ) ) oldest_idx = slot_idx;
+  }
+
+  FD_TEST( oldest_idx!=ULONG_MAX );
+  ctx->txncache_slots[ oldest_idx ].entry_cnt = 7UL;
+  fd_sstxncache_hash_t oldest_entries[ 7UL ];
+  ctx->txncache_entries = oldest_entries;
+
+  blockhash_group_t oldest_group = {
+    .slot               = 1000UL,
+    .txncache_entry_idx = oldest_idx*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT,
+    .txncache_entry_cnt = 7UL
+  };
+  ulong group_slot_idx = oldest_group.txncache_entry_idx/FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT;
+  FD_TEST( group_slot_idx<ctx->txncache_slots_len );
+  FD_TEST( ctx->txncache_slots[ group_slot_idx ].slot==oldest_group.slot );
+
+  FD_TEST( test_txncache_staging_slot_prepare( ctx, 999UL )==ULONG_MAX );
+  FD_TEST( ctx->txncache_slots[ oldest_idx ].slot==1000UL );
+
+  ulong replacement_idx = test_txncache_staging_slot_prepare( ctx, 1200UL );
+  FD_TEST( replacement_idx==oldest_idx );
+  FD_TEST( ctx->txncache_slots[ group_slot_idx ].slot!=oldest_group.slot );
+  FD_TEST( ctx->txncache_slots[ replacement_idx ].slot==1200UL );
+  FD_TEST( ctx->txncache_slots[ replacement_idx ].entry_cnt==0UL );
+}
+
+static void
+test_txncache_staging_fits_one_gigantic_page( void ) {
+  fd_topo_tile_t tile = {0};
+  tile.snapin.max_live_slots = 2048UL;
+  FD_TEST( scratch_footprint( &tile )<(1UL<<30) );
+}
+
+static void
+test_txncache_staging_validates_stale_group_offsets( void ) {
+  fd_snapin_tile_t ctx[ 1 ] = {0};
+  ctx->txncache_current_slot_idx       = ULONG_MAX;
+  ctx->txncache_current_slot_entry_cnt = 0UL;
+  ctx->txncache_slots_len              = 0UL;
+  ctx->seed = 1UL;
+
+  static uchar const blockhash[ 32UL ] = {1U};
+  blockhash_group_t groups[ 2UL ] = {
+    {
+      .slot               = 1000UL,
+      .txnhash_offset     = 1UL,
+      .txncache_entry_idx = 0UL,
+      .txncache_entry_cnt = 0UL
+    },
+    {
+      .slot               = 1200UL,
+      .txnhash_offset     = 2UL,
+      .txncache_entry_idx = 0UL,
+      .txncache_entry_cnt = 0UL
+    }
+  };
+  fd_memcpy( groups[ 0UL ].blockhash, blockhash, sizeof(blockhash) );
+  fd_memcpy( groups[ 1UL ].blockhash, blockhash, sizeof(blockhash) );
+  ctx->blockhash_groups     = groups;
+  ctx->blockhash_groups_len = 2UL;
+
+  for( ulong i=0UL; i<FD_TXNCACHE_MAX_SLOT_DELTAS; i++ ) {
+    test_txncache_staging_slot_begin( ctx, 1000UL+i );
+  }
+  test_txncache_staging_slot_begin( ctx, 1200UL );
+
+  fd_sstxncache_hash_t entries[ 1UL ];
+  ctx->txncache_entries = entries;
+
+  ulong shmem_sz = fd_txncache_shmem_footprint( 1UL, 1UL, 0 );
+  shmem_sz = fd_ulong_align_up( shmem_sz, fd_txncache_shmem_align() );
+  void * shmem = aligned_alloc( fd_txncache_shmem_align(), shmem_sz );
+  FD_TEST( shmem );
+  fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem, 1UL, 1UL, 0, 0UL ) );
+  FD_TEST( txncache_shmem );
+
+  ulong local_sz = fd_ulong_align_up( fd_txncache_footprint( 1UL ), fd_txncache_align() );
+  void * local = aligned_alloc( fd_txncache_align(), local_sz );
+  FD_TEST( local );
+  ctx->txncache = fd_txncache_join( fd_txncache_new( local, txncache_shmem ) );
+  FD_TEST( ctx->txncache );
+
+  fd_snapshot_manifest_blockhash_t blockhashes[ FD_BLOCKHASHES_MAX ] = {{ .hash_index = 0UL }};
+  fd_memcpy( blockhashes[ 0UL ].hash, blockhash, sizeof(blockhash) );
+  FD_TEST( populate_txncache( ctx, blockhashes, 1UL )==1 );
+
+  free( local );
+  free( shmem );
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -182,6 +310,9 @@ main( int     argc,
   test_batch_stake_delegation();
   test_streaming_stake_delegation();
   test_txncache_staging_entry_size();
+  test_txncache_staging_evicts_oldest_slot();
+  test_txncache_staging_fits_one_gigantic_page();
+  test_txncache_staging_validates_stale_group_offsets();
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();
   return 0;

--- a/src/discof/restore/utils/fd_slot_delta_parser.c
+++ b/src/discof/restore/utils/fd_slot_delta_parser.c
@@ -26,6 +26,7 @@ struct fd_slot_delta_parser_private {
   int     state;                       /* parser state machine */
   int     entry_avail;                 /* whether a parsed entry is available */
   int     group_avail;                 /* whether a parsed group is available */
+  int     slot_avail;                  /* whether a parsed slot is available */
 
   uchar * dst;                         /* where to store the next parsed value */
   ulong   dst_cur;                     /* offset into dst */
@@ -199,6 +200,7 @@ state_process( fd_slot_delta_parser_t * parser ) {
       parser->state = STATE_SLOT_DELTA_STATUS_LEN;
       break;
     case STATE_SLOT_DELTA_STATUS_LEN:
+      parser->slot_avail = 1;
       if( FD_UNLIKELY( !parser->slot_delta_status_len ) ) loop( parser );
       else                                                parser->state = STATE_STATUS_BLOCKHASH;
       break;
@@ -314,6 +316,7 @@ fd_slot_delta_parser_new( void * shmem ) {
 
   parser->entry_avail       = 0;
   parser->group_avail       = 0;
+  parser->slot_avail        = 0;
   parser->slot_pool_ele_cnt = 0UL;
   parser->state             = STATE_DONE;
 
@@ -360,6 +363,7 @@ fd_slot_delta_parser_init( fd_slot_delta_parser_t * parser ) {
 
   parser->entry_avail = 0;
   parser->group_avail = 0;
+  parser->slot_avail  = 0;
 }
 
 int
@@ -399,16 +403,26 @@ fd_slot_delta_parser_consume( fd_slot_delta_parser_t *                parser,
       parser->dst_sz  = state_size( parser );
       parser->dst_cur = 0UL;
 
-      if( FD_LIKELY( parser->group_avail ) ) {
+      if( FD_LIKELY( parser->slot_avail ) ) {
         FD_TEST( parser->entry_avail==0 );
+        FD_TEST( parser->group_avail==0 );
+        parser->slot_avail      = 0;
+        result->slot            = parser->entry->slot;
+        result->bytes_consumed  = (ulong)(data - buf);
+        return FD_SLOT_DELTA_PARSER_ADVANCE_SLOT;
+      } else if( FD_LIKELY( parser->group_avail ) ) {
+        FD_TEST( parser->entry_avail==0 );
+        FD_TEST( parser->slot_avail==0 );
         parser->group_avail          = 0;
         result->entry                = NULL;
         result->group.blockhash      = parser->entry->blockhash;
         result->group.txnhash_offset = parser->txnhash_offset;
+        result->group.slot           = parser->entry->slot;
         result->bytes_consumed       = (ulong)(data - buf);
         return FD_SLOT_DELTA_PARSER_ADVANCE_GROUP;
       } else if( FD_LIKELY( parser->entry_avail ) ) {
         FD_TEST( parser->group_avail==0 );
+        FD_TEST( parser->slot_avail==0 );
         parser->entry_avail    = 0;
         result->entry          = parser->entry;
         result->bytes_consumed = (ulong)(data - buf);

--- a/src/discof/restore/utils/fd_slot_delta_parser.h
+++ b/src/discof/restore/utils/fd_slot_delta_parser.h
@@ -102,7 +102,8 @@ fd_slot_delta_parser_init( fd_slot_delta_parser_t * parser );
 #define FD_SLOT_DELTA_PARSER_ADVANCE_AGAIN                            ( 0)
 #define FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY                            ( 1)
 #define FD_SLOT_DELTA_PARSER_ADVANCE_GROUP                            ( 2)
-#define FD_SLOT_DELTA_PARSER_ADVANCE_DONE                             ( 3)
+#define FD_SLOT_DELTA_PARSER_ADVANCE_SLOT                             ( 3)
+#define FD_SLOT_DELTA_PARSER_ADVANCE_DONE                             ( 4)
 
 static inline const char *
 fd_slot_delta_parser_advance_str( int err ) {
@@ -116,6 +117,7 @@ fd_slot_delta_parser_advance_str( int err ) {
     case FD_SLOT_DELTA_PARSER_ADVANCE_AGAIN:                            return "again";
     case FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY:                            return "entry";
     case FD_SLOT_DELTA_PARSER_ADVANCE_GROUP:                            return "group";
+    case FD_SLOT_DELTA_PARSER_ADVANCE_SLOT:                             return "slot";
     case FD_SLOT_DELTA_PARSER_ADVANCE_DONE:                             return "done";
     default:                                                            return "unknown";
   }
@@ -125,10 +127,12 @@ struct fd_slot_delta_parser_advance_result {
   ulong bytes_consumed;
   union {
     fd_sstxncache_entry_t const * entry;
+    ulong                         slot;
 
     struct {
       uchar const * blockhash;
       ulong         txnhash_offset;
+      ulong         slot;
     } group;
   };
 };

--- a/src/discof/restore/utils/test_slot_delta_parser.c
+++ b/src/discof/restore/utils/test_slot_delta_parser.c
@@ -323,6 +323,40 @@ test_one_entry( fd_slot_delta_parser_t * parser ) {
 }
 
 static void
+test_group_reports_slot( fd_slot_delta_parser_t * parser ) {
+  uchar input[ 97UL ];
+  fd_slot_delta_parser_init( parser );
+  mock_one_input_with_error( input, sizeof(input), 1, 1000UL, MOCK_ERROR_TYPE_NONE, 0 );
+
+  fd_slot_delta_parser_advance_result_t result[1];
+  int res = fd_slot_delta_parser_consume( parser, input, sizeof(input), result );
+  FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_SLOT );
+  ulong slot_bytes_consumed = result->bytes_consumed;
+  res = fd_slot_delta_parser_consume( parser, input+slot_bytes_consumed, sizeof(input)-slot_bytes_consumed, result );
+  FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP );
+  FD_TEST( result->group.slot==1000UL );
+}
+
+static void
+test_zero_status_slot_is_reported( fd_slot_delta_parser_t * parser ) {
+  uchar input[ 25UL ];
+  ulong slots[ 1UL ]        = {1000UL};
+  ulong num_statuses[ 1UL ] = {0UL};
+  uchar * p = mock_slot_delta_input( input, sizeof(input), 1UL, slots, num_statuses, NULL, NULL, NULL );
+  FD_TEST( (ulong)(p-input)==sizeof(input) );
+  fd_slot_delta_parser_init( parser );
+
+  fd_slot_delta_parser_advance_result_t result[1];
+  int res = fd_slot_delta_parser_consume( parser, input, sizeof(input), result );
+  FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_SLOT );
+  FD_TEST( result->slot==1000UL );
+  FD_TEST( result->bytes_consumed==sizeof(input) );
+
+  res = fd_slot_delta_parser_consume( parser, input+sizeof(input), 0UL, result );
+  FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_DONE );
+}
+
+static void
 test_one_entry_not_root( fd_slot_delta_parser_t * parser ) {
   uchar input[ 97UL ];
   mock_one_input_with_error( input, sizeof(input), 0, 1000UL, MOCK_ERROR_TYPE_NONE, 0 );
@@ -395,13 +429,18 @@ test_unexpected_eof_in_instr_borsh_io_error( fd_slot_delta_parser_t * parser ) {
 
   fd_slot_delta_parser_advance_result_t result[1];
   int res = fd_slot_delta_parser_consume( parser, input, sizeof(input), result );
+  FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_SLOT );
+  ulong slot_bytes_consumed = result->bytes_consumed;
+  uchar const * input_cur = input + slot_bytes_consumed;
+
+  res = fd_slot_delta_parser_consume( parser, input_cur, sizeof(input)-slot_bytes_consumed, result );
   FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP );
   ulong group_bytes_consumed = result->bytes_consumed;
-  uchar const * input_cur = input + result->bytes_consumed;
+  input_cur += result->bytes_consumed;
 
-  res = fd_slot_delta_parser_consume( parser, input_cur, sizeof(input)-group_bytes_consumed, result );
+  res = fd_slot_delta_parser_consume( parser, input_cur, sizeof(input)-slot_bytes_consumed-group_bytes_consumed, result );
   FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_AGAIN );
-  FD_TEST( result->bytes_consumed==sizeof(input)-group_bytes_consumed );
+  FD_TEST( result->bytes_consumed==sizeof(input)-slot_bytes_consumed-group_bytes_consumed );
 
   res = fd_slot_delta_parser_consume( parser, input_cur, 0UL, result );
   FD_TEST( res==FD_SLOT_DELTA_PARSER_ADVANCE_ERROR_UNEXPECTED_EOF );
@@ -529,6 +568,8 @@ int main( int     argc,
   FD_TEST( slot_delta_parser );
 
   test_one_entry( slot_delta_parser );
+  test_group_reports_slot( slot_delta_parser );
+  test_zero_status_slot_is_reported( slot_delta_parser );
   test_one_entry_not_root( slot_delta_parser );
 
   test_one_entry_with_txn_error( slot_delta_parser );

--- a/src/flamenco/runtime/fd_txncache_private.h
+++ b/src/flamenco/runtime/fd_txncache_private.h
@@ -10,7 +10,7 @@
    and returning pages to the pool, but not so high that the memory
    wasted from blockhashes with only one transaction is significant. */
 
-#define FD_TXNCACHE_TXNS_PER_PAGE (16384UL)
+#define FD_TXNCACHE_TXNS_PER_PAGE (8192UL)
 
 /* The maximum distance a transaction blockhash reference can be
    (inclusive).  For example, if no slots were skipped, and the value is

--- a/src/flamenco/runtime/fd_txncache_shmem.c
+++ b/src/flamenco/runtime/fd_txncache_shmem.c
@@ -41,7 +41,7 @@ fd_txncache_max_txnpages( ulong max_active_slots,
      staged snapshot load) plus every other pool fork full of live
      inserts.
 
-     The snapshot transient is at most 300 slot deltas at
+     The snapshot transient retains at most 151 slot deltas at
      max_txn_per_slot entries each.  max_txn_per_slot is 2x the actual
      per slot transaction limit, because Agave snapshots contain each
      transaction twice (once keyed by signature, once by message hash,
@@ -61,7 +61,7 @@ fd_txncache_max_txnpages( ulong max_active_slots,
        back to every active slot simultaneously full. */
     result = max_active_slots-1UL+max_active_slots*(1UL+(max_txn_per_slot-1UL)/FD_TXNCACHE_TXNS_PER_PAGE);
   } else {
-    ulong snapshot_budget = FD_TXNCACHE_SNAPSHOT_SLOT_DELTA_MAX*max_txn_per_slot;
+    ulong snapshot_budget = FD_TXNCACHE_MAX_SLOT_DELTAS*max_txn_per_slot;
     ulong live_budget     = (max_active_slots-1UL)*((max_txn_per_slot+1UL)/2UL);
     result = max_active_slots-1UL
            + 1UL+(snapshot_budget+live_budget-1UL)/FD_TXNCACHE_TXNS_PER_PAGE;

--- a/src/flamenco/runtime/fd_txncache_shmem.h
+++ b/src/flamenco/runtime/fd_txncache_shmem.h
@@ -7,12 +7,11 @@
 
 #define FD_TXNCACHE_SHMEM_MAGIC (0xF17EDA2CE58CC4E1UL) /* FIREDANCE SMCCHE V1 */
 
-/* The maximum number of slot deltas an Agave snapshot can contain,
-   from status_cache.rs::MAX_CACHE_ENTRIES.  Must match
-   FD_SLOT_DELTA_MAX_ENTRIES in the slot delta parser.  Used to bound
-   the snapshot load transient when sizing the txnpage pool. */
+/* FD_TXNCACHE_MAX_SLOT_DELTAS is the practical bound on the maximum
+   number of slot deltas that can be stored into the txncache.  This
+   bound is derived from the recent blockhashes sysvar. */
 
-#define FD_TXNCACHE_SNAPSHOT_SLOT_DELTA_MAX (300UL)
+#define FD_TXNCACHE_MAX_SLOT_DELTAS (151UL)
 
 typedef struct { ushort val; } fd_txncache_fork_id_t;
 

--- a/src/flamenco/runtime/test_txncache.c
+++ b/src/flamenco/runtime/test_txncache.c
@@ -23,6 +23,15 @@ test_bucket_cnt( void ) {
   FD_TEST( fd_txncache_bucket_cnt( FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT )==24510UL );
 }
 
+static void
+test_page_sizing( void ) {
+  ulong const max_active_slots = 2199UL;
+  ulong const max_txn_per_slot = 196078UL;
+
+  FD_TEST( fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot, 0 )==32118UL );
+  FD_TEST( fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, 0 )==32118UL );
+}
+
 void
 test0( uchar * scratch0,
        uchar * scratch1 ) {
@@ -502,6 +511,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   test_bucket_cnt();
+  test_page_sizing();
 
   ulong max_footprint_shmem = fd_txncache_shmem_footprint( 4096UL, FD_MAX_TXN_PER_SLOT, 0 );
   ulong max_footprint_local = fd_txncache_footprint( FD_MAX_TXN_PER_SLOT );


### PR DESCRIPTION
1. shrink snapshot txncache parsing buffer
2. reduce txns per page
reduces footprint by 2GiB