### PR TITLE
replay: apply alpenglow footer side effects

### DIFF
--- a/src/choreo/votor/ag_cert_serde.c
+++ b/src/choreo/votor/ag_cert_serde.c
@@ -126,6 +126,11 @@ base3_bitmap_de( ag_bls_agg_t * base,
   return AG_CERT_DE_SUCCESS;
 }
 
+/* TODO: check serde accepting AG_BLS_SIGNERS_MAX (2048) vs AG_VAT_MAX
+   (2000); reward processing ignores bits past the validator count
+   instead of rejecting the cert. Check what Agave does with signer bits
+   >= the epoch's validator set size and match it. */
+
 static int
 footer_aggregate_de( ag_bls_agg_t * agg,
                      uchar const *  buf,

--- a/src/discof/backup/fd_ssmanifest_encoder.c
+++ b/src/discof/backup/fd_ssmanifest_encoder.c
@@ -199,6 +199,7 @@ ENCODE_FN {
     ushort      commission   = 0;
     ulong       ec_cnt       = 0UL;
     fd_epoch_credits_t const * ec = NULL;
+    uchar bls_key[ AG_BLS_PUB_COMPRESSED_SZ ] = {0};
 
     fd_collector_overrides_t * overrides = fd_bank_collector_overrides( bank );
     ushort co_root = fd_collector_overrides_get_root_idx( overrides );
@@ -209,7 +210,7 @@ ENCODE_FN {
     if( entry_type==2U ) {
       fd_vote_stakes_t_1_iter_t * iter = fd_type_pun( enc->vote_stakes_iter_mem );
       FD_TEST( !fd_vote_stakes_t_1_iter_done( vote_stakes, fork_id, iter ) );
-      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission, NULL );
+      fd_vote_stakes_t_1_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, &commission, bls_key );
       ec = find_epoch_credits( enc->bank, &pubkey );
       FD_TEST( ec );
       ec_cnt = ec->cnt;
@@ -217,7 +218,7 @@ ENCODE_FN {
     } else if( entry_type==1U ) {
       fd_vote_stakes_t_2_iter_t * iter = fd_type_pun( enc->vote_stakes_iter_mem );
       FD_TEST( !fd_vote_stakes_t_2_iter_done( vote_stakes, fork_id, iter ) );
-      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, &commission, NULL, NULL );
+      fd_vote_stakes_t_2_iter_ele( vote_stakes, fork_id, iter, &pubkey, &node_account, &stake, NULL, NULL, &commission, NULL, bls_key );
       co_epoch = fd_ulong_sat_sub( bank->f.epoch, 1UL );
     } else {
       /* The bank epoch credits will have the resolved commission for
@@ -243,11 +244,15 @@ ENCODE_FN {
       fd_collector_overrides_query( overrides, co_root, co_epoch, &pubkey, &inflation_collector, &block_collector );
     }
 
+    /* A zeroed key means no BLS key is registered (serialized as None) */
+    static uchar const no_bls_key[ AG_BLS_PUB_COMPRESSED_SZ ] = {0};
+    int has_bls = !fd_memeq( bls_key, no_bls_key, AG_BLS_PUB_COMPRESSED_SZ );
+
     enc->total_stake += stake;
 
     FD_TEST( ec_cnt<=FD_EPOCH_CREDITS_MAX );
 
-    ulong data_length = 186UL + 24UL * ec_cnt;
+    ulong data_length = 186UL + fd_ulong_if( !!has_bls, AG_BLS_PUB_COMPRESSED_SZ, 0UL ) + 24UL * ec_cnt;
 
     /* Vote account key + stake */
     PUSH_VAL( fd_pubkey_t, pubkey );
@@ -266,7 +271,13 @@ ENCODE_FN {
     PUSH_VAL( ushort, commission ); /* inflation_rewards_commission_bps */
     PUSH_VAL( ushort, (ushort)0 ); /* block_revenue_commission_bps */
     PUSH_VAL( ulong,  0UL      ); /* pending_delegator_rewards */
-    PUSH_VAL( uchar,  0        ); /* bls_pubkey_compressed = None */
+    if( has_bls ) {
+      typedef struct { uchar b[ AG_BLS_PUB_COMPRESSED_SZ ]; } bls_key_compressed_t;
+      PUSH_VAL( uchar, 1        ); /* bls_pubkey_compressed = Some */
+      PUSH_VAL( bls_key_compressed_t, *(bls_key_compressed_t const *)bls_key );
+    } else {
+      PUSH_VAL( uchar, 0        ); /* bls_pubkey_compressed = None */
+    }
     PUSH_VAL( ulong,  0UL      ); /* votes_length = 0 */
     PUSH_VAL( uchar,  0        ); /* root_slot = None */
     PUSH_VAL( ulong,  0UL      ); /* authorized_voters_length = 0 */

--- a/src/discof/backup/fd_ssmanifest_writer.c
+++ b/src/discof/backup/fd_ssmanifest_writer.c
@@ -1,5 +1,6 @@
 #include "fd_ssmanifest_writer.h"
 #include "../../flamenco/runtime/fd_system_ids.h"
+#include "../../choreo/votor/ag_bls.h"
 
 #define STATE_BLOCKHASH_QUEUE        1
 #define STATE_HASHES                 2

--- a/src/discof/replay/Local.mk
+++ b/src/discof/replay/Local.mk
@@ -1,12 +1,16 @@
 $(call add-hdrs,fd_execrp.h)
+$(call add-hdrs,fd_block_marker.h)
+$(call add-objs,fd_block_marker,fd_discof)
+$(call make-unit-test,test_block_marker,test_block_marker,fd_discof fd_choreo fd_flamenco fd_ballet fd_util)
+$(call run-unit-test,test_block_marker)
 $(call add-objs,fd_rdisp,fd_discof)
 $(call make-unit-test,test_rdisp,test_rdisp,fd_discof fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_rdisp)
 $(call add-objs,fd_sched,fd_discof)
-$(call make-unit-test,test_sched,test_sched,fd_discof fd_disco fd_flamenco fd_ballet fd_tango fd_util)
+$(call make-unit-test,test_sched,test_sched,fd_discof fd_choreo fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_sched)
 ifdef FD_HAS_HOSTED
-$(call make-fuzz-test,fuzz_sched_rdisp,fuzz_sched_rdisp,fd_discof fd_disco fd_flamenco fd_ballet fd_tango fd_util)
+$(call make-fuzz-test,fuzz_sched_rdisp,fuzz_sched_rdisp,fd_discof fd_choreo fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 endif
 
 ifdef FD_HAS_ZSTD # required to load snapshot

--- a/src/discof/replay/fd_block_marker.c
+++ b/src/discof/replay/fd_block_marker.c
@@ -1,0 +1,202 @@
+#include "fd_block_marker.h"
+
+#include "../../ballet/txn/fd_compact_u16.h"
+#include "../../choreo/votor/ag_cert_serde.h"
+
+
+#define CHECK_LEFT( n ) do {                                            \
+  if( FD_UNLIKELY( (n)>rem ) ) return FD_BLOCK_MARKER_DE_ERR_TRUNCATED; \
+} while( 0 )
+
+#define ADVANCE( n ) do { buf += (n); rem -= (n); } while( 0 )
+
+static int
+option_de( uchar const ** _buf,
+           ulong *        _rem,
+           int *          present ) {
+  uchar const * buf = *_buf;
+  ulong         rem = *_rem;
+  CHECK_LEFT( 1UL );
+  if( FD_UNLIKELY( buf[0]>1 ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  *present = buf[0];
+  ADVANCE( 1UL );
+  *_buf = buf; *_rem = rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}
+
+/* reward_cert_de deserializes a SkipRewardCertificate
+   (has_block_id=0) or a NotarRewardCertificate (has_block_id=1):
+
+     slot (8) | [block_id (32)] | compressed BLS signature (96) |
+     bitmap byte count (ushort) | bitmap
+
+   where bitmap is a base2 bitmap: version (1) | bit count (u16 LE) |
+   payload.  Only base2 bitmaps are accepted. */
+
+static int
+reward_cert_de( fd_reward_cert_t * cert,
+                uchar const **     _buf,
+                ulong *            _rem,
+                int                has_block_id ) {
+  uchar const * buf = *_buf;
+  ulong         rem = *_rem;
+
+  ulong block_id_sz = has_block_id ? sizeof(fd_hash_t) : 0UL;
+  CHECK_LEFT( 8UL+block_id_sz+AG_BLS_SIG_COMPRESSED_SZ );
+  cert->slot = FD_LOAD( ulong, buf );
+  fd_memset( cert->block_id.uc, 0, sizeof(fd_hash_t) );
+  if( has_block_id ) fd_memcpy( cert->block_id.uc, buf+8UL, sizeof(fd_hash_t) );
+  fd_memcpy( cert->sig, buf+8UL+block_id_sz, AG_BLS_SIG_COMPRESSED_SZ );
+  ADVANCE( 8UL+block_id_sz+AG_BLS_SIG_COMPRESSED_SZ );
+
+  /* bit map */
+  ulong cu16_sz = fd_cu16_dec_sz( buf, rem );
+  if( FD_UNLIKELY( !cu16_sz ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  ulong bitmap_sz = (ulong)fd_cu16_dec_fixed( buf, cu16_sz );
+  ADVANCE( cu16_sz );
+  CHECK_LEFT( bitmap_sz );
+
+  if( FD_UNLIKELY( bitmap_sz<3UL ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  if( FD_UNLIKELY( buf[0]!=0     ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED; /* base2 */
+  ulong nbits = (ulong)FD_LOAD( ushort, buf+1UL );
+  if( FD_UNLIKELY( nbits>AG_VAT_MAX               ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  if( FD_UNLIKELY( bitmap_sz-3UL!=(nbits+7UL)/8UL ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  cert->nbits = (ushort)nbits;
+  fd_memset( cert->signer_set, 0, sizeof(cert->signer_set) );
+  uchar const * payload = buf+3UL;
+  for( ulong r=0UL; r<nbits; r++ ) {
+    if( payload[ r>>3 ] & (uchar)(1U<<(r&7U)) ) cert->signer_set[ r>>6 ] |= 1UL<<(r&63UL);
+  }
+  ADVANCE( bitmap_sz );
+
+  *_buf = buf; *_rem = rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}
+
+int
+fd_block_header_de( fd_block_header_t * header,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz ) {
+  ulong rem = buf_max;
+
+  CHECK_LEFT( 1UL );
+  if( FD_UNLIKELY( buf[0]!=1 ) ) return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED; /* VersionedBlockHeader tag */
+  ADVANCE( 1UL );
+
+  CHECK_LEFT( 8UL+sizeof(fd_hash_t) );
+  header->parent_slot = FD_LOAD( ulong, buf );
+  fd_memcpy( header->parent_block_id.uc, buf+8UL, sizeof(fd_hash_t) );
+  ADVANCE( 8UL+sizeof(fd_hash_t) );
+
+  if( buf_sz ) *buf_sz = buf_max-rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}
+
+int
+fd_update_parent_de( fd_update_parent_t * update_parent,
+                     uchar const *        buf,
+                     ulong                buf_max,
+                     ulong *              buf_sz ) {
+  ulong rem = buf_max;
+
+  CHECK_LEFT( 1UL );
+  if( FD_UNLIKELY( buf[0]!=1 ) ) return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED; /* VersionedUpdateParent tag */
+  ADVANCE( 1UL );
+
+  CHECK_LEFT( 8UL+sizeof(fd_hash_t) );
+  update_parent->new_parent_slot = FD_LOAD( ulong, buf );
+  fd_memcpy( update_parent->new_parent_block_id.uc, buf+8UL, sizeof(fd_hash_t) );
+  ADVANCE( 8UL+sizeof(fd_hash_t) );
+
+  if( buf_sz ) *buf_sz = buf_max-rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}
+
+int
+fd_block_footer_de( fd_block_footer_t * footer,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz ) {
+  ulong rem = buf_max;
+  int   err;
+
+  footer->has_fast_final_cert   = 0;
+  footer->has_final_cert        = 0;
+  footer->has_skip_reward_cert  = 0;
+  footer->has_notar_reward_cert = 0;
+
+  CHECK_LEFT( 1UL );
+  if( FD_UNLIKELY( buf[0]!=1 ) ) return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED; /* VersionedBlockFooter tag */
+  ADVANCE( 1UL );
+
+  CHECK_LEFT( sizeof(fd_hash_t)+8UL+1UL );
+  fd_memcpy( footer->bank_hash.uc, buf, sizeof(fd_hash_t) );
+  footer->block_producer_time_nanos = FD_LOAD( ulong, buf+sizeof(fd_hash_t) );
+  footer->user_agent_len            = (ulong)buf[ sizeof(fd_hash_t)+8UL ];
+  ADVANCE( sizeof(fd_hash_t)+8UL+1UL );
+
+  CHECK_LEFT( footer->user_agent_len );
+  fd_memcpy( footer->user_agent, buf, footer->user_agent_len );
+  ADVANCE( footer->user_agent_len );
+
+  int present;
+  if( FD_UNLIKELY( (err=option_de( &buf, &rem, &present )) ) ) return err;
+  if( present ) {
+    ulong consumed;
+    int   is_fast = ag_cert_block_final_de( &footer->fast_final_cert, &footer->final_cert, &footer->notar_cert, buf, rem, &consumed );
+    if( FD_UNLIKELY( is_fast<0 ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+    footer->has_fast_final_cert = is_fast==1;
+    footer->has_final_cert      = is_fast==0;
+    ADVANCE( consumed );
+  }
+
+  if( FD_UNLIKELY( (err=option_de( &buf, &rem, &present )) ) ) return err;
+  if( present ) {
+    if( FD_UNLIKELY( (err=reward_cert_de( &footer->skip_reward_cert, &buf, &rem, 0 )) ) ) return err;
+    footer->has_skip_reward_cert = 1;
+  }
+
+  if( FD_UNLIKELY( (err=option_de( &buf, &rem, &present )) ) ) return err;
+  if( present ) {
+    if( FD_UNLIKELY( (err=reward_cert_de( &footer->notar_reward_cert, &buf, &rem, 1 )) ) ) return err;
+    footer->has_notar_reward_cert = 1;
+  }
+
+  if( buf_sz ) *buf_sz = buf_max-rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}
+
+int
+fd_block_marker_de( fd_block_marker_t * marker,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz ) {
+  ulong rem = buf_max;
+
+  CHECK_LEFT( FD_BLOCK_MARKER_PREAMBLE_SZ );
+  if( FD_UNLIKELY( FD_LOAD( ulong,  buf     )!=0UL ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;   /* marker flag */
+  if( FD_UNLIKELY( FD_LOAD( ushort, buf+8UL )!=1   ) ) return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED; /* VersionedBlockMarker tag */
+  uchar variant = buf[ 10UL ];
+  ulong length  = (ulong)FD_LOAD( ushort, buf+11UL );
+  ADVANCE( FD_BLOCK_MARKER_PREAMBLE_SZ );
+
+  CHECK_LEFT( length );
+
+  marker->variant = variant;
+
+  /* payload deserializer may consume less than length */
+  int err;
+  switch( variant ) {
+    case FOOTER:        err = fd_block_footer_de ( &marker->footer,        buf, length, NULL ); break;
+    case HEADER:        err = fd_block_header_de ( &marker->header,        buf, length, NULL ); break;
+    case UPDATE_PARENT: err = fd_update_parent_de( &marker->update_parent, buf, length, NULL ); break;
+    case GENESIS_CERTIFICATE: return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED;
+    default:                  return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
+  }
+  if( FD_UNLIKELY( err ) ) return err;
+  ADVANCE( length );
+
+  if( buf_sz ) *buf_sz = buf_max-rem;
+  return FD_BLOCK_MARKER_DE_SUCCESS;
+}

--- a/src/discof/replay/fd_block_marker.h
+++ b/src/discof/replay/fd_block_marker.h
@@ -1,68 +1,115 @@
 #ifndef HEADER_fd_src_discof_replay_fd_block_marker_h
 #define HEADER_fd_src_discof_replay_fd_block_marker_h
 
-#include "../../util/fd_util_base.h"
+/* fd_block_marker deserializes Alpenglow block markers. */
+
 #include "../../flamenco/fd_flamenco_base.h"
+#include "../../flamenco/rewards/fd_reward_cert.h"
+#include "../../choreo/votor/ag_cert.h"
 
+#define FD_BLOCK_MARKER_DE_SUCCESS         ( 0)
+#define FD_BLOCK_MARKER_DE_ERR_TRUNCATED   (-1) /* input ended short of the encoding */
+#define FD_BLOCK_MARKER_DE_ERR_MALFORMED   (-2) /* not a valid encoding */
+#define FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED (-3) /* valid, but a version/variant we don't handle */
 
-/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L251 */
-struct __attribute__((packed)) fd_block_header {
-   uchar header_version;
-   struct {
-     ulong     parent_slot;
-     fd_hash_t parent_block_id;
-   } v1;
-};
-typedef struct fd_block_header fd_block_header_t;
-
-/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L240 */
-struct __attribute__((packed)) fd_block_footer {
-   uchar footer_version;
-   struct {
-     fd_hash_t bank_hash;
-     ulong     block_producer_time_nanos;
-     uchar     block_user_agent_length;
-     /* optional fields... */
-     // uchar   block_user_agent[255];
-     /* uchar   has_final_cert;
-        uchar   final_cert[255];
-
-        uchar   has_skip_reward_cert;
-        uchar   skip_reward_cert[255];
-        uchar   has_notar_reward_cert;
-        uchar notar_reward_cert[255]; */
-   } v1;
-};
-typedef struct fd_block_footer fd_block_footer_t;
-
-/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L257 */
-struct __attribute__((packed)) fd_update_parent {
-   uchar     update_parent_version;
-   ulong     new_parent_slot;
-   fd_hash_t new_parent_block_id;
-};
-typedef struct fd_update_parent fd_update_parent_t;
+/* Size of the fixed marker preamble: marker_flag (8) + version (2) +
+   variant (1) + length (2). */
+#define FD_BLOCK_MARKER_PREAMBLE_SZ (13UL)
 
 /* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L381 */
 enum fd_block_marker_variant {
    FOOTER = 0,
    HEADER = 1,
    UPDATE_PARENT = 2,
-   GENESIS_CERTIFICATE = 3, /* ??? */
+   GENESIS_CERTIFICATE = 3,
 };
+struct fd_block_header {
+   ulong     parent_slot;
+   fd_hash_t parent_block_id;
+};
+typedef struct fd_block_header fd_block_header_t;
 
 /* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/entry/src/block_component.rs#L436 */
-struct __attribute__((packed)) fd_block_marker {
-   ulong  marker_flag; /* always 0 */
-   ushort version;     /* block marker header version, currently 1  */
-   uchar  variant;     /* variant of block marker */
-   ushort length;
+struct fd_update_parent {
+   ulong     new_parent_slot;
+   fd_hash_t new_parent_block_id;
+};
+typedef struct fd_update_parent fd_update_parent_t;
+
+#define FD_BLOCK_FOOTER_USER_AGENT_MAX (255UL)
+
+struct fd_block_footer {
+   fd_hash_t bank_hash;
+   ulong     block_producer_time_nanos;
+   ulong     user_agent_len;
+   uchar     user_agent[ FD_BLOCK_FOOTER_USER_AGENT_MAX ];
+
+   /* Optional finalization certa, shape validated and agg
+      signatures decompressed, but not verified. A fast finalization
+      cert fills fast_final_cert; a slow one fills final_cert +
+      notar_cert. */
+   int                  has_fast_final_cert;
+   int                  has_final_cert;
+   ag_fast_final_cert_t fast_final_cert;
+   ag_final_cert_t      final_cert;
+   ag_notar_cert_t      notar_cert;
+
+   /* Optional reward certs. Shapes are validated but signatures are
+      not verified. */
+   int              has_skip_reward_cert;
+   fd_reward_cert_t skip_reward_cert;
+   int              has_notar_reward_cert;
+   fd_reward_cert_t notar_reward_cert;
+};
+typedef struct fd_block_footer fd_block_footer_t;
+
+struct fd_block_marker {
+   uchar variant; /* enum fd_block_marker_variant */
    union {
-    fd_block_header_t header;
-    fd_block_footer_t footer;
+    fd_block_header_t  header;
+    fd_block_footer_t  footer;
     fd_update_parent_t update_parent;
-   } data;
+   };
 };
 typedef struct fd_block_marker fd_block_marker_t;
 
-#endif /*HEADER_fd_src_discof_replay_fd_block_marker_h */
+FD_PROTOTYPES_BEGIN
+
+/* The deserializers below decode a versioned block marker payload,
+   with buf pointing at the payload byte (FD_BLOCK_MARKER_PREAMBLE_SZ
+   into the marker). returns FD_BLOCK_MARKER_DE_SUCCESS and write
+   the number of bytes consumed to buf_sz (if non-NULL) on success, and
+   return FD_BLOCK_MARKER_DE_ERR_* on failure. */
+
+int
+fd_block_header_de( fd_block_header_t * header,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz );
+
+int
+fd_block_footer_de( fd_block_footer_t * footer,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz );
+
+int
+fd_update_parent_de( fd_update_parent_t * update_parent,
+                     uchar const *        buf,
+                     ulong                buf_max,
+                     ulong *              buf_sz );
+
+/* fd_block_marker_de deserializes a whole block marker, with buf
+   pointing at the marker flag (the start of the entry batch). Trailing
+   bytes past buf_max are not consumed.  buf_sz set to
+   FD_BLOCK_MARKER_PREAMBLE_SZ + length on success, and returns
+   FD_BLOCK_MARKER_DE_SUCCESS or FD_BLOCK_MARKER_DE_ERR_* on failure */
+int
+fd_block_marker_de( fd_block_marker_t * marker,
+                    uchar const *       buf,
+                    ulong               buf_max,
+                    ulong *             buf_sz );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_discof_replay_fd_block_marker_h */

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -37,6 +37,7 @@
 #include "../repair/fd_repair_tile.h"
 #include "../../flamenco/runtime/fd_runtime.h"
 #include "../../flamenco/runtime/fd_runtime_stack.h"
+
 #include "../../flamenco/runtime/sysvar/fd_sysvar_cache.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_stake_history.h"
 #include "../../flamenco/runtime/sysvar/fd_sysvar_epoch_schedule.h"
@@ -875,6 +876,26 @@ publish_txn_executed( fd_replay_tile_t *  ctx,
 }
 
 static void
+mark_bank_dead( fd_replay_tile_t *  ctx,
+                fd_stem_context_t * stem,
+                ulong               bank_idx,
+                int                 dead_reason,
+                int                 abandoned_reason );
+
+/* replay_epoch_info returns the ranked Alpenglow validator set tracked
+   for epoch, NULL if unknown. */
+
+static ag_epoch_info_t const *
+replay_epoch_info( void * _ctx,
+                   ulong  epoch ) {
+  fd_replay_tile_t * ctx = (fd_replay_tile_t *)_ctx;
+  for( ulong i=0UL; i<FD_REPLAY_VTR_EPOCH_WINDOW; i++ ) {
+    if( ctx->epoch_vtrs[ i ].epoch==epoch ) return ctx->epoch_vtrs[ i ].info;
+  }
+  return NULL;
+}
+
+static void
 replay_block_finalize( fd_replay_tile_t *  ctx,
                        fd_stem_context_t * stem,
                        fd_bank_t *         bank ) {
@@ -890,8 +911,40 @@ replay_block_finalize( fd_replay_tile_t *  ctx,
   ulong execution_fees_pre_settle = bank->f.execution_fees;
   ulong priority_fees_pre_settle  = bank->f.priority_fees;
 
+  /* Apply footer side effects before hashing. */
+  if( FD_UNLIKELY( ctx->is_alpenglow ) ) {
+    fd_footer_certs_t certs[1];
+    certs->fast_final_cert   = fd_sched_get_fast_final_cert  ( ctx->sched, bank->idx );
+    certs->final_cert        = fd_sched_get_final_cert       ( ctx->sched, bank->idx );
+    certs->final_notar_cert  = fd_sched_get_final_notar_cert ( ctx->sched, bank->idx );
+    certs->skip_reward_cert  = fd_sched_get_skip_reward_cert ( ctx->sched, bank->idx );
+    certs->notar_reward_cert = fd_sched_get_notar_reward_cert( ctx->sched, bank->idx );
+
+    // TODO missing cert verify - inline to replay or use new verify tiles
+    if( FD_UNLIKELY( fd_runtime_apply_footer( bank, ctx->accdb, ctx->capture_ctx, certs,
+                                              fd_sched_get_footer_producer_time_nanos( ctx->sched, bank->idx ),
+                                              replay_epoch_info, ctx ) ) ) {
+      FD_LOG_CRIT(( "slot %lu: footer cert processing failed; marking bank dead", bank->f.slot ));
+      return;
+    }
+  }
+
   /* Do hashing and other end-of-block processing. */
   fd_runtime_block_execute_finalize( bank, ctx->accdb, ctx->capture_ctx );
+
+  if( FD_UNLIKELY( ctx->is_alpenglow ) ) {
+    fd_hash_t const * footer_bank_hash = fd_sched_get_footer_bank_hash( ctx->sched, bank->idx );
+    if( FD_UNLIKELY( memcmp( footer_bank_hash->uc, bank->f.bank_hash.uc, sizeof(fd_hash_t) ) ) ) {
+      FD_BASE58_ENCODE_32_BYTES( footer_bank_hash->uc,   footer_bank_hash_b58   );
+      FD_BASE58_ENCODE_32_BYTES( bank->f.bank_hash.uc, executed_bank_hash_b58 );
+      FD_LOG_CRIT(( "slot %lu: bank hash mismatch, footer declares %s but executed %s. ", bank->f.slot, footer_bank_hash_b58, executed_bank_hash_b58 ));
+      return;
+    } else {
+      FD_BASE58_ENCODE_32_BYTES( footer_bank_hash->uc,   footer_bank_hash_b58 );
+      FD_BASE58_ENCODE_32_BYTES( bank->f.bank_hash.uc, executed_bank_hash_b58 );
+      FD_LOG_INFO(( "slot %lu: bank hash matches, footer declares %s, executed %s", bank->f.slot, footer_bank_hash_b58, executed_bank_hash_b58 ));
+    }
+  }
 
   /* Copy out cost tracker fields before freezing */
   fd_replay_slot_completed_t * slot_info = fd_chunk_to_laddr( ctx->replay_out->mem, ctx->replay_out->chunk );
@@ -1404,12 +1457,6 @@ try_become_leader( fd_replay_tile_t *  ctx,
   return 1;
 }
 
-static void
-mark_bank_dead( fd_replay_tile_t *  ctx,
-                fd_stem_context_t * stem,
-                ulong               bank_idx,
-                int                 dead_reason,
-                int                 abandoned_reason );
 
 static void
 process_poh_message( fd_replay_tile_t *                 ctx,
@@ -3691,7 +3738,7 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_TEST( ctx->reception_stats_cnt );
   for( ulong i=0UL; i<ctx->reception_stats_cnt; i++ ) ctx->reception_stats[ i ].slot = ULONG_MAX;
   ctx->reasm_evicted = NULL;
-  ctx->is_alpenglow = tile->replay.alpenglow;
+  ctx->is_alpenglow             = tile->replay.alpenglow;
 
   ctx->leader_stats.slot = ULONG_MAX;
 

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -205,10 +205,17 @@ struct fd_sched_block {
   uchar               fec_buf[ FD_SCHED_MAX_FEC_BUF_SZ ]; /* The previous FEC set could have some residual data that only becomes
                                                              parseable after the next FEC set is ingested. */
   uint                shred_blk_offs[ FD_SHRED_BLK_MAX ]; /* The byte offsets into block data of ingested shreds */
+
+  /* Alpenglow block footer, deserialized out of the marker batch at
+     parse time.  footer_present is set if the block carries a footer
+     marker and it is seen by sched; footer is only meaningful in that
+     case. */
+  int               footer_present;
+  fd_block_footer_t footer;
 };
 typedef struct fd_sched_block fd_sched_block_t;
 
-FD_STATIC_ASSERT( sizeof(fd_sched_block_t)==596704UL, fd_sched_block );
+FD_STATIC_ASSERT( sizeof(fd_sched_block_t)==599296UL, fd_sched_block );
 FD_STATIC_ASSERT( sizeof(fd_hash_t)==sizeof(((fd_microblock_hdr_t *)0)->hash), unexpected poh hash size );
 
 
@@ -1876,6 +1883,62 @@ fd_sched_get_shred_cnt( fd_sched_t * sched, ulong bank_idx ) {
   return block->shred_cnt;
 }
 
+fd_hash_t const *
+fd_sched_get_footer_bank_hash( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return block->footer_present ? &block->footer.bank_hash : NULL;
+}
+
+ulong
+fd_sched_get_footer_producer_time_nanos( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return block->footer_present ? block->footer.block_producer_time_nanos : 0UL;
+}
+
+fd_reward_cert_t const *
+fd_sched_get_skip_reward_cert( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return ( block->footer_present && block->footer.has_skip_reward_cert ) ? &block->footer.skip_reward_cert : NULL;
+}
+
+fd_reward_cert_t const *
+fd_sched_get_notar_reward_cert( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return ( block->footer_present && block->footer.has_notar_reward_cert ) ? &block->footer.notar_reward_cert : NULL;
+}
+
+ag_fast_final_cert_t const *
+fd_sched_get_fast_final_cert( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return ( block->footer_present && block->footer.has_fast_final_cert ) ? &block->footer.fast_final_cert : NULL;
+}
+
+ag_final_cert_t const *
+fd_sched_get_final_cert( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return ( block->footer_present && block->footer.has_final_cert ) ? &block->footer.final_cert : NULL;
+}
+
+ag_notar_cert_t const *
+fd_sched_get_final_notar_cert( fd_sched_t * sched, ulong bank_idx ) {
+  FD_TEST( sched->canary==FD_SCHED_MAGIC );
+  FD_TEST( bank_idx<sched->block_cnt_max );
+  fd_sched_block_t * block = block_pool_ele( sched, bank_idx );
+  return ( block->footer_present && block->footer.has_final_cert ) ? &block->footer.notar_cert : NULL;
+}
+
 void
 fd_sched_metrics_write( fd_sched_t * sched ) {
   FD_MGAUGE_SET( REPLAY, SCHED_ACTIVE_BANK_INDEX, sched->active_bank_idx );
@@ -1991,6 +2054,8 @@ add_block( fd_sched_t * sched,
   block->hashes_per_tick              = ULONG_MAX;
   block->inconsistent_hashes_per_tick = 0;
   block->zero_hash_tick               = 0;
+
+  block->footer_present = 0;
 
   block->mblks_rem        = 0UL;
   block->txns_rem         = 0UL;
@@ -2306,17 +2371,18 @@ fd_sched_parse( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_ctx_
 
       block->fec_sob = 0;
 
-      /* TODO parse alpenglow block markers */
       if( FD_UNLIKELY( !block->mblks_rem && sched->is_alpenglow ) ) {
-        if( block->fec_buf_sz < sizeof(ulong) + sizeof(ushort) + sizeof(uchar) ) FD_LOG_CRIT(( "unhandled bad block marker - should mark dead"));
-        fd_block_marker_t const * m = (fd_block_marker_t const *)fd_type_pun_const( block->fec_buf );
-        if( m->variant==HEADER ) {
-          // TODO
-        } else if( m->variant==FOOTER ) {
-          // TODO
-        } else if( m->variant==UPDATE_PARENT ) {
-          // TODO
-          FD_LOG_CRIT(( "UNHANDLED alpenglow update parent: slot %lu", block->slot ));
+        fd_block_marker_t marker[1];
+        int err = fd_block_marker_de( marker, block->fec_buf, (ulong)block->fec_buf_sz, NULL );
+        if( FD_UNLIKELY( err ) ) {
+          FD_LOG_INFO(( "bad block: slot %lu, unable to parse footer marker (err %d)", block->slot, err ));
+          return FD_SCHED_DEAD_REASON_BAD_FOOTER;
+        }
+        if( marker->variant==FOOTER ) {
+          block->footer         = marker->footer;
+          block->footer_present = 1;
+        } else if( marker->variant==UPDATE_PARENT ) {
+          FD_LOG_CRIT(( "UNHANDLED alpenglow update parent: slot %lu, new_parent_slot %lu", block->slot, marker->update_parent.new_parent_slot ));
         }
       } else if( FD_UNLIKELY( !block->mblks_rem && !sched->is_alpenglow ) ) {
         FD_LOG_INFO(( "bad block: ZERO_MICROBLOCKS, slot %lu, parent slot %lu, mblk_cnt %u (%u ticks)", block->slot, block->parent_slot, block->mblk_cnt, block->mblk_tick_cnt ));

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_discof_replay_fd_sched_h
 
 #include "fd_rdisp.h"
+#include "fd_block_marker.h"
 #include "../../disco/fd_txn_p.h"
 #include "../../disco/store/fd_store.h" /* for fd_store_fec_t */
 #include "../../flamenco/accdb/fd_accdb.h"
@@ -193,7 +194,7 @@ typedef struct fd_sched_task fd_sched_task_t;
 #define FD_SCHED_DEAD_REASON_ENTRY_HASH_MISMATCH         (17) /* PoH hash of a transaction entry did not verify, detected when the entry's PoH hashing task completed. */
 #define FD_SCHED_DEAD_REASON_ENTRY_HASH_MISMATCH_INGEST  (18) /* PoH hash of a transaction entry did not verify, detected at FEC ingest when a later FEC set completed the entry's transactions. */
 #define FD_SCHED_DEAD_REASON_DEAD_ANCESTOR               (19) /* The block went down with its lineage.  Whether the lineage was discarded or ruled invalid is distinguished by fd_sched_block_is_discarded. */
-
+#define FD_SCHED_DEAD_REASON_BAD_FOOTER                  (20) /* The block's footer was invalid. */
 /* Cause to pass to fd_sched_block_abandon().  A block is considered
    invalid when it violates the protocol, so validity is a function of
    the block's content.  A block may be discarded (temporarily) because
@@ -478,6 +479,46 @@ fd_sched_get_poh( fd_sched_t * sched, ulong bank_idx );
 
 uint
 fd_sched_get_shred_cnt( fd_sched_t * sched, ulong bank_idx );
+
+/* fd_sched_get_footer_bank_hash returns the bank hash in the block
+   footer, or NULL if no footer marker has been parsed for the block.
+   The hash stays valid until the block is pruned. */
+fd_hash_t const *
+fd_sched_get_footer_bank_hash( fd_sched_t * sched, ulong bank_idx );
+
+/* fd_sched_get_footer_producer_time_nanos returns the producer
+   timestamp in the block footer, or 0 if no footer marker has been
+   parsed for the block. */
+ulong
+fd_sched_get_footer_producer_time_nanos( fd_sched_t * sched, ulong bank_idx );
+
+/* fd_sched_get_{skip,notar}_reward_cert return the skip/notar reward
+   cert deserialized out of the block footer.  Returns NULL if the
+   footer carries none or no footer marker has been parsed for the
+   block.  The cert's shape was validated at parse time, but its
+   signature is not verified.  The cert stays valid until the block is
+   pruned. */
+fd_reward_cert_t const *
+fd_sched_get_skip_reward_cert( fd_sched_t * sched, ulong bank_idx );
+
+fd_reward_cert_t const *
+fd_sched_get_notar_reward_cert( fd_sched_t * sched, ulong bank_idx );
+
+/* fd_sched_get_{fast_final,final,final_notar}_cert return the
+   finalization cert deserialized out of the block footer.  A fast
+   finalization cert yields fast_final only; a slow one yields final +
+   final_notar.  Returns NULL if the footer carries none (of that kind)
+   or no footer marker has been parsed for the block.  The certs' shapes
+   were validated at parse time, but their signatures are not verified.
+   The certs stay valid until the block is pruned. */
+ag_fast_final_cert_t const *
+fd_sched_get_fast_final_cert( fd_sched_t * sched, ulong bank_idx );
+
+ag_final_cert_t const *
+fd_sched_get_final_cert( fd_sched_t * sched, ulong bank_idx );
+
+ag_notar_cert_t const *
+fd_sched_get_final_notar_cert( fd_sched_t * sched, ulong bank_idx );
 
 void
 fd_sched_metrics_write( fd_sched_t * sched );

--- a/src/discof/replay/test_block_marker.c
+++ b/src/discof/replay/test_block_marker.c
@@ -1,0 +1,392 @@
+#include "fd_block_marker.h"
+
+/* Test vectors are hand-encoded per the wincode wire format in Agave
+   entry/src/block_component.rs (all integers little endian). */
+
+static uchar g_buf[ 2048UL ];
+static ulong g_sz;
+
+static void
+emit_reset( void ) {
+  g_sz = 0UL;
+}
+
+static void
+emit( void const * bytes,
+      ulong        sz ) {
+  FD_TEST( g_sz+sz<=sizeof(g_buf) );
+  fd_memcpy( g_buf+g_sz, bytes, sz );
+  g_sz += sz;
+}
+
+static void
+emit_u8( uchar v ) {
+  emit( &v, 1UL );
+}
+
+static void
+emit_u16( ushort v ) {
+  emit( &v, 2UL );
+}
+
+static void
+emit_u64( ulong v ) {
+  emit( &v, 8UL );
+}
+
+static void
+emit_rep( uchar v,
+          ulong cnt ) {
+  for( ulong i=0UL; i<cnt; i++ ) emit_u8( v );
+}
+
+/* emit_cu16 emits a ShortU16 (valid for v<0x4000). */
+
+static void
+emit_cu16( ushort v ) {
+  if( v<0x80 ) {
+    emit_u8( (uchar)v );
+  } else {
+    emit_u8( (uchar)((v&0x7f)|0x80) );
+    emit_u8( (uchar)(v>>7) );
+  }
+}
+
+static fd_hash_t
+hash_of( uchar fill ) {
+  fd_hash_t h;
+  fd_memset( h.uc, (int)fill, sizeof(fd_hash_t) );
+  return h;
+}
+
+/* emit_preamble emits marker_flag | version | variant | length. */
+
+static void
+emit_preamble( uchar  variant,
+               ushort length ) {
+  emit_u64( 0UL );
+  emit_u16( (ushort)1 );
+  emit_u8 ( variant   );
+  emit_u16( length    );
+}
+
+/* emit_votes_aggregate emits a VotesAggregate whose signature is the
+   compressed G2 point at infinity (so it decompresses) and whose base2
+   bitmap sets signer ranks [0,signer_cnt) out of nbits. */
+
+static void
+emit_votes_aggregate( ulong nbits,
+                      ulong signer_cnt ) {
+  emit_u8 ( 0xc0 ); emit_rep( 0x00, 95UL );  /* compressed signature: infinity */
+  ulong payload = (nbits+7UL)/8UL;
+  emit_u16( (ushort)(3UL+payload) );         /* bitmap byte count */
+  emit_u8 ( 0 );                             /* base2 bitmap */
+  emit_u16( (ushort)nbits );                 /* bit count */
+  ulong off = g_sz;
+  emit_rep( 0x00, payload );
+  for( ulong i=0UL; i<signer_cnt; i++ ) g_buf[ off+(i>>3) ] = (uchar)( g_buf[ off+(i>>3) ] | (1U<<(i&7U)) );
+}
+
+static void
+test_header( void ) {
+  fd_hash_t parent_id = hash_of( 0x11 );
+
+  emit_reset();
+  emit_preamble( HEADER, (ushort)41 );
+  emit_u8 ( 1 );                              /* VersionedBlockHeader::V1 */
+  emit_u64( 1234UL );                         /* parent_slot */
+  emit( parent_id.uc, sizeof(fd_hash_t) );    /* parent_block_id */
+  ulong trailing = g_sz;
+  emit_rep( 0xee, 7UL );                      /* trailing bytes are not the marker's */
+
+  fd_block_marker_t marker[1];
+  ulong             consumed = 0UL;
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, &consumed )==FD_BLOCK_MARKER_DE_SUCCESS );
+  FD_TEST( consumed==trailing );
+  FD_TEST( marker->variant==HEADER );
+  FD_TEST( marker->header.parent_slot==1234UL );
+  FD_TEST( !memcmp( marker->header.parent_block_id.uc, parent_id.uc, sizeof(fd_hash_t) ) );
+
+  /* every strict prefix of the marker is truncated */
+  for( ulong sz=0UL; sz<trailing; sz++ ) {
+    FD_TEST( fd_block_marker_de( marker, g_buf, sz, NULL )==FD_BLOCK_MARKER_DE_ERR_TRUNCATED );
+  }
+}
+
+static void
+test_update_parent( void ) {
+  fd_hash_t new_parent_id = hash_of( 0x22 );
+
+  emit_reset();
+  emit_preamble( UPDATE_PARENT, (ushort)41 );
+  emit_u8 ( 1 );                                /* VersionedUpdateParent::V1 */
+  emit_u64( 5678UL );                           /* new_parent_slot */
+  emit( new_parent_id.uc, sizeof(fd_hash_t) );  /* new_parent_block_id */
+
+  fd_block_marker_t marker[1];
+  ulong             consumed = 0UL;
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, &consumed )==FD_BLOCK_MARKER_DE_SUCCESS );
+  FD_TEST( consumed==g_sz );
+  FD_TEST( marker->variant==UPDATE_PARENT );
+  FD_TEST( marker->update_parent.new_parent_slot==5678UL );
+  FD_TEST( !memcmp( marker->update_parent.new_parent_block_id.uc, new_parent_id.uc, sizeof(fd_hash_t) ) );
+}
+
+static void
+test_footer_no_certs( void ) {
+  fd_hash_t bank_hash = hash_of( 0x33 );
+
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)(1UL+32UL+8UL+1UL+5UL+3UL) );
+  emit_u8 ( 1 );                            /* VersionedBlockFooter::V1 */
+  emit( bank_hash.uc, sizeof(fd_hash_t) );  /* bank_hash */
+  emit_u64( 987654321UL );                  /* block_producer_time_nanos */
+  emit_u8 ( 5 );                            /* user agent len */
+  emit( "agave", 5UL );                     /* user agent */
+  emit_u8 ( 0 );                            /* block_final_cert: None */
+  emit_u8 ( 0 );                            /* skip_reward_cert: None */
+  emit_u8 ( 0 );                            /* notar_reward_cert: None */
+
+  fd_block_marker_t marker[1];
+  ulong             consumed = 0UL;
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, &consumed )==FD_BLOCK_MARKER_DE_SUCCESS );
+  FD_TEST( consumed==g_sz );
+  FD_TEST( marker->variant==FOOTER );
+  FD_TEST( !memcmp( marker->footer.bank_hash.uc, bank_hash.uc, sizeof(fd_hash_t) ) );
+  FD_TEST( marker->footer.block_producer_time_nanos==987654321UL );
+  FD_TEST( marker->footer.user_agent_len==5UL );
+  FD_TEST( !memcmp( marker->footer.user_agent, "agave", 5UL ) );
+  FD_TEST( !marker->footer.has_fast_final_cert  );
+  FD_TEST( !marker->footer.has_final_cert       );
+  FD_TEST( !marker->footer.has_skip_reward_cert  );
+  FD_TEST( !marker->footer.has_notar_reward_cert );
+}
+
+static void
+test_footer_with_certs( int has_notar_aggregate ) {
+  fd_hash_t bank_hash = hash_of( 0x44 );
+  fd_hash_t block_id  = hash_of( 0x55 );
+
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)0 ); /* length patched below */
+  ulong payload_off = g_sz;
+  emit_u8 ( 1 );                            /* VersionedBlockFooter::V1 */
+  emit( bank_hash.uc, sizeof(fd_hash_t) );  /* bank_hash */
+  emit_u64( 42UL );                         /* block_producer_time_nanos */
+  emit_u8 ( 0 );                            /* empty user agent */
+
+  emit_u8( 1 );                             /* block_final_cert: Some */
+  emit_u64( 777UL );                        /* BlockFinalizationCert::slot */
+  emit( block_id.uc, sizeof(fd_hash_t) );   /* BlockFinalizationCert::block_id */
+  emit_votes_aggregate( 13UL, 7UL );        /* final_aggregate, signer ranks 0-6 */
+  emit_u8( (uchar)!!has_notar_aggregate );  /* notar_aggregate tag */
+  if( has_notar_aggregate ) emit_votes_aggregate( 13UL, 5UL ); /* signer ranks 0-4 */
+
+  emit_u8( 1 );                             /* skip_reward_cert: Some */
+  emit_u64( 775UL );                        /* SkipRewardCertificate::slot */
+  emit_rep( 0xf3, 96UL );                   /* compressed signature */
+  emit_cu16( 5 );                           /* bitmap byte count */
+  emit_u8 ( 0 ); emit_u16( 13 );            /* base2 bitmap over 13 signers */
+  emit_u8 ( 0xa5 ); emit_u8( 0x14 );        /* signer ranks 0, 2, 5, 7, 10, 12 */
+
+  emit_u8( 1 );                             /* notar_reward_cert: Some */
+  emit_u64( 776UL );                        /* NotarRewardCertificate::slot */
+  emit( block_id.uc, sizeof(fd_hash_t) );   /* NotarRewardCertificate::block_id */
+  emit_rep( 0xf4, 96UL );                   /* compressed signature */
+  emit_cu16( 200 );                         /* bitmap byte count (ShortU16, 2 bytes) */
+  emit_u8 ( 0 ); emit_u16( 1576 );          /* base2 bitmap over 1576 signers */
+  emit_rep( 0xff, 197UL );                  /* every signer rank set */
+
+  FD_STORE( ushort, g_buf+FD_BLOCK_MARKER_PREAMBLE_SZ-2UL, (ushort)(g_sz-payload_off) );
+
+  fd_block_marker_t marker[1];
+  ulong             consumed = 0UL;
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, &consumed )==FD_BLOCK_MARKER_DE_SUCCESS );
+  FD_TEST( consumed==g_sz );
+  FD_TEST( marker->variant==FOOTER );
+  FD_TEST( marker->footer.user_agent_len==0UL );
+
+  if( has_notar_aggregate ) {
+    /* slow finalization: final + notar certs */
+    FD_TEST( !marker->footer.has_fast_final_cert && marker->footer.has_final_cert );
+    FD_TEST( marker->footer.final_cert.slot==777UL );
+    FD_TEST( marker->footer.final_cert.agg_sig.bitmask[ 0 ]==0x7fUL );
+    FD_TEST( marker->footer.notar_cert.slot==777UL );
+    FD_TEST( !memcmp( marker->footer.notar_cert.block_hash, block_id.uc, sizeof(fd_hash_t) ) );
+    FD_TEST( marker->footer.notar_cert.agg_sig.bitmask[ 0 ]==0x1fUL );
+  } else {
+    /* fast finalization */
+    FD_TEST( marker->footer.has_fast_final_cert && !marker->footer.has_final_cert );
+    FD_TEST( marker->footer.fast_final_cert.slot==777UL );
+    FD_TEST( !memcmp( marker->footer.fast_final_cert.block_hash, block_id.uc, sizeof(fd_hash_t) ) );
+    FD_TEST( marker->footer.fast_final_cert.agg_sig.bitmask[ 0 ]==0x7fUL );
+  }
+
+  fd_hash_t zero_id = hash_of( 0x00 );
+  fd_reward_cert_t const * skip = &marker->footer.skip_reward_cert;
+  FD_TEST( marker->footer.has_skip_reward_cert );
+  FD_TEST( skip->slot==775UL );
+  FD_TEST( !memcmp( skip->block_id.uc, zero_id.uc, sizeof(fd_hash_t) ) );
+  for( ulong i=0UL; i<sizeof(skip->sig); i++ ) FD_TEST( skip->sig[ i ]==0xf3 );
+  FD_TEST( skip->nbits==13 );
+  FD_TEST( skip->signer_set[ 0 ]==0x14a5UL );
+  for( ulong w=1UL; w<FD_REWARD_CERT_SET_WORDS; w++ ) FD_TEST( !skip->signer_set[ w ] );
+
+  fd_reward_cert_t const * notar = &marker->footer.notar_reward_cert;
+  FD_TEST( marker->footer.has_notar_reward_cert );
+  FD_TEST( notar->slot==776UL );
+  FD_TEST( !memcmp( notar->block_id.uc, block_id.uc, sizeof(fd_hash_t) ) );
+  for( ulong i=0UL; i<sizeof(notar->sig); i++ ) FD_TEST( notar->sig[ i ]==0xf4 );
+  FD_TEST( notar->nbits==1576 );
+  for( ulong r=0UL; r<AG_VAT_MAX; r++ ) {
+    int set = !!( notar->signer_set[ r>>6 ] & (1UL<<(r&63UL)) );
+    FD_TEST( set==(r<1576UL) );
+  }
+
+  /* every strict prefix of the marker is truncated */
+  for( ulong sz=0UL; sz<g_sz; sz++ ) {
+    int err = fd_block_marker_de( marker, g_buf, sz, NULL );
+    FD_TEST( err==FD_BLOCK_MARKER_DE_ERR_TRUNCATED || err==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+  }
+}
+
+/* footer_skip_cert_de builds a footer whose only cert is a skip reward
+   cert carrying the given bitmap and returns the deserializer's error
+   code. */
+
+static int
+footer_skip_cert_de( uchar const * bitmap,
+                     ulong         bitmap_sz ) {
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)0 ); /* length patched below */
+  ulong payload_off = g_sz;
+  emit_u8 ( 1 );                /* VersionedBlockFooter::V1 */
+  emit_rep( 0x66, 32UL );       /* bank_hash */
+  emit_u64( 0UL );              /* block_producer_time_nanos */
+  emit_u8 ( 0 );                /* empty user agent */
+  emit_u8 ( 0 );                /* block_final_cert: None */
+  emit_u8 ( 1 );                /* skip_reward_cert: Some */
+  emit_u64( 775UL );            /* SkipRewardCertificate::slot */
+  emit_rep( 0xf3, 96UL );       /* compressed signature */
+  emit_cu16( (ushort)bitmap_sz );
+  emit( bitmap, bitmap_sz );
+  emit_u8 ( 0 );                /* notar_reward_cert: None */
+  FD_STORE( ushort, g_buf+FD_BLOCK_MARKER_PREAMBLE_SZ-2UL, (ushort)(g_sz-payload_off) );
+
+  fd_block_marker_t marker[1];
+  return fd_block_marker_de( marker, g_buf, g_sz, NULL );
+}
+
+static void
+test_reward_cert_bitmap_errors( void ) {
+  uchar bitmap[ 512 ];
+
+  /* well-formed base2 bitmap */
+  bitmap[ 0 ] = 0;
+  FD_STORE( ushort, bitmap+1UL, (ushort)13 );
+  bitmap[ 3 ] = 0xa5; bitmap[ 4 ] = 0x14;
+  FD_TEST( footer_skip_cert_de( bitmap, 5UL )==FD_BLOCK_MARKER_DE_SUCCESS );
+
+  /* base3 bitmap version */
+  bitmap[ 0 ] = 1;
+  FD_TEST( footer_skip_cert_de( bitmap, 5UL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+  bitmap[ 0 ] = 0;
+
+  /* bitmap too short for its header */
+  FD_TEST( footer_skip_cert_de( bitmap, 2UL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  /* payload length inconsistent with the bit count */
+  FD_TEST( footer_skip_cert_de( bitmap, 6UL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  /* bit count over AG_VAT_MAX */
+  FD_STORE( ushort, bitmap+1UL, (ushort)(AG_VAT_MAX+1UL) );
+  fd_memset( bitmap+3UL, 0, (AG_VAT_MAX+1UL+7UL)/8UL );
+  FD_TEST( footer_skip_cert_de( bitmap, 3UL+(AG_VAT_MAX+1UL+7UL)/8UL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+}
+
+static void
+test_final_cert_bitmap_bound( void ) {
+  /* a finalization cert aggregate bitmap over AG_BLS_SIGNERS_MAX
+     signers is malformed */
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)0 ); /* length patched below */
+  ulong payload_off = g_sz;
+  emit_u8 ( 1 );                /* VersionedBlockFooter::V1 */
+  emit_rep( 0x66, 32UL );       /* bank_hash */
+  emit_u64( 0UL );              /* block_producer_time_nanos */
+  emit_u8 ( 0 );                /* empty user agent */
+  emit_u8 ( 1 );                /* block_final_cert: Some */
+  emit_u64( 777UL );            /* BlockFinalizationCert::slot */
+  emit_rep( 0x55, 32UL );       /* BlockFinalizationCert::block_id */
+  emit_votes_aggregate( AG_BLS_SIGNERS_MAX+1UL, 0UL );
+  emit_u8 ( 0 );                /* notar_aggregate: None */
+  emit_u8 ( 0 );                /* skip_reward_cert: None */
+  emit_u8 ( 0 );                /* notar_reward_cert: None */
+  FD_STORE( ushort, g_buf+FD_BLOCK_MARKER_PREAMBLE_SZ-2UL, (ushort)(g_sz-payload_off) );
+
+  fd_block_marker_t marker[1];
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+}
+
+static void
+test_errors( void ) {
+  fd_block_marker_t marker[1];
+
+  /* nonzero marker flag */
+  emit_reset();
+  emit_u64( 1UL ); emit_u16( 1 ); emit_u8( HEADER ); emit_u16( 41 ); emit_rep( 0, 41UL );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  /* unsupported marker version */
+  emit_reset();
+  emit_u64( 0UL ); emit_u16( 2 ); emit_u8( HEADER ); emit_u16( 41 ); emit_rep( 0, 41UL );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED );
+
+  /* genesis certificate variant is recognized but unsupported */
+  emit_reset();
+  emit_preamble( GENESIS_CERTIFICATE, (ushort)1 ); emit_u8( 0 );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED );
+
+  /* unknown variant tag */
+  emit_reset();
+  emit_preamble( (uchar)7, (ushort)1 ); emit_u8( 0 );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  /* unsupported payload version */
+  emit_reset();
+  emit_preamble( HEADER, (ushort)41 );
+  emit_u8( 2 ); emit_rep( 0, 40UL );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED );
+
+  /* announced length exceeds the input */
+  emit_reset();
+  emit_preamble( HEADER, (ushort)42 );
+  emit_u8( 1 ); emit_rep( 0, 40UL );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_TRUNCATED );
+
+  /* option tag out of range */
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)(1UL+32UL+8UL+1UL+1UL) );
+  emit_u8( 1 ); emit_rep( 0x66, 32UL ); emit_u64( 0UL ); emit_u8( 0 );
+  emit_u8( 2 ); /* block_final_cert tag */
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_header();
+  test_update_parent();
+  test_footer_no_certs();
+  test_footer_with_certs( 0 );
+  test_footer_with_certs( 1 );
+  test_reward_cert_bitmap_errors();
+  test_final_cert_bitmap_bound();
+  test_errors();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/discof/replay/test_sched.c
+++ b/src/discof/replay/test_sched.c
@@ -12,7 +12,7 @@
 
 static void
 test_sched_footprint( void ) {
-  FD_TEST( fd_sched_footprint( 512UL, 4UL )==14043648UL );
+  FD_TEST( fd_sched_footprint( 512UL, 4UL )==14054016UL );
 }
 
 static void

--- a/src/flamenco/rewards/Local.mk
+++ b/src/flamenco/rewards/Local.mk
@@ -5,6 +5,10 @@ $(call add-objs,fd_stake_rewards,fd_flamenco)
 
 $(call add-hdrs,fd_rewards.h)
 $(call add-objs,fd_rewards,fd_flamenco)
+
+$(call add-hdrs,fd_reward_cert.h)
+$(call add-hdrs,fd_alpen_rewards.h)
+$(call add-objs,fd_alpen_rewards,fd_flamenco)
 $(call make-unit-test,test_inflation_rate,test_inflation_rate,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_inflation_rate)
 

--- a/src/flamenco/rewards/fd_alpen_rewards.c
+++ b/src/flamenco/rewards/fd_alpen_rewards.c
@@ -1,0 +1,352 @@
+#include "fd_alpen_rewards.h"
+#include "fd_epoch_inflation_account.h"
+
+#include "../runtime/fd_accdb_svm.h"
+#include "../runtime/fd_pubkey_utils.h"
+#include "../runtime/program/vote/fd_vote_state_versioned.h"
+#include "../runtime/sysvar/fd_sysvar_epoch_schedule.h"
+
+/* https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/votor-messages/src/reward_certificate.rs#L20 */
+#define NUM_SLOTS_FOR_REWARD (8UL)
+
+#define RANK_SET_WORDS ((AG_VAT_MAX+63UL)/64UL)
+
+FD_STATIC_ASSERT( MAX_EPOCH_CREDITS_HISTORY==64UL,             epoch_credits_bound );
+FD_STATIC_ASSERT( RANK_SET_WORDS==FD_REWARD_CERT_SET_WORDS,    rank_set_words );
+FD_STATIC_ASSERT( RANK_SET_WORDS==signer_set_word_cnt,         agg_set_words );
+
+/* credits_increment mirrors Agave's alpenglow increment_credits
+   (vote_reward.rs): accumulate credits into the tail epoch_credits
+   entry, starting a new entry on epoch changes and inserting the
+   tower->alpenglow migration marker in the migration epoch.  The
+   deque's capacity is MAX_EPOCH_CREDITS_HISTORY+1 while Agave pushes
+   into an unbounded Vec before trimming, so we drop the head early
+   when full; the final trimmed state is the same. */
+
+static void
+credits_increment( fd_vote_epoch_credits_t * ec,
+                   ulong                     migration_epoch,
+                   ulong                     epoch,
+                   ulong                     credits /* nonzero */ ) {
+  if( epoch==migration_epoch ) {
+    int have_marker = 0;
+    for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( ec );
+         !deq_fd_vote_epoch_credits_t_iter_done( ec, iter );
+         iter = deq_fd_vote_epoch_credits_t_iter_next( ec, iter ) ) {
+      if( fd_vote_epoch_credits_is_alpenglow_marker( deq_fd_vote_epoch_credits_t_iter_ele( ec, iter ) ) ) { have_marker = 1; break; }
+    }
+    if( !have_marker ) {
+      if( FD_UNLIKELY( deq_fd_vote_epoch_credits_t_full( ec ) ) ) deq_fd_vote_epoch_credits_t_pop_head( ec );
+      deq_fd_vote_epoch_credits_t_push_tail( ec, (fd_vote_epoch_credits_t){ .epoch=ULONG_MAX, .credits=ULONG_MAX, .prev_credits=ULONG_MAX } );
+    }
+  }
+
+  ulong cnt = deq_fd_vote_epoch_credits_t_cnt( ec );
+  if( FD_UNLIKELY( !cnt ) ) {
+    deq_fd_vote_epoch_credits_t_push_tail( ec, (fd_vote_epoch_credits_t){ .epoch=epoch, .credits=credits, .prev_credits=0UL } );
+    return;
+  }
+
+  fd_vote_epoch_credits_t * last = deq_fd_vote_epoch_credits_t_peek_tail( ec );
+
+  if( fd_vote_epoch_credits_is_alpenglow_marker( last ) ) {
+    /* If there was a tower entry before the marker, its final credits
+       form this entry's initial credits. */
+    ulong final_tower_credits = 0UL;
+    if( cnt>=2UL ) {
+      ulong idx = 0UL;
+      for( deq_fd_vote_epoch_credits_t_iter_t iter = deq_fd_vote_epoch_credits_t_iter_init( ec );
+           !deq_fd_vote_epoch_credits_t_iter_done( ec, iter );
+           iter = deq_fd_vote_epoch_credits_t_iter_next( ec, iter ) ) {
+        if( idx==cnt-2UL ) { final_tower_credits = deq_fd_vote_epoch_credits_t_iter_ele( ec, iter )->credits; break; }
+        idx++;
+      }
+    }
+    if( FD_UNLIKELY( deq_fd_vote_epoch_credits_t_full( ec ) ) ) deq_fd_vote_epoch_credits_t_pop_head( ec );
+    deq_fd_vote_epoch_credits_t_push_tail( ec, (fd_vote_epoch_credits_t){
+      .epoch        = epoch,
+      .credits      = fd_ulong_sat_add( credits, final_tower_credits ),
+      .prev_credits = final_tower_credits } );
+    while( deq_fd_vote_epoch_credits_t_cnt( ec )>MAX_EPOCH_CREDITS_HISTORY ) deq_fd_vote_epoch_credits_t_pop_head( ec );
+    return;
+  }
+
+  if( last->epoch==epoch ) {
+    last->credits = fd_ulong_sat_add( last->credits, credits );
+    return;
+  }
+
+  if( last->credits==last->prev_credits ) {
+    /* Different epochs but the latest epoch earned no credits, reuse
+       the entry. */
+    last->epoch   = epoch;
+    last->credits = fd_ulong_sat_add( last->credits, credits );
+    return;
+  }
+
+  ulong final_credits = last->credits;
+  if( FD_UNLIKELY( deq_fd_vote_epoch_credits_t_full( ec ) ) ) deq_fd_vote_epoch_credits_t_pop_head( ec );
+  deq_fd_vote_epoch_credits_t_push_tail( ec, (fd_vote_epoch_credits_t){
+    .epoch        = epoch,
+    .credits      = fd_ulong_sat_add( credits, final_credits ),
+    .prev_credits = final_credits } );
+  while( deq_fd_vote_epoch_credits_t_cnt( ec )>MAX_EPOCH_CREDITS_HISTORY ) deq_fd_vote_epoch_credits_t_pop_head( ec );
+}
+
+/* vs_maybe_update_votes mirrors VoteState::maybe_update_votes: the
+   votes deque is replaced by a single landed vote on the latest voted
+   slot, and last_timestamp advances to the slot's timestamp if newer. */
+
+static void
+vs_maybe_update_votes( fd_vote_state_versioned_t * vs,
+                       ulong                       slot,
+                       long                        slot_timestamp_ns ) {
+  ulong latest = slot;
+  ulong const * last_voted = fd_vsv_get_last_voted_slot( vs );
+  if( last_voted && *last_voted>latest ) latest = *last_voted;
+  ulong const * root = fd_vsv_get_root_slot( vs );
+  if( root && *root>latest ) latest = *root;
+
+  fd_landed_vote_t * votes = fd_vsv_get_votes_mutable( vs );
+  deq_fd_landed_vote_t_remove_all( votes );
+  deq_fd_landed_vote_t_push_tail( votes, (fd_landed_vote_t){ .latency=0, .lockout={ .slot=latest, .confirmation_count=1U } } );
+
+  long timestamp = slot_timestamp_ns/1000000000L;
+  if( timestamp>fd_vsv_get_last_timestamp( vs )->timestamp ) {
+    fd_vsv_set_last_timestamp( vs, &(fd_vote_block_timestamp_t){ .slot=slot, .timestamp=timestamp } );
+  }
+}
+
+/* vote_update describes the mutations to apply to one vote account. */
+
+struct vote_update {
+  int   update_votes; ulong vote_slot; long vote_ts_ns;
+  int   update_root;  ulong root_slot;
+  ulong credits;      /* 0 = none */
+  ulong migration_epoch;
+  ulong current_epoch;
+};
+typedef struct vote_update vote_update_t;
+
+static void
+vote_account_modify( fd_bank_t *           bank,
+                     fd_accdb_t *          accdb,
+                     fd_capture_ctx_t *    capture_ctx,
+                     fd_pubkey_t const *   pk,
+                     vote_update_t const * upd ) {
+  static FD_TL fd_vote_state_versioned_t vs[1];
+  static FD_TL uchar                     buf[ 8192UL ];
+
+  fd_acc_t acc = fd_accdb_read_one( accdb, bank->accdb_fork_id, pk->uc );
+  if( FD_UNLIKELY( !acc.lamports || !fd_vsv_is_correct_size_owner_and_init( acc.owner, acc.data, acc.data_len ) ) ) {
+    fd_accdb_unread_one( accdb, &acc );
+    return;
+  }
+  if( FD_UNLIKELY( fd_vsv_deserialize( &acc, vs ) ) ) {
+    fd_accdb_unread_one( accdb, &acc );
+    return;
+  }
+  ulong       data_len = acc.data_len;
+  fd_pubkey_t owner;
+  fd_memcpy( owner.uc, acc.owner, sizeof(fd_pubkey_t) );
+  fd_accdb_unread_one( accdb, &acc );
+
+  if( upd->update_votes ) vs_maybe_update_votes( vs, upd->vote_slot, upd->vote_ts_ns );
+  if( upd->update_root ) {
+    ulong const * root = fd_vsv_get_root_slot( vs );
+    ulong latest_root  = fd_ulong_max( root ? *root : upd->root_slot, upd->root_slot );
+    fd_vsv_set_root_slot( vs, &latest_root );
+  }
+  if( upd->credits ) credits_increment( fd_vsv_get_epoch_credits_mutable( vs ), upd->migration_epoch, upd->current_epoch, upd->credits );
+
+  fd_memset( buf, 0, data_len );
+  if( FD_UNLIKELY( fd_vote_state_versioned_serialize( vs, buf, data_len ) ) ) {
+    FD_BASE58_ENCODE_32_BYTES( pk->uc, pk_b58 );
+    FD_LOG_WARNING(( "slot %lu: vote account %s failed to serialize; skipping", bank->f.slot, pk_b58 ));
+    return;
+  }
+  fd_accdb_svm_write( bank, accdb, capture_ctx, pk, &owner, buf, data_len, 0UL, 0 );
+}
+
+void
+fd_alpenglow_pda( char const *  seed,
+                  fd_pubkey_t * out ) {
+  fd_pubkey_t const * feature_id = &ids[ offsetof( fd_features_t, alpenglow )>>3 ].id;
+
+  uchar const * seed_   = (uchar const *)seed;
+  ulong         seed_sz = strlen( seed );
+  uchar         bump;
+  uint          custom_err;
+  FD_TEST( fd_pubkey_find_program_address( feature_id, 1UL, &seed_, &seed_sz, out, &bump, &custom_err )==FD_PUBKEY_SUCCESS );
+}
+
+ulong
+fd_alpenglow_migration_slot( fd_bank_t *  bank,
+                             fd_accdb_t * accdb ) {
+  if( FD_UNLIKELY( !FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) return ULONG_MAX;
+
+  fd_pubkey_t genesis_cert_addr;
+  fd_alpenglow_pda( "carlgration", &genesis_cert_addr );
+
+  ulong    migration_slot = ULONG_MAX;
+  fd_acc_t acc = fd_accdb_read_one( accdb, bank->accdb_fork_id, genesis_cert_addr.uc );
+  if( FD_LIKELY( acc.lamports && acc.data_len>=8UL ) ) migration_slot = FD_LOAD( ulong, acc.data );
+  fd_accdb_unread_one( accdb, &acc );
+  return migration_slot;
+}
+
+/* slot_timestamp backdates the footer timestamp by the duration of
+   slots (slot, bank_slot], taking into account reduced slot times.
+
+   https://github.com/anza-xyz/agave/blob/v4.3/runtime/src/block_component_processor/vote_reward.rs#L505 */
+static long
+slot_timestamp( fd_bank_t * bank,
+                ulong       slot,
+                ulong       footer_time_nanos ) {
+  ulong dur = fd_slot_params_slot_range_duration_ns( bank, slot+1UL, bank->f.slot+1UL );
+  return fd_long_sat_sub( (long)footer_time_nanos, (long)dur );
+}
+
+int
+fd_alpen_rewards_apply( fd_bank_t *               bank,
+                         fd_accdb_t *              accdb,
+                         fd_capture_ctx_t *        capture_ctx,
+                         fd_footer_certs_t const * certs,
+                         ulong                     footer_time_nanos,
+                         fd_footer_epoch_info_fn_t epoch_info_fn,
+                         void *                    epoch_info_ctx ) {
+  ulong bank_slot       = bank->f.slot;
+  ulong current_epoch   = fd_slot_to_epoch( &bank->f.epoch_schedule, bank_slot, NULL );
+  ulong migration_epoch = ULONG_MAX;
+  ulong leader_credits  = 0UL;
+
+  /* credits for the attested voters of the reward slot */
+
+  if( certs->skip_reward_cert || certs->notar_reward_cert ) {
+    ulong reward_set[ RANK_SET_WORDS ] = {0};
+    ulong skip_slot = ULONG_MAX, notar_slot = ULONG_MAX;
+    if( certs->skip_reward_cert ) {
+      skip_slot = certs->skip_reward_cert->slot;
+      for( ulong w=0UL; w<RANK_SET_WORDS; w++ ) reward_set[ w ] |= certs->skip_reward_cert->signer_set[ w ];
+    }
+    if( certs->notar_reward_cert ) {
+      notar_slot = certs->notar_reward_cert->slot;
+      for( ulong w=0UL; w<RANK_SET_WORDS; w++ ) reward_set[ w ] |= certs->notar_reward_cert->signer_set[ w ];
+    }
+    if( FD_UNLIKELY( skip_slot!=ULONG_MAX && notar_slot!=ULONG_MAX && skip_slot!=notar_slot ) ) {
+      FD_LOG_WARNING(( "slot %lu: reward cert slots differ: skip %lu, notar %lu", bank_slot, skip_slot, notar_slot ));
+      return -1;
+    }
+    ulong reward_slot = fd_ulong_min( skip_slot, notar_slot );
+
+    ulong migration_slot = fd_alpenglow_migration_slot( bank, accdb );
+    if( FD_UNLIKELY( migration_slot==ULONG_MAX ) ) {
+      FD_LOG_WARNING(( "slot %lu: reward cert but no genesis certificate account", bank_slot ));
+      return -1;
+    }
+    migration_epoch = fd_slot_to_epoch( &bank->f.epoch_schedule, migration_slot, NULL );
+
+    if( FD_UNLIKELY( fd_ulong_sat_add( reward_slot, NUM_SLOTS_FOR_REWARD )!=bank_slot || reward_slot<=migration_slot ) ) {
+      FD_LOG_WARNING(( "slot %lu: invalid reward cert slot %lu (migration slot %lu)", bank_slot, reward_slot, migration_slot ));
+      return -1;
+    }
+
+    ulong reward_epoch = fd_slot_to_epoch( &bank->f.epoch_schedule, reward_slot, NULL );
+
+    ag_epoch_info_t const * info = epoch_info_fn( epoch_info_ctx, reward_epoch );
+    if( FD_UNLIKELY( !info ) ) {
+      FD_LOG_WARNING(( "slot %lu: no validator set for reward slot %lu", bank_slot, reward_slot ));
+      return -1;
+    }
+
+    fd_epoch_inflation_account_state_t inflation[1];
+    fd_epoch_inflation_state_t const * inflation_state = NULL;
+    if( FD_LIKELY( fd_epoch_inflation_account_read( bank, accdb, inflation ) ) ) {
+      if(      inflation->current.epoch==reward_epoch                     ) inflation_state = &inflation->current;
+      else if( inflation->has_prev && inflation->prev.epoch==reward_epoch ) inflation_state = &inflation->prev;
+    }
+    if( FD_UNLIKELY( !inflation_state ) ) {
+      FD_LOG_WARNING(( "slot %lu: no epoch inflation state for reward slot %lu", bank_slot, reward_slot ));
+      return -1;
+    }
+    ulong max_reward      = inflation_state->max_possible_validator_reward;
+    ulong slots_per_epoch = inflation_state->slots_per_epoch;
+
+    ulong total_stake = fd_vote_stakes_total_stake( fd_bank_vote_stakes( bank ), reward_epoch );
+    if( FD_UNLIKELY( !total_stake ) ) {
+      FD_LOG_WARNING(( "slot %lu: no epoch stakes for reward epoch %lu", bank_slot, reward_epoch ));
+      return -1;
+    }
+
+    long ts_ns = slot_timestamp( bank, reward_slot, footer_time_nanos );
+    for( ulong r=0UL; r<info->validator_cnt; r++ ) {
+      if( !( reward_set[ r>>6 ] & (1UL<<(r&63UL)) ) ) continue;
+      /* per-slot, stake-fractional reward; split half validator, half
+         (rounded up) leader */
+      uint128 numerator   = (uint128)max_reward*(uint128)info->validators[ r ].stake;
+      uint128 denominator = (uint128)slots_per_epoch*(uint128)total_stake;
+      ulong   reward      = denominator ? (ulong)( numerator/denominator ) : 0UL;
+      ulong   validator_reward = reward/2UL;
+      leader_credits = fd_ulong_sat_add( leader_credits, reward-validator_reward );
+
+      vote_update_t upd = {
+        .update_votes    = 1, .vote_slot = reward_slot, .vote_ts_ns = ts_ns,
+        .credits         = validator_reward,
+        .migration_epoch = migration_epoch,
+        .current_epoch   = current_epoch,
+      };
+      vote_account_modify( bank, accdb, capture_ctx, fd_type_pun_const( info->validators[ r ].vote_key ), &upd );
+    }
+  }
+
+  /* finalization cert: root/votes/timestamp for the signers */
+
+  if( certs->fast_final_cert || certs->final_cert ) {
+    ulong final_slot;
+    ulong final_set[ RANK_SET_WORDS ] = {0};
+    if( certs->fast_final_cert ) {
+      final_slot = certs->fast_final_cert->slot;
+      for( ulong w=0UL; w<RANK_SET_WORDS; w++ ) final_set[ w ] |= certs->fast_final_cert->agg_sig.bitmask[ w ];
+    } else {
+      final_slot = certs->final_cert->slot;
+      for( ulong w=0UL; w<RANK_SET_WORDS; w++ ) final_set[ w ] |= certs->final_cert->agg_sig.bitmask[ w ];
+      if( FD_LIKELY( certs->final_notar_cert ) ) {
+        for( ulong w=0UL; w<RANK_SET_WORDS; w++ ) final_set[ w ] |= certs->final_notar_cert->agg_sig.bitmask[ w ];
+      }
+    }
+
+    ag_epoch_info_t const * info = epoch_info_fn( epoch_info_ctx, fd_slot_to_epoch( &bank->f.epoch_schedule, final_slot, NULL ) );
+    if( FD_UNLIKELY( !info ) ) {
+      FD_LOG_WARNING(( "slot %lu: no validator set for finalized slot %lu", bank_slot, final_slot ));
+      return -1;
+    }
+
+    long ts_ns = slot_timestamp( bank, final_slot, footer_time_nanos );
+    for( ulong r=0UL; r<info->validator_cnt; r++ ) {
+      if( !( final_set[ r>>6 ] & (1UL<<(r&63UL)) ) ) continue;
+      vote_update_t upd = {
+        .update_root  = 1, .root_slot = final_slot,
+        .update_votes = 1, .vote_slot = final_slot, .vote_ts_ns = ts_ns,
+      };
+      vote_account_modify( bank, accdb, capture_ctx, fd_type_pun_const( info->validators[ r ].vote_key ), &upd );
+    }
+  }
+
+  /* leader rewards */
+
+  if( leader_credits ) {
+    fd_pubkey_t const * leader_vote_pubkey = fd_epoch_leaders_get_vote( fd_bank_epoch_leaders_query( bank, current_epoch ), bank_slot );
+    if( FD_UNLIKELY( !leader_vote_pubkey ) ) {
+      FD_LOG_WARNING(( "slot %lu: leader vote account unknown; dropping %lu leader reward credits (bank hash will diverge)", bank_slot, leader_credits ));
+    } else {
+      vote_update_t upd = {
+        .credits         = leader_credits,
+        .migration_epoch = migration_epoch,
+        .current_epoch   = current_epoch,
+      };
+      vote_account_modify( bank, accdb, capture_ctx, leader_vote_pubkey, &upd );
+    }
+  }
+
+  return 0;
+}

--- a/src/flamenco/rewards/fd_alpen_rewards.h
+++ b/src/flamenco/rewards/fd_alpen_rewards.h
@@ -1,0 +1,78 @@
+#ifndef HEADER_fd_src_flamenco_rewards_fd_alpen_rewards_h
+#define HEADER_fd_src_flamenco_rewards_fd_alpen_rewards_h
+
+/* fd_alpen_rewards provides APIS for applying the vote account side
+   effects of an Alpenglow block footer's certificates.
+
+   see runtime/src/block_component_processor/vote_reward.rs:
+
+   - The skip/notar reward certs attest which validators voted on the
+     reward slot (NUM_SLOTS_FOR_REWARD before the block's slot).  Each
+     attested validator earns credits in its vote account's
+     epoch_credits, and half of each award accrues to the block leader's
+     vote account.
+   - The finalization cert signers get root_slot / votes /
+     last_timestamp refreshed in their vote states. */
+
+#include "fd_reward_cert.h"
+#include "../runtime/fd_bank.h"
+#include "../../choreo/votor/ag_epoch_info.h"
+#include "../../choreo/votor/ag_cert.h"
+
+/* fd_footer_epoch_info_fn_t returns the ranked Alpenglow validator set
+   for epoch, NULL if unknown. */
+typedef ag_epoch_info_t const * (*fd_footer_epoch_info_fn_t)( void * ctx, ulong epoch );
+
+struct fd_footer_certs {
+  ag_fast_final_cert_t const * fast_final_cert;   /* fast BlockFinalizationCert */
+  ag_final_cert_t const *      final_cert;        /* slow BlockFinalizationCert */
+  ag_notar_cert_t const *      final_notar_cert;  /* notar aggregate accompanying final_cert */
+  fd_reward_cert_t const *     skip_reward_cert;  /* SkipRewardCertificate  */
+  fd_reward_cert_t const *     notar_reward_cert; /* NotarRewardCertificate */
+};
+typedef struct fd_footer_certs fd_footer_certs_t;
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_alpenglow_pda derives the off-curve PDA of the alpenglow feature
+   id with the given seed cstr.  These PDAs address the alpenglow-native
+   accounts: the genesis certificate ("carlgration"), the alpenclock
+   ("alpenclock") and the epoch inflation state ("vote_reward_account").
+   */
+
+void
+fd_alpenglow_pda( char const *  seed,
+                  fd_pubkey_t * out );
+
+/* fd_alpenglow_migration_slot reads the alpenglow genesis block's slot
+   from the genesis certificate account.  The account is written by the
+   first alpenglow block, so at block start a non-ULONG_MAX result means
+   the parent is at or past the migration.
+
+   https://github.com/anza-xyz/agave/blob/ef210d67f2fabeee1730498188fa78854260c679/runtime/src/bank.rs#L6733
+
+   Returns ULONG_MAX if the alpenglow feature is not active on the bank
+   or the account is missing. */
+
+ulong
+fd_alpenglow_migration_slot( fd_bank_t *  bank,
+                             fd_accdb_t * accdb );
+
+/* fd_alpen_rewards_apply applies the cert side effects to the bank's
+   accounts.  certs fields are NULL when the footer did not carry the
+   respective cert.  footer_time_nanos is the footer's producer
+   timestamp.
+   Returns 0 on success and -1 if processing of the bank should fail */
+
+int
+fd_alpen_rewards_apply( fd_bank_t *               bank,
+                         fd_accdb_t *              accdb,
+                         fd_capture_ctx_t *        capture_ctx,
+                         fd_footer_certs_t const * certs,
+                         ulong                     footer_time_nanos,
+                         fd_footer_epoch_info_fn_t epoch_info_fn,
+                         void *                    epoch_info_ctx );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_flamenco_rewards_fd_alpen_rewards_h */

--- a/src/flamenco/rewards/fd_reward_cert.h
+++ b/src/flamenco/rewards/fd_reward_cert.h
@@ -1,0 +1,30 @@
+#ifndef HEADER_fd_src_flamenco_rewards_fd_reward_cert_h
+#define HEADER_fd_src_flamenco_rewards_fd_reward_cert_h
+
+#include "../fd_flamenco_base.h"
+/* TODO: layering violation, flamenco must not depend on choreo.  Sink
+   the Alpenglow base constants into flamenco. */
+#include "../../choreo/votor/ag_votor_base.h" /* AG_VAT_MAX */
+#include "../../choreo/votor/ag_bls.h" /* AG_BLS_SIG_COMPRESSED_SZ */
+
+/* FD_REWARD_CERT_SET_WORDS is the word count of a reward cert signer
+   rank set (bit r set <=> the validator with rank r in the reward
+   epoch's ranked Alpenglow validator set signed). */
+#define FD_REWARD_CERT_SET_WORDS ((AG_VAT_MAX+63UL)/64UL)
+
+/* fd_reward_cert is a deserialized SkipRewardCertificate or
+   NotarRewardCertificate out of an Alpenglow block footer (see
+   fd_block_marker.h for the wire layout and deserializer).  The shape
+   (including the signer bitmap) is validated at deserialization time,
+   but the signature is NOT verified; it is retained in compressed form
+   for the votor/cert-verify path. */
+struct fd_reward_cert {
+  ulong     slot;
+  fd_hash_t block_id; /* zero for skip reward certs (the wire carries none) */
+  uchar     sig[ AG_BLS_SIG_COMPRESSED_SZ ]; /* compressed BLS signature, unverified */
+  ushort    nbits;    /* bit count of the signer bitmap, <=AG_VAT_MAX */
+  ulong     signer_set[ FD_REWARD_CERT_SET_WORDS ]; /* decoded base2 signer bitmap */
+};
+typedef struct fd_reward_cert fd_reward_cert_t;
+
+#endif /* HEADER_fd_src_flamenco_rewards_fd_reward_cert_h */

--- a/src/flamenco/rewards/fd_rewards.c
+++ b/src/flamenco/rewards/fd_rewards.c
@@ -2,6 +2,7 @@
 #include "fd_stake_rewards.h"
 #include "fd_reward_epoch_delegated_stakes.h"
 #include "fd_epoch_inflation_account.h"
+#include "fd_alpen_rewards.h"
 
 #include "../runtime/sysvar/fd_sysvar_epoch_rewards.h"
 #include "../runtime/sysvar/fd_sysvar_epoch_schedule.h"
@@ -602,6 +603,29 @@ fd_rewards_inflation_collector( fd_bank_t *         bank,
                                 NULL );
 }
 
+/* rewarded_epoch_is_alpenglow checks if the rewarded
+   epoch contains or follows the alpenglow migration.  This is distinct
+   from the alpenglow feature being active: between feature activation
+   and the migration slot (and for the epoch that ended at the
+   activation boundary) stake rewards are still computed the tower way.
+
+   See https://github.com/anza-xyz/agave/blob/ef22c39d51b90c1f4cfccfe1f9fde94471c6242a/runtime/src/alpenglow_epoch_type.rs#L154
+
+   TODO: the migration epoch itself is a mixed Tower+Alpenglow epoch
+   (Agave AlpenglowEpochType::MigrationEpoch) whose stake rewards must
+   prorate tower and alpenglow points over num_tower_slots/num_ag_slots
+   (Agave calculate_migration_points); it is currently treated as fully
+   alpenglow. */
+
+static int
+rewarded_epoch_is_alpenglow( fd_bank_t *  bank,
+                             fd_accdb_t * accdb,
+                             ulong        rewarded_epoch ) {
+  ulong migration_slot = fd_alpenglow_migration_slot( bank, accdb );
+  if( FD_LIKELY( migration_slot==ULONG_MAX ) ) return 0;
+  return fd_slot_to_epoch( &bank->f.epoch_schedule, migration_slot, NULL )<=rewarded_epoch;
+}
+
 /* https://github.com/anza-xyz/agave/blob/cbc8320d35358da14d79ebcada4dfb6756ffac79/programs/stake/src/rewards.rs#L33
    https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/runtime/src/inflation_rewards/mod.rs#L204-L371 */
 static int
@@ -857,9 +881,9 @@ calculate_alpenglow_points( fd_epoch_credits_t const *    epoch_credits,
   ulong base             = epoch_credits->base_credits;
   ulong credits_in_vote  = cnt ? base+epoch_credits->credits_delta[ cnt-1UL ] : 0UL;
 
-  *result = (fd_calculated_stake_points_t) {
-    .new_credits_observed = credits_in_stake,
-  };
+  result->points.ud                                = 0;
+  result->new_credits_observed                     = credits_in_stake;
+  result->force_credits_update_with_skipped_reward = 0;
 
   if( FD_UNLIKELY( credits_in_vote<credits_in_stake ) ) {
     result->new_credits_observed                     = credits_in_vote;
@@ -900,7 +924,7 @@ calculate_alpenglow_points( fd_epoch_credits_t const *    epoch_credits,
 }
 
 static inline void
-calculate_stake_points_for_reward( fd_bank_t *                    bank,
+calculate_stake_points_for_reward( int                            alpenglow_enabled,
                                    fd_runtime_stack_t *           runtime_stack,
                                    fd_epoch_credits_t *           epoch_credits,
                                    fd_stake_history_t const *     stake_history,
@@ -910,7 +934,7 @@ calculate_stake_points_for_reward( fd_bank_t *                    bank,
                                    ulong                          rewarded_epoch,
                                    ulong                          tower_fast_path_epoch,
                                    fd_calculated_stake_points_t * result ) {
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) {
+  if( FD_UNLIKELY( alpenglow_enabled ) ) {
     ulong                    validator_reward_epoch_stake = 0UL;
     fd_stake_accum_t const * accumulated                  = fd_stake_accum_map_ele_query_const(
         runtime_stack->stakes.stake_accum_map,
@@ -947,7 +971,8 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
                                      ulong                          rewarded_epoch,
                                      fd_runtime_stack_t *           runtime_stack ) {
   /* Calculate the points for each stake delegation */
-  uint128 total_points = 0;
+  uint128 total_points      = 0;
+  int     alpenglow_enabled = rewarded_epoch_is_alpenglow( bank, accdb, rewarded_epoch );
 
   fd_vote_rewards_t *     vote_ele     = runtime_stack->stakes.vote_ele;
   fd_vote_rewards_map_t * vote_ele_map = runtime_stack->stakes.vote_map;
@@ -984,7 +1009,7 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
 
     fd_epoch_credits_t * epoch_credits = &epoch_credits_arr[ idx ];
 
-    calculate_stake_points_for_reward( bank,
+    calculate_stake_points_for_reward( alpenglow_enabled,
                                        runtime_stack,
                                        epoch_credits,
                                        stake_history,
@@ -995,7 +1020,7 @@ calculate_reward_points_partitioned( fd_bank_t *                    bank,
                                        rewarded_epoch,
                                        stake_points_result );
 
-    if( FD_LIKELY( !FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) {
+    if( FD_LIKELY( !alpenglow_enabled ) ) {
       total_points += stake_points_result->points.ud;
     }
   }
@@ -1061,6 +1086,8 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
                               int                            is_recalculation ) {
 
   runtime_stack->stakes.stake_rewards_cnt = 0UL;
+
+  int alpenglow_enabled = rewarded_epoch_is_alpenglow( bank, accdb, rewarded_epoch );
 
   fd_calculated_stake_rewards_t calculated_stake_rewards_[1];
   fd_epoch_credits_t *          epoch_credits_arr = fd_bank_epoch_credits( bank );
@@ -1138,7 +1165,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
       /* We have not cached the stake points yet if we are recalculating
          stake rewards so we need to recalculate them.  ULONG_MAX
          disables the tag fast path. */
-      calculate_stake_points_for_reward( bank,
+      calculate_stake_points_for_reward( alpenglow_enabled,
                                          runtime_stack,
                                          epoch_credits,
                                          stake_history,
@@ -1160,7 +1187,7 @@ calculate_stake_vote_rewards( fd_bank_t *                    bank,
         rewarded_epoch,
         total_rewards,
         total_points,
-        FD_FEATURE_ACTIVE_BANK( bank, alpenglow ),
+        alpenglow_enabled,
         runtime_stack,
         stake_points_result,
         calculated_stake_rewards );
@@ -1227,6 +1254,8 @@ setup_stake_partitions( fd_bank_t *                    bank,
                         ulong                          total_rewards,
                         uint128                        total_points ) {
 
+  int alpenglow_enabled = rewarded_epoch_is_alpenglow( bank, accdb, rewarded_epoch );
+
   fd_stake_rewards_t * stake_rewards     = fd_bank_stake_rewards_modify( bank );
   fd_epoch_credits_t * epoch_credits_arr = fd_bank_epoch_credits( bank );
 
@@ -1271,7 +1300,7 @@ setup_stake_partitions( fd_bank_t *                    bank,
       fd_epoch_credits_t * epoch_credits = &epoch_credits_arr[ idx ];
 
       fd_calculated_stake_points_t stake_points_result[1];
-      calculate_stake_points_for_reward( bank,
+      calculate_stake_points_for_reward( alpenglow_enabled,
                                          runtime_stack,
                                          epoch_credits,
                                          stake_history,
@@ -1291,7 +1320,7 @@ setup_stake_partitions( fd_bank_t *                    bank,
           rewarded_epoch,
           total_rewards,
           total_points,
-          FD_FEATURE_ACTIVE_BANK( bank, alpenglow ),
+          alpenglow_enabled,
           runtime_stack,
           stake_points_result,
           calculated_stake_rewards );
@@ -1363,7 +1392,7 @@ calculate_validator_rewards( fd_bank_t *                    bank,
 
   /* Tower requires a non-zero global points denominator.  Alpenglow
      stake rewards are already denominated in lamports per validator. */
-  if( FD_LIKELY( !FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) && !total_points ) {
+  if( FD_LIKELY( !rewarded_epoch_is_alpenglow( bank, accdb, rewarded_epoch ) ) && !total_points ) {
     *rewards_out = 0UL;
   }
 
@@ -1442,7 +1471,7 @@ calculate_rewards_for_partitioning( fd_bank_t *                            bank,
                                               bank->f.capitalization,
                                               prev_epoch,
                                               &rewards );
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) {
+  if( FD_UNLIKELY( rewarded_epoch_is_alpenglow( bank, accdb, prev_epoch ) ) ) {
     rewards.validator_rewards = fd_epoch_inflation_rewards_for_epoch( bank, accdb, prev_epoch );
   }
 
@@ -1882,7 +1911,7 @@ fd_begin_partitioned_rewards( fd_bank_t *                    bank,
                               ulong                          parent_epoch,
                               ulong                          parent_capitalization ) {
 
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) {
+  if( FD_UNLIKELY( rewarded_epoch_is_alpenglow( bank, accdb, parent_epoch ) ) ) {
     fd_reward_epoch_stakes_set( bank,
                                 accdb,
                                 capture_ctx,
@@ -2066,7 +2095,7 @@ recalculate_partitioned_rewards( fd_banks_t *              banks,
   ulong const epoch          = bank->f.epoch;
   ulong const rewarded_epoch = fd_ulong_sat_sub( epoch, 1UL );
 
-  if( FD_UNLIKELY( FD_FEATURE_ACTIVE_BANK( bank, alpenglow ) ) ) {
+  if( FD_UNLIKELY( rewarded_epoch_is_alpenglow( bank, accdb, rewarded_epoch ) ) ) {
     fd_reward_epoch_stakes_restore( bank, accdb, rewarded_epoch, runtime_stack );
   }
 

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -12,6 +12,9 @@
 #include "fd_compute_budget_details.h"
 #include "tests/fd_dump_pb.h"
 
+#include "fd_system_ids.h"
+#include "sysvar/fd_sysvar.h"
+#include "sysvar/fd_sysvar_clock.h"
 #include "sysvar/fd_sysvar_epoch_schedule.h"
 #include "sysvar/fd_sysvar_recent_hashes.h"
 #include "sysvar/fd_sysvar_stake_history.h"
@@ -733,9 +736,13 @@ fd_runtime_block_sysvar_update_pre_execute( fd_bank_t *          bank,
 
   fd_runtime_new_fee_rate_governor_derived( bank, bank->f.parent_signature_cnt );
 
-  fd_epoch_schedule_t const * epoch_schedule = &bank->f.epoch_schedule;
-  ulong                       parent_epoch   = fd_slot_to_epoch( epoch_schedule, bank->f.parent_slot, NULL );
-  fd_sysvar_clock_update( bank, accdb, capture_ctx, runtime_stack, &parent_epoch );
+  if( fd_alpenglow_migration_slot( bank, accdb )!=ULONG_MAX ) {
+    fd_sysvar_clock_update_slot_alpenglow( bank, accdb, capture_ctx );
+  } else {
+    fd_epoch_schedule_t const * epoch_schedule = &bank->f.epoch_schedule;
+    ulong                       parent_epoch   = fd_slot_to_epoch( epoch_schedule, bank->f.parent_slot, NULL );
+    fd_sysvar_clock_update( bank, accdb, capture_ctx, runtime_stack, &parent_epoch );
+  }
 
   // It has to go into the current txn previous info but is not in slot 0
   if( bank->f.slot != 0 ) {
@@ -1650,6 +1657,51 @@ fd_runtime_read_genesis( fd_banks_t *              banks,
 
   int err = fd_runtime_process_genesis_block( bank, accdb, capture_ctx, runtime_stack );
   if( FD_UNLIKELY( err ) ) FD_LOG_CRIT(( "genesis slot 0 execute failed with error %d", err ));
+}
+
+int
+fd_runtime_apply_footer( fd_bank_t *               bank,
+                         fd_accdb_t *              accdb,
+                         fd_capture_ctx_t *        capture_ctx,
+                         fd_footer_certs_t const * certs,
+                         ulong                     producer_time_nanos,
+                         fd_footer_epoch_info_fn_t epoch_info_fn,
+                         void *                    epoch_info_ctx ) {
+
+  /* Rewrite the clock sysvar and the alpenclock account from the
+     footer's producer timestamp (Agave Bank::update_clock_from_footer).
+     The clock must be applied before the reward certs. */
+
+  long unix_timestamp = (long)( producer_time_nanos/1000000000UL );
+
+  fd_sol_sysvar_clock_t clock_[1];
+  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( accdb, bank->accdb_fork_id, clock_ );
+  if( FD_UNLIKELY( !clock ) ) FD_LOG_ERR(( "fd_sysvar_clock_read failed" ));
+
+  fd_epoch_schedule_t const * epoch_schedule = &bank->f.epoch_schedule;
+  ulong current_epoch = fd_slot_to_epoch( epoch_schedule, bank->f.slot, NULL );
+
+  fd_sol_sysvar_clock_t new_clock = {
+    .slot                  = bank->f.slot,
+    .epoch_start_timestamp = clock->epoch_start_timestamp,
+    .epoch                 = current_epoch,
+    .leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( epoch_schedule, bank->f.slot ),
+    .unix_timestamp        = unix_timestamp,
+  };
+  fd_sysvar_account_update( bank, accdb, capture_ctx, &fd_sysvar_clock_id, &new_clock, sizeof(fd_sol_sysvar_clock_t) );
+
+  fd_pubkey_t alpenclock_addr;
+  fd_alpenglow_pda( "alpenclock", &alpenclock_addr );
+
+  /* size the alpenclock balance with default rent */
+  uchar data[ 8UL ];
+  FD_STORE( ulong, data, producer_time_nanos );
+  fd_accdb_svm_write( bank, accdb, capture_ctx, &alpenclock_addr, &fd_solana_system_program_id,
+                      data, sizeof(data), fd_rent_exempt_minimum_balance( &FD_RENT_DEFAULT_PARAMS, sizeof(data) ), 0 );
+
+  return fd_alpen_rewards_apply( bank, accdb, capture_ctx, certs,
+                                  producer_time_nanos,
+                                  epoch_info_fn, epoch_info_ctx );
 }
 
 void

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -11,6 +11,7 @@
 #include "context/fd_exec_instr_ctx.h"
 #include "../fd_flamenco_base.h"
 #include "../accdb/fd_accdb.h"
+#include "../rewards/fd_alpen_rewards.h"
 
 /* The general structure for executing transactions in Firedancer can
    be thought of as a state machine where transaction execution is a
@@ -357,6 +358,20 @@ void
 fd_runtime_block_execute_finalize( fd_bank_t *        bank,
                                    fd_accdb_t  *      accdb,
                                    fd_capture_ctx_t * capture_ctx );
+
+/* fd_runtime_apply_footer applies an Alpenglow block footer's side
+   effects to the bank's accounts.  The clock sysvar and the
+   alpenclock account are rewritten from the footer's producer timestamp,
+   then the rewards are applied to the vote accounts.  Returns 0 on
+   success, -1 on failure and bank should be marked dead. */
+int
+fd_runtime_apply_footer( fd_bank_t *               bank,
+                         fd_accdb_t *              accdb,
+                         fd_capture_ctx_t *        capture_ctx,
+                         fd_footer_certs_t const * certs,
+                         ulong                     producer_time_nanos,
+                         fd_footer_epoch_info_fn_t epoch_info_fn,
+                         void *                    epoch_info_ctx );
 
 /* fd_runtime_prepare_and_execute_txn is responsible for executing a
    fd_txn_in_t against a fd_runtime_t and a fd_bank_t.  The results of

--- a/src/flamenco/runtime/program/vote/fd_vote_state_versioned.c
+++ b/src/flamenco/runtime/program/vote/fd_vote_state_versioned.c
@@ -411,7 +411,7 @@ fd_vsv_set_root_slot( fd_vote_state_versioned_t * self, ulong * root_slot ) {
   }
 }
 
-static void
+void
 fd_vsv_set_last_timestamp( fd_vote_state_versioned_t *       self,
                            fd_vote_block_timestamp_t const * last_timestamp ) {
   switch( self->kind ) {

--- a/src/flamenco/runtime/program/vote/fd_vote_state_versioned.h
+++ b/src/flamenco/runtime/program/vote/fd_vote_state_versioned.h
@@ -138,6 +138,10 @@ fd_vsv_set_block_revenue_commission_bps( fd_vote_state_versioned_t * self,
 void
 fd_vsv_set_root_slot( fd_vote_state_versioned_t * self, ulong * root_slot );
 
+void
+fd_vsv_set_last_timestamp( fd_vote_state_versioned_t *       self,
+                           fd_vote_block_timestamp_t const * last_timestamp );
+
 /* https://github.com/anza-xyz/agave/blob/v3.1.1/programs/vote/src/vote_state/handler.rs#L843-L851 */
 int
 fd_vsv_set_vote_account_state( fd_exec_instr_ctx_t const * ctx,

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.c
@@ -323,3 +323,30 @@ fd_sysvar_clock_update( fd_bank_t *          bank,
   /* https://github.com/anza-xyz/agave/blob/v2.3.7/runtime/src/bank.rs#L2209-L2214 */
   fd_sysvar_clock_write( bank, accdb, capture_ctx, clock );
 }
+
+void
+fd_sysvar_clock_update_slot_alpenglow( fd_bank_t *        bank,
+                                       fd_accdb_t *       accdb,
+                                       fd_capture_ctx_t * capture_ctx ) {
+  fd_sol_sysvar_clock_t clock_[1];
+  fd_sol_sysvar_clock_t * clock = fd_sysvar_clock_read( accdb, bank->accdb_fork_id, clock_ );
+  if( FD_UNLIKELY( !clock ) ) FD_LOG_ERR(( "fd_sysvar_clock_read failed" ));
+
+  fd_epoch_schedule_t const * epoch_schedule = &bank->f.epoch_schedule;
+  ulong current_epoch = fd_slot_to_epoch( epoch_schedule, bank->f.slot,        NULL );
+  ulong parent_epoch  = fd_slot_to_epoch( epoch_schedule, bank->f.parent_slot, NULL );
+
+  long epoch_start_timestamp;
+  if(      FD_UNLIKELY( !bank->f.slot               ) ) epoch_start_timestamp = unix_timestamp_from_genesis( bank );
+  else if( FD_UNLIKELY( parent_epoch!=current_epoch ) ) epoch_start_timestamp = clock->unix_timestamp;
+  else                                                  epoch_start_timestamp = clock->epoch_start_timestamp;
+
+  *clock = (fd_sol_sysvar_clock_t){
+    .slot                  = bank->f.slot,
+    .epoch_start_timestamp = epoch_start_timestamp,
+    .epoch                 = current_epoch,
+    .leader_schedule_epoch = fd_slot_to_leader_schedule_epoch( epoch_schedule, bank->f.slot ),
+    .unix_timestamp        = clock->unix_timestamp, /* parent's footer timestamp */
+  };
+  fd_sysvar_clock_write( bank, accdb, capture_ctx, clock );
+}

--- a/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_clock.h
@@ -53,6 +53,20 @@ fd_sysvar_clock_update( fd_bank_t *          bank,
                         fd_runtime_stack_t * runtime_stack,
                         ulong const *        parent_epoch );
 
+/* fd_sysvar_clock_update_slot_for_alpenglow advances the clock sysvar's
+   slot, epoch and leader_schedule_epoch at the start of an alpenglow
+   block, without the stake-weighted timestamp calculation.
+
+   https://github.com/anza-xyz/agave/blob/386cf57c45e135d8a3a8b7d16877eb896f695c64/runtime/src/bank.rs#L2507
+
+   At an epoch boundary the parent's timestamp becomes the epoch start
+   timestamp. */
+
+void
+fd_sysvar_clock_update_slot_alpenglow( fd_bank_t *        bank,
+                                       fd_accdb_t *       accdb,
+                                       fd_capture_ctx_t * capture_ctx );
+
 FD_PROTOTYPES_END
 
 #endif /* HEADER_fd_src_flamenco_runtime_sysvar_fd_sysvar_clock_h */

--- a/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
+++ b/src/flamenco/runtime/sysvar/fd_sysvar_rent.h
@@ -11,6 +11,11 @@
    https://github.com/anza-xyz/agave/blob/v4.1.0-beta.1/runtime/src/rent_collector.rs#L50-L57 */
 #define FD_SIMD_0194_NEW_BURN_PERCENT (50)
 
+/* alpenclock and genesis certificate account rent is pinned to the
+   default rent values here:
+   https://github.com/anza-xyz/solana-sdk/blob/rent%40v4.3.0/rent/src/lib.rs#L87-L95 */
+#define FD_RENT_DEFAULT_PARAMS ((fd_rent_t){ .lamports_per_uint8_year=6960UL, .exemption_threshold=1.0, .burn_percent=(uchar)50 })
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_sysvar_rent_init copies the cached rent sysvar stored from the

--- a/src/flamenco/runtime/tests/Local.mk
+++ b/src/flamenco/runtime/tests/Local.mk
@@ -18,8 +18,8 @@ $(call add-objs,generated/context.pb generated/instr.pb generated/txn.pb generat
 
 ifdef FD_HAS_HOSTED
 SOL_COMPAT_FLAGS:=-Wl,--version-script=src/flamenco/runtime/tests/libfd_exec_sol_compat.map
-$(call make-unit-test,test_sol_compat,test_sol_compat,fd_flamenco_test fd_discof fd_flamenco fd_disco fd_reedsol fd_tango fd_ballet fd_util)
-$(call make-shared,libfd_exec_sol_compat.so,fd_sol_compat,fd_flamenco_test fd_discof fd_flamenco fd_disco fd_reedsol fd_ballet fd_util,$(SOL_COMPAT_FLAGS))
+$(call make-unit-test,test_sol_compat,test_sol_compat,fd_flamenco_test fd_discof fd_choreo fd_flamenco fd_disco fd_reedsol fd_tango fd_ballet fd_util)
+$(call make-shared,libfd_exec_sol_compat.so,fd_sol_compat,fd_flamenco_test fd_discof fd_choreo fd_flamenco fd_disco fd_reedsol fd_ballet fd_util,$(SOL_COMPAT_FLAGS))
 $(call make-unit-test,test_sol_compat_so,test_sol_compat_so,fd_util)
 endif
 

--- a/src/flamenco/runtime/tests/test_inflation_rewards.c
+++ b/src/flamenco/runtime/tests/test_inflation_rewards.c
@@ -340,6 +340,34 @@ reward_epoch_stakes_account_id( void ) {
   return *address;
 }
 
+/* Writes the "carlgration" genesis certificate account, marking the
+   chain as migrated to alpenglow at migration_slot.  The reward gates
+   key on this (rewarded_epoch_is_alpenglow), not on the feature bit. */
+static void
+set_alpenglow_migration( fd_svm_mini_t * mini,
+                         ulong           migration_slot ) {
+  fd_pubkey_t   program_id  = alpenglow_feature_id();
+  uchar const   seed[]      = "carlgration";
+  uchar const * seeds[1]    = { seed };
+  ulong         seed_szs[1] = { sizeof(seed)-1UL };
+  fd_pubkey_t   address[1];
+  uchar         bump_seed;
+  uint          custom_err  = 0U;
+  FD_TEST( !fd_pubkey_find_program_address( &program_id, 1UL, seeds, seed_szs,
+                                            address, &bump_seed, &custom_err ) );
+
+  uchar data[8];
+  FD_STORE( ulong, data, migration_slot );
+
+  fd_acc_t acc = {0};
+  fd_memcpy( acc.pubkey, address->uc, 32UL );
+  fd_memcpy( acc.owner, fd_solana_system_program_id.uc, 32UL );
+  acc.lamports = 1000000UL;
+  acc.data_len = sizeof(data);
+  acc.data     = data;
+  fd_svm_mini_put_account_rooted( mini, &acc );
+}
+
 static void
 init_epoch_inflation_account( fd_svm_mini_t * mini ) {
   fd_pubkey_t address  = epoch_inflation_account_id();
@@ -426,6 +454,7 @@ test_alpenglow_reward_uses_vote_credits( fd_svm_mini_t * mini ) {
   ulong root_idx = fd_svm_mini_reset( mini, params );
 
   activate_alpenglow( mini );
+  set_alpenglow_migration( mini, TEST_ROOT_SLOT );
   init_epoch_inflation_account( mini );
 
   fd_pubkey_t identity_key, vote_key, stake_key;
@@ -497,6 +526,7 @@ test_alpenglow_preserves_commission_remainder( fd_svm_mini_t * mini ) {
   ulong root_idx = fd_svm_mini_reset( mini, params );
 
   activate_alpenglow( mini );
+  set_alpenglow_migration( mini, TEST_ROOT_SLOT );
   init_epoch_inflation_account( mini );
 
   fd_pubkey_t identity_key, vote_key, stake_key;

--- a/src/flamenco/stakes/fd_vote_stakes.c
+++ b/src/flamenco/stakes/fd_vote_stakes.c
@@ -704,6 +704,24 @@ fd_vote_stakes_cnt_t_2( fd_vote_stakes_t const * vote_stakes,
   return vacc_pool_used( t_2_vacc_pool( vote_stakes, (ulong)fork_id_epoch( fork_id ) & 1UL ) );
 }
 
+ulong
+fd_vote_stakes_total_stake( fd_vote_stakes_t const * vote_stakes,
+                            ulong                    epoch ) {
+  ulong idx = epoch & 1UL;
+  if( FD_UNLIKELY( vote_stakes->t_2_epoch[ idx ]!=epoch ) ) return 0UL;
+
+  vacc_t *     pool = t_2_vacc_pool( vote_stakes, idx );
+  vacc_map_t * map  = t_2_vacc_map ( vote_stakes, idx );
+
+  ulong total = 0UL;
+  for( vacc_map_iter_t iter = vacc_map_iter_init( map, pool );
+       !vacc_map_iter_done( iter, map, pool );
+       iter = vacc_map_iter_next( iter, map, pool ) ) {
+    total += vacc_map_iter_ele_const( iter, map, pool )->stake;
+  }
+  return total;
+}
+
 FD_STATIC_ASSERT( FD_VOTE_STAKES_T_1_ITER_FOOTPRINT == sizeof(vacc_map_iter_t), t_1_iter_footprint );
 FD_STATIC_ASSERT( FD_VOTE_STAKES_T_1_ITER_ALIGN == alignof(vacc_map_iter_t), t_1_iter_align );
 FD_STATIC_ASSERT( FD_VOTE_STAKES_T_2_ITER_FOOTPRINT == sizeof(vacc_map_iter_t), t_2_iter_footprint );

--- a/src/flamenco/stakes/fd_vote_stakes.h
+++ b/src/flamenco/stakes/fd_vote_stakes.h
@@ -203,6 +203,15 @@ ulong
 fd_vote_stakes_cnt_t_2( fd_vote_stakes_t const * vote_stakes,
                         ulong                    fork_id );
 
+/* fd_vote_stakes_total_stake returns the total stake of the epoch
+   stakes set for epoch.
+   epoch must be the current (the t-2 set) or the one before it
+   (the t-3 set); returns 0 if that epoch's set is not resident. */
+
+ulong
+fd_vote_stakes_total_stake( fd_vote_stakes_t const * vote_stakes,
+                            ulong                    epoch );
+
 /* Defined below are the iterators for the t-1 and t-2 sets.  These
    iterators will NOT skip over invalid vote accounts intentionally.
    The reason being is that invalid vote accounts are still considered


### PR DESCRIPTION
Still missing footer validation on fields, 
cert verification
marking dead on sched parse / bad footer application
need to read e-1 (t-3) stakes, because rewards are applied for 8 slots prior and if we boot within 8 slots of the epoch boundary then we need the prior epochs stakes