### PR TITLE
discof, flamenco: add support for no-op transactions (relax_fee_payer_constraint)

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -327,6 +327,12 @@ handle_microblock( fd_execle_tile_t *  ctx,
     /* Stash the result in the flags value so that pack can inspect it. */
     txn->flags = (txn->flags & 0x00FFFFFFU) | ((uint)(-txn_out->err.txn_err)<<24);
 
+    /* Drop no-op transactions, we don't want to include these as they
+       charge no fees. */
+    if( FD_UNLIKELY( txn_out->err.is_noop ) ) {
+      txn_out->err.is_committable = 0;
+    }
+
     if( FD_UNLIKELY( !txn_out->err.is_committable ) ) {
       FD_TEST( !txn_out->err.is_fees_only );
       fd_runtime_cancel_txn( ctx->runtime, bank, txn_in, txn_out, ctx->report_transaction_diffs );

--- a/src/discof/execle/test_execle_tile.c
+++ b/src/discof/execle/test_execle_tile.c
@@ -1070,6 +1070,51 @@ FD_UNIT_TEST( execle_simple_fee_payer_fail ) {
   test_env_destroy( env );
 }
 
+/* Test for relax_fee_payer_constraint feature: we want to drop no-op
+   transactions in the leader pipeline, as they do not charge any fees
+   and so it is not profitable to include them. */
+FD_UNIT_TEST( execle_simple_fee_payer_fail_relaxed ) {
+  test_env_t * env = test_env_create();
+  fd_bank_t * bank = fd_svm_mini_bank( env->mini, env->bank_idx );
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, relax_fee_payer_constraint, 0UL );
+
+  fd_pubkey_t missing_fee_payer = { .ul = { 0x3333UL } };
+  fd_pubkey_t data_acct         = { .ul = { 0x4444UL } };
+  ulong const data_acct_start = 777UL;
+  test_fund_account( env, &data_acct, data_acct_start );
+
+  fd_txn_p_t txn[1];
+  test_build_empty_txn( txn, bank, missing_fee_payer, data_acct, 12UL, 0 );
+  test_execle_run( env, txn, 1UL, 4U, 18UL, 0 );
+
+  test_assert_nonbundle_out( env, 1UL, 4U );
+  fd_txn_p_t const * out_txn = fd_chunk_to_laddr( env->execle->out_poh->mem, test_out_poh_meta( 0UL )->chunk );
+  FD_TEST( env->execle->txn_out[0].err.is_noop );
+
+  /* The execle tile should have set is_committable to false */
+  FD_TEST( !env->execle->txn_out[0].err.is_committable );
+  FD_TEST( !env->execle->txn_out[0].err.is_fees_only );
+  FD_TEST( env->execle->txn_out[0].err.txn_err==FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND );
+  FD_TEST( !(out_txn->flags & FD_TXN_P_FLAGS_SANITIZE_SUCCESS) );
+  FD_TEST( !(out_txn->flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS) );
+  FD_TEST( (out_txn->flags & FD_TXN_P_FLAGS_RESULT_MASK)==((uint)(-FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND)<<24) );
+
+  /* The transaction was dropped, so nothing was charged
+     and everything is rebated. */
+  FD_TEST( test_read_lamports( env, &data_acct )==data_acct_start );
+  FD_TEST( !bank->f.txn_count       );
+  FD_TEST( !bank->f.signature_count );
+  FD_TEST( fd_bank_cost_tracker_query( bank )->block_cost==0UL );
+  FD_TEST( out_txn->execle_cu.actual_consumed_cus==0U );
+  FD_TEST( out_txn->execle_cu.rebated_cus==
+           txn->pack_cu.non_execution_cus + txn->pack_cu.requested_exec_plus_acct_data_cus );
+
+  FD_TEST( env->execle->metrics.txn_landed[ FD_METRICS_ENUM_TRANSACTION_LANDED_V_UNLANDED_IDX ]==1UL );
+  FD_TEST( env->execle->metrics.txn_result[ FD_METRICS_ENUM_TRANSACTION_RESULT_V_ACCOUNT_NOT_FOUND_IDX ]==1UL );
+
+  test_env_destroy( env );
+}
+
 FD_UNIT_TEST( execle_simple_error ) {
   /* System transfer fails during execution */
   test_env_t * env = test_env_create();

--- a/src/discof/execrp/fd_execrp_tile.c
+++ b/src/discof/execrp/fd_execrp_tile.c
@@ -185,6 +185,7 @@ publish_txn_finalized_msg( fd_execrp_tile_t *  ctx,
   msg->txn_exec->txn_idx         = ctx->txn_idx;
   msg->txn_exec->is_committable  = ctx->txn_out.err.is_committable;
   msg->txn_exec->is_fees_only    = ctx->txn_out.err.is_fees_only;
+  msg->txn_exec->is_noop         = ctx->txn_out.err.is_noop;
   msg->txn_exec->txn_err         = ctx->txn_out.err.txn_err;
   msg->txn_exec->is_simple_vote  = ctx->txn_out.details.is_simple_vote;
 

--- a/src/discof/execrp/test_execrp_tile.c
+++ b/src/discof/execrp/test_execrp_tile.c
@@ -525,12 +525,55 @@ FD_UNIT_TEST( execrp_simple_fee_payer_fail ) {
   FD_TEST( !env->execrp->txn_out.err.is_committable );
   FD_TEST( env->execrp->txn_out.err.txn_err==FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND );
   FD_TEST( !out_msg->txn_exec->is_committable );
+  FD_TEST( !out_msg->txn_exec->is_noop );
   FD_TEST( out_msg->txn_exec->txn_err==FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND );
   FD_TEST( out_msg->txn_exec->tick_load_start !=LONG_MAX );
   FD_TEST( out_msg->txn_exec->tick_commit_start==LONG_MAX );
   FD_TEST( out_msg->txn_exec->tick_commit_end  ==LONG_MAX );
   FD_TEST( !out_msg->txn_exec->compute_units_consumed );
   FD_TEST( test_read_lamports( env, &data_acct )==data_acct_start );
+
+  test_env_destroy( env );
+}
+
+/* Test for relax_fee_payer_constraint feature: a transaction with
+   an invalid fee payer should be classified as a "no-op" transaction,
+   have no effect on the account state, not charge any fees, but is
+   valid to include in the block. */
+FD_UNIT_TEST( execrp_simple_fee_payer_fail_relaxed ) {
+  test_env_t * env = test_env_create();
+  fd_bank_t * bank = fd_svm_mini_bank( env->mini, env->bank_idx );
+  FD_FEATURE_SET_ACTIVE( &bank->f.features, relax_fee_payer_constraint, 0UL );
+
+  fd_pubkey_t missing_fee_payer = { .ul = { 0x3333UL } };
+  fd_pubkey_t data_acct         = { .ul = { 0x4444UL } };
+  ulong const data_acct_start = 777UL;
+  test_fund_account( env, &data_acct, data_acct_start );
+
+  fd_txn_p_t txn[1];
+  test_build_empty_txn( txn, bank, missing_fee_payer, data_acct, 12UL, 0 );
+  fd_execrp_task_done_msg_t const * out_msg = test_execrp_run( env, txn, 19UL );
+
+  FD_TEST( env->execrp->txn_out.err.is_committable );
+  FD_TEST( env->execrp->txn_out.err.is_noop        );
+  FD_TEST( !env->execrp->txn_out.err.is_fees_only  );
+  FD_TEST( env->execrp->txn_out.err.txn_err==FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND );
+  FD_TEST( out_msg->txn_exec->is_committable );
+  FD_TEST( out_msg->txn_exec->is_noop        );
+  FD_TEST( !out_msg->txn_exec->is_fees_only  );
+  FD_TEST( out_msg->txn_exec->txn_err==FD_RUNTIME_TXN_ERR_ACCOUNT_NOT_FOUND );
+
+  /* No fees charged */
+  FD_TEST( !bank->f.execution_fees );
+  FD_TEST( !bank->f.priority_fees  );
+
+  /* No change on the account state */
+  FD_TEST( test_read_lamports( env, &data_acct )==data_acct_start );
+  FD_TEST( !test_read_lamports( env, &missing_fee_payer ) );
+
+  /* It does count towards the bank hash signature count */
+  FD_TEST( bank->f.txn_count==1UL       );
+  FD_TEST( bank->f.signature_count==1UL );
 
   test_env_destroy( env );
 }

--- a/src/discof/replay/fd_execrp.h
+++ b/src/discof/replay/fd_execrp.h
@@ -68,6 +68,9 @@ struct fd_execrp_txn_exec_done_msg {
        if( is_fees_only ) {
          instructions will not be executed
          txn_err will be non-zero and will be one of the account loader errors
+       } else if( is_noop ) {
+         instructions will not be executed and no fees charged
+         txn_err will be non-zero and will be a fee payer validation error
        } else {
          instructions will execute
          if( txn_err is non-zero ) {
@@ -83,6 +86,7 @@ struct fd_execrp_txn_exec_done_msg {
   */
   int is_committable;
   int is_fees_only;
+  int is_noop;
   int txn_err;
   int is_simple_vote;
 

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -910,6 +910,7 @@ publish_txn_executed( fd_replay_tile_t *  ctx,
   txn_executed->txn_err = txn_info->txn_err;
   txn_executed->is_committable = !!(txn_info->flags&FD_SCHED_TXN_IS_COMMITTABLE);
   txn_executed->is_fees_only = !!(txn_info->flags&FD_SCHED_TXN_IS_FEES_ONLY);
+  txn_executed->is_noop = !!(txn_info->flags&FD_SCHED_TXN_IS_NOOP);
   txn_executed->is_simple_vote = txn_info->is_simple_vote;
   txn_executed->tick_parsed = txn_info->tick_parsed;
   txn_executed->tick_sigverify_disp = txn_info->tick_sigverify_disp;
@@ -3053,6 +3054,7 @@ process_exec_task_done( fd_replay_tile_t *          ctx,
         txn_info->txn_err = msg->txn_exec->txn_err;
         txn_info->flags  |= fd_ulong_if( msg->txn_exec->is_committable, FD_SCHED_TXN_IS_COMMITTABLE, 0UL );
         txn_info->flags  |= fd_ulong_if( msg->txn_exec->is_fees_only,   FD_SCHED_TXN_IS_FEES_ONLY,   0UL );
+        txn_info->flags  |= fd_ulong_if( msg->txn_exec->is_noop,        FD_SCHED_TXN_IS_NOOP,        0UL );
       }
       if( FD_UNLIKELY( (txn_info->flags&FD_SCHED_TXN_REPLAY_DONE)==FD_SCHED_TXN_REPLAY_DONE ) ) { /* UNLIKELY because generally exec happens before sigverify. */
         publish_txn_executed( ctx, stem, bank->idx, txn_idx );
@@ -3067,6 +3069,7 @@ process_exec_task_done( fd_replay_tile_t *          ctx,
         txn_info->txn_err = FD_RUNTIME_TXN_ERR_SIGNATURE_FAILURE;
         txn_info->flags  &= ~FD_SCHED_TXN_IS_COMMITTABLE;
         txn_info->flags  &= ~FD_SCHED_TXN_IS_FEES_ONLY;
+        txn_info->flags  &= ~FD_SCHED_TXN_IS_NOOP;
       }
       if( FD_UNLIKELY( msg->txn_sigverify->err && bank->state!=FD_BANK_STATE_DEAD ) ) {
         /* Every transaction in a valid block has to sigverify.

--- a/src/discof/replay/fd_replay_tile.h
+++ b/src/discof/replay/fd_replay_tile.h
@@ -190,6 +190,7 @@ struct fd_replay_txn_executed {
   fd_txn_p_t txn[ 1 ];
   int is_committable;
   int is_fees_only;
+  int is_noop;
   int txn_err;
   int is_simple_vote;
 

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -89,6 +89,7 @@ typedef struct fd_sched_fec fd_sched_fec_t;
 #define FD_SCHED_TXN_SIGVERIFY_DONE (0x0002UL)
 #define FD_SCHED_TXN_IS_COMMITTABLE (0x0004UL)
 #define FD_SCHED_TXN_IS_FEES_ONLY   (0x0008UL)
+#define FD_SCHED_TXN_IS_NOOP        (0x0010UL)
 #define FD_SCHED_TXN_REPLAY_DONE    (FD_SCHED_TXN_EXEC_DONE|FD_SCHED_TXN_SIGVERIFY_DONE)
 
 struct fd_sched_txn_info {

--- a/src/flamenco/features/fd_features_generated.c
+++ b/src/flamenco/features/fd_features_generated.c
@@ -2007,6 +2007,12 @@ fd_feature_id_t const ids[] = {
     .name                      = "alpenglow",
     .cleaned_up                = 0 },
 
+  { .index                     = offsetof(fd_features_t, relax_fee_payer_constraint)>>3,
+    .id                        = {"\xd3\x67\x76\x96\x3e\x25\x7f\x1e\x4e\xa2\x79\xb4\x3b\xf4\xe5\xf1\x35\xea\xf4\xd9\xf9\xd7\xf1\xfa\x82\x59\x8a\xfb\xa8\xfb\x03\xab"},
+                                 /* FEEXbxUuKobtrt1qNK5pjtzbPQhsppBTrNNG74xu4mai */
+    .name                      = "relax_fee_payer_constraint",
+    .cleaned_up                = 0 },
+
   { .index = ULONG_MAX }
 };
 
@@ -2316,6 +2322,7 @@ typedef struct fd_feature_id_lookup_entry fd_feature_id_lookup_entry_t;
 #define MAP_PERFECT_290 0x9c92e629e8d74f0dUL, .val = &ids[290]
 #define MAP_PERFECT_291 0x8ea2469cb4e5a93cUL, .val = &ids[291]
 #define MAP_PERFECT_292 0xb2513619e40fef85UL, .val = &ids[292]
+#define MAP_PERFECT_293 0x1e7f253e967667d3UL, .val = &ids[293]
 
 #include "../../util/tmpl/fd_map_perfect.c"
 
@@ -2619,4 +2626,5 @@ FD_STATIC_ASSERT( offsetof( fd_features_t, custom_commission_collector          
 FD_STATIC_ASSERT( offsetof( fd_features_t, enable_tx_v1                                            )>>3==290UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, double_disinflation_rate                                )>>3==291UL, layout );
 FD_STATIC_ASSERT( offsetof( fd_features_t, alpenglow                                               )>>3==292UL, layout );
+FD_STATIC_ASSERT( offsetof( fd_features_t, relax_fee_payer_constraint                              )>>3==293UL, layout );
 FD_STATIC_ASSERT( sizeof( fd_features_t )>>3==FD_FEATURE_ID_CNT, layout );

--- a/src/flamenco/features/fd_features_generated.h
+++ b/src/flamenco/features/fd_features_generated.h
@@ -8,10 +8,10 @@
 #endif
 
 /* FEATURE_ID_CNT is the number of features in ids */
-#define FD_FEATURE_ID_CNT (293UL)
+#define FD_FEATURE_ID_CNT (294UL)
 
 /* Feature set ID calculated from all feature names */
-#define FD_FEATURE_SET_ID (2746196230U)
+#define FD_FEATURE_SET_ID (168928925U)
 
 union fd_features {
   ulong f[ FD_FEATURE_ID_CNT ];
@@ -309,5 +309,6 @@ union fd_features {
     /* 0x9c92e629e8d74f0d */ ulong enable_tx_v1;
     /* 0x8ea2469cb4e5a93c */ ulong double_disinflation_rate;
     /* 0xb2513619e40fef85 */ ulong alpenglow;
+    /* 0x1e7f253e967667d3 */ ulong relax_fee_payer_constraint;
   };
 };

--- a/src/flamenco/features/feature_map.json
+++ b/src/flamenco/features/feature_map.json
@@ -291,5 +291,6 @@
   {"name":"custom_commission_collector","pubkey":"3HcSrCTGXTUnrTueHi4DAwNuMxZSsm5xui2Ax3mgxHqf"},
   {"name":"enable_tx_v1","pubkey":"txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL"},
   {"name":"double_disinflation_rate","pubkey":"55oikhjJ2LUi1xdgJ17ueRyHFURZEw32asT3iAKfh7gg"},
-  {"name":"alpenglow","pubkey":"A1pengvuM6JEcyNuTnMqepBKhwHE3N6PmUrdATGawhJS","old":"A1PeNGc3D8SQmKwdYf4qj1XG7XgWVSuFQaiJSCQj775h"}
+  {"name":"alpenglow","pubkey":"A1pengvuM6JEcyNuTnMqepBKhwHE3N6PmUrdATGawhJS","old":"A1PeNGc3D8SQmKwdYf4qj1XG7XgWVSuFQaiJSCQj775h"},
+  {"name":"relax_fee_payer_constraint","pubkey":"FEEXbxUuKobtrt1qNK5pjtzbPQhsppBTrNNG74xu4mai"}
 ]

--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -977,7 +977,30 @@ fd_runtime_pre_execute_check( fd_runtime_t *      runtime,
      https://github.com/anza-xyz/agave/blob/ced98f1ebe73f7e9691308afa757323003ff744f/svm/src/transaction_processor.rs#L236-L249 */
   err = fd_executor_validate_transaction_fee_payer( bank, txn_in, txn_out );
   if( FD_UNLIKELY( err!=FD_RUNTIME_EXECUTE_SUCCESS ) ) {
-    txn_out->err.is_committable = 0;
+    /* As of the relax_fee_payer_constraint feature, a transaction with
+       an invalid fee payer can be included in the block. The
+       transaction has no effect on account state and charges no fees.
+       These are called "no-op" transactions. They consume block space
+       (charging the requested CUs) and their loaded accounts data size
+       is charged at their loaded accounts data size limit.
+
+       Firedancer does not produce blocks containing no-op transactions
+       but we need to be able to replay blocks containing these.
+
+       The exception is durable nonce transactions - durable nonce
+       transactions with invalid fee payers are not allowed in a block,
+       and if a block contains any such transactions it is invalid.
+
+       https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/svm/src/transaction_processor.rs#L741-L770 */
+    if( FD_FEATURE_ACTIVE_BANK( bank, relax_fee_payer_constraint ) &&
+        txn_out->accounts.nonce_idx_in_txn==ULONG_MAX ) {
+      txn_out->err.is_committable = 1;
+      txn_out->err.is_noop        = 1;
+      txn_out->err.is_fees_only   = 0;
+    } else {
+      txn_out->err.is_committable = 0;
+      txn_out->err.is_noop        = 0;
+    }
     return err;
   }
 
@@ -1160,7 +1183,9 @@ fd_runtime_commit_txn( fd_runtime_t *      runtime,
     fd_txncache_insert( runtime->status_cache, bank->txncache_fork_id, txn_out->details.blockhash.uc, txn_out->details.blake_txn_msg_hash.uc );
   }
 
-  if( FD_UNLIKELY( txn_out->err.txn_err ) ) {
+  /* No-op transactions have no effect on the state so we should skip
+     these rollbacks. */
+  if( FD_UNLIKELY( txn_out->err.txn_err && !txn_out->err.is_noop ) ) {
     /* With nonce account rollbacks, there are three cases:
 
        1. No nonce account in the transaction
@@ -1308,6 +1333,7 @@ fd_runtime_new_txn_out( fd_txn_in_t const * txn_in,
 
   txn_out->err.is_committable = 1;
   txn_out->err.is_fees_only   = 0;
+  txn_out->err.is_noop        = 0;
   txn_out->err.txn_err        = FD_RUNTIME_EXECUTE_SUCCESS;
   txn_out->err.exec_err       = FD_EXECUTOR_INSTR_SUCCESS;
   txn_out->err.exec_err_kind  = FD_EXECUTOR_ERR_KIND_NONE;
@@ -1337,14 +1363,21 @@ fd_runtime_prepare_and_execute_txn( fd_runtime_t *      runtime,
     }
   }
 
-  /* Transaction sanitization.  If a transaction can't be committed or is
-     fees-only, we return early. */
+  /* Transaction sanitization.  If a transaction can't be committed, is
+     fees-only, or a no-op, we return early. */
   txn_out->err.txn_err = fd_runtime_pre_execute_check( runtime, bank, txn_in, txn_out );
   ulong cu_before = txn_out->details.compute_budget.compute_meter;
 
   /* Execute the transaction if eligible to do so. */
   if( FD_LIKELY( txn_out->err.is_committable ) ) {
-    if( FD_LIKELY( !txn_out->err.is_fees_only ) ) {
+    if( FD_UNLIKELY( txn_out->err.is_noop ) ) {
+      /* No-op transactions charge the requested CUs and loaded
+         account data size limit.
+         https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/svm/src/transaction_processor.rs#L757-L767
+         https://github.com/anza-xyz/agave/blob/v4.3.0-beta.0/svm/src/transaction_processing_result.rs#L92-L106 */
+      txn_out->details.compute_budget.compute_meter = 0UL;
+      txn_out->details.loaded_accounts_data_size    = txn_out->details.compute_budget.loaded_accounts_data_size_limit;
+    } else if( FD_LIKELY( !txn_out->err.is_fees_only ) ) {
       txn_out->details.exec_start_ticks = fd_tickcount();
       txn_out->err.txn_err = fd_execute_txn( runtime, bank, txn_in, txn_out );
     }

--- a/src/flamenco/runtime/fd_runtime.h
+++ b/src/flamenco/runtime/fd_runtime.h
@@ -236,6 +236,7 @@ struct fd_txn_out {
   struct {
     int  is_committable;
     int  is_fees_only;
+    int  is_noop;
     int  txn_err;
     /* These are error fields produced by instruction execution
        when txn_err == FD_RUNTIME_TXN_ERR_INSTRUCTION_ERROR (-9). */

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -1222,7 +1222,7 @@ create_txn_result_protobuf_from_txn( fd_exec_test_txn_result_t ** txn_result_out
   txn_result->rollback_accounts = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_exec_test_acct_state_t), sizeof(fd_exec_test_acct_state_t) * 2UL );
   if( FD_UNLIKELY( _l > out_end ) ) abort();
 
-  if( txn_out->err.is_fees_only || exec_res!=FD_RUNTIME_EXECUTE_SUCCESS ) {
+  if( ( txn_out->err.is_fees_only || exec_res!=FD_RUNTIME_EXECUTE_SUCCESS ) && !txn_out->err.is_noop ) {
     /* If the transaction errored, capture the rollback accounts (fee payer and nonce). */
     if( FD_LIKELY( txn_out->accounts.nonce_idx_in_txn!=FD_FEE_PAYER_TXN_IDX ) ) {
       write_account_to_result1(
@@ -1263,7 +1263,7 @@ create_txn_result_protobuf_from_txn( fd_exec_test_txn_result_t ** txn_result_out
     }
   }
 
-  if( !txn_out->err.is_fees_only ) {
+  if( !txn_out->err.is_fees_only && !txn_out->err.is_noop ) {
     /* Executed: writable accounts. */
     for( ulong j=0UL; j<txn_out->accounts.cnt; j++ ) {
       if( !fd_runtime_account_is_writable_idx( txn_in, txn_out, (ushort)j ) ) {

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -160,3 +160,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l programdata-closeslot -m 10
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l programdata-poison -m 10000 -e 562
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l double_disinflation_rate -m 2000000 -e 840
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l double_disinflation_rate_snapshot -m 2000000 -e 840
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l relax_fee_payer_constraint -m 2000000 -e 400


### PR DESCRIPTION
`relax_fee_payer_constraint` (https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0290-relax-fee-payer-constraint.md) introduces the concept of a "no-op" transaction.

These transactions:
- Have no effect on the account state
- Charge no fees
- Consume the requested CUs and the loaded accounts data size limit
- Are not packed by Firedancer or Agave by default

As of `relax_fee_payer_constraint`, transactions with invalid fee payers are allowed inside a block, but are treated as no-op transactions. The exception is durable nonce transactions with invalid fee payers, which are still not allowed in the block.

This is to facilitate bankless leader/async execution: allowing the block packer to produce blocks without needing to keep up to the head of the chain.

As these charge no fees, there is no incentive for the block producer to include them.

Tested with ledgers and local clusters.