### PR TITLE
bn254: speedup fp add/sub

### DIFF
--- a/src/ballet/bigint/fd_uint256_mul.h
+++ b/src/ballet/bigint/fd_uint256_mul.h
@@ -55,6 +55,24 @@ fd_ulong_sub_borrow(
 # endif
 }
 
+INLINE void
+fd_ulong_add_carry(
+    ulong * r,   /* out (r=a+b+ci) */
+    int *   c,   /* out carry flag */
+    ulong   a0,
+    ulong   a1,
+    int     ci   /* in carry flag */
+) {
+# if FD_HAS_X86
+  *c = (uchar)_addcarry_u64( (uchar)ci, a0, a1, (unsigned long long *)r );
+# else
+  ulong r0 = a0 + a1;
+  ulong r1 = r0 + !!ci;
+  *r = r1;
+  *c = (int)((r0 < a0) | (r1 < r0));
+# endif
+}
+
 #if FD_HAS_INT128
 
 INLINE void

--- a/src/ballet/bigint/test_uint256.c
+++ b/src/ballet/bigint/test_uint256.c
@@ -12,12 +12,26 @@ test_ulong_sub_borrow( void ) {
   fd_ulong_sub_borrow( &r, &b, 2UL,       2UL, 1 );  FD_TEST( r==ULONG_MAX && b==1 );
 }
 
+static void
+test_ulong_add_carry( void ) {
+  ulong r;
+  int   c;
+
+  fd_ulong_add_carry( &r, &c, 0UL,       0UL, 0 );  FD_TEST( r==0UL       && c==0 );
+  fd_ulong_add_carry( &r, &c, ULONG_MAX, 0UL, 0 );  FD_TEST( r==ULONG_MAX && c==0 );
+  fd_ulong_add_carry( &r, &c, ULONG_MAX, 1UL, 0 );  FD_TEST( r==0UL       && c==1 );
+  fd_ulong_add_carry( &r, &c, 4UL,       2UL, 1 );  FD_TEST( r==7UL       && c==0 );
+  fd_ulong_add_carry( &r, &c, ULONG_MAX, 0UL, 1 );  FD_TEST( r==0UL       && c==1 );
+  fd_ulong_add_carry( &r, &c, ULONG_MAX, ULONG_MAX, 1 );  FD_TEST( r==ULONG_MAX && c==1 );
+}
+
 int
 main( int    argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
   test_ulong_sub_borrow();
+  test_ulong_add_carry();
   /* TODO more checks here */
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/ballet/bn254/fd_bn254_field_inl.h
+++ b/src/ballet/bn254/fd_bn254_field_inl.h
@@ -12,14 +12,6 @@
 #if FD_HAS_S2NBIGNUM
 #include "../../third_party/s2n-bignum/include/s2n-bignum.h"
 #endif
-#if FD_HAS_X86
-#if defined(__GNUC__) && !defined(__clang__)
-#include <x86gprintrin.h> /* adc/sbb only; ~200x smaller than immintrin.h */
-#else
-#include <immintrin.h>
-#endif
-#endif
-
 /* Fp = base field */
 
 #define FLAG_INF  ((uchar)(1 << 6))
@@ -144,8 +136,32 @@ INLINE fd_bn254_fp_t *
 fd_bn254_fp_add( fd_bn254_fp_t * r,
                  fd_bn254_fp_t const * a,
                  fd_bn254_fp_t const * b ) {
+#if FD_HAS_X86 && defined(__ADX__)
+  /* t = a + b (a,b < p < 2^254 so no carry out of 254 bits)
+     then r = min(t, t - p) via a branchless borrow-select.
+     This ends up being a shorter dependency chain than fiat's wide-add
+     + cmov strategy. */
+  ulong t0,t1,t2,t3, s0,s1,s2,s3;
+  int c = 0;
+  fd_ulong_add_carry( &t0, &c, a->limbs[0], b->limbs[0], c );
+  fd_ulong_add_carry( &t1, &c, a->limbs[1], b->limbs[1], c );
+  fd_ulong_add_carry( &t2, &c, a->limbs[2], b->limbs[2], c );
+  fd_ulong_add_carry( &t3, &c, a->limbs[3], b->limbs[3], c );
+  int br = 0;
+  fd_ulong_sub_borrow( &s0, &br, t0, fd_bn254_const_p->limbs[0], br );
+  fd_ulong_sub_borrow( &s1, &br, t1, fd_bn254_const_p->limbs[1], br );
+  fd_ulong_sub_borrow( &s2, &br, t2, fd_bn254_const_p->limbs[2], br );
+  fd_ulong_sub_borrow( &s3, &br, t3, fd_bn254_const_p->limbs[3], br );
+
+  r->limbs[0] = br ? t0 : s0;
+  r->limbs[1] = br ? t1 : s1;
+  r->limbs[2] = br ? t2 : s2;
+  r->limbs[3] = br ? t3 : s3;
+  return r;
+#else
   fiat_bn254_add( r->limbs, a->limbs, b->limbs );
   return r;
+#endif
 }
 
 /* r = a + b, output in [0, 2p).
@@ -156,17 +172,12 @@ fd_bn254_fp_add_lazy( fd_bn254_fp_t * r,
                       fd_bn254_fp_t const * a,
                       fd_bn254_fp_t const * b ) {
 #if FD_HAS_X86
-  unsigned long long t0, t1, t2, t3;
-  uchar c = 0;
-  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[0], (unsigned long long)b->limbs[0], &t0 );
-  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[1], (unsigned long long)b->limbs[1], &t1 );
-  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[2], (unsigned long long)b->limbs[2], &t2 );
-  c = (uchar)_addcarry_u64( c, (unsigned long long)a->limbs[3], (unsigned long long)b->limbs[3], &t3 );
+  int c = 0;
+  fd_ulong_add_carry( &r->limbs[0], &c, a->limbs[0], b->limbs[0], c );
+  fd_ulong_add_carry( &r->limbs[1], &c, a->limbs[1], b->limbs[1], c );
+  fd_ulong_add_carry( &r->limbs[2], &c, a->limbs[2], b->limbs[2], c );
+  fd_ulong_add_carry( &r->limbs[3], &c, a->limbs[3], b->limbs[3], c );
   (void)c; /* p < 2^254 so c is always 0 for a, b < 2p */
-  r->limbs[0] = (ulong)t0;
-  r->limbs[1] = (ulong)t1;
-  r->limbs[2] = (ulong)t2;
-  r->limbs[3] = (ulong)t3;
   return r;
 #else
   /* We find no performance improvement on non-x86 targets, so we
@@ -179,8 +190,29 @@ INLINE fd_bn254_fp_t *
 fd_bn254_fp_sub( fd_bn254_fp_t * r,
                  fd_bn254_fp_t const * a,
                  fd_bn254_fp_t const * b ) {
+#if FD_HAS_X86 && defined(__ADX__)
+  ulong t0,t1,t2,t3;
+  int br = 0;
+  fd_ulong_sub_borrow( &t0, &br, a->limbs[0], b->limbs[0], br );
+  fd_ulong_sub_borrow( &t1, &br, a->limbs[1], b->limbs[1], br );
+  fd_ulong_sub_borrow( &t2, &br, a->limbs[2], b->limbs[2], br );
+  fd_ulong_sub_borrow( &t3, &br, a->limbs[3], b->limbs[3], br );
+  ulong mask = (ulong)0 - (ulong)br; /* all-ones if borrow */
+  int c = 0;
+  fd_ulong_add_carry( &t0, &c, t0, mask & fd_bn254_const_p->limbs[0], c );
+  fd_ulong_add_carry( &t1, &c, t1, mask & fd_bn254_const_p->limbs[1], c );
+  fd_ulong_add_carry( &t2, &c, t2, mask & fd_bn254_const_p->limbs[2], c );
+  fd_ulong_add_carry( &t3, &c, t3, mask & fd_bn254_const_p->limbs[3], c );
+
+  r->limbs[0] = t0; 
+  r->limbs[1] = t1; 
+  r->limbs[2] = t2; 
+  r->limbs[3] = t3;
+  return r;
+#else
   fiat_bn254_sub( r->limbs, a->limbs, b->limbs );
   return r;
+#endif
 }
 
 INLINE fd_bn254_fp_t *


### PR DESCRIPTION
After:

GCC:
```
fd_bn254_g1_add_syscall               408.941K/s/core     2445.339 ns/call
fd_bn254_g2_add_syscall               311.158K/s/core     3213.806 ns/call
fd_bn254_g1_scalar_mul_syscall         18.791K/s/core    53217.184 ns/call
fd_bn254_g2_scalar_mul_syscall          4.961K/s/core   201566.047 ns/call
fd_bn254_final_exp                      3.862K/s/core   258951.703 ns/call
fd_bn254_g1_compress                50225.766K/s/core       19.910 ns/call
fd_bn254_g1_decompress                119.880K/s/core     8341.672 ns/call
fd_bn254_g2_compress                33812.113K/s/core       29.575 ns/call
fd_bn254_g2_decompress                 53.221K/s/core    18789.588 ns/call
fd_bn254_pairing_is_one_syscall         1.174K/s/core   851785.250 ns/call
```

Clang:
```
fd_bn254_g1_add_syscall               429.124K/s/core     2330.331 ns/call
fd_bn254_g2_add_syscall               346.454K/s/core     2886.385 ns/call
fd_bn254_g1_scalar_mul_syscall         21.153K/s/core    47273.797 ns/call
fd_bn254_g2_scalar_mul_syscall          5.581K/s/core   179165.438 ns/call
fd_bn254_final_exp                      4.351K/s/core   229832.156 ns/call
fd_bn254_g1_compress                77947.789K/s/core       12.829 ns/call
fd_bn254_g1_decompress                116.034K/s/core     8618.143 ns/call
fd_bn254_g2_compress                63819.875K/s/core       15.669 ns/call
fd_bn254_g2_decompress                 52.107K/s/core    19191.170 ns/call
fd_bn254_pairing_is_one_syscall         1.351K/s/core   740140.562 ns/call
```


Before:

GCC:
```
fd_bn254_g1_add_syscall               406.394K/s/core     2460.663 ns/call
fd_bn254_g2_add_syscall               298.317K/s/core     3352.142 ns/call
fd_bn254_g1_scalar_mul_syscall         15.003K/s/core    66655.383 ns/call
fd_bn254_g2_scalar_mul_syscall          3.929K/s/core   254550.000 ns/call
fd_bn254_final_exp                      2.231K/s/core   448209.469 ns/call
fd_bn254_g1_compress                52050.531K/s/core       19.212 ns/call
fd_bn254_g1_decompress                120.344K/s/core     8309.489 ns/call
fd_bn254_g2_compress                31478.117K/s/core       31.768 ns/call
fd_bn254_g2_decompress                 53.438K/s/core    18713.158 ns/call
fd_bn254_pairing_is_one_syscall         0.801K/s/core  1248514.500 ns/call
```

Clang:
```
fd_bn254_g1_add_syscall               418.505K/s/core     2389.459 ns/call
fd_bn254_g2_add_syscall               332.704K/s/core     3005.677 ns/call
fd_bn254_g1_scalar_mul_syscall         16.229K/s/core    61618.777 ns/call
fd_bn254_g2_scalar_mul_syscall          4.355K/s/core   229621.281 ns/call
fd_bn254_final_exp                      2.716K/s/core   368255.438 ns/call
fd_bn254_g1_compress                78167.141K/s/core       12.793 ns/call
fd_bn254_g1_decompress                114.881K/s/core     8704.677 ns/call
fd_bn254_g2_compress                64308.270K/s/core       15.550 ns/call
fd_bn254_g2_decompress                 51.725K/s/core    19332.939 ns/call
fd_bn254_pairing_is_one_syscall         0.938K/s/core  1066637.500 ns/call
```