### PR TITLE
snapmk: fix perf hazard handling fragmented accounts

### DIFF
--- a/src/discof/backup/fd_backup_disk.h
+++ b/src/discof/backup/fd_backup_disk.h
@@ -7,6 +7,7 @@
 #include "fd_backup.h"
 #include "fd_backup_accidx.h"
 #include "fd_backup_shmem.h"
+#include "../../tango/fd_tango_base.h"
 
 /* FD_SNAPMK_PF_LEAD is how far ahead of the record cursor the parser
    prefetches disk bytes. */
@@ -160,6 +161,123 @@ fd_snapmk_accparse_keep( fd_snapmk_accparse_t * parse ) {
   ulong chain_idx = fd_backup_accidx_chain( &parse->idx, parse->meta.pubkey );
   fd_snapmk_accparse_lookup( parse, &chain_idx, &parse->acc_file_off, &parse->acc_idx, 1UL );
   return parse->acc_idx!=UINT_MAX;
+}
+
+/* fd_snapmk_accparse_publish produces an account-aligned frag from
+   accumulated source data.  It returns meta if a frag was produced and
+   NULL otherwise.  In particular, after discarding a complete record it
+   returns NULL at the clean record boundary so the caller can retry the
+   whole-record batch path on the remaining input. */
+
+static inline fd_frag_meta_t *
+fd_snapmk_accparse_publish( fd_snapmk_accparse_t * parse,
+                            fd_frag_meta_t *       meta ) {
+  for(;;) {
+    if( FD_UNLIKELY( parse->pub_pending ) ) {
+      meta->sig    = parse->pub_gaddr;
+      meta->chunk  = parse->acc_idx;
+      meta->sz     = 0;
+      meta->ctl    = (ushort)fd_frag_meta_ctl( FD_BACKUP_ORIG_ACC_DISK, parse->pub_som, parse->pub_eom, 0 );
+      meta->tsorig = 0U;
+      meta->tspub  = (uint)parse->pub_sz;
+      parse->pub_pending = 0;
+      return meta;
+    }
+
+    if( FD_UNLIKELY( !parse->data_sz ) ) return NULL;
+
+    if( FD_UNLIKELY( !parse->acc_active ) ) {
+      if( FD_UNLIKELY( !parse->meta_sz ) ) {
+        parse->acc_file_off = parse->src_off;
+        parse->acc_snap_sz  = 0U;
+        parse->acc_idx      = UINT_MAX;
+        parse->acc_keep     = 1U;
+      }
+
+      ulong meta_rem = sizeof(fd_accdb_disk_meta_t) - (ulong)parse->meta_sz;
+      ulong take     = fd_ulong_min( meta_rem, parse->data_sz );
+      fd_memcpy( parse->buf + parse->meta_sz, parse->data, take );
+      parse->meta_sz   += (uint)take;
+      parse->data      += take;
+      parse->data_sz   -= take;
+      parse->src_gaddr += take;
+      parse->src_off   += take;
+
+      if( FD_UNLIKELY( parse->meta_sz < sizeof(fd_accdb_disk_meta_t) ) ) continue;
+
+      ulong data_sz = (ulong)FD_ACCDB_SIZE_DATA( parse->meta.size );
+      ulong snap_sz = sizeof(snap_acc_hdr_t) + fd_ulong_align_up( data_sz, 8UL );
+      if( FD_UNLIKELY( data_sz>UINT_MAX ) ) {
+        FD_LOG_CRIT(( "accdb disk account data too large (%lu bytes)", data_sz ));
+      }
+      if( FD_UNLIKELY( snap_sz>UINT_MAX ) ) {
+        FD_LOG_CRIT(( "snapshot account record too large (%lu bytes)", snap_sz ));
+      }
+
+      parse->acc_active  = 1;
+      parse->acc_off     = 0U;
+      parse->acc_sz      = (uint)data_sz;
+      parse->acc_snap_sz = (uint)snap_sz;
+      parse->meta_sz     = 0U;
+      parse->acc_keep    = (uint)fd_snapmk_accparse_keep( parse );
+
+      if( FD_UNLIKELY( !parse->acc_sz ) ) {
+        if( FD_LIKELY( parse->acc_keep ) ) {
+          parse->pub_gaddr   = 0UL;
+          parse->pub_sz      = 0U;
+          parse->pub_som     = 1;
+          parse->pub_eom     = 1;
+          parse->pub_pending = 1;
+        }
+        parse->acc_active = 0;
+        parse->acc_off    = 0U;
+        parse->acc_sz     = 0U;
+        if( FD_UNLIKELY( !parse->acc_keep ) ) return NULL;
+        continue;
+      }
+
+      continue;
+    }
+
+    ulong acc_rem = (ulong)parse->acc_sz - (ulong)parse->acc_off;
+    ulong take    = fd_ulong_min( acc_rem, parse->data_sz );
+    if( FD_UNLIKELY( !take ) ) return NULL;
+
+    if( FD_UNLIKELY( !parse->acc_keep ) ) {
+      parse->acc_off   += (uint)take;
+      parse->data      += take;
+      parse->data_sz   -= take;
+      parse->src_gaddr += take;
+      parse->src_off   += take;
+      if( FD_UNLIKELY( parse->acc_off==parse->acc_sz ) ) {
+        parse->acc_active = 0;
+        parse->acc_off    = 0U;
+        parse->acc_sz     = 0U;
+        parse->acc_keep   = 1U;
+        return NULL;
+      }
+      continue;
+    }
+
+    uint old_acc_off = parse->acc_off;
+    parse->pub_gaddr   = parse->src_gaddr;
+    parse->pub_sz      = (uint)take;
+    parse->pub_som     = !old_acc_off;
+    parse->pub_eom     = ( old_acc_off + take )==parse->acc_sz;
+    parse->pub_pending = 1;
+
+    parse->acc_off   += (uint)take;
+    parse->data      += take;
+    parse->data_sz   -= take;
+    parse->src_gaddr += take;
+    parse->src_off   += take;
+
+    if( FD_UNLIKELY( parse->pub_eom ) ) {
+      parse->acc_active = 0;
+      parse->acc_sz     = 0U;
+      parse->acc_off    = 0U;
+    }
+  }
 }
 
 /* fd_snapmk_accparse_prestage consumes up to FD_BACKUP_DISK_PARA whole

--- a/src/discof/backup/fd_snapmk_tile.c
+++ b/src/discof/backup/fd_snapmk_tile.c
@@ -1633,124 +1633,6 @@ snap_start( fd_snapmk_t *                  ctx,
   return 1;
 }
 
-/* fd_snapmk_accparse_publish produces an account-aligned frag from
-   accumulated source data.  Should be called after each accparse_insert
-   calls.  Returns meta if a frag was produced, NULL otherwise.
-   meta->sig set to the wksp-relative pos.  meta->tspub is the account
-   data byte count for this frag.  meta->ctl.som=1 set if this is the
-   first frag of an account, meta->ctl.eom=1 set if it's the last (both
-   if the frag fully contains the account). */
-
-static inline fd_frag_meta_t *
-fd_snapmk_accparse_publish( fd_snapmk_accparse_t * parse,
-                            fd_frag_meta_t *       meta ) {
-  for(;;) {
-    if( FD_UNLIKELY( parse->pub_pending ) ) {
-      meta->sig    = parse->pub_gaddr;
-      meta->chunk  = parse->acc_idx;
-      meta->sz     = 0;
-      meta->ctl    = (ushort)fd_frag_meta_ctl( FD_BACKUP_ORIG_ACC_DISK, parse->pub_som, parse->pub_eom, 0 );
-      meta->tsorig = 0U;
-      meta->tspub  = (uint)parse->pub_sz;
-      parse->pub_pending = 0;
-      return meta;
-    }
-
-    if( FD_UNLIKELY( !parse->data_sz ) ) return NULL;
-
-    if( FD_UNLIKELY( !parse->acc_active ) ) {
-      if( FD_UNLIKELY( !parse->meta_sz ) ) {
-        parse->acc_file_off = parse->src_off;
-        parse->acc_snap_sz  = 0U;
-        parse->acc_idx      = UINT_MAX;
-        parse->acc_keep     = 1U;
-      }
-
-      ulong meta_rem = sizeof(fd_accdb_disk_meta_t) - (ulong)parse->meta_sz;
-      ulong take     = fd_ulong_min( meta_rem, parse->data_sz );
-      fd_memcpy( parse->buf + parse->meta_sz, parse->data, take );
-      parse->meta_sz   += (uint)take;
-      parse->data      += take;
-      parse->data_sz   -= take;
-      parse->src_gaddr += take;
-      parse->src_off   += take;
-
-      if( FD_UNLIKELY( parse->meta_sz < sizeof(fd_accdb_disk_meta_t) ) ) continue;
-
-      ulong data_sz = (ulong)FD_ACCDB_SIZE_DATA( parse->meta.size );
-      ulong snap_sz = sizeof(snap_acc_hdr_t) + fd_ulong_align_up( data_sz, 8UL );
-      if( FD_UNLIKELY( data_sz>UINT_MAX ) ) {
-        FD_LOG_CRIT(( "accdb disk account data too large (%lu bytes)", data_sz ));
-      }
-      if( FD_UNLIKELY( snap_sz>UINT_MAX ) ) {
-        FD_LOG_CRIT(( "snapshot account record too large (%lu bytes)", snap_sz ));
-      }
-
-      parse->acc_active  = 1;
-      parse->acc_off     = 0U;
-      parse->acc_sz      = (uint)data_sz;
-      parse->acc_snap_sz = (uint)snap_sz;
-      parse->meta_sz     = 0U;
-      parse->acc_keep    = (uint)fd_snapmk_accparse_keep( parse );
-
-      if( FD_UNLIKELY( !parse->acc_sz ) ) {
-        if( FD_LIKELY( parse->acc_keep ) ) {
-          parse->pub_gaddr   = 0UL;
-          parse->pub_sz      = 0U;
-          parse->pub_som     = 1;
-          parse->pub_eom     = 1;
-          parse->pub_pending = 1;
-        }
-        parse->acc_active = 0;
-        parse->acc_off    = 0U;
-        parse->acc_sz     = 0U;
-        continue;
-      }
-
-      continue;
-    }
-
-    ulong acc_rem = (ulong)parse->acc_sz - (ulong)parse->acc_off;
-    ulong take    = fd_ulong_min( acc_rem, parse->data_sz );
-    if( FD_UNLIKELY( !take ) ) return NULL;
-
-    if( FD_UNLIKELY( !parse->acc_keep ) ) {
-      parse->acc_off   += (uint)take;
-      parse->data      += take;
-      parse->data_sz   -= take;
-      parse->src_gaddr += take;
-      parse->src_off   += take;
-      if( FD_UNLIKELY( parse->acc_off==parse->acc_sz ) ) {
-        parse->acc_active = 0;
-        parse->acc_off    = 0U;
-        parse->acc_sz     = 0U;
-        parse->acc_keep   = 1U;
-      }
-      continue;
-    }
-
-    uint old_acc_off = parse->acc_off;
-    parse->pub_gaddr   = parse->src_gaddr;
-    parse->pub_sz      = (uint)take;
-    parse->pub_som     = !old_acc_off;
-    parse->pub_eom     = ( old_acc_off + take )==parse->acc_sz;
-    parse->pub_pending = 1;
-
-    parse->acc_off   += (uint)take;
-    parse->data      += take;
-    parse->data_sz   -= take;
-    parse->src_gaddr += take;
-    parse->src_off   += take;
-
-    if( FD_UNLIKELY( parse->pub_eom ) ) {
-      parse->acc_active = 0;
-      parse->acc_sz     = 0U;
-      parse->acc_off    = 0U;
-    }
-  }
-
-}
-
 /* snapzp_stamp_shadow tracks the snaprd frag seq corresponding to an
    upcoming snapmk_zp publish. */
 
@@ -1832,6 +1714,13 @@ snaprd_frag( fd_snapmk_t *       ctx,
 
     fd_frag_meta_t meta[1];
     if( FD_UNLIKELY( !fd_snapmk_accparse_publish( parse, meta ) ) ) {
+      /* A discarded straddling record can finish before the end of this
+         frag.  Retry from (B) while the parser is at the clean boundary,
+         instead of consuming the rest of the frag through the scalar
+         fallback. */
+      if( FD_LIKELY( parse->data_sz && !parse->acc_active &&
+                     !parse->meta_sz && !parse->pub_pending ) ) continue;
+
       parse->input_active = 0;
       /* A prestaged batch references the current frag's bytes and must
           be drained before this frag is released (publish_batch above

--- a/src/discof/backup/test_backup_disk.c
+++ b/src/discof/backup/test_backup_disk.c
@@ -31,7 +31,12 @@ env_reset( void ) {
   FD_TEST( visited );
   visited_set_null( visited );
 
-  parse->visited_set = visited;
+  fd_backup_accidx_t idx = parse->idx;
+  *parse = (fd_snapmk_accparse_t) {
+    .idx         = idx,
+    .visited_set = visited,
+    .acc_keep    = 1U
+  };
 }
 
 /* pubkey_n returns a distinct address for n. */
@@ -299,6 +304,132 @@ test_prestage_skips_too_new( void ) {
   FD_TEST( !parse->data_sz ); /* every record consumed, skipped ones too */
 }
 
+/* record_init writes one disk record and returns its total byte size. */
+
+static ulong
+record_init( uchar *       dst,
+             uchar const * pubkey,
+             uint          generation,
+             uint          data_sz ) {
+  fd_accdb_disk_meta_t * dm = (fd_accdb_disk_meta_t *)dst;
+  memset( dm, 0, sizeof(fd_accdb_disk_meta_t) );
+  memcpy( dm->pubkey, pubkey, 32UL );
+  dm->size       = data_sz;
+  dm->generation = generation;
+  memset( dst + sizeof(fd_accdb_disk_meta_t), 0xa5, data_sz );
+  return sizeof(fd_accdb_disk_meta_t) + (ulong)data_sz;
+}
+
+/* Performance regression: a record that straddles a frag boundary caused
+   the scalar loop to consume all following stale records, resulting in a
+   ton of non-parallel accdb pointer chasing.  The fix was to return to the
+   batch path as soon as possible, so map chain walks are parallelized
+   across multiple accounts. */
+
+static void
+test_scalar_skip_yields_to_batch( void ) {
+  env_reset();
+
+  ulong const file_off0 = 0x30000UL;
+  uint  const data_sz0  = 16U;
+  ulong const split0    = 5UL;
+  ulong const tail0     = (ulong)data_sz0 - split0;
+  ulong const rec_sz    = sizeof(fd_accdb_disk_meta_t) + 8UL;
+
+  uchar full0[ sizeof(fd_accdb_disk_meta_t) + data_sz0 ];
+  uchar frag1[ tail0 + 2UL*rec_sz ];
+
+  uchar const * pk0 = pubkey_n( 300UL );
+  record_init( full0, pk0, 5U, data_sz0 );
+  ulong chain0 = fd_backup_accidx_chain( &parse->idx, pk0 );
+  index_add( 60U, chain0, pk0, 5U, 1000UL, 0xdead0000UL );
+
+  memcpy( frag1, full0+sizeof(fd_accdb_disk_meta_t)+split0, tail0 );
+  for( ulong i=0UL; i<2UL; i++ ) {
+    uchar const * pk = pubkey_n( 301UL+i );
+    record_init( frag1 + tail0 + i*rec_sz, pk, 5U, 8U );
+    ulong chain = fd_backup_accidx_chain( &parse->idx, pk );
+    index_add( (uint)(61UL+i), chain, pk, 5U, 1000UL, 0xbeef0000UL+i );
+  }
+
+  parse->data            = full0;
+  parse->data_sz         = sizeof(fd_accdb_disk_meta_t) + split0;
+  parse->src_gaddr       = 0x100000UL;
+  parse->frag_base_gaddr = parse->src_gaddr;
+  parse->src_off         = file_off0;
+  parse->pf_cursor       = full0;
+
+  fd_backup_disk_batch_msg_t batch[1];
+  fd_frag_meta_t             meta [1];
+  FD_TEST( fd_snapmk_accparse_publish_batch( parse, batch )==0UL );
+  FD_TEST( !fd_snapmk_accparse_publish( parse, meta ) );
+  FD_TEST( parse->acc_active );
+  FD_TEST( parse->acc_off==split0 );
+
+  parse->data            = frag1;
+  parse->data_sz         = sizeof(frag1);
+  parse->src_gaddr       = 0x200000UL;
+  parse->frag_base_gaddr = parse->src_gaddr;
+  parse->pf_cursor       = frag1;
+
+  FD_TEST( !fd_snapmk_accparse_publish( parse, meta ) );
+  FD_TEST( !parse->acc_active && !parse->meta_sz && !parse->pub_pending );
+  FD_TEST( parse->data==frag1+tail0 );
+  FD_TEST( parse->data_sz==2UL*rec_sz );
+
+  FD_TEST( fd_snapmk_accparse_publish_batch( parse, batch )==2UL );
+  FD_TEST( batch->frag_off[ 0 ]==tail0          );
+  FD_TEST( batch->frag_off[ 1 ]==tail0+rec_sz   );
+  FD_TEST( batch->acc_idx [ 0 ]==UINT_MAX       );
+  FD_TEST( batch->acc_idx [ 1 ]==UINT_MAX       );
+  FD_TEST( !parse->data_sz );
+
+  /* Also cover a torn, zero-data stale record. */
+  env_reset();
+
+  ulong const file_off2 = 0x40000UL;
+  ulong const split2    = 20UL;
+  ulong const tail2     = sizeof(fd_accdb_disk_meta_t)-split2;
+  uchar full2[ sizeof(fd_accdb_disk_meta_t) ];
+  uchar frag2[ split2 ];
+  uchar frag3[ tail2 + rec_sz ];
+
+  uchar const * pk2 = pubkey_n( 310UL );
+  record_init( full2, pk2, 5U, 0U );
+  memcpy( frag2, full2, split2 );
+  memcpy( frag3, full2+split2, tail2 );
+  ulong chain2 = fd_backup_accidx_chain( &parse->idx, pk2 );
+  index_add( 70U, chain2, pk2, 5U, 1000UL, 0xcafe0000UL );
+
+  uchar const * pk3 = pubkey_n( 311UL );
+  record_init( frag3+tail2, pk3, 5U, 8U );
+  ulong chain3 = fd_backup_accidx_chain( &parse->idx, pk3 );
+  index_add( 71U, chain3, pk3, 5U, 1000UL, 0xcafe0001UL );
+
+  parse->data            = frag2;
+  parse->data_sz         = sizeof(frag2);
+  parse->src_gaddr       = 0x300000UL;
+  parse->frag_base_gaddr = parse->src_gaddr;
+  parse->src_off         = file_off2;
+  parse->pf_cursor       = frag2;
+  FD_TEST( !fd_snapmk_accparse_publish( parse, meta ) );
+  FD_TEST( parse->meta_sz==split2 );
+
+  parse->data            = frag3;
+  parse->data_sz         = sizeof(frag3);
+  parse->src_gaddr       = 0x400000UL;
+  parse->frag_base_gaddr = parse->src_gaddr;
+  parse->pf_cursor       = frag3;
+  FD_TEST( !fd_snapmk_accparse_publish( parse, meta ) );
+  FD_TEST( !parse->acc_active && !parse->meta_sz && !parse->pub_pending );
+  FD_TEST( parse->data==frag3+tail2 );
+  FD_TEST( parse->data_sz==rec_sz );
+  FD_TEST( fd_snapmk_accparse_publish_batch( parse, batch )==1UL );
+  FD_TEST( batch->frag_off[ 0 ]==tail2    );
+  FD_TEST( batch->acc_idx [ 0 ]==UINT_MAX );
+  FD_TEST( !parse->data_sz );
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -333,6 +464,7 @@ main( int     argc,
   test_keep_derives_chain();
   test_keep_skips_too_new();
   test_prestage_skips_too_new();
+  test_scalar_skip_yields_to_batch();
 
   /* every lookup must have released its epoch announcement */
   FD_TEST( epoch_slot==ULONG_MAX );


### PR DESCRIPTION
Fixes a performance issue in the snapshot creator, reducing snap
creation time from 23min to 2min30s on slow boxes.

Problem:
- if the disk is slow, snapshot creation suspends rooting for a
  large number of slots
- if an account from disk is fragmented across two read buffers,
  the snapshot producer enters a scalar/fallback loop
- the snapshot producer stays in the scalar mode for the entire
  rest of the tail frag, instead of switching over to batch
  processing
- most disk read frags split accounts at the boundaries,
  effectively disabling the batch path once accdb partitions
  containing lots of new small accounts are reached

The fix: eagerly yield from the fallback path and try to get back
into the batch loop handling multiple accounts in a disk frag in
parallel.
