### PR TITLE
waltz: use shared constant for endpoint buffer limits

### DIFF
--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -3,6 +3,7 @@
 
 #include "../../disco/topo/fd_topo.h"
 #include "../../ballet/base58/fd_base58.h"
+#include "../../waltz/http/fd_url.h"
 
 #include <net/if.h>
 
@@ -127,7 +128,7 @@ struct fd_configf {
   } runtime;
 
   struct {
-    char host[ 256 ];
+    char host[ FD_FQDN_BUF_MAX ];
   } gossip;
 
   struct {
@@ -148,7 +149,7 @@ struct fd_configf {
       } gossip;
 
       ulong servers_cnt;
-      char  servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX ][ 128 ];
+      char  servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX ][ FD_URL_MAX ];
     } sources;
 
     int  incremental_snapshots;
@@ -318,7 +319,7 @@ struct fd_config {
 
   struct {
     ulong         entrypoints_cnt;
-    char          entrypoints[ GOSSIP_TILE_ENTRYPOINTS_MAX ][ 262 ];
+    char          entrypoints[ GOSSIP_TILE_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
     ushort        port;
   } gossip;
 
@@ -455,8 +456,8 @@ struct fd_config {
 
     struct {
       int  enabled;
-      char url[ 256 ];
-      char tls_domain_name[ 256 ];
+      char url[ FD_URL_MAX ];
+      char tls_domain_name[ FD_SNI_BUF_MAX ];
       char tip_distribution_program_addr[ FD_BASE58_ENCODED_32_SZ ];
       char tip_payment_program_addr[ FD_BASE58_ENCODED_32_SZ ];
       char tip_distribution_authority[ FD_BASE58_ENCODED_32_SZ ];
@@ -493,7 +494,7 @@ struct fd_config {
     } metric;
 
     struct {
-      char url[ 256 ];
+      char url[ FD_URL_MAX ];
     } event;
 
     struct {

--- a/src/app/shared/test_config_parse.c
+++ b/src/app/shared/test_config_parse.c
@@ -58,6 +58,32 @@ main( int     argc,
   FD_TEST( config->gossip.entrypoints_cnt == 1 );
   FD_TEST( 0==strcmp( config->gossip.entrypoints[0], "208.91.106.45:8080" ) );
 
+  /* Maximum-sized URL values survive config extraction. */
+
+  char endpoint[ FD_URL_MAX ];
+  fd_memcpy( endpoint, "https://", 8UL );
+  fd_memset( endpoint+8UL, 'a', FD_FQDN_BUF_MAX-1UL );
+  fd_memcpy( endpoint+8UL+FD_FQDN_BUF_MAX-1UL, ":65535", 6UL );
+  endpoint[ FD_URL_MAX-1UL ] = '\0';
+
+  char  cfg_str_limits[ 4096 ];
+  ulong cfg_str_limits_sz;
+  FD_TEST( fd_cstr_printf_check( cfg_str_limits, sizeof(cfg_str_limits), &cfg_str_limits_sz,
+                                "[snapshots.sources]\n"
+                                "servers = [\"%s\"]\n"
+                                "[tiles.bundle]\n"
+                                "url = \"%s\"\n",
+                                endpoint, endpoint ) );
+
+  memset( config, 0, sizeof(config_t) );
+  config->is_firedancer = 1;
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_limits, cfg_str_limits_sz, pod, scratch, sizeof(scratch), NULL )==FD_TOML_SUCCESS );
+  FD_TEST( fd_config_extract_pod( pod, config )==config );
+  FD_TEST( config->firedancer.snapshots.sources.servers_cnt==1UL );
+  FD_TEST( !strcmp( config->firedancer.snapshots.sources.servers[0], endpoint ) );
+  FD_TEST( !strcmp( config->tiles.bundle.url, endpoint ) );
+
   /* Reject unrecognized config keys */
 
   memset( config, 0, sizeof(config_t) );

--- a/src/disco/bundle/fd_bundle_tile.c
+++ b/src/disco/bundle/fd_bundle_tile.c
@@ -175,12 +175,12 @@ fd_bundle_tile_publish_block_engine_update(
 
   strncpy( update->name, "jito", sizeof(update->name) );
 
-  /* Deliberately silently truncates */
-  snprintf( update->url, sizeof(update->url), "%s://%.*s:%u",
-            ctx->is_ssl ? "https" : "http",
-            (int)ctx->server_fqdn_len,
-            ctx->server_fqdn,
-            ctx->server_tcp_port );
+  FD_TEST( fd_cstr_printf_check( update->url, sizeof(update->url), NULL,
+                                "%s://%.*s:%u",
+                                ctx->is_ssl ? "https" : "http",
+                                (int)ctx->server_fqdn_len,
+                                ctx->server_fqdn,
+                                ctx->server_tcp_port ) );
 
   /* Format IPv4 string */
   snprintf( update->ip_cstr, sizeof(update->ip_cstr),
@@ -332,7 +332,7 @@ fd_bundle_tile_parse_endpoint( fd_bundle_tile_t *     ctx,
                                           "[tiles.bundle.url]" ) ) ) {
     FD_LOG_ERR(( "Could not parse [tiles.bundle.url]" ));
   }
-  if( FD_UNLIKELY( url->host_len > 255 ) ) {
+  if( FD_UNLIKELY( url->host_len>=FD_FQDN_BUF_MAX ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }
   fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( ctx->server_fqdn ), url->host, url->host_len ) );

--- a/src/disco/bundle/fd_bundle_tile.h
+++ b/src/disco/bundle/fd_bundle_tile.h
@@ -11,6 +11,7 @@
    - Does busy polling (no power saving features) */
 
 #include "../topo/fd_topo.h"
+#include "../../waltz/http/fd_url.h"
 
 struct fd_bundle_tile;
 typedef struct fd_bundle_tile fd_bundle_tile_t;
@@ -22,7 +23,7 @@ typedef struct fd_bundle_tile fd_bundle_tile_t;
 
 struct fd_bundle_block_engine_update {
   char name[ 16 ];
-  char url[ 256 ];
+  char url[ FD_URL_MAX ];
   char ip_cstr[ 40 ]; /* IPv4 or IPv6 cstr */
 };
 typedef struct fd_bundle_block_engine_update fd_bundle_block_engine_update_t;

--- a/src/disco/bundle/fd_bundle_tile_private.h
+++ b/src/disco/bundle/fd_bundle_tile_private.h
@@ -8,6 +8,7 @@
 #include "../keyguard/fd_keyswitch.h"
 #include "../keyguard/fd_keyguard_client.h"
 #include "../../waltz/grpc/fd_grpc_client.h"
+#include "../../waltz/http/fd_url.h"
 #include "../../waltz/resolv/fd_netdb.h"
 #include "../../waltz/fd_rtt_est.h"
 #include "../../util/alloc/fd_alloc.h"
@@ -109,9 +110,9 @@ struct fd_bundle_tile {
 # endif /* FD_HAS_OPENSSL */
 
   /* Config */
-  char   server_fqdn[ 256 ]; /* cstr */
+  char   server_fqdn[ FD_FQDN_BUF_MAX ]; /* cstr */
   ulong  server_fqdn_len;
-  char   server_sni[ 256 ]; /* cstr */
+  char   server_sni[ FD_SNI_BUF_MAX ]; /* cstr */
   ulong  server_sni_len;
   ushort server_tcp_port;
 

--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -106,7 +106,7 @@ struct fd_event_client {
      authenticating. */
   long auth_deadline;
 
-  char   server_fqdn[ 256 ]; /* cstr */
+  char   server_fqdn[ FD_FQDN_BUF_MAX ]; /* cstr */
   ulong  server_fqdn_len;
   uint   server_ip4_addr;
   ushort server_tcp_port;
@@ -180,7 +180,7 @@ fd_event_client_new( void *                 shmem,
                                           "[tiles.event.url]" ) ) ) {
     FD_LOG_ERR(( "Could not parse [tiles.event.url]" ));
   }
-  if( FD_UNLIKELY( url->host_len > 255 ) ) {
+  if( FD_UNLIKELY( url->host_len>=FD_FQDN_BUF_MAX ) ) {
     FD_LOG_CRIT(( "Invalid url->host_len" )); /* unreachable */
   }
   fd_cstr_fini( fd_cstr_append_text( fd_cstr_init( client->server_fqdn ), url->host, url->host_len ) );

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -20,6 +20,7 @@
 #include "../../util/fd_util_base.h"
 #include "../../util/hist/fd_histf.h"
 #include "../../waltz/http/fd_http_server.h"
+#include "../../waltz/http/fd_url.h"
 #include "../../flamenco/accdb/fd_accdb_cache.h"
 #include "../../flamenco/accdb/fd_accdb_shmem.h"
 
@@ -883,7 +884,7 @@ struct fd_gui {
   struct {
     int has_block_engine;
     char name[ 16 ];
-    char url[ 256 ];
+    char url[ FD_URL_MAX ];
     char ip_cstr[ 40 ]; /* IPv4 or IPv6 cstr */
     int status;
   } block_engine;

--- a/src/disco/topo/fd_dns_resolve.c
+++ b/src/disco/topo/fd_dns_resolve.c
@@ -69,7 +69,7 @@ fd_dns_resolve_addresses( char const *            address,
 void
 fd_dns_peer_parse( char const * peer,
                    char const * config_str,
-                   char         hostname[ static 256UL ],
+                   char         hostname[ static FD_FQDN_BUF_MAX ],
                    ushort *     port,
                    int *        is_https ) {
 
@@ -96,7 +96,7 @@ fd_dns_peer_parse( char const * peer,
   if( FD_UNLIKELY( !fqdn_len ) ) {
     FD_LOG_ERR(( "invalid [%s] entry \"%s\": no hostname", config_str, host_port ));
   }
-  if( FD_UNLIKELY( fqdn_len>255 ) ) {
+  if( FD_UNLIKELY( fqdn_len>=FD_FQDN_BUF_MAX ) ) {
     FD_LOG_ERR(( "invalid [%s] entry \"%s\": hostname too long", config_str, host_port ));
   }
   fd_memcpy( hostname, host_port, fqdn_len );
@@ -125,7 +125,7 @@ fd_dns_resolve_peers( char const *    peers,
   if( FD_UNLIKELY( peer_cnt>FD_DNS_RESOLVE_PEERS_MAX ) ) FD_LOG_ERR(( "too many [%s] entries (%lu)", config_str, peer_cnt ));
   if( FD_UNLIKELY( !peer_cnt ) ) return;
 
-  char hostname[ FD_DNS_RESOLVE_PEERS_MAX ][ 256UL ];
+  char hostname[ FD_DNS_RESOLVE_PEERS_MAX ][ FD_FQDN_BUF_MAX ];
   for( ulong i=0UL; i<peer_cnt; i++ ) {
     fd_dns_peer_parse( peers+i*peer_stride, config_str, hostname[ i ], &out[ i ].port, NULL );
   }

--- a/src/disco/topo/fd_dns_resolve.h
+++ b/src/disco/topo/fd_dns_resolve.h
@@ -11,6 +11,7 @@
    bundle tiles. */
 
 #include "../../util/net/fd_net_headers.h" /* fd_ip4_port_t */
+#include "../../waltz/fd_fqdn.h"           /* FD_FQDN_BUF_MAX */
 
 #include <netdb.h> /* struct addrinfo */
 
@@ -65,7 +66,7 @@ fd_dns_resolve_peers( char const *    peers,
 void
 fd_dns_peer_parse( char const * peer,
                    char const * config_str,
-                   char         hostname[ static 256UL ],
+                   char         hostname[ static FD_FQDN_BUF_MAX ],
                    ushort *     port,
                    int *        is_https );
 

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -4,6 +4,7 @@
 #include "../stem/fd_stem.h"
 #include "../../tango/fd_tango.h"
 #include "../../waltz/xdp/fd_xdp1.h"
+#include "../../waltz/http/fd_url.h"
 #include "../../ballet/base58/fd_base58.h"
 #include "../../flamenco/fd_flamenco_base.h"
 #include "../../util/net/fd_net_headers.h"
@@ -228,7 +229,7 @@ struct fd_topo_tile {
       char identity_key_path[ PATH_MAX ];
 
       ulong entrypoints_cnt;
-      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
 
       long boot_timestamp_nanos;
 
@@ -237,7 +238,7 @@ struct fd_topo_tile {
       ushort shred_version;
       int allow_private_address;
 
-      char          gossip_host[ 256 ];
+      char          gossip_host[ FD_FQDN_BUF_MAX ];
       fd_ip4_port_t gossip_addr;
       fd_ip4_port_t src_addr;
     } gossvf;
@@ -246,11 +247,11 @@ struct fd_topo_tile {
       char identity_key_path[ PATH_MAX ];
 
       ulong entrypoints_cnt;
-      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
 
       long boot_timestamp_nanos;
 
-      char   gossip_host[ 256 ];
+      char   gossip_host[ FD_FQDN_BUF_MAX ];
       uint   net_ip_addr; /* net.ip_addr fallback when gossip_host empty */
       uint   ip_addr;
       uint   bind_ip_addr;
@@ -295,9 +296,9 @@ struct fd_topo_tile {
     } dedup;
 
     struct {
-      char  url[ 256 ];
+      char  url[ FD_URL_MAX ];
       ulong url_len;
-      char  sni[ 256 ];
+      char  sni[ FD_SNI_BUF_MAX ];
       ulong sni_len;
       char  identity_key_path[ PATH_MAX ];
       char  key_log_path[ PATH_MAX ];
@@ -309,7 +310,7 @@ struct fd_topo_tile {
     } bundle;
 
     struct {
-      char   url[ 256 ];
+      char   url[ FD_URL_MAX ];
       char   identity_key_path[ PATH_MAX ];
       char   action[ 16 ];
       uchar  genesis_hash[ 32 ];
@@ -424,7 +425,7 @@ struct fd_topo_tile {
       int  delay_startup;
 
       int    snapshot_server_enabled;
-      char   snapshot_server_host[ 256 ];
+      char   snapshot_server_host[ FD_FQDN_BUF_MAX ];
       ushort snapshot_server_port;
     } rpc;
 
@@ -617,7 +618,7 @@ struct fd_topo_tile {
       char snapshots_path[ PATH_MAX ];
 
       ulong entrypoints_cnt;
-      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
 
       struct {
         uint max_local_full_effective_age;
@@ -632,7 +633,7 @@ struct fd_topo_tile {
         } gossip;
 
         ulong         servers_cnt;
-        char          servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX ][ 128 ];
+        char          servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX ][ FD_URL_MAX ];
       } sources;
 
       int  incremental_snapshots;
@@ -667,7 +668,7 @@ struct fd_topo_tile {
 
       ushort expected_shred_version;
       ulong entrypoints_cnt;
-      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
     } ipecho;
 
     struct {
@@ -684,7 +685,7 @@ struct fd_topo_tile {
 
       ushort expected_shred_version;
       ulong entrypoints_cnt;
-      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ 262 ];
+      char  entrypoints[ FD_TOPO_GOSSIP_ENTRYPOINTS_MAX ][ FD_HOSTPORT_BUF_MAX ];
 
       int has_expected_genesis_hash;
       uchar expected_genesis_hash[ 32UL ];

--- a/src/disco/topo/test_dns_resolve.c
+++ b/src/disco/topo/test_dns_resolve.c
@@ -15,7 +15,7 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   ulong peer_cnt = fd_ulong_min( (ulong)( argc-1 ), FD_DNS_RESOLVE_PEERS_MAX );
-  static char peers[ FD_DNS_RESOLVE_PEERS_MAX ][ 262UL ];
+  static char peers[ FD_DNS_RESOLVE_PEERS_MAX ][ FD_HOSTPORT_BUF_MAX ];
   for( ulong i=0UL; i<peer_cnt; i++ ) fd_cstr_ncpy( peers[ i ], argv[ 1+i ], sizeof(peers[ i ]) );
 
   fd_ip4_port_t out[ FD_DNS_RESOLVE_PEERS_MAX ];

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -108,14 +108,14 @@ struct fd_snapct_tile {
 
   fd_adns_t * adns;
   struct {
-    char   hostname[ 256UL ];
+    char   hostname[ FD_FQDN_BUF_MAX ];
     ushort port; /* net order */
     int    is_https;
     int    resolved;
     long   retry_nanos; /* re-queue due time, 0 while in flight */
   } dns_servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX ];
   struct {
-    char   hostname[ 256UL ];
+    char   hostname[ FD_FQDN_BUF_MAX ];
     ushort port;
     int    resolved;
     long   retry_nanos;
@@ -124,7 +124,7 @@ struct fd_snapct_tile {
   ulong resolved_servers_cnt;
   struct {
     fd_ip4_port_t addr;
-    char          hostname[ 256UL ];
+    char          hostname[ FD_FQDN_BUF_MAX ];
     int           is_https;
   } resolved_servers[ FD_TOPO_SNAPSHOTS_SERVERS_MAX_RESOLVED ];
 

--- a/src/discof/restore/utils/fd_ssctrl.h
+++ b/src/discof/restore/utils/fd_ssctrl.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_discof_restore_utils_fd_ssctrl_h
 
 #include "../../../util/net/fd_net_headers.h"
+#include "../../../waltz/fd_fqdn.h"
 #include "../../../flamenco/runtime/fd_runtime_const.h"
 
 /* The snapshot tiles have a somewhat involved state machine, which is
@@ -126,7 +127,7 @@ typedef struct fd_ssctrl_init {
   ulong         slot; /* slot advertised by the snapshot peer */
   fd_ip4_port_t addr;
   uchar         snapshot_hash[ FD_HASH_FOOTPRINT ]; /* advertised snapshot hash from snapshot file name */
-  char          hostname[ 256UL ];
+  char          hostname[ FD_FQDN_BUF_MAX ];
   char          path[ PATH_MAX ];
   ulong         path_len;
   int           is_https;

--- a/src/discof/restore/utils/fd_sspeer.h
+++ b/src/discof/restore/utils/fd_sspeer.h
@@ -3,13 +3,14 @@
 
 #include "../../../util/fd_util_base.h"
 #include "../../../util/net/fd_net_headers.h"
+#include "../../../waltz/fd_fqdn.h"
 #include "../../../flamenco/fd_flamenco_base.h"
 
 struct fd_sspeer_key {
   union {
     fd_pubkey_t pubkey[ 1 ];        /* gossip peers: key by pubkey. */
     struct {                        /* HTTP server peers: key by hostname + addr. */
-      char          hostname[ 256 ];
+      char          hostname[ FD_FQDN_BUF_MAX ];
       fd_ip4_port_t resolved_addr;  /* disambiguates multiple IPs for same hostname. */
     } url;
   };

--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -21,6 +21,7 @@
 #include "../../util/net/fd_ip4.h"
 #include "../../waltz/http/fd_http_server.h"
 #include "../../waltz/http/fd_http_server_private.h"
+#include "../../waltz/http/fd_url.h"
 
 #include <stddef.h>
 #include <sys/socket.h>
@@ -308,7 +309,7 @@ struct fd_rpc_tile {
 
   /* Redirect to snapshot server */
   int    snapshot_server_enabled;
-  char   snapshot_server_url[ 288UL ];
+  char   snapshot_server_url[ FD_URL_MAX ];
 };
 
 typedef struct fd_rpc_tile fd_rpc_tile_t;

--- a/src/discoh/guih/fd_guih.h
+++ b/src/discoh/guih/fd_guih.h
@@ -18,6 +18,7 @@
 #include "../../util/hist/fd_histf.h"
 #include "../../util/math/fd_stat.h" /* fd_sort_up_ulong_* */
 #include "../../waltz/http/fd_http_server.h"
+#include "../../waltz/http/fd_url.h"
 
 #include <math.h> /* exp */
 
@@ -791,7 +792,7 @@ struct fd_guih {
   struct {
     int has_block_engine;
     char name[ 16 ];
-    char url[ 256 ];
+    char url[ FD_URL_MAX ];
     char ip_cstr[ 40 ]; /* IPv4 or IPv6 cstr */
     int status;
   } block_engine;

--- a/src/waltz/Local.mk
+++ b/src/waltz/Local.mk
@@ -1,3 +1,3 @@
 $(call make-lib,fd_waltz)
-$(call add-hdrs,fd_waltz_base.h)
+$(call add-hdrs,fd_waltz_base.h fd_fqdn.h)
 $(call add-hdrs,fd_rtt_est.h)

--- a/src/waltz/fd_fqdn.h
+++ b/src/waltz/fd_fqdn.h
@@ -1,0 +1,18 @@
+#ifndef HEADER_fd_src_waltz_fd_fqdn_h
+#define HEADER_fd_src_waltz_fd_fqdn_h
+
+/* Cstr storage capacity for host names used by Waltz URL and resolver
+   APIs: up to 255 bytes plus the terminating NUL.  This is a storage
+   bound, not a DNS validity limit; DNS syntax and its 253-byte textual
+   limit without a trailing dot are enforced separately. */
+#define FD_FQDN_BUF_MAX (255UL+1UL)
+
+/* TLS SNI contains a host name. */
+#define FD_SNI_BUF_MAX FD_FQDN_BUF_MAX
+
+/* Cstr storage capacity for a maximum-sized host followed by ':', a
+   five-digit port, and the terminating NUL.  FD_FQDN_BUF_MAX already
+   accounts for the terminating NUL. */
+#define FD_HOSTPORT_BUF_MAX (FD_FQDN_BUF_MAX+6UL)
+
+#endif /* HEADER_fd_src_waltz_fd_fqdn_h */

--- a/src/waltz/grpc/fd_grpc_client.h
+++ b/src/waltz/grpc/fd_grpc_client.h
@@ -5,6 +5,7 @@
    streaming gRPC requests over HTTP/2+TLS. */
 
 #include "fd_grpc_codec.h"
+#include "../fd_fqdn.h"
 #include "../../third_party/nanopb/pb_firedancer.h" /* pb_msgdesc_t */
 #if FD_HAS_OPENSSL
 #include <openssl/types.h> /* SSL */
@@ -198,8 +199,8 @@ fd_grpc_client_set_version( fd_grpc_client_t * client,
                             ulong              version_len );
 
 /* fd_grpc_client_set_authority sets the authority header to the
-   specified hostname and port number.  host_len should be <= 255,
-   otherwise host is truncated. */
+   specified hostname and port number.  host_len should be less than
+   FD_FQDN_BUF_MAX, otherwise host is truncated. */
 
 void
 fd_grpc_client_set_authority( fd_grpc_client_t * client,

--- a/src/waltz/grpc/fd_grpc_client_private.h
+++ b/src/waltz/grpc/fd_grpc_client_private.h
@@ -105,9 +105,9 @@ struct fd_grpc_client_private {
   fd_h2_rbuf_t frame_tx[1]; /* unencrypted HTTP/2 TX frame buffer */
 
   /* HTTP/2 authority */
-  char   host[ 256 ];
+  char   host[ FD_FQDN_BUF_MAX ];
   ushort port; /* <=65535 */
-  uchar  host_len; /* <=255 */
+  uchar  host_len; /* <FD_FQDN_BUF_MAX */
 
   /* TLS connection */
   uint  ssl_hs_done : 1;

--- a/src/waltz/grpc/fd_grpc_codec.h
+++ b/src/waltz/grpc/fd_grpc_codec.h
@@ -46,7 +46,7 @@ typedef struct fd_grpc_hdr fd_grpc_hdr_t;
 
 struct fd_grpc_req_hdrs {
   char const * host; /* excluding port */
-  ulong        host_len; /* <=255 */
+  ulong        host_len;
   ushort       port;
   char const * path;
   ulong        path_len;

--- a/src/waltz/grpc/fuzz_grpc_h2_gen_req_hdr.c
+++ b/src/waltz/grpc/fuzz_grpc_h2_gen_req_hdr.c
@@ -9,6 +9,7 @@
 
 #include "fd_grpc_codec.h"
 #include "../h2/fd_h2_rbuf.h"
+#include "../fd_fqdn.h"
 
 int
 LLVMFuzzerInitialize( int *argc,
@@ -38,7 +39,7 @@ expect_hdr( fd_hpack_rd_t *hpack_rd, fd_h2_hdr_t *hdr, uchar **scratch,
 int
 LLVMFuzzerTestOneInput( uchar const *data,
                         ulong size ) {
-  char host[256], path[256], bearer_auth[256], version[256];
+  char host[FD_FQDN_BUF_MAX], path[256], bearer_auth[256], version[256];
   char host_port[512], user_agent[512];
   ulong minimum_len = sizeof( ushort )+ // port
                       sizeof( char )+ // https

--- a/src/waltz/http/fd_url.c
+++ b/src/waltz/http/fd_url.c
@@ -56,7 +56,7 @@ fd_url_parse_cstr( fd_url_t *   const url,
     }
   }
 
-  if( FD_UNLIKELY( host_len>255 ) ) {
+  if( FD_UNLIKELY( host_len>=FD_FQDN_BUF_MAX ) ) {
     *opt_err = FD_URL_ERR_HOST_OVERSZ;
     return NULL;
   }

--- a/src/waltz/http/fd_url.h
+++ b/src/waltz/http/fd_url.h
@@ -6,6 +6,7 @@
    This API is by no means compliant.  Works only for basic strings.  */
 
 #include "../../util/fd_util_base.h"
+#include "../fd_fqdn.h"
 
 /* fd_url_t holds a bunch of pointers into an URL string. */
 
@@ -14,7 +15,7 @@ struct fd_url {
   ulong        scheme_len;
 
   char const * host;
-  ulong        host_len; /* <=255 */
+  ulong        host_len; /* <FD_FQDN_BUF_MAX */
 
   char const * port;
   ulong        port_len;
@@ -29,6 +30,12 @@ typedef struct fd_url fd_url_t;
 #define FD_URL_ERR_SCHEME      1
 #define FD_URL_ERR_HOST_OVERSZ 2
 #define FD_URL_ERR_USERINFO    3
+
+/* Storage required for an HTTP(S) origin containing a maximum-sized
+   host and an explicit five-digit port, including the terminating NUL.
+   Paths, queries, and fragments are not included. */
+#define FD_URL_FORMAT_OVERHEAD (14UL)
+#define FD_URL_MAX             (FD_FQDN_BUF_MAX+FD_URL_FORMAT_OVERHEAD)
 
 FD_PROTOTYPES_BEGIN
 
@@ -56,7 +63,7 @@ fd_url_parse_cstr( fd_url_t *   url,
      - If the URL omits an explicit port we default to 443/80 and then flip
        `is_ssl` based on the scheme so downstream sockets know whether
        to open TLS.
-     - Host names larger than 255 bytes are rejected
+     - Hosts containing FD_FQDN_BUF_MAX bytes or more are rejected
    The function does not enforce the host being non-empty; that is left to
    the caller because some control paths treat an empty host differently
    (e.g. surfacing a custom error message).

--- a/src/waltz/http/test_url.c
+++ b/src/waltz/http/test_url.c
@@ -138,6 +138,34 @@ test_url_parse( void ) {
     FD_TEST( !memcmp( url.port, "8080", 4 ) );
   }
 
+  { /* Maximum-sized endpoint */
+    char endpoint[ FD_URL_MAX ];
+    fd_memcpy( endpoint, "https://", 8UL );
+    fd_memset( endpoint+8UL, 'a', FD_FQDN_BUF_MAX-1UL );
+    fd_memcpy( endpoint+8UL+FD_FQDN_BUF_MAX-1UL, ":65535", 6UL );
+    endpoint[ FD_URL_MAX-1UL ] = '\0';
+
+    fd_url_t url;
+    ushort port;
+    _Bool  is_ssl;
+    FD_TEST( !fd_url_parse_endpoint( &url, endpoint, FD_URL_MAX-1UL, &port, &is_ssl, "test URL" ) );
+    FD_TEST( url.host_len==FD_FQDN_BUF_MAX-1UL );
+    FD_TEST( port==USHORT_MAX && is_ssl );
+  }
+
+  { /* Host one byte over the supported maximum */
+    char endpoint[ FD_URL_MAX+1UL ];
+    fd_memcpy( endpoint, "https://", 8UL );
+    fd_memset( endpoint+8UL, 'a', FD_FQDN_BUF_MAX );
+    fd_memcpy( endpoint+8UL+FD_FQDN_BUF_MAX, ":65535", 6UL );
+    endpoint[ FD_URL_MAX ] = '\0';
+
+    fd_url_t url;
+    int err;
+    FD_TEST( !fd_url_parse_cstr( &url, endpoint, FD_URL_MAX, &err ) );
+    FD_TEST( err==FD_URL_ERR_HOST_OVERSZ );
+  }
+
   { /* Invalid scheme */
     fd_url_t url;
     int err;

--- a/src/waltz/resolv/fd_adns.h
+++ b/src/waltz/resolv/fd_adns.h
@@ -14,6 +14,7 @@
    (before the sandbox). */
 
 #include "../../util/fd_util_base.h"
+#include "../fd_fqdn.h"
 
 #define FD_ADNS_MAGIC (0xF17EDA2CEADD5000) /* FIREDANCE ADNS V0 */
 
@@ -59,9 +60,9 @@ fd_adns_leave( fd_adns_t * adns );
 void *
 fd_adns_delete( void * shadns );
 
-/* Queue name (cstr, <=255 chars) for resolution.  req_id is an opaque
-   cookie returned with the result.  Returns 0 on success, -1 if the
-   request table is full. */
+/* Queue name (cstr fitting in FD_FQDN_BUF_MAX bytes) for resolution.
+   req_id is an opaque cookie returned with the result.  Returns 0 on
+   success, -1 if the request table is full. */
 
 int
 fd_adns_resolve( fd_adns_t *  adns,

--- a/src/waltz/resolv/fd_getaddrinfo.c
+++ b/src/waltz/resolv/fd_getaddrinfo.c
@@ -39,7 +39,7 @@ fd_getaddrinfo( char const * restrict          host,
   }
 
   struct address addrs[ MAXADDRS ];
-  char canon[ 256 ];
+  char canon[ FD_FQDN_BUF_MAX ];
   int const naddrs = fd_lookup_name( addrs, canon, host, family, flags );
   if( naddrs < 0 ) return naddrs;
 

--- a/src/waltz/resolv/fd_lookup.h
+++ b/src/waltz/resolv/fd_lookup.h
@@ -6,6 +6,7 @@
 #include <features.h>
 #include <netinet/in.h>
 #include "fd_netdb.h"
+#include "../fd_fqdn.h"
 
 struct aibuf {
   fd_addrinfo_t ai;
@@ -41,7 +42,7 @@ typedef struct fd_resolvconf fd_resolvconf_t;
 
 __attribute__((__visibility__("hidden"))) int
 fd_lookup_name( struct address buf[ static MAXADDRS ],
-                char           canon[ static 256 ],
+                char           canon[ static FD_FQDN_BUF_MAX ],
                 const char *   name,
                 int            family,
                 int            flags );

--- a/src/waltz/resolv/fd_lookup_name.c
+++ b/src/waltz/resolv/fd_lookup_name.c
@@ -21,7 +21,7 @@
 static int
 is_valid_hostname( char const * host ) {
   uchar const * s;
-  if( strnlen( host, 255 )-1 >= 254 ) return 0;
+  if( strnlen( host, FD_FQDN_BUF_MAX-1UL )-1UL>=FD_FQDN_BUF_MAX-2UL ) return 0;
   for( s=(void *)host; *s>=0x80 || *s=='.' || *s=='-' || fd_isalnum( *s ); s++ );
   return !*s;
 }
@@ -56,7 +56,7 @@ name_from_numeric( struct address buf[ static 1 ],
 
 static int
 name_from_hosts( struct address buf[ static MAXADDRS ],
-                 char           canon[ static 256 ],
+                 char           canon[ static FD_FQDN_BUF_MAX ],
                  char const *   name,
                  int            family ) {
   ulong l = strlen( name );
@@ -132,7 +132,7 @@ dns_parse_callback( void *       c,
                     int          len,
                     void const * packet,
                     int          plen ) {
-  char tmp[256];
+  char tmp[ FD_FQDN_BUF_MAX ];
   int family = AF_UNSPEC;
   struct dpc_ctx *ctx = c;
   if( rr == RR_CNAME ) {
@@ -161,7 +161,7 @@ dns_parse_callback( void *       c,
 
 static int
 name_from_dns( struct address          buf[ static MAXADDRS ],
-               char                    canon[ static 256 ],
+               char                    canon[ static FD_FQDN_BUF_MAX ],
                char const *            name,
                int                     family,
                fd_resolvconf_t const * conf ) {
@@ -212,7 +212,7 @@ name_from_dns( struct address          buf[ static MAXADDRS ],
 
 static int
 name_from_dns_search( struct address buf[ static MAXADDRS ],
-                      char           canon[ static 256 ],
+                      char           canon[ static FD_FQDN_BUF_MAX ],
                       char const *   name,
                       int            family ) {
   fd_resolvconf_t conf;
@@ -229,7 +229,7 @@ name_from_dns_search( struct address buf[ static MAXADDRS ],
   if( !l || name[l-1]=='.' ) return FD_EAI_NONAME;
 
   /* This can never happen; the caller already checked length. */
-  if( l >= 256 ) return FD_EAI_NONAME;
+  if( l>=FD_FQDN_BUF_MAX ) return FD_EAI_NONAME;
 
   /* Name with search domain appended is setup in canon[]. This both
    * provides the desired default canonical name (if the requested
@@ -246,11 +246,11 @@ int
 fd_dns_ip4_local( char const * name,
                   uint *       addrs,
                   ulong        addr_max ) {
-  ulong l = strnlen( name, 255 );
-  if( FD_UNLIKELY( l-1UL>=254UL ) ) return FD_EAI_NONAME;
+  ulong l = strnlen( name, FD_FQDN_BUF_MAX-1UL );
+  if( FD_UNLIKELY( l-1UL>=FD_FQDN_BUF_MAX-2UL ) ) return FD_EAI_NONAME;
 
   struct address buf[ MAXADDRS ];
-  char           canon[ 256 ];
+  char           canon[ FD_FQDN_BUF_MAX ];
   int cnt = name_from_numeric( buf, name, AF_INET );
   if( !cnt ) cnt = name_from_hosts( buf, canon, name, AF_INET );
   if( cnt<=0 ) return cnt;
@@ -283,7 +283,7 @@ fd_dns_ip4_answer( uchar const * answer,
   if( FD_UNLIKELY( (answer[ 3 ]&15)!=0 ) ) return FD_EAI_FAIL;
 
   struct address buf[ MAXADDRS ];
-  char           canon[ 256 ] = {0};
+  char           canon[ FD_FQDN_BUF_MAX ] = {0};
   struct dpc_ctx ctx = { .addrs = buf, .canon = canon, .rrtype = RR_A };
   int parse_err = fd_dns_parse( answer, (int)fd_ulong_min( answer_sz, ABUF_SIZE ), dns_parse_callback, &ctx );
   /* A malformed/truncated packet with no usable leading records is
@@ -402,7 +402,7 @@ addrcmp( void const * _a,
 
 int
 fd_lookup_name( struct address buf[ static MAXADDRS ],
-                char           canon[ static 256 ],
+                char           canon[ static FD_FQDN_BUF_MAX ],
                 char const *   name,
                 int            family,
                 int            flags ) {
@@ -411,8 +411,8 @@ fd_lookup_name( struct address buf[ static MAXADDRS ],
   *canon = 0;
   if( name ) {
     /* reject empty name and check len so it fits into temp bufs */
-    size_t l = strnlen( name, 255 );
-    if( l-1 >= 254 )
+    size_t l = strnlen( name, FD_FQDN_BUF_MAX-1UL );
+    if( l-1UL>=FD_FQDN_BUF_MAX-2UL )
       return FD_EAI_NONAME;
     memcpy( canon, name, l+1 );
   }

--- a/src/waltz/resolv/fd_res_mkquery.c
+++ b/src/waltz/resolv/fd_res_mkquery.c
@@ -1,4 +1,5 @@
 #include "fd_resolv.h"
+#include "../fd_fqdn.h"
 #include "../../util/log/fd_log.h" /* fd_tickcount() support */
 #include <string.h>
 
@@ -13,7 +14,7 @@ fd_res_mkquery( int           op,
                 int           type,
                 uchar *       buf,
                 int           buflen ) {
-  size_t l = strnlen( dname, 255 );
+  size_t l = strnlen( dname, FD_FQDN_BUF_MAX-1UL );
 
   if( l && dname[l-1]=='.' ) l--;
   if( l && dname[l-1]=='.' ) return -1;

--- a/src/waltz/resolv/fuzz_dn_expand.c
+++ b/src/waltz/resolv/fuzz_dn_expand.c
@@ -28,7 +28,7 @@ LLVMFuzzerInitialize( int *argc,
 int
 LLVMFuzzerTestOneInput( uchar const *data,
                         ulong        size ) {
-  char tmp[256] = {0};
+  char tmp[ FD_FQDN_BUF_MAX ] = {0};
 
   /* Need at least two bytes for the offset plus one byte of data */
   if( FD_UNLIKELY( size<3 )) {

--- a/src/waltz/resolv/fuzz_dns_parse.c
+++ b/src/waltz/resolv/fuzz_dns_parse.c
@@ -28,7 +28,7 @@ LLVMFuzzerTestOneInput( uchar const *data,
   uint8_t rrtype = (data[ 0 ] & 1u) ? RR_A : RR_AAAA;
 
   struct address addrs[ MAXADDRS ] = {0};
-  char           canon[ 256 ]      = {0};
+  char           canon[ FD_FQDN_BUF_MAX ] = {0};
   struct dpc_ctx ctx = {
       .addrs = addrs,
       .canon = canon,


### PR DESCRIPTION
## Summary

- define shared capacities for hostnames and SNI, host:port values, and HTTP(S) origins
- apply them across config, topology, resolvers, bundle and event clients, snapshots, RPC, and GUI status
- replace duplicated host bounds and make block-engine URL formatting checked instead of truncating

## Bounds

- hostname and SNI: 256 bytes (255-byte value plus NUL)
- host:port: 262 bytes (hostname, colon, five-digit port, and NUL)
- HTTP(S) origin: 270 bytes (HTTPS scheme, hostname, port, and NUL)

The URL bound excludes paths, queries, and fragments. DNS syntax and its 253-byte limit without a trailing dot remain enforced separately.