### PR TITLE
config: reject invalid array values

### DIFF
--- a/src/app/platform/fd_config_macros.c
+++ b/src/app/platform/fd_config_macros.c
@@ -39,7 +39,8 @@
         return NULL;                                                   \
       }                                                                \
       fd_pod_info_t sub_info = fd_pod_iter_info( iter );               \
-      fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ); \
+      if( FD_UNLIKELY( !fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ) ) ) \
+        return NULL;                                                    \
       j++;                                                             \
     }                                                                  \
     config->cfg_path ## _cnt = j;                                      \
@@ -63,7 +64,8 @@
         return NULL;                                                   \
       }                                                                \
       fd_pod_info_t sub_info = fd_pod_iter_info( iter );               \
-      fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ); \
+      if( FD_UNLIKELY( !fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ) ) ) \
+        return NULL;                                                    \
       j++;                                                             \
     }                                                                  \
     config->cfg_path ## _cnt = j;                                      \

--- a/src/app/shared/test_config_parse.c
+++ b/src/app/shared/test_config_parse.c
@@ -8,6 +8,14 @@ static char const cfg_str_1[] =
   "[gossip]\n"
   "  entrypoints = [\"208.91.106.45:8080\"]";
 
+static char const cfg_str_oversized_array[] =
+  "[ledger]\n"
+  "  account_indexes = [\"01234567890123456789012345678901\"]";
+
+static char const cfg_str_invalid_aliased_array[] =
+  "[consensus]\n"
+  "  authorized_voter_paths = [1]";
+
 static char const cfg_str_2[] =
   "wumbo = \"mini\"";
 
@@ -83,6 +91,18 @@ main( int     argc,
   FD_TEST( config->firedancer.snapshots.sources.servers_cnt==1UL );
   FD_TEST( !strcmp( config->firedancer.snapshots.sources.servers[0], endpoint ) );
   FD_TEST( !strcmp( config->tiles.bundle.url, endpoint ) );
+
+  /* Reject invalid direct and aliased array elements. */
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_oversized_array, sizeof(cfg_str_oversized_array)-1UL, pod, scratch, sizeof(scratch), NULL )==FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_invalid_aliased_array, sizeof(cfg_str_invalid_aliased_array)-1UL, pod, scratch, sizeof(scratch), NULL )==FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
 
   /* Reject unrecognized config keys */
 


### PR DESCRIPTION
## Summary

- propagate element conversion failures from CFG_POP_ARRAY and CFG_POP1_ARRAY
- reject oversized or incorrectly typed array elements instead of continuing with an incremented element count
- cover both direct and aliased array extraction paths

Previously, a per-element conversion error was reported but ignored, allowing config extraction to succeed.