### PR TITLE
config: reject arrays whose elements fail validation

### DIFF
--- a/src/app/platform/fd_config_macros.c
+++ b/src/app/platform/fd_config_macros.c
@@ -39,7 +39,9 @@
         return NULL;                                                   \
       }                                                                \
       fd_pod_info_t sub_info = fd_pod_iter_info( iter );               \
-      fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ); \
+      if( FD_UNLIKELY( !fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), \
+          &sub_info, key ) ) )                                         \
+        return NULL;                                                   \
       j++;                                                             \
     }                                                                  \
     config->cfg_path ## _cnt = j;                                      \
@@ -63,7 +65,9 @@
         return NULL;                                                   \
       }                                                                \
       fd_pod_info_t sub_info = fd_pod_iter_info( iter );               \
-      fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), &sub_info, key ); \
+      if( FD_UNLIKELY( !fdctl_cfg_get_##type( &config->cfg_path[j], sizeof(config->cfg_path[j]), \
+          &sub_info, key ) ) )                                         \
+        return NULL;                                                   \
       j++;                                                             \
     }                                                                  \
     config->cfg_path ## _cnt = j;                                      \

--- a/src/app/shared/test_config_parse.c
+++ b/src/app/shared/test_config_parse.c
@@ -91,6 +91,46 @@ main( int     argc,
   FD_TEST( fd_toml_parse( cfg_str_2, sizeof(cfg_str_2)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
   FD_TEST( !fd_config_extract_pod( pod, config ) );
 
+  /* Reject configs where any element of an array fails validation. A single
+     invalid element rejects the whole key rather than being skipped while
+     still counted in the extracted array. */
+
+  static char const cfg_str_6[] =
+    "[gossip]\n"
+    "  entrypoints = [\"208.91.106.45:8080\", 123]";
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_6, sizeof(cfg_str_6)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
+
+  /* An entrypoint longer than its fixed destination slot is likewise rejected */
+
+  char long_entrypoint[ FD_HOSTPORT_BUF_MAX+16UL ];
+  fd_memset( long_entrypoint, 'a', sizeof(long_entrypoint)-1UL );
+  long_entrypoint[ sizeof(long_entrypoint)-1UL ] = '\0';
+
+  char  cfg_str_long_ep[ 1024 ];
+  ulong cfg_str_long_ep_sz;
+  FD_TEST( fd_cstr_printf_check( cfg_str_long_ep, sizeof(cfg_str_long_ep), &cfg_str_long_ep_sz,
+                                 "[gossip]\nentrypoints = [\"%s\"]", long_entrypoint ) );
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_long_ep, cfg_str_long_ep_sz, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
+
+  /* Same rejection for CFG_POP1_ARRAY keys */
+
+  static char const cfg_str_7[] =
+    "[consensus]\n"
+    "  authorized_voter_paths = [\"/ok.json\", false]";
+
+  memset( config, 0, sizeof(config_t) );
+  pod = fd_pod_join( fd_pod_new( pod_mem, sizeof(pod_mem) ) );
+  FD_TEST( fd_toml_parse( cfg_str_7, sizeof(cfg_str_7)-1, pod, scratch, sizeof(scratch), NULL ) == FD_TOML_SUCCESS );
+  FD_TEST( !fd_config_extract_pod( pod, config ) );
+
   /* The default config must parse fine */
 
   memset( config, 0, sizeof(config_t) );


### PR DESCRIPTION
## What

`CFG_POP_ARRAY` and `CFG_POP1_ARRAY` ignored the return value of the element getter, while the scalar `CFG_POP` path already rejects the whole key when its getter fails.

## Why

When one element of an array-valued key fails validation, for example a non-string entry in `gossip.entrypoints` or a value too long for its fixed destination slot, the getter writes nothing and returns 0. The array macros discarded that result and incremented the index anyway, so extraction succeeded with the bad element present as an empty string and counted in `*_cnt`. Because `fd_pod_remove` still runs afterward, the leftover-key check cannot catch it either. The invalid value then surfaces later as a confusing failure somewhere else, such as an empty entrypoint reaching DNS resolution.

## Change

Check the getter's return value in both array macros and reject the config with a warning naming the key, matching what the scalar path does. Regression tests in `test_config_parse.c` cover a wrong-type element in both macros and an over-long entrypoint string.