### PR TITLE
http: accept requests that exactly fill the read buffer

### DIFF
--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -464,6 +464,7 @@ accept_conns( fd_http_server_t * http ) {
     http->conns[ conn_id ].state                  = FD_HTTP_SERVER_CONNECTION_STATE_READING;
     http->conns[ conn_id ].request_bytes_read     = 0UL;
     http->conns[ conn_id ].request_head_len       = 0UL;
+    http->conns[ conn_id ].request_total_len      = 0UL;
     http->conns[ conn_id ].response_bytes_written = 0UL;
 
     if( FD_UNLIKELY( http->callbacks.open ) ) {
@@ -499,6 +500,14 @@ read_conn_http( fd_http_server_t * http,
   http->metrics.bytes_read += (ulong)sz;
   conn->request_bytes_read += (ulong)sz;
 
+  /* While the head is parsed and the total size is known, only the body is
+     pending. Skip parsing entirely so a client dripping the body one byte
+     at a time costs O(1) per read instead of O(head length). */
+  if( FD_UNLIKELY( conn->request_total_len!=0UL &&
+                   conn->request_bytes_read<conn->request_total_len ) ) {
+    return;
+  }
+
   char const * method;
   ulong method_len;
   char const * path;
@@ -509,7 +518,8 @@ read_conn_http( fd_http_server_t * http,
   /* If the head already parsed on an earlier read (the body was pending),
      the parser's partial-head fast path would search for the terminator
      beyond its known position and wrongly report the request incomplete.
-     Reparse from scratch so the headers regenerate for this invocation. */
+     Reparse exactly once with the fast path disabled now that the full
+     request has arrived, so the headers regenerate for this invocation. */
   ulong last_len = conn->request_head_len ? 0UL : conn->request_bytes_read - (ulong)sz;
   int result = phr_parse_request( conn->request_bytes,
                                   conn->request_bytes_read,
@@ -590,7 +600,10 @@ read_conn_http( fd_http_server_t * http,
 
 
     if( FD_UNLIKELY( conn->request_bytes_read<(ulong)result+content_len ) ) {
-      return; /* Request still partial, wait for more data */
+      /* Body still pending: remember the validated total so subsequent
+         reads skip parsing until the full request has arrived. */
+      conn->request_total_len = (ulong)result + content_len;
+      return;
     }
   }
 

--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -497,10 +497,6 @@ read_conn_http( fd_http_server_t * http,
   /* New data was read... process it */
   http->metrics.bytes_read += (ulong)sz;
   conn->request_bytes_read += (ulong)sz;
-  if( FD_UNLIKELY( conn->request_bytes_read==http->max_request_len ) ) {
-    close_conn( http, conn_idx, FD_HTTP_SERVER_CONNECTION_CLOSE_LARGE_REQUEST );
-    return;
-  }
 
   char const * method;
   ulong method_len;
@@ -516,7 +512,15 @@ read_conn_http( fd_http_server_t * http,
                                   &minor_version,
                                   headers, &num_headers,
                                   conn->request_bytes_read - (ulong)sz );
-  if( FD_UNLIKELY( -2==result ) ) return; /* Request still partial, wait for more data */
+  if( FD_UNLIKELY( -2==result ) ) { /* Request still partial, wait for more data */
+    /* A full buffer that still does not parse means the head alone exceeds
+       max_request_len. Requests that do parse are allowed to occupy the
+       whole buffer: a POST with total_len==max_request_len is valid. */
+    if( FD_UNLIKELY( conn->request_bytes_read==http->max_request_len ) ) {
+      close_conn( http, conn_idx, FD_HTTP_SERVER_CONNECTION_CLOSE_LARGE_REQUEST );
+    }
+    return;
+  }
   else if( FD_UNLIKELY( -1==result ) ) {
     close_conn( http, conn_idx, FD_HTTP_SERVER_CONNECTION_CLOSE_BAD_REQUEST );
     return;

--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -463,6 +463,7 @@ accept_conns( fd_http_server_t * http ) {
     http->pollfds[ conn_id ].events = POLLIN;
     http->conns[ conn_id ].state                  = FD_HTTP_SERVER_CONNECTION_STATE_READING;
     http->conns[ conn_id ].request_bytes_read     = 0UL;
+    http->conns[ conn_id ].request_head_len       = 0UL;
     http->conns[ conn_id ].response_bytes_written = 0UL;
 
     if( FD_UNLIKELY( http->callbacks.open ) ) {
@@ -505,13 +506,19 @@ read_conn_http( fd_http_server_t * http,
   int minor_version;
   struct phr_header headers[ 32 ];
   ulong num_headers = 32UL;
+  /* If the head already parsed on an earlier read (the body was pending),
+     the parser's partial-head fast path would search for the terminator
+     beyond its known position and wrongly report the request incomplete.
+     Reparse from scratch so the headers regenerate for this invocation. */
+  ulong last_len = conn->request_head_len ? 0UL : conn->request_bytes_read - (ulong)sz;
   int result = phr_parse_request( conn->request_bytes,
                                   conn->request_bytes_read,
                                   &method, &method_len,
                                   &path, &path_len,
                                   &minor_version,
                                   headers, &num_headers,
-                                  conn->request_bytes_read - (ulong)sz );
+                                  last_len );
+  if( FD_UNLIKELY( result>0 ) ) conn->request_head_len = (ulong)result;
   if( FD_UNLIKELY( -2==result ) ) { /* Request still partial, wait for more data */
     /* A full buffer that still does not parse means the head alone exceeds
        max_request_len. Requests that do parse are allowed to occupy the

--- a/src/waltz/http/fd_http_server_private.h
+++ b/src/waltz/http/fd_http_server_private.h
@@ -31,6 +31,10 @@ struct fd_http_server_connection {
 
   char * request_bytes;
   ulong  request_bytes_read;
+  /* Length of the parsed request head once phr_parse_request has succeeded.
+     A pending body may require more reads; the parser's partial-head fast
+     path must not reapply past the known terminator. */
+  ulong  request_head_len;
 
   fd_http_server_response_t response;
   ulong response_bytes_written;

--- a/src/waltz/http/fd_http_server_private.h
+++ b/src/waltz/http/fd_http_server_private.h
@@ -35,6 +35,10 @@ struct fd_http_server_connection {
      A pending body may require more reads; the parser's partial-head fast
      path must not reapply past the known terminator. */
   ulong  request_head_len;
+  /* Total expected request size (head plus body) once the head has parsed
+     and Content-Length validation passed. While buffered bytes are below
+     this, parsing is skipped entirely so body drips cost O(1) per read. */
+  ulong  request_total_len;
 
   fd_http_server_response_t response;
   ulong response_bytes_written;

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -348,17 +348,26 @@ test_exact_max_request_len_accepted( void ) {
 
   /* A POST whose head and body together occupy exactly max_request_len
      bytes. The body bound admits it (total_len<=max_request_len), so it
-     must be parsed and dispatched rather than closed as oversized. */
-  char tail[] = " HTTP/1.1\r\nHost: localhost\r\nContent-Length: 8\r\n\r\nxxxxxxxx";
-  ulong tail_len = strlen( tail );
-  ulong pad_digits = params.max_request_len - 6UL - 1UL - tail_len; /* "POST /" + digits + tail */
-  FD_TEST( pad_digits>0UL && pad_digits<1000UL );
-
+     must be parsed and dispatched rather than closed as oversized. The
+     path stays short (the server caps it at 127 bytes); an ordinary
+     header carries the padding instead. */
   char req[ 1025 ];
   ulong pos = 0UL;
-  fd_memcpy( req+pos, "POST /", 6UL ); pos += 6UL;
-  memset( req+pos, '0', pad_digits );  pos += pad_digits;
-  fd_memcpy( req+pos, tail, tail_len ); pos += tail_len;
+  struct { char const * s; } parts[] = {
+    { "POST /p HTTP/1.1\r\n" },
+    { "Host: localhost\r\n" },
+    { "Content-Length: 8\r\n" },
+    { "X-Pad: " },
+  };
+  for( ulong i=0UL; i<sizeof(parts)/sizeof(parts[0]); i++ ) {
+    ulong len = strlen( parts[i].s );
+    fd_memcpy( req+pos, parts[i].s, len );
+    pos += len;
+  }
+  memset( req+pos, '0', 951UL );
+  pos += 951UL;
+  fd_memcpy( req+pos, "\r\n\r\nxxxxxxxx", 13UL );
+  pos += 13UL;
   req[ pos ] = '\0';
   FD_TEST( pos==params.max_request_len );
   send_all( client_fd, req, pos );

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -463,8 +463,13 @@ test_exact_max_request_len_fragmented( void ) {
 
   ulong const first_read_len = params.max_request_len - 4UL; /* head (1016) + 4 body bytes */
   send_all( client_fd, req, first_read_len );
-  fd_http_server_poll( http, 1, ULONG_MAX ); /* accepts the connection */
-  fd_http_server_poll( http, 1, ULONG_MAX ); /* first read: head parsed, body pending */
+  /* A TCP send does not bound the server's read. Drive polls until this
+     read has actually parsed the head, otherwise the follow-up parse would
+     not exercise the recorded-head path. */
+  for( ulong i=0UL; i<200UL && http->conns[0].request_head_len==0UL; i++ ) {
+    fd_http_server_poll( http, 1, ULONG_MAX );
+  }
+  FD_TEST( http->conns[0].request_head_len==1016UL );
   FD_TEST( request_cnt==0UL );
   FD_TEST( state.close_cnt==0UL );
 
@@ -475,6 +480,80 @@ test_exact_max_request_len_fragmented( void ) {
 
   FD_TEST( request_cnt==1UL );
   FD_TEST( state.close_cnt==0UL );
+
+  close( client_fd );
+  close( fd_http_server_fd( http ) );
+  fd_http_server_delete( fd_http_server_leave( http ) );
+  free( scratch );
+}
+
+static void
+test_oversized_head_closes( void ) {
+  /* A buffer that fills without the head ever completing must close with
+     LARGE_REQUEST via the full-buffer branch, not stall forever. */
+  fd_http_server_params_t params = {
+    .max_connection_cnt    = 1UL,
+    .max_ws_connection_cnt = 0UL,
+    .max_request_len       = 1024UL,
+    .max_ws_recv_frame_len = 1024UL,
+    .max_ws_send_frame_cnt = 1UL,
+    .outgoing_buffer_sz    = 1024UL,
+  };
+  overflow_close_state_t state = {0};
+  fd_http_server_callbacks_t callbacks = {
+    .request    = request_count,
+    .close      = close_capture,
+    .ws_open    = NULL,
+    .ws_close   = NULL,
+    .ws_message = NULL,
+  };
+
+  ulong footprint = fd_ulong_align_up( fd_http_server_footprint( params ), 128UL );
+  uchar * scratch = aligned_alloc( 128UL, footprint );
+  FD_TEST( scratch );
+
+  fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
+  FD_TEST( http );
+  FD_TEST( fd_http_server_listen( http, 0U, 0U ) );
+
+  struct sockaddr_in server_addr = {0};
+  socklen_t server_addr_sz = sizeof( server_addr );
+  FD_TEST( !getsockname( fd_http_server_fd( http ), fd_type_pun( &server_addr ), &server_addr_sz ) );
+  ushort server_port = ntohs( server_addr.sin_port );
+
+  int client_fd = socket( AF_INET, SOCK_STREAM, 0 );
+  FD_TEST( client_fd>=0 );
+
+  struct sockaddr_in connect_addr = {
+    .sin_family      = AF_INET,
+    .sin_port        = htons( server_port ),
+    .sin_addr.s_addr = htonl( INADDR_LOOPBACK ),
+  };
+  FD_TEST( !connect( client_fd, fd_type_pun( &connect_addr ), sizeof( connect_addr ) ) );
+
+  request_cnt = 0UL;
+
+  /* Header lines only, no terminating blank line anywhere in the first
+     max_request_len bytes: the head can never complete. */
+  char req[ 2049 ];
+  ulong pos = 0UL;
+  fd_memcpy( req+pos, "POST /p HTTP/1.1\r\nHost: localhost\r\n", 35UL ); pos += 35UL;
+  while( pos<2048UL ) {
+    ulong line_len = strlen( "X-Pad: 00000000000000000000\r\n" );
+    if( pos+line_len>2048UL ) break;
+    fd_memcpy( req+pos, "X-Pad: 00000000000000000000\r\n", line_len );
+    pos += line_len;
+  }
+  FD_TEST( pos>params.max_request_len );
+
+  send_all( client_fd, req, pos );
+  for( ulong i=0UL; i<200UL && state.close_cnt==0UL; i++ ) {
+    fd_http_server_poll( http, 1, ULONG_MAX );
+  }
+
+  FD_TEST( state.close_cnt==1UL );
+  FD_TEST( state.last_reason==FD_HTTP_SERVER_CONNECTION_CLOSE_LARGE_REQUEST );
+  FD_TEST( request_cnt==0UL );
 
   close( client_fd );
   close( fd_http_server_fd( http ) );
@@ -1059,6 +1138,7 @@ main( int     argc,
   test_content_length_overflow_close();
   test_exact_max_request_len_accepted();
   test_exact_max_request_len_fragmented();
+  test_oversized_head_closes();
   test_poll_conn_max();
   test_treap_seed();
   test_poll_interest();

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -366,8 +366,9 @@ test_exact_max_request_len_accepted( void ) {
   }
   memset( req+pos, '0', 951UL );
   pos += 951UL;
-  fd_memcpy( req+pos, "\r\n\r\nxxxxxxxx", 13UL );
-  pos += 13UL;
+  char const tail[] = "\r\n\r\nxxxxxxxx"; /* 12 request bytes */
+  fd_memcpy( req+pos, tail, sizeof(tail)-1UL );
+  pos += sizeof(tail)-1UL;
   req[ pos ] = '\0';
   FD_TEST( pos==params.max_request_len );
   send_all( client_fd, req, pos );

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -533,17 +533,16 @@ test_oversized_head_closes( void ) {
 
   request_cnt = 0UL;
 
-  /* Header lines only, no terminating blank line anywhere in the first
-     max_request_len bytes: the head can never complete. */
+  /* One unterminated header line: the head can never complete within
+     max_request_len bytes, and the header count stays far below the
+     parser's 32-header capacity so the failure lands on the -2 path. */
   char req[ 2049 ];
   ulong pos = 0UL;
-  fd_memcpy( req+pos, "POST /p HTTP/1.1\r\nHost: localhost\r\n", 35UL ); pos += 35UL;
-  while( pos<2048UL ) {
-    ulong line_len = strlen( "X-Pad: 00000000000000000000\r\n" );
-    if( pos+line_len>2048UL ) break;
-    fd_memcpy( req+pos, "X-Pad: 00000000000000000000\r\n", line_len );
-    pos += line_len;
-  }
+  char const * prefix = "POST /p HTTP/1.1\r\nHost: localhost\r\nX-Pad: ";
+  ulong prefix_len = strlen( prefix );
+  fd_memcpy( req+pos, prefix, prefix_len ); pos += prefix_len;
+  memset( req+pos, '0', 2048UL-pos );
+  pos = 2048UL;
   FD_TEST( pos>params.max_request_len );
 
   send_all( client_fd, req, pos );

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -387,6 +387,95 @@ test_exact_max_request_len_accepted( void ) {
 }
 
 static void
+test_exact_max_request_len_fragmented( void ) {
+  /* Same boundary as above, but the request arrives in two writes with the
+     head completing in the first read together with some body bytes. The
+     parser's partial-head fast path must not misreport the reassembled
+     buffer once it fills exactly. */
+  fd_http_server_params_t params = {
+    .max_connection_cnt    = 1UL,
+    .max_ws_connection_cnt = 0UL,
+    .max_request_len       = 1024UL,
+    .max_ws_recv_frame_len = 1024UL,
+    .max_ws_send_frame_cnt = 1UL,
+    .outgoing_buffer_sz    = 1024UL,
+  };
+  overflow_close_state_t state = {0};
+  fd_http_server_callbacks_t callbacks = {
+    .request    = request_count,
+    .close      = close_capture,
+    .ws_open    = NULL,
+    .ws_close   = NULL,
+    .ws_message = NULL,
+  };
+
+  ulong footprint = fd_ulong_align_up( fd_http_server_footprint( params ), 128UL );
+  uchar * scratch = aligned_alloc( 128UL, footprint );
+  FD_TEST( scratch );
+
+  fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
+  FD_TEST( http );
+  FD_TEST( fd_http_server_listen( http, 0U, 0U ) );
+
+  struct sockaddr_in server_addr = {0};
+  socklen_t server_addr_sz = sizeof( server_addr );
+  FD_TEST( !getsockname( fd_http_server_fd( http ), fd_type_pun( &server_addr ), &server_addr_sz ) );
+  ushort server_port = ntohs( server_addr.sin_port );
+
+  int client_fd = socket( AF_INET, SOCK_STREAM, 0 );
+  FD_TEST( client_fd>=0 );
+
+  struct sockaddr_in connect_addr = {
+    .sin_family      = AF_INET,
+    .sin_port        = htons( server_port ),
+    .sin_addr.s_addr = htonl( INADDR_LOOPBACK ),
+  };
+  FD_TEST( !connect( client_fd, fd_type_pun( &connect_addr ), sizeof( connect_addr ) ) );
+
+  char req[ 1025 ];
+  ulong pos = 0UL;
+  struct { char const * s; } parts[] = {
+    { "POST /p HTTP/1.1\r\n" },
+    { "Host: localhost\r\n" },
+    { "Content-Length: 8\r\n" },
+    { "X-Pad: " },
+  };
+  for( ulong i=0UL; i<sizeof(parts)/sizeof(parts[0]); i++ ) {
+    ulong len = strlen( parts[i].s );
+    fd_memcpy( req+pos, parts[i].s, len );
+    pos += len;
+  }
+  memset( req+pos, '0', 951UL );
+  pos += 951UL;
+  char const tail[] = "\r\n\r\nxxxxxxxx"; /* 12 request bytes */
+  fd_memcpy( req+pos, tail, sizeof(tail)-1UL );
+  pos += sizeof(tail)-1UL;
+  req[ pos ] = '\0';
+  FD_TEST( pos==params.max_request_len );
+
+  /* First read: the complete head plus more than three body bytes. */
+  ulong first_read_len = 100UL;
+  send_all( client_fd, req, first_read_len );
+  fd_http_server_poll( http, 1, ULONG_MAX );
+  FD_TEST( request_cnt==0UL ); /* body still pending */
+  FD_TEST( state.close_cnt==0UL );
+
+  /* Second read completes the body and fills the buffer exactly. */
+  send_all( client_fd, req+first_read_len, pos-first_read_len );
+  for( ulong i=0UL; i<200UL && request_cnt<1UL; i++ ) {
+    fd_http_server_poll( http, 1, ULONG_MAX );
+  }
+
+  FD_TEST( request_cnt==1UL );
+  FD_TEST( state.close_cnt==0UL );
+
+  close( client_fd );
+  close( fd_http_server_fd( http ) );
+  fd_http_server_delete( fd_http_server_leave( http ) );
+  free( scratch );
+}
+
+static void
 test_poll_conn_max( void ) {
   fd_http_server_params_t params = {
     .max_connection_cnt    = 2UL,
@@ -962,6 +1051,7 @@ main( int     argc,
   test_oring();
   test_content_length_overflow_close();
   test_exact_max_request_len_accepted();
+  test_exact_max_request_len_fragmented();
   test_poll_conn_max();
   test_treap_seed();
   test_poll_interest();

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -432,6 +432,14 @@ test_exact_max_request_len_fragmented( void ) {
   };
   FD_TEST( !connect( client_fd, fd_type_pun( &connect_addr ), sizeof( connect_addr ) ) );
 
+  request_cnt = 0UL;
+
+  /* A POST whose head and body together occupy exactly max_request_len
+     bytes, delivered in two writes. The first server read carries the
+     complete head plus four body bytes; the parser records the head and
+     waits for the rest. The second read fills the buffer exactly, so the
+     follow-up parse must not let the partial-head fast path skip past the
+     known terminator. */
   char req[ 1025 ];
   ulong pos = 0UL;
   struct { char const * s; } parts[] = {
@@ -453,15 +461,14 @@ test_exact_max_request_len_fragmented( void ) {
   req[ pos ] = '\0';
   FD_TEST( pos==params.max_request_len );
 
-  /* First read: the complete head plus more than three body bytes. */
-  ulong first_read_len = 100UL;
+  ulong const first_read_len = params.max_request_len - 4UL; /* head (1016) + 4 body bytes */
   send_all( client_fd, req, first_read_len );
-  fd_http_server_poll( http, 1, ULONG_MAX );
-  FD_TEST( request_cnt==0UL ); /* body still pending */
+  fd_http_server_poll( http, 1, ULONG_MAX ); /* accepts the connection */
+  fd_http_server_poll( http, 1, ULONG_MAX ); /* first read: head parsed, body pending */
+  FD_TEST( request_cnt==0UL );
   FD_TEST( state.close_cnt==0UL );
 
-  /* Second read completes the body and fills the buffer exactly. */
-  send_all( client_fd, req+first_read_len, pos-first_read_len );
+  send_all( client_fd, req+first_read_len, 4UL );
   for( ulong i=0UL; i<200UL && request_cnt<1UL; i++ ) {
     fd_http_server_poll( http, 1, ULONG_MAX );
   }

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -305,6 +305,78 @@ test_content_length_overflow_close( void ) {
 }
 
 static void
+test_exact_max_request_len_accepted( void ) {
+  fd_http_server_params_t params = {
+    .max_connection_cnt    = 1UL,
+    .max_ws_connection_cnt = 0UL,
+    .max_request_len       = 1024UL,
+    .max_ws_recv_frame_len = 1024UL,
+    .max_ws_send_frame_cnt = 1UL,
+    .outgoing_buffer_sz    = 1024UL,
+  };
+  overflow_close_state_t state = {0};
+  fd_http_server_callbacks_t callbacks = {
+    .request    = request_count,
+    .close      = close_capture,
+    .ws_open    = NULL,
+    .ws_close   = NULL,
+    .ws_message = NULL,
+  };
+
+  ulong footprint = fd_ulong_align_up( fd_http_server_footprint( params ), 128UL );
+  uchar * scratch = aligned_alloc( 128UL, footprint );
+  FD_TEST( scratch );
+
+  fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
+  FD_TEST( http );
+  FD_TEST( fd_http_server_listen( http, 0U, 0U ) );
+
+  struct sockaddr_in server_addr = {0};
+  socklen_t server_addr_sz = sizeof( server_addr );
+  FD_TEST( !getsockname( fd_http_server_fd( http ), fd_type_pun( &server_addr ), &server_addr_sz ) );
+  ushort server_port = ntohs( server_addr.sin_port );
+
+  int client_fd = socket( AF_INET, SOCK_STREAM, 0 );
+  FD_TEST( client_fd>=0 );
+
+  struct sockaddr_in connect_addr = {
+    .sin_family      = AF_INET,
+    .sin_port        = htons( server_port ),
+    .sin_addr.s_addr = htonl( INADDR_LOOPBACK ),
+  };
+  FD_TEST( !connect( client_fd, fd_type_pun( &connect_addr ), sizeof( connect_addr ) ) );
+
+  /* A POST whose head and body together occupy exactly max_request_len
+     bytes. The body bound admits it (total_len<=max_request_len), so it
+     must be parsed and dispatched rather than closed as oversized. */
+  char tail[] = " HTTP/1.1\r\nHost: localhost\r\nContent-Length: 8\r\n\r\nxxxxxxxx";
+  ulong tail_len = strlen( tail );
+  ulong pad_digits = params.max_request_len - 6UL - 1UL - tail_len; /* "POST /" + digits + tail */
+  FD_TEST( pad_digits>0UL && pad_digits<1000UL );
+
+  char req[ 1025 ];
+  ulong pos = 0UL;
+  fd_memcpy( req+pos, "POST /", 6UL ); pos += 6UL;
+  memset( req+pos, '0', pad_digits );  pos += pad_digits;
+  fd_memcpy( req+pos, tail, tail_len ); pos += tail_len;
+  req[ pos ] = '\0';
+  FD_TEST( pos==params.max_request_len );
+  send_all( client_fd, req, pos );
+
+  for( ulong i=0UL; i<200UL && request_cnt<1UL; i++ ) {
+    fd_http_server_poll( http, 1, ULONG_MAX );
+  }
+
+  FD_TEST( request_cnt==1UL );
+  FD_TEST( state.close_cnt==0UL );
+
+  close( client_fd );
+  close( fd_http_server_fd( http ) );
+  fd_http_server_delete( fd_http_server_leave( http ) );
+  free( scratch );
+}
+
+static void
 test_poll_conn_max( void ) {
   fd_http_server_params_t params = {
     .max_connection_cnt    = 2UL,
@@ -879,6 +951,7 @@ main( int     argc,
 
   test_oring();
   test_content_length_overflow_close();
+  test_exact_max_request_len_accepted();
   test_poll_conn_max();
   test_treap_seed();
   test_poll_interest();


### PR DESCRIPTION
## What

`read_conn_http` closed the connection as `LARGE_REQUEST` as soon as the accumulated request reached `max_request_len` bytes, before attempting to parse it.

## Why

The POST path explicitly admits a total size of `max_request_len` (`total_len > max_request_len` is what gets rejected), so the two bounds disagree at the boundary. A request whose head and body together occupy exactly `max_request_len` bytes can never complete: the final read fills the buffer to capacity and trips the early close first, even though the request is valid under the body bound. The same applies to a GET whose head is exactly `max_request_len` bytes.

Since reads are clamped to the remaining buffer space, the accumulated length can never exceed `max_request_len`, so every maximum-size request hit this path.

## Change

Remove the pre-parse close. Treat a full buffer as oversized only when the head still does not parse (`phr_parse_request` returns -2); requests that do parse proceed through the existing content-length bounds, which already admit an exact fill. An incomplete head in a full buffer is genuinely oversized and still closes with `LARGE_REQUEST`.

Added `test_exact_max_request_len_accepted`: it sends a POST whose head and body total exactly 1024 bytes against a server with `max_request_len` 1024, and asserts the request callback fires with no connection close.