### PR TITLE
backup: fix crash if snapshot deleted while read inflight

### DIFF
--- a/src/discof/backup/fd_snapsv_tile.c
+++ b/src/discof/backup/fd_snapsv_tile.c
@@ -1112,15 +1112,21 @@ shovel_comp_disk( fd_snapsv_t *       ctx,
                  "unexpected shovel disk completion" );
   conn->disk_inflight = 0U;
 
+  /* snapshot file recycled between submission and completion? */
+  if( FD_UNLIKELY( !conn_snap_entry( conn ) ) ) {
+    conn->res.close_kind = FD_SNAPSV_CLOSE_ABORT;
+    conn->closing        = 1U;
+    shovel( ctx, stem, conn_idx, now );
+    return;
+  }
+
   ulong rem     = conn->snap.req_off1 - conn->snap.req_cur;
   ulong read_sz = fd_ulong_min( ctx->iobuf_sz, rem );
   if( FD_UNLIKELY( res<=0 || (ulong)res>read_sz ) ) {
     if( res<0 ) {
       FD_LOG_WARNING(( "snapshot read failed (%i-%s)", -res, fd_io_strerror( -res ) ));
     } else if( !res ) {
-      if( FD_UNLIKELY( conn_snap_entry( conn ) ) ) {
-        FD_LOG_WARNING(( "snapshot file ended early" ));
-      }
+      FD_LOG_WARNING(( "snapshot file ended early" ));
     } else {
       FD_LOG_WARNING(( "snapshot read returned too many bytes (%i>%lu)", res, read_sz ));
     }

--- a/src/discof/backup/test_snapsv_tile.c
+++ b/src/discof/backup/test_snapsv_tile.c
@@ -915,6 +915,74 @@ FD_UNIT_TEST( snap_body_deleted_midway ) {
   snapsv_env_destroy( env );
 }
 
+/* shoveling_conn returns the conn that is currently streaming a
+   snapshot body, or NULL if there is none. */
+
+static snapsv_conn_t *
+shoveling_conn( fd_snapsv_t * ctx ) {
+  for( ulong i=0UL; i<ctx->conn_max; i++ ) {
+    if( ctx->conn0[ i ].state==CONN_STATE_RES_SHOVEL ) return &ctx->conn0[ i ];
+  }
+  return NULL;
+}
+
+/* A snapshot read that is already submitted when the snapshot is
+   deleted may land after snapmk recycled the file.  Those bytes must
+   not reach the client. */
+
+FD_UNIT_TEST( snap_body_deleted_read_inflight ) {
+  char name[ FD_SNAP_NAME_MAX ];
+  snapsv_env_t * env = snap_env( name, 1 );
+  fd_snapsv_t * ctx = env->ctx;
+
+  char req[ 256 ];
+  fd_cstr_printf( req, sizeof(req), NULL, "GET /%s HTTP/1.1\r\n\r\n", name );
+
+  fake_client_t fake;
+  fake_client_req( &fake, req );
+  uint iter = 0U;
+  for( ; iter<64U && fake.res_sz<=4096U; iter++ ) snapsv_step( env, &fake, iter );
+  FD_TEST( fake.res_sz>4096U );
+
+  /* stop with a read SQE submitted but not yet executed by the fake */
+  snapsv_conn_t * conn = shoveling_conn( ctx );
+  FD_TEST( conn );
+  int charge_busy = 0;
+  for( uint end=iter+64U; iter<end; iter++ ) {
+    after_credit_pre( ctx, env->stem, &charge_busy, (long)iter*STEP_NANOS );
+    if( conn->disk_inflight ) break;
+    fake_client_drive( &fake, ctx->ring->sq, ctx->ring->cq );
+    after_credit_post( ctx, env->stem, &charge_busy, (long)iter*STEP_NANOS );
+  }
+  FD_TEST( conn->disk_inflight );
+
+  /* delete the snapshot and rewrite the file underneath the in-flight
+     read, the way snapmk recycles a pool slot */
+  static uchar snap_file_orig[ SNAP_FILE_SZ ];
+  memcpy( snap_file_orig, snap_file, SNAP_FILE_SZ );
+  snapsv_env_del_snap( env, 100UL, ULONG_MAX );
+  memset( snap_file, 0xa5, SNAP_FILE_SZ );
+
+  fake_client_drive( &fake, ctx->ring->sq, ctx->ring->cq );
+  after_credit_post( ctx, env->stem, &charge_busy, (long)iter*STEP_NANOS );
+  for( uint end=iter+256U; iter<end; iter++ ) snapsv_step( env, &fake, iter );
+
+  static char res[ SNAP_RES_MAX ];
+  ulong res_len = sizeof(res);
+  fake_client_res( &fake, res, &res_len );
+
+  ulong        body_len;
+  char const * body = res_body( res, res_len, &body_len );
+  FD_TEST( body_len && body_len<SNAP_FILE_SZ );
+  FD_TEST( !memcmp( body, snap_file_orig, body_len ) );
+
+  memcpy( snap_file, snap_file_orig, SNAP_FILE_SZ );
+
+  FD_TEST( !ctx->conn_cnt );
+  FD_TEST( ctx->iobuf_free_cnt==2U*CONN_MAX );
+  snapsv_env_destroy( env );
+}
+
 struct snapsv_event {
   fd_snapsv_msg_snap_t msg;
   int                  som;


### PR DESCRIPTION
When the snapshot creator recycles a snapshot, the underlying file
is immediately truncated.  This will cause any inflight io_uring
READ_FIXED ops to fail.  Handle this race gracefully in the read
completion handler.

Closes https://github.com/firedancer-io/auditor-internal/issues/593