### PR TITLE
faster hash function for pubkeys

### DIFF
--- a/src/ballet/txn/fd_txn_build.h
+++ b/src/ballet/txn/fd_txn_build.h
@@ -6,7 +6,7 @@
 
 #include "fd_txn.h"
 #include "../../disco/fd_txn_p.h"
-#include "../../flamenco/accdb/fd_accdb.h"
+#include "../../util/fd_hash32.h"
 
 /* The fd_txn_builder_t class provides methods for assembling a txn.
    fd_txn_builder_t is a static size struct, so a local declaration is a
@@ -43,7 +43,7 @@ typedef struct fd_txn_b_instr fd_txn_b_instr_t;
 #define MAP_IDX_T         uchar
 #define MAP_KEY_T         fd_acct_addr_t
 #define MAP_KEY_EQ(a,b)   0==memcmp( a, b, sizeof(fd_acct_addr_t) )
-#define MAP_KEY_HASH(k,s) fd_accdb_hash( (k)->b, (s) )
+#define MAP_KEY_HASH(k,s) fd_hash32( (k)->b, (s) )
 #define MAP_NEXT  map_next
 #include "../../util/tmpl/fd_map_chain.c"
 #define FD_TXN_B_ADDR_CHAIN_CNT (2*FD_TXN_ACCT_ADDR_MAX)

--- a/src/choreo/ghost/fd_ghost.c
+++ b/src/choreo/ghost/fd_ghost.c
@@ -1,4 +1,5 @@
 #include "fd_ghost.h"
+#include "../../util/fd_hash32.h"
 
 #define POOL_NAME blk_pool
 #define POOL_T    fd_ghost_blk_t
@@ -22,7 +23,7 @@
 #define MAP_KEY                            addr
 #define MAP_KEY_T                          fd_pubkey_t
 #define MAP_KEY_EQ(k0,k1)                  (!memcmp((k0),(k1), sizeof(fd_pubkey_t)))
-#define MAP_KEY_HASH(key,seed)             (fd_hash((seed),(key),sizeof(fd_pubkey_t)))
+#define MAP_KEY_HASH(key,seed)             (fd_hash32( (key)->uc, (seed) ))
 #define MAP_PREV                           map.prev
 #define MAP_NEXT                           map.next
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -24,6 +24,7 @@
 #include "../../waltz/http/fd_http_server.h"
 #include "../../discof/restore/utils/fd_ssmsg.h"
 #include "../topo/fd_topo.h"
+#include "../../util/fd_hash32.h"
 
 #if FD_HAS_ZSTD
 #define FD_GUI_GEOIP_ZSTD_COMPRESSION_LEVEL 19
@@ -256,7 +257,7 @@ typedef struct fd_gui_peers_gossip_stats fd_gui_peers_gossip_stats_t;
 #define MAP_IDX_T ulong
 #define MAP_NEXT  map.next
 #define MAP_PREV  map.prev
-#define MAP_KEY_HASH(k,s) (fd_hash( (s), (k)->uc, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(k,s) (fd_hash32( (k)->uc, (s) ))
 #define MAP_KEY_EQ(k0,k1) (!memcmp((k0)->uc, (k1)->uc, 32UL))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
@@ -268,7 +269,7 @@ typedef struct fd_gui_peers_gossip_stats fd_gui_peers_gossip_stats_t;
 #define MAP_IDX_T ulong
 #define MAP_NEXT  pubkey_map.next
 #define MAP_PREV  pubkey_map.prev
-#define MAP_KEY_HASH(k,s) (fd_hash( (s), (k)->uc, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(k,s) (fd_hash32( (k)->uc, (s) ))
 #define MAP_KEY_EQ(k0,k1) (!memcmp((k0)->uc, (k1)->uc, 32UL))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/disco/shred/fd_shred_dest.c
+++ b/src/disco/shred/fd_shred_dest.c
@@ -1,5 +1,5 @@
 #include "fd_shred_dest.h"
-#include "../../flamenco/accdb/fd_accdb.h"
+#include "../../util/fd_hash32.h"
 
 struct pubkey_to_idx {
   fd_pubkey_t key;
@@ -17,7 +17,7 @@ static const fd_pubkey_t null_pubkey = {{ 0 }};
 #define MAP_MEMOIZE           0
 #define MAP_KEY_INVAL(k)      MAP_KEY_EQUAL((k),MAP_KEY_NULL)
 #define MAP_KEY_EQUAL(k0,k1)  (!memcmp( (k0).key, (k1).key, 32UL ))
-#define MAP_KEY_HASH(k,s)     ((MAP_HASH_T)fd_accdb_hash( (k).key, (s) ))
+#define MAP_KEY_HASH(k,s)     ((MAP_HASH_T)fd_hash32( (k).key, (s) ))
 
 #include "../../util/tmpl/fd_map_dynamic.c"
 

--- a/src/discof/backup/fd_backup_accidx.h
+++ b/src/discof/backup/fd_backup_accidx.h
@@ -9,6 +9,7 @@
    or UINT_MAX for "end of chain". */
 
 #include "../../flamenco/accdb/fd_accdb_private.h"
+#include "../../util/fd_hash32.h"
 
 struct fd_backup_accidx {
   uint const *               acc_map;      /* map chains */
@@ -33,7 +34,7 @@ FD_PROTOTYPES_BEGIN
 FD_FN_PURE static inline ulong
 fd_backup_accidx_chain( fd_backup_accidx_t const * idx,
                         uchar const                pubkey[ static 32 ] ) {
-  return fd_accdb_hash( pubkey, idx->seed ) & idx->chain_mask;
+  return fd_hash32( pubkey, idx->seed ) & idx->chain_mask;
 }
 
 /* fd_backup_accidx_valid returns 1 if ele addresses an acc_pool element,

--- a/src/discof/gossip/fd_gossvf_tile.c
+++ b/src/discof/gossip/fd_gossvf_tile.c
@@ -9,6 +9,7 @@
 #include "../../flamenco/gossip/fd_ping_tracker.h"
 #include "../../flamenco/leaders/fd_leaders_base.h"
 #include "../../util/net/fd_net_headers.h"
+#include "../../util/fd_hash32.h"
 #include "../../disco/net/fd_net_tile.h"
 #include "generated/fd_gossvf_tile_seccomp.h"
 
@@ -83,7 +84,7 @@ typedef struct stake stake_t;
 #define MAP_PREV               map.prev
 #define MAP_NEXT               map.next
 #define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
-#define MAP_KEY_HASH(key,seed) fd_hash( (seed), (key)->uc, sizeof(fd_pubkey_t) )
+#define MAP_KEY_HASH(key,seed) fd_hash32( (key)->uc, (seed) )
 #include "../../util/tmpl/fd_map_chain.c"
 
 #define POOL_NAME  ping_pool
@@ -99,7 +100,7 @@ typedef struct stake stake_t;
 #define MAP_PREV               map.prev
 #define MAP_NEXT               map.next
 #define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
-#define MAP_KEY_HASH(key,seed) fd_hash( (seed), (key)->uc, sizeof(fd_pubkey_t) )
+#define MAP_KEY_HASH(key,seed) fd_hash32( (key)->uc, (seed) )
 #include "../../util/tmpl/fd_map_chain.c"
 
 #define POOL_NAME  stake_pool
@@ -115,7 +116,7 @@ typedef struct stake stake_t;
 #define MAP_PREV               map.prev
 #define MAP_NEXT               map.next
 #define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
-#define MAP_KEY_HASH(key,seed) fd_hash( (seed), (key)->uc, sizeof(fd_pubkey_t) )
+#define MAP_KEY_HASH(key,seed) fd_hash32( (key)->uc, (seed) )
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
 

--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -15,6 +15,7 @@
 #include "../../waltz/openssl/fd_openssl_tile.h"
 #include "../../waltz/resolv/fd_netdb.h"
 #include "../../waltz/resolv/fd_adns.h"
+#include "../../util/fd_hash32.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -65,7 +66,7 @@ typedef struct gossip_ci_entry gossip_ci_entry_t;
 #define MAP_KEY_T              fd_pubkey_t
 #define MAP_NEXT               map_next
 #define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
-#define MAP_KEY_HASH(key,seed) fd_hash( seed, key, sizeof(fd_pubkey_t) )
+#define MAP_KEY_HASH(key,seed) fd_hash32( key->uc, seed )
 #include "../../util/tmpl/fd_map_chain.c"
 
 /* Standalone blacklist keyed on fd_sspeer_key_t (peer identity).

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -25,6 +25,7 @@
 #include "../../flamenco/runtime/program/vote/fd_vote_state_versioned.h"
 #include "../../flamenco/runtime/program/vote/fd_vote_codec.h"
 #include "../../util/pod/fd_pod.h"
+#include "../../util/fd_hash32.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -212,7 +213,7 @@ typedef struct epoch_vtr epoch_vtr_t;
 #define MAP_KEY                vote_acc
 #define MAP_KEY_T              fd_pubkey_t
 #define MAP_KEY_EQ(k0,k1)      (!memcmp((k0),(k1),sizeof(fd_pubkey_t)))
-#define MAP_KEY_HASH(key,seed) (fd_hash((seed),(key),sizeof(fd_pubkey_t)))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( (key)->uc, (seed) ))
 #define MAP_NEXT               next
 #include "../../util/tmpl/fd_map_chain.c"
 

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -2,6 +2,7 @@
 #include "fd_accdb.h"
 #include "fd_accdb_shmem.h"
 #include "fd_accdb_private.h"
+#include "../../util/fd_hash32.h"
 
 #if FD_TMPL_USE_HANDHOLDING
 #include "../../ballet/txn/fd_txn.h"
@@ -491,7 +492,7 @@ fd_accdb_snapshot_load_end( fd_accdb_t * accdb ) {
 static inline uint
 delta_chain( fd_accdb_shmem_t const * accdb,
              uchar const              pubkey[ 32 ] ) {
-  uint hash = (uint)fd_accdb_hash( pubkey, accdb->delta.seed );
+  uint hash = (uint)fd_hash32( pubkey, accdb->delta.seed );
   return hash & accdb->delta.chain_mask;
 }
 
@@ -1913,7 +1914,7 @@ background_compact( fd_accdb_t * accdb,
      offset matches the record we are compacting. */
   fd_accdb_accmeta_t * accmeta = NULL;
   ulong source_packed = 0UL;
-  uint acc_idx = FD_VOLATILE_CONST( accdb->acc_map[ fd_accdb_hash( meta->pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL) ] );
+  uint acc_idx = FD_VOLATILE_CONST( accdb->acc_map[ fd_hash32( meta->pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL) ] );
   while( acc_idx!=UINT_MAX ) {
     fd_accdb_accmeta_t * candidate = &accdb->acc_pool[ acc_idx ];
     uint next_idx = FD_VOLATILE_CONST( candidate->map.next );
@@ -2202,7 +2203,7 @@ fd_accdb_acquire_inner( fd_accdb_t *          accdb,
      fd_accdb_release before the head-pointer store.  Multiple
      concurrent releases serialize on the CAS of the chain head. */
   for( ulong i=0UL; i<pubkeys_cnt; i++ ) {
-    acc_map_idxs[ i ] = fd_accdb_hash( pubkeys[ i ], accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+    acc_map_idxs[ i ] = fd_hash32( pubkeys[ i ], accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
     uint acc = FD_VOLATILE_CONST( accdb->acc_map[ acc_map_idxs[ i ] ] );
     while( acc!=UINT_MAX ) {
       fd_accdb_accmeta_t const * candidate_acc = &accdb->acc_pool[ acc ];
@@ -3499,7 +3500,7 @@ fd_accdb_read_one_nocache( fd_accdb_t *       accdb,
   //    for the detailed safety argument under concurrent prepend.
   uint root_generation = accdb->fork_pool[ accdb->shmem->root_fork_id.val ].shmem->generation;
   fd_accdb_fork_t * fork = &accdb->fork_pool[ fork_id.val ];
-  ulong hash = fd_accdb_hash( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+  ulong hash = fd_hash32( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
   uint acc_idx = FD_VOLATILE_CONST( accdb->acc_map[ hash ] );
   fd_accdb_accmeta_t const * accmeta = NULL;
   while( acc_idx!=UINT_MAX ) {
@@ -3661,7 +3662,7 @@ fd_accdb_exists( fd_accdb_t *       accdb,
 
   uint root_generation = accdb->fork_pool[ accdb->shmem->root_fork_id.val ].shmem->generation;
   fd_accdb_fork_t * fork = &accdb->fork_pool[ fork_id.val ];
-  ulong hash = fd_accdb_hash( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+  ulong hash = fd_hash32( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
   uint acc = FD_VOLATILE_CONST( accdb->acc_map[ hash ] );
   while( acc!=UINT_MAX ) {
     fd_accdb_accmeta_t const * candidate_acc = &accdb->acc_pool[ acc ];
@@ -3697,7 +3698,7 @@ fd_accdb_probe_pd_this_fork( fd_accdb_t *       accdb,
 
   uint root_generation = accdb->fork_pool[ accdb->shmem->root_fork_id.val ].shmem->generation;
   fd_accdb_fork_t * fork = &accdb->fork_pool[ fork_id.val ];
-  ulong hash = fd_accdb_hash( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+  ulong hash = fd_hash32( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
   uint acc = FD_VOLATILE_CONST( accdb->acc_map[ hash ] );
   while( acc!=UINT_MAX ) {
     fd_accdb_accmeta_t const * candidate_acc = &accdb->acc_pool[ acc ];
@@ -3745,7 +3746,7 @@ fd_accdb_lamports( fd_accdb_t *       accdb,
 
   uint root_generation = accdb->fork_pool[ accdb->shmem->root_fork_id.val ].shmem->generation;
   fd_accdb_fork_t * fork = &accdb->fork_pool[ fork_id.val ];
-  ulong hash = fd_accdb_hash( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+  ulong hash = fd_hash32( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
   uint acc = FD_VOLATILE_CONST( accdb->acc_map[ hash ] );
   while( acc!=UINT_MAX ) {
     fd_accdb_accmeta_t const * candidate_acc = &accdb->acc_pool[ acc ];
@@ -3944,7 +3945,7 @@ fd_accdb_snapshot_write_one( fd_accdb_t *       accdb,
     fork_gen = fork->shmem->generation;
   }
 
-  ulong hash = fd_accdb_hash( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
+  ulong hash = fd_hash32( pubkey, accdb->shmem->seed )&(accdb->shmem->chain_cnt-1UL);
 
   *out_replaced_lamports = 0UL;
 
@@ -4079,7 +4080,7 @@ fd_accdb_snapshot_write_batch( fd_accdb_t *        accdb,
   int                  skip[ 8 ];
 
   for( ulong i=0UL; i<cnt; i++ ) {
-    hashes[ i ]          = fd_accdb_hash( pubkeys[ i ], seed ) & chain_msk;
+    hashes[ i ]          = fd_hash32( pubkeys[ i ], seed ) & chain_msk;
     existing[ i ]        = NULL;
     cross_existing[ i ]  = NULL;
     skip[ i ]            = 0;

--- a/src/flamenco/accdb/fd_accdb_base.h
+++ b/src/flamenco/accdb/fd_accdb_base.h
@@ -1,62 +1,12 @@
 #ifndef HEADER_fd_src_flamenco_accdb_fd_accdb_base_h
 #define HEADER_fd_src_flamenco_accdb_fd_accdb_base_h
 
-#include "../../util/bits/fd_bits.h"
+#include "../../util/fd_hash32.h"
 
 struct fd_accdb_private;
 typedef struct fd_accdb_private fd_accdb_t;
 
 struct fd_accdb_fork_id { ushort val; };
 typedef struct fd_accdb_fork_id fd_accdb_fork_id_t;
-
-#if FD_HAS_INT128
-
-static inline ulong
-fd_xxh3_mul128_fold64( ulong lhs, ulong rhs ) {
-  uint128 product = (uint128)lhs * (uint128)rhs;
-  return (ulong)product ^ (ulong)( product>>64 );
-}
-
-static inline ulong
-fd_xxh3_mix16b( ulong i0, ulong i1,
-                ulong s0, ulong s1,
-                ulong seed ) {
-  return fd_xxh3_mul128_fold64( i0 ^ (s0 + seed), i1 ^ (s1 - seed) );
-}
-
-FD_FN_PURE static inline ulong
-fd_accdb_hash( uchar const key[ 32 ],
-               ulong       seed ) {
-  ulong k0 = FD_LOAD( ulong, key+ 0 );
-  ulong k1 = FD_LOAD( ulong, key+ 8 );
-  ulong k2 = FD_LOAD( ulong, key+16 );
-  ulong k3 = FD_LOAD( ulong, key+24 );
-  ulong acc = 32 * 0x9E3779B185EBCA87ULL;
-  acc += fd_xxh3_mix16b( k0, k1, 0xbe4ba423396cfeb8UL, 0x1cad21f72c81017cUL, seed );
-  acc += fd_xxh3_mix16b( k2, k3, 0xdb979083e96dd4deUL, 0x1f67b3b7a4a44072UL, seed );
-  acc = acc ^ (acc >> 37);
-  acc *= 0x165667919E3779F9ULL;
-  acc = acc ^ (acc >> 32);
-  return acc;
-}
-
-#else
-
-/* If the target does not support xxHash3, fallback to the 'old' key
-   hash function.
-
-   FIXME This version is vulnerable to HashDoS */
-
-FD_FN_PURE static inline ulong
-fd_accdb_hash( uchar const key[ 32 ],
-               ulong       seed ) {
-  /* tons of ILP */
-  return (fd_ulong_hash( seed ^ (1UL<<0) ^ FD_LOAD( ulong, key+ 0 ) )   ^
-          fd_ulong_hash( seed ^ (1UL<<1) ^ FD_LOAD( ulong, key+ 8 ) ) ) ^
-         (fd_ulong_hash( seed ^ (1UL<<2) ^ FD_LOAD( ulong, key+16 ) ) ^
-          fd_ulong_hash( seed ^ (1UL<<3) ^ FD_LOAD( ulong, key+24 ) ) );
-}
-
-#endif /* FD_HAS_INT128 */
 
 #endif /* HEADER_fd_src_flamenco_accdb_fd_accdb_base_h */

--- a/src/flamenco/gossip/fd_crds.c
+++ b/src/flamenco/gossip/fd_crds.c
@@ -2,7 +2,7 @@
 
 #include "fd_active_set.h"
 #include "../../ballet/sha256/fd_sha256.h"
-#include "../accdb/fd_accdb.h" /* for fd_accdb_hash, which we use for CRDS eviction */
+#include "../../util/fd_hash32.h" /* for fd_hash32, which we use for CRDS eviction */
 
 #include <string.h>
 
@@ -292,7 +292,7 @@ lookup_hash( fd_crds_key_t const * key,
   default:
     break;
   }
-  return fd_accdb_hash( key->pubkey, seed^hash_fn );
+  return fd_hash32( key->pubkey, seed^hash_fn );
 }
 
 static inline int

--- a/src/flamenco/gossip/fd_gossip_purged.h
+++ b/src/flamenco/gossip/fd_gossip_purged.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_flamenco_gossip_fd_gossip_purged_h
 
 #include "../fd_flamenco_base.h"
+#include "../../util/fd_hash32.h"
 
 /* fd_gossip_purged implements the "purged" side-table of the CRDS.
    When a CRDS entry is overridden by a newer value, fails to insert
@@ -121,7 +122,7 @@ FD_STATIC_ASSERT( sizeof(fd_crds_purged_t)==128UL, purged_entry_footprint );
 #define MAP_PREV               nci_map.prev
 #define MAP_NEXT               nci_map.next
 #define MAP_KEY_EQ(k0,k1)      fd_pubkey_eq( k0, k1 )
-#define MAP_KEY_HASH(key,seed) fd_hash( (seed), (key)->uc, sizeof(fd_pubkey_t) )
+#define MAP_KEY_HASH(key,seed) fd_hash32( (key)->uc, (seed) )
 #define MAP_MULTI              1
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/flamenco/gossip/fd_ping_tracker.c
+++ b/src/flamenco/gossip/fd_ping_tracker.c
@@ -1,4 +1,5 @@
 #include "fd_ping_tracker.h"
+#include "../../util/fd_hash32.h"
 
 #include "../../ballet/sha256/fd_sha256.h"
 #include "../../util/log/fd_log.h"
@@ -90,7 +91,7 @@ typedef struct fd_ping_peer fd_ping_peer_t;
 #define MAP_IDX_T ulong
 #define MAP_NEXT  map_next
 #define MAP_PREV  map_prev
-#define MAP_KEY_HASH(k,s) fd_hash( (s), (k)->b, sizeof((k)->b) )
+#define MAP_KEY_HASH(k,s) fd_hash32( (k)->b, (s) )
 #define MAP_KEY_EQ(k0,k1) (!memcmp((k0)->b, (k1)->b, 32UL))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/flamenco/gossip/fd_prune_finder.c
+++ b/src/flamenco/gossip/fd_prune_finder.c
@@ -1,4 +1,5 @@
 #include "fd_prune_finder.h"
+#include "../../util/fd_hash32.h"
 #include "../../util/log/fd_log.h"
 
 /* Maximum number of origins tracked in the outer map.  Matches
@@ -95,7 +96,7 @@ typedef struct fd_prune_origin fd_prune_origin_t;
 #define MAP_IDX_T ulong
 #define MAP_NEXT  map_next
 #define MAP_PREV  map_prev
-#define MAP_KEY_HASH(k,s) fd_hash( (s), (k)->b, sizeof((k)->b) )
+#define MAP_KEY_HASH(k,s) fd_hash32( (k)->b, (s) )
 #define MAP_KEY_EQ(k0,k1) (!memcmp((k0)->b, (k1)->b, 32UL))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/flamenco/gossip/test_gossip_purged.c
+++ b/src/flamenco/gossip/test_gossip_purged.c
@@ -29,8 +29,8 @@ main( int     argc,
 
   ulong hash0 = nci_origin_map_key_hash( &key0, seed );
   ulong hash1 = nci_origin_map_key_hash( &key1, seed );
-  FD_TEST( hash0==fd_hash( seed, key0.uc, sizeof(fd_pubkey_t) ) );
-  FD_TEST( hash1==fd_hash( seed, key1.uc, sizeof(fd_pubkey_t) ) );
+  FD_TEST( hash0==fd_hash32( key0.uc, seed ) );
+  FD_TEST( hash1==fd_hash32( key1.uc, seed ) );
   FD_TEST( hash0!=hash1 );
 
   uchar iter_mem[16UL] __attribute__((aligned(8)));

--- a/src/flamenco/runtime/fd_blockhashes.h
+++ b/src/flamenco/runtime/fd_blockhashes.h
@@ -2,7 +2,7 @@
 #define HEADER_fd_src_flamenco_runtime_fd_blockhashes_h
 
 #include "../fd_flamenco_base.h"
-#include "../accdb/fd_accdb.h"
+#include "../../util/fd_hash32.h"
 
 /* fd_blockhashes.h provides a "blockhash queue" API.  The blockhash
    queue is a consensus-relevant data structure that is part of the slot
@@ -42,7 +42,7 @@ typedef struct fd_blockhash_info fd_blockhash_info_t;
 #define MAP_IDX_T         ushort
 #define MAP_NEXT          next
 #define MAP_KEY_EQ(k0,k1) fd_hash_eq( (k0), (k1) )
-#define MAP_KEY_HASH(k,s) fd_accdb_hash( (k->uc), (s) )
+#define MAP_KEY_HASH(k,s) fd_hash32( (k->uc), (s) )
 #include "../../util/tmpl/fd_map_chain.c"
 
 /* fd_blockhashes_t is the class representing a blockhash queue.

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -7,6 +7,7 @@
 #include "../features/fd_features.h"
 #include "../vm/fd_vm_base.h"
 #include "program/fd_system_program.h"
+#include "../../util/fd_hash32.h"
 
 struct account_cost {
   fd_pubkey_t account;
@@ -24,7 +25,7 @@ typedef struct account_cost account_cost_t;
 #define MAP_ELE_T              account_cost_t
 #define MAP_KEY                account
 #define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
-#define MAP_KEY_HASH(key,seed) (fd_hash( seed, key, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( key->uc, seed ))
 #define MAP_NEXT               map.next
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/flamenco/runtime/tests/fd_dump_pb.c
+++ b/src/flamenco/runtime/tests/fd_dump_pb.c
@@ -10,6 +10,7 @@
 #include "../program/fd_precompiles.h"
 #include "../../../third_party/nanopb/pb_encode.h"
 #include "../fd_runtime_stack.h"
+#include "../../../util/fd_hash32.h"
 
 #include <stdio.h> /* fopen */
 #include <unistd.h> /* access */
@@ -31,7 +32,7 @@ typedef struct fd_dump_account_key fd_dump_account_t;
 #define MAP_KEY_EQUAL(k0,k1)  fd_pubkey_eq( &(k0), &(k1) )
 #define MAP_KEY_EQUAL_IS_SLOW (0)
 #define MAP_MEMOIZE           (0)
-#define MAP_KEY_HASH(key)     ((uint)fd_hash( 0UL, (key).uc, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(key)     ((uint)fd_hash32( (key).uc, 0UL ))
 #include "../../../util/tmpl/fd_map.c"
 
 struct fd_dump_account_key_set {

--- a/src/flamenco/stakes/fd_collector_overrides.c
+++ b/src/flamenco/stakes/fd_collector_overrides.c
@@ -1,5 +1,6 @@
 #include "fd_collector_overrides.h"
 #include "../fd_rwlock.h"
+#include "../../util/fd_hash32.h"
 
 struct override_ele {
   fd_pubkey_t pubkey;
@@ -29,7 +30,7 @@ typedef struct override_ele override_ele_t;
 #define MAP_ELE_T                          override_ele_t
 #define MAP_KEY                            pubkey
 #define MAP_KEY_EQ(k0,k1)                  (!memcmp( k0, k1, sizeof(fd_pubkey_t) ))
-#define MAP_KEY_HASH(key,seed)             (fd_hash( seed, key, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(key,seed)             (fd_hash32( key->uc, seed ))
 #define MAP_PREV                           prev_multi
 #define MAP_NEXT                           next_multi
 #define MAP_IDX_T                          uint

--- a/src/flamenco/stakes/fd_stake_delegations.c
+++ b/src/flamenco/stakes/fd_stake_delegations.c
@@ -1,6 +1,7 @@
 #include "fd_stake_delegations.h"
 #include "fd_stakes.h"
 #include "../runtime/sysvar/fd_sysvar_stake_history.h"
+#include "../../util/fd_hash32.h"
 
 #define POOL_NAME  root_pool
 #define POOL_T     fd_stake_delegation_t
@@ -14,7 +15,7 @@
 #define MAP_ELE_T              fd_stake_delegation_t
 #define MAP_KEY                stake_account
 #define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
-#define MAP_KEY_HASH(key,seed) (fd_accdb_hash( key->uc, seed ))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( key->uc, seed ))
 #define MAP_NEXT               next_
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"
@@ -24,7 +25,7 @@
 #define MAP_ELE_T              fd_stake_delegation_t
 #define MAP_KEY                stake_account
 #define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
-#define MAP_KEY_HASH(key,seed) (fd_accdb_hash( key->uc, seed ))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( key->uc, seed ))
 #define MAP_NEXT               next_
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"
@@ -56,7 +57,7 @@ typedef struct fork_pool_ele fork_pool_ele_t;
 #define MAP_ELE_T              fd_stake_delegation_ref_t
 #define MAP_KEY                stake_account
 #define MAP_KEY_EQ(k0,k1)      (fd_pubkey_eq( k0, k1 ))
-#define MAP_KEY_HASH(key,seed) (fd_accdb_hash( key->uc, seed ))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( key->uc, seed ))
 #define MAP_NEXT               next_
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"

--- a/src/flamenco/stakes/fd_vote_stakes.c
+++ b/src/flamenco/stakes/fd_vote_stakes.c
@@ -4,6 +4,7 @@
 #include "../runtime/fd_runtime_const.h"
 #include "../runtime/program/vote/fd_vote_state_versioned.h"
 #include "../../util/bits/fd_bits.h"
+#include "../../util/fd_hash32.h"
 #include "../../util/log/fd_log.h"
 
 #define FD_VOTE_STAKES_MAGIC          (0xF17EDA2CE7601E70UL) /* FIREDANCER VOTE STAKES V0 */
@@ -40,7 +41,7 @@ typedef struct vacc vacc_t;
 #define MAP_ELE_T              vacc_t
 #define MAP_KEY                pubkey
 #define MAP_KEY_EQ(k0,k1)      (!memcmp( k0, k1, sizeof(fd_pubkey_t) ))
-#define MAP_KEY_HASH(key,seed) (fd_hash( seed, key, sizeof(fd_pubkey_t) ))
+#define MAP_KEY_HASH(key,seed) (fd_hash32( key->uc, seed ))
 #define MAP_IDX_T              uint
 #include "../../util/tmpl/fd_map_chain.c"
 

--- a/src/util/Local.mk
+++ b/src/util/Local.mk
@@ -1,5 +1,6 @@
 $(call make-lib,fd_util)
 $(call add-hdrs,fd_util_base.h fd_util.h)
+$(call add-hdrs,fd_hash32.h)
 $(call add-objs,fd_hash fd_util,fd_util)
 $(call add-hdrs,fd_version.h)
 $(call add-objs,fd_version,fd_util)

--- a/src/util/fd_hash32.h
+++ b/src/util/fd_hash32.h
@@ -1,0 +1,56 @@
+#ifndef HEADER_fd_src_util_fd_hash32_h
+#define HEADER_fd_src_util_fd_hash32_h
+
+#include "bits/fd_bits.h"
+
+#if FD_HAS_INT128
+
+static inline ulong
+fd_xxh3_mul128_fold64( ulong lhs, ulong rhs ) {
+  uint128 product = (uint128)lhs * (uint128)rhs;
+  return (ulong)product ^ (ulong)( product>>64 );
+}
+
+static inline ulong
+fd_xxh3_mix16b( ulong i0, ulong i1,
+                ulong s0, ulong s1,
+                ulong seed ) {
+  return fd_xxh3_mul128_fold64( i0 ^ (s0 + seed), i1 ^ (s1 - seed) );
+}
+
+FD_FN_PURE static inline ulong
+fd_hash32( uchar const key[ 32 ],
+           ulong       seed ) {
+  ulong k0 = FD_LOAD( ulong, key+ 0 );
+  ulong k1 = FD_LOAD( ulong, key+ 8 );
+  ulong k2 = FD_LOAD( ulong, key+16 );
+  ulong k3 = FD_LOAD( ulong, key+24 );
+  ulong acc = 32 * 0x9E3779B185EBCA87ULL;
+  acc += fd_xxh3_mix16b( k0, k1, 0xbe4ba423396cfeb8UL, 0x1cad21f72c81017cUL, seed );
+  acc += fd_xxh3_mix16b( k2, k3, 0xdb979083e96dd4deUL, 0x1f67b3b7a4a44072UL, seed );
+  acc = acc ^ (acc >> 37);
+  acc *= 0x165667919E3779F9ULL;
+  acc = acc ^ (acc >> 32);
+  return acc;
+}
+
+#else
+
+/* If the target does not support xxHash3, fallback to the 'old' key
+   hash function.
+
+   FIXME This version is vulnerable to HashDoS */
+
+FD_FN_PURE static inline ulong
+fd_hash32( uchar const key[ 32 ],
+           ulong       seed ) {
+  /* tons of ILP */
+  return (fd_ulong_hash( seed ^ (1UL<<0) ^ FD_LOAD( ulong, key+ 0 ) )   ^
+          fd_ulong_hash( seed ^ (1UL<<1) ^ FD_LOAD( ulong, key+ 8 ) ) ) ^
+         (fd_ulong_hash( seed ^ (1UL<<2) ^ FD_LOAD( ulong, key+16 ) ) ^
+          fd_ulong_hash( seed ^ (1UL<<3) ^ FD_LOAD( ulong, key+24 ) ) );
+}
+
+#endif /* FD_HAS_INT128 */
+
+#endif /* HEADER_fd_src_util_fd_hash32_h */


### PR DESCRIPTION
Use fast unrolled xxHash3 for all hash functions that use 32 byte
input.  Large free performance win.

- rename fd_accdb_hash to fd_hash32 and move to src/util
- replace all 32-byte usages of fd_hash with fd_hash32
