### PR TITLE
sandbox: raise retained file descriptor limit

### DIFF
--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -72,7 +72,8 @@ fd_topo_run_tile( fd_topo_t *          topo,
     tile_run->privileged_init( topo, tile );
 
   ulong allow_fds_offset = 0UL;
-  int allow_fds[ 256 ] = { 0 };
+  int allow_fds[ FD_SANDBOX_ALLOWED_FD_CNT_MAX ];
+  for( ulong i=0UL; i<FD_SANDBOX_ALLOWED_FD_CNT_MAX; i++ ) allow_fds[ i ] = -1;
   if( FD_LIKELY( -1!=allow_fd ) ) {
     allow_fds_offset = 1UL;
     allow_fds[ 0 ] = allow_fd;
@@ -81,7 +82,7 @@ fd_topo_run_tile( fd_topo_t *          topo,
   if( FD_LIKELY( tile_run->populate_allowed_fds ) ) {
     allow_fds_cnt = tile_run->populate_allowed_fds( topo,
                                                     tile,
-                                                    (sizeof(allow_fds)/sizeof(allow_fds[ 0 ]))-allow_fds_offset,
+                                                    FD_SANDBOX_ALLOWED_FD_CNT_MAX-allow_fds_offset,
                                                     allow_fds+allow_fds_offset );
   }
 

--- a/src/discof/capture/fd_solcap_tile.c
+++ b/src/discof/capture/fd_solcap_tile.c
@@ -137,8 +137,10 @@ populate_allowed_seccomp( fd_topo_t const *      topo,
 static ulong
 populate_allowed_fds( fd_topo_t const *      topo,
                       fd_topo_tile_t const * tile,
-                      ulong                  out_fds_cnt FD_PARAM_UNUSED,
+                      ulong                  out_fds_cnt,
                       int *                  out_fds ) {
+  if( FD_UNLIKELY( out_fds_cnt<4UL ) ) FD_LOG_ERR(( "out_fds_cnt %lu", out_fds_cnt ));
+
   void * scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
   fd_solcap_tile_ctx_t const * ctx = (fd_solcap_tile_ctx_t const *)scratch;
 

--- a/src/discof/restore/fd_snapld_tile.c
+++ b/src/discof/restore/fd_snapld_tile.c
@@ -157,7 +157,7 @@ populate_allowed_fds( fd_topo_t const *      topo,
                       fd_topo_tile_t const * tile,
                       ulong                  out_fds_cnt,
                       int *                  out_fds ) {
-  if( FD_UNLIKELY( out_fds_cnt<4UL ) ) FD_LOG_ERR(( "out_fds_cnt %lu", out_fds_cnt ));
+  if( FD_UNLIKELY( out_fds_cnt<5UL ) ) FD_LOG_ERR(( "out_fds_cnt %lu", out_fds_cnt ));
 
   ulong out_cnt = 0;
   out_fds[ out_cnt++ ] = 2UL; /* stderr */

--- a/src/util/sandbox/fd_sandbox.c
+++ b/src/util/sandbox/fd_sandbox.c
@@ -134,8 +134,8 @@ fd_sandbox_private_explicit_clear_environment_variables( void ) {
 void
 fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descriptor_cnt,
                                                  int const * allowed_file_descriptor ) {
-  if( allowed_file_descriptor_cnt>256UL ) FD_LOG_ERR(( "allowed_file_descriptors_cnt must not be more than 256" ));
-  int seen_fds[ 256 ] = {0};
+  if( FD_UNLIKELY( allowed_file_descriptor_cnt>FD_SANDBOX_ALLOWED_FD_CNT_MAX ) ) FD_LOG_ERR(( "allowed_file_descriptor_cnt must not exceed %lu", FD_SANDBOX_ALLOWED_FD_CNT_MAX ));
+  int seen_fds[ FD_SANDBOX_ALLOWED_FD_CNT_MAX ] = {0};
 
   for( ulong i=0UL; i<allowed_file_descriptor_cnt; i++ ) {
     if( allowed_file_descriptor[ i ]<0 || allowed_file_descriptor[ i ]==INT_MAX )

--- a/src/util/sandbox/fd_sandbox.h
+++ b/src/util/sandbox/fd_sandbox.h
@@ -7,6 +7,10 @@
 
 #include <linux/filter.h> /* FIXME: HMMMM */
 
+/* Maximum number of open file descriptors that may be retained when
+   entering the sandbox. */
+#define FD_SANDBOX_ALLOWED_FD_CNT_MAX (1024UL)
+
 FD_PROTOTYPES_BEGIN
 
 /* fd_sandbox_requires_cap_sys_admin checks if the current environment

--- a/src/util/sandbox/fd_sandbox_private.h
+++ b/src/util/sandbox/fd_sandbox_private.h
@@ -40,12 +40,13 @@ fd_sandbox_private_explicit_clear_environment_variables( void );
    spawned the Firedancer process with unexpected file descriptors still
    open.
 
-   allowed_file_descriptors_cnt must be less than 256, and the
-   allowed_file_descriptor list must not have any duplicate entries or
-   else the process will be exited with an error. */
+   allowed_file_descriptors_cnt must not exceed
+   FD_SANDBOX_ALLOWED_FD_CNT_MAX, and the allowed_file_descriptor list
+   must not have any duplicate entries or else the process will be
+   exited with an error. */
 
 void
-fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descriptor_cnt /* Must be in [0, 256] */,
+fd_sandbox_private_check_exact_file_descriptors( ulong       allowed_file_descriptor_cnt /* Must be in [0, FD_SANDBOX_ALLOWED_FD_CNT_MAX] */,
                                                  int const * allowed_file_descriptor );  /* Assumed to have allowed_file_descriptor_cnt entries */
 
 /* Sets the real, effective, and saved set-user-ID of the calling

--- a/src/util/sandbox/test_sandbox.c
+++ b/src/util/sandbox/test_sandbox.c
@@ -36,7 +36,7 @@
       FD_TEST( WEXITSTATUS( wstatus )==code );            \
     } else {                                              \
       do { child; } while ( 0 );                          \
-      exit( EXIT_SUCCESS );                               \
+      _exit( EXIT_SUCCESS );                              \
     }                                                     \
 } while( 0 )
 
@@ -52,7 +52,7 @@
       FD_TEST( WTERMSIG( wstatus )==code );               \
     } else {                                              \
       do { child; } while ( 0 );                          \
-      exit( EXIT_SUCCESS );                               \
+      _exit( EXIT_SUCCESS );                              \
     }                                                     \
 } while( 0 )
 
@@ -108,12 +108,22 @@ test_check_file_descriptors_inner( void ) {
   TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( 4UL, allow_fds ), 1 );
   TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( 5UL, allow_fds2 ), 0 );
 
-  int too_many_fds[ 257 ];
-  for( int i=0UL; i<257; i++) too_many_fds[ i ] = i;
-  for( int i=5UL; i<256; i++) FD_TEST(-1!=dup2( 3, i ));
-  TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( 256UL, too_many_fds ), 0 );
-  FD_TEST( -1!=dup2( 3, 256 ) );
-  TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( 257UL, too_many_fds ), 1 );
+  struct rlimit nofile_limit;
+  FD_TEST( !getrlimit( RLIMIT_NOFILE, &nofile_limit ) );
+  ulong required_nofile_limit = FD_SANDBOX_ALLOWED_FD_CNT_MAX+2UL;
+  if( FD_UNLIKELY( nofile_limit.rlim_max<(rlim_t)required_nofile_limit ) ) {
+    FD_LOG_WARNING(( "Maximum allowed file descriptor test skipped - RLIMIT_NOFILE hard limit is %lu", (ulong)nofile_limit.rlim_max ));
+    return;
+  }
+  nofile_limit.rlim_cur = (rlim_t)required_nofile_limit;
+  FD_TEST( !setrlimit( RLIMIT_NOFILE, &nofile_limit ) );
+
+  int many_fds[ FD_SANDBOX_ALLOWED_FD_CNT_MAX+1UL ];
+  for( ulong i=0UL; i<FD_SANDBOX_ALLOWED_FD_CNT_MAX+1UL; i++ ) many_fds[ i ] = (int)i;
+  for( int i=5; i<(int)FD_SANDBOX_ALLOWED_FD_CNT_MAX; i++ ) FD_TEST( -1!=dup2( 3, i ) );
+  TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( FD_SANDBOX_ALLOWED_FD_CNT_MAX, many_fds ), 0 );
+  FD_TEST( -1!=dup2( 3, (int)FD_SANDBOX_ALLOWED_FD_CNT_MAX ) );
+  TEST_FORK_EXIT_CODE( fd_sandbox_private_check_exact_file_descriptors( FD_SANDBOX_ALLOWED_FD_CNT_MAX+1UL, many_fds ), 1 );
 }
 
 void
@@ -152,6 +162,10 @@ test_deny_namespaces_inner( void ) {
     FD_TEST( *endptr=='\n' );
     FD_TEST( value>1UL );
   }
+
+  /* Match fd_sandbox_private_enter_no_seccomp: create the parent mount
+     namespace before reserving the second namespace for pivot_root. */
+  FD_TEST( !unshare( CLONE_NEWNS ) );
 
   fd_sandbox_private_deny_namespaces();
 
@@ -420,33 +434,27 @@ test_resource_limits( void ) {
 #define SYS_landlock_create_ruleset 444
 #endif
 
-struct landlock_ruleset_attr {
-    __u64 handled_access_fs;
-};
+#define LANDLOCK_CREATE_RULESET_VERSION (1U << 0)
 
 void
 test_landlock_inner( void ) {
-  struct landlock_ruleset_attr attr = {
-    .handled_access_fs = 0, /* No access to anything. */
-  };
-
-  int landlock_fd = (int)syscall( SYS_landlock_create_ruleset, &attr, 8, 0 );
-  if( FD_UNLIKELY( landlock_fd==-1 && errno==ENOSYS ) ) {
+  long abi = syscall( SYS_landlock_create_ruleset, NULL, 0, LANDLOCK_CREATE_RULESET_VERSION );
+  if( FD_UNLIKELY( abi==-1L && (errno==ENOSYS || errno==EOPNOTSUPP) ) ) {
     FD_LOG_WARNING(( "Test skipped - landlock not supported" ));
     return;
   }
-  FD_TEST( landlock_fd>=0 );
-  FD_TEST( !close( landlock_fd ) );
+  FD_TEST( abi>=1L );
 
   int dirfd = open( "/", O_RDONLY );
   FD_TEST( dirfd>=0 );
   FD_TEST( !close( dirfd ) );
 
+  FD_TEST( !prctl( PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0 ) );
   fd_sandbox_private_landlock_restrict_self( 0, 0 );
 
   int fd = open( "/", O_RDONLY );
   FD_LOG_WARNING(( "%d %d %s", fd, errno, fd_io_strerror( errno ) ));
-  FD_TEST( -1==fd && errno==EPERM );
+  FD_TEST( -1==fd && errno==EACCES );
 }
 
 void
@@ -478,7 +486,7 @@ test_seccomp( void ) {
     child;                                                                                              \
   } while(0), code )
 
-  TEST_FORK_SECCOMP_EXIT_CODE( FD_LOG_DEBUG(( "Allowed!" )), 0 );
+  TEST_FORK_SECCOMP_EXIT_CODE( FD_TEST( 0L==write( 2, NULL, 0UL ) ), 0 );
   TEST_FORK_SECCOMP_EXIT_CODE( fsync( 3 ), 0 );
   TEST_FORK_SECCOMP_SIGNAL( getpid(), SIGSYS );
   TEST_FORK_SECCOMP_SIGNAL( fsync( 2 ), SIGSYS );


### PR DESCRIPTION
Needs to be slightly higher since `diag` tile needs more than 2*tile_cnt descriptors