### PR TITLE
snapct: extend filtering for gossip snapshot download sources

### DIFF
--- a/src/discof/restore/fd_snapct_tile.c
+++ b/src/discof/restore/fd_snapct_tile.c
@@ -1439,6 +1439,17 @@ gossip_frag( fd_snapct_tile_t *  ctx,
       fd_ip4_port_t new_addr;
       new_addr.addr = msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].is_ipv6 ? 0 : msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].ip4;
       new_addr.port = msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].port;
+      /* Sanitize non-public/multicast/broadcast addresses to zero so
+         they are never stored in entry->rpc_addr or handed to
+         downstream code paths (e.g. on_snapshot_hash).  Normalizing
+         before comparing against cur_addr avoids repeated selector
+         removals and log warnings on every gossip refresh. */
+      uint unfiltered_addr = new_addr.addr;
+      if( FD_UNLIKELY( !fd_ip4_addr_is_public( new_addr.addr ) ||
+                        fd_ip4_addr_is_mcast( new_addr.addr )  ||
+                        fd_ip4_addr_is_bcast( new_addr.addr ) ) ) {
+        new_addr.l = 0;
+      }
 
       if( FD_UNLIKELY( new_addr.l!=cur_addr.l ) ) {
         fd_sspeer_key_t entry_key = {0};
@@ -1458,6 +1469,9 @@ gossip_frag( fd_snapct_tile_t *  ctx,
             }
           }
         } else {
+          if( FD_UNLIKELY( !!unfiltered_addr ) ) {
+            FD_LOG_WARNING(( "filtered non-public RPC address " FD_IP4_ADDR_FMT " from gossip peer", FD_IP4_ADDR_FMT_ARGS( unfiltered_addr ) ));
+          }
           fd_sspeer_selector_remove( ctx->selector, &entry_key );
         }
         if( FD_LIKELY( !!cur_addr.l ) ) {

--- a/src/discof/restore/test_snapct_tile.c
+++ b/src/discof/restore/test_snapct_tile.c
@@ -20,6 +20,22 @@ send_contact_info( fd_snapct_tile_t *           ctx,
 }
 
 static void
+send_contact_info_with_rpc( fd_snapct_tile_t *           ctx,
+                            fd_gossip_update_message_t * msg,
+                            ulong                        idx,
+                            fd_pubkey_t const *          pubkey,
+                            fd_ip4_port_t                rpc_addr ) {
+  fd_memset( msg, 0, sizeof(*msg) );
+  msg->tag = FD_GOSSIP_UPDATE_TAG_CONTACT_INFO;
+  fd_memcpy( msg->origin, pubkey->uc, sizeof(fd_pubkey_t) );
+  msg->contact_info->idx = idx;
+  msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].is_ipv6 = 0;
+  msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].ip4     = rpc_addr.addr;
+  msg->contact_info->value->sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_RPC ].port    = rpc_addr.port;
+  gossip_frag( ctx, FD_GOSSIP_UPDATE_TAG_CONTACT_INFO, FD_GOSSIP_UPDATE_SZ_CONTACT_INFO, 0UL );
+}
+
+static void
 send_contact_info_remove( fd_snapct_tile_t *           ctx,
                           fd_gossip_update_message_t * msg,
                           ulong                        idx,
@@ -111,6 +127,42 @@ setup_blacklist_snapct( void *              scratch,
   FD_TEST( ctx->selector );
   FD_TEST( ctx->blacklist_pool );
   FD_TEST( ctx->blacklist_map );
+
+  *ctx_out = ctx;
+}
+
+static void
+setup_full_snapct( void *                       scratch,
+                   fd_ssping_t *                ssping,
+                   fd_snapct_tile_t **          ctx_out,
+                   fd_gossip_update_message_t * msg ) {
+  FD_SCRATCH_ALLOC_INIT( l, scratch );
+  fd_snapct_tile_t *  ctx      = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_snapct_tile_t),  sizeof(fd_snapct_tile_t)                                                   );
+  memset( ctx, 0, sizeof(fd_snapct_tile_t) );
+  gossip_ci_entry_t * ci_table = FD_SCRATCH_ALLOC_APPEND( l, alignof(gossip_ci_entry_t), sizeof(gossip_ci_entry_t)*GOSSIP_PEERS_MAX                                 );
+  void *              ci_map   = FD_SCRATCH_ALLOC_APPEND( l, gossip_ci_map_align(),      gossip_ci_map_footprint( gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ) ) );
+  void *              sel      = FD_SCRATCH_ALLOC_APPEND( l, fd_sspeer_selector_align(), fd_sspeer_selector_footprint( TOTAL_PEERS_MAX )                            );
+  void *              bl_pool  = FD_SCRATCH_ALLOC_APPEND( l, blacklist_pool_align(),     blacklist_pool_footprint( TOTAL_PEERS_MAX )                                );
+  void *              bl_map   = FD_SCRATCH_ALLOC_APPEND( l, blacklist_map_align(),      blacklist_map_footprint( blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ) )  );
+
+  fd_memset( ci_table, 0, sizeof(gossip_ci_entry_t)*GOSSIP_PEERS_MAX );
+  ctx->gossip.ci_table = ci_table;
+  ctx->gossip.ci_map   = gossip_ci_map_join( gossip_ci_map_new( ci_map, gossip_ci_map_chain_cnt_est( GOSSIP_PEERS_MAX ), TEST_GOSSIP_CI_SEED ) );
+  FD_TEST( ctx->gossip.ci_map );
+
+  ctx->ssping         = ssping;
+  ctx->selector       = fd_sspeer_selector_join( fd_sspeer_selector_new( sel, TOTAL_PEERS_MAX, TEST_SELECTOR_SEED ) );
+  ctx->blacklist_pool = blacklist_pool_join( blacklist_pool_new( bl_pool, TOTAL_PEERS_MAX ) );
+  ctx->blacklist_map  = blacklist_map_join( blacklist_map_new( bl_map, blacklist_map_chain_cnt_est( TOTAL_PEERS_MAX ), TEST_BLACKLIST_SEED ) );
+  FD_TEST( ctx->selector );
+  FD_TEST( ctx->blacklist_pool );
+  FD_TEST( ctx->blacklist_map );
+
+  ctx->gossip_in_mem = msg;
+  ctx->gossip_enabled = 1;
+  ctx->config.sources.gossip.allow_any      = 1;
+  ctx->config.sources.gossip.allow_list_cnt = 0UL;
+  ctx->config.sources.gossip.block_list_cnt = 0UL;
 
   *ctx_out = ctx;
 }
@@ -503,6 +555,82 @@ test_blacklist_pool_exhaustion( fd_ssping_t * ssping ) {
   free( scratch );
 }
 
+static void
+test_contact_info_public_rpc_address( fd_ssping_t * ssping ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_full_snapct( scratch, ssping, &ctx, msg );
+
+  ulong const idx = 3UL;
+  fd_pubkey_t  peer = test_pubkey( 0x55 );
+  fd_ip4_port_t pub = test_addr( 0x08080808 /* 8.8.8.8 */, 8899 );
+
+  send_contact_info_with_rpc( ctx, msg, idx, &peer, pub );
+
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.ci_table[ idx ].rpc_addr.l==pub.l );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( ctx->selector ) );
+
+  /* Clean up ssping state so the shared instance can be reused. */
+  fd_ssping_remove( ctx->ssping, pub );
+
+  free( scratch );
+}
+
+static void
+test_contact_info_invalid_rpc_address_cleared( fd_ssping_t * ssping ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_full_snapct( scratch, ssping, &ctx, msg );
+
+  ulong const idx = 4UL;
+  fd_pubkey_t   peer    = test_pubkey( 0x66 );
+  fd_ip4_port_t private = test_addr( 0x0A000001 /* 10.0.0.1 */, 8899 );
+
+  send_contact_info_with_rpc( ctx, msg, idx, &peer, private );
+
+  /* The peer is allowed, but its address should have been normalized
+     to zero by the sanitizer. */
+  FD_TEST( ctx->gossip.ci_table[ idx ].allowed );
+  FD_TEST( ctx->gossip.ci_table[ idx ].rpc_addr.l==0UL );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( ctx->selector ) );
+
+  free( scratch );
+}
+
+static void
+test_contact_info_public_to_invalid_update( fd_ssping_t * ssping ) {
+  void * scratch = aligned_alloc( scratch_align(), scratch_footprint( NULL ) ); FD_TEST( scratch );
+
+  fd_gossip_update_message_t msg[1] __attribute__((aligned(FD_CHUNK_ALIGN)));
+  fd_snapct_tile_t * ctx;
+  setup_full_snapct( scratch, ssping, &ctx, msg );
+
+  ulong const idx = 5UL;
+  fd_pubkey_t   peer = test_pubkey( 0x77 );
+  fd_ip4_port_t pub  = test_addr( 0x01020304 /* 1.2.3.4 */, 8899 );
+
+  /* First gossip refresh: public address is accepted. */
+  send_contact_info_with_rpc( ctx, msg, idx, &peer, pub );
+  FD_TEST( ctx->gossip.ci_table[ idx ].rpc_addr.l==pub.l );
+  FD_TEST( 1UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( ctx->selector ) );
+
+  /* Second gossip refresh: peer now advertises a private address. */
+  fd_ip4_port_t private = test_addr( 0xC0A80001 /* 192.168.0.1 */, 8899 );
+  send_contact_info_with_rpc( ctx, msg, idx, &peer, private );
+
+  /* The address should be zeroed and the peer removed from the
+     selector.  ssping should have removed the old public address. */
+  FD_TEST( ctx->gossip.ci_table[ idx ].rpc_addr.l==0UL );
+  FD_TEST( 0UL==fd_sspeer_selector_peer_map_by_key_ele_cnt( ctx->selector ) );
+
+  free( scratch );
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -527,6 +655,10 @@ main( int     argc,
   FD_TEST( _ssping_mem );
   fd_ssping_t * ssping = fd_ssping_join( fd_ssping_new( _ssping_mem, ssping_max, TEST_SSPING_SEED, on_ping_stub, NULL ) );
   FD_TEST( ssping );
+
+  test_contact_info_public_rpc_address( ssping );
+  test_contact_info_invalid_rpc_address_cleared( ssping );
+  test_contact_info_public_to_invalid_update( ssping );
 
   test_blacklist_peer_basic( ssping );
   test_blacklist_peer_dedup( ssping );

--- a/src/util/net/fd_ip4.h
+++ b/src/util/net/fd_ip4.h
@@ -23,6 +23,20 @@
 #define FD_IP4_OPT_EOL ((uchar)0)   /* This is the end of the options list */
 
 /* All of the below are in network byte order */
+
+/* RFC 791 - "This network" */
+#define IP4_THIS_NET_START_NET       FD_IP4_ADDR(  0,   0,   0,   0)
+#define IP4_THIS_NET_END_NET         FD_IP4_ADDR(  0, 255, 255, 255)
+
+/* RFC 1112 - Reserved/future use */
+#define IP4_RESERVED_START_NET       FD_IP4_ADDR(240,   0,   0,   0)
+#define IP4_RESERVED_END_NET         FD_IP4_ADDR(255, 255, 255, 254)
+
+/* RFC 1122 - Loopback */
+#define IP4_LOOPBACK_START_NET       FD_IP4_ADDR(127,   0,   0,   0)
+#define IP4_LOOPBACK_END_NET         FD_IP4_ADDR(127, 255, 255, 255)
+
+/* RFC 1918 - Private-use */
 #define IP4_PRIVATE_RANGE1_START_NET FD_IP4_ADDR( 10,   0,   0,   0)
 #define IP4_PRIVATE_RANGE1_END_NET   FD_IP4_ADDR( 10, 255, 255, 255)
 #define IP4_PRIVATE_RANGE2_START_NET FD_IP4_ADDR(172,  16,   0,   0)
@@ -30,8 +44,36 @@
 #define IP4_PRIVATE_RANGE3_START_NET FD_IP4_ADDR(192, 168,   0,   0)
 #define IP4_PRIVATE_RANGE3_END_NET   FD_IP4_ADDR(192, 168, 255, 255)
 
-#define IP4_LOOPBACK_START_NET       FD_IP4_ADDR(127,   0,   0,   0)
-#define IP4_LOOPBACK_END_NET         FD_IP4_ADDR(127, 255, 255, 255)
+/* RFC 2544 - Benchmarking */
+#define IP4_BENCH_START_NET          FD_IP4_ADDR(198,  18,   0,   0)
+#define IP4_BENCH_END_NET            FD_IP4_ADDR(198,  19, 255, 255)
+
+/* RFC 3927 - Link-local */
+#define IP4_LINK_LOCAL_START_NET     FD_IP4_ADDR(169, 254,   0,   0)
+#define IP4_LINK_LOCAL_END_NET       FD_IP4_ADDR(169, 254, 255, 255)
+
+/* RFC 5737 - Documentation */
+#define IP4_TEST_NET_1_START_NET     FD_IP4_ADDR(192,   0,   2,   0)
+#define IP4_TEST_NET_1_END_NET       FD_IP4_ADDR(192,   0,   2, 255)
+#define IP4_TEST_NET_2_START_NET     FD_IP4_ADDR(198,  51, 100,   0)
+#define IP4_TEST_NET_2_END_NET       FD_IP4_ADDR(198,  51, 100, 255)
+#define IP4_TEST_NET_3_START_NET     FD_IP4_ADDR(203,   0, 113,   0)
+#define IP4_TEST_NET_3_END_NET       FD_IP4_ADDR(203,   0, 113, 255)
+
+/* RFC 6598 - Shared address (CGNAT) */
+#define IP4_CGNAT_START_NET          FD_IP4_ADDR(100,  64,   0,   0)
+#define IP4_CGNAT_END_NET            FD_IP4_ADDR(100, 127, 255, 255)
+
+/* RFC 6890 - IETF protocol assignments
+   Note: 192.0.0.9 (PCP anycast, RFC 7723) and 192.0.0.10 (TURN anycast,
+   RFC 8155) are globally reachable but intentionally not carved out; no
+   validator will serve snapshots or publish gossip from these addresses. */
+#define IP4_PROTO_ASSIGN_START_NET   FD_IP4_ADDR(192,   0,   0,   0)
+#define IP4_PROTO_ASSIGN_END_NET     FD_IP4_ADDR(192,   0,   0, 255)
+
+/* RFC 7526 - 6to4 relay anycast (deprecated) */
+#define IP4_6TO4_RELAY_START_NET     FD_IP4_ADDR(192,  88,  99,   0)
+#define IP4_6TO4_RELAY_END_NET       FD_IP4_ADDR(192,  88,  99, 255)
 
 union fd_ip4_hdr {
   struct {
@@ -205,9 +247,19 @@ fd_cstr_to_ip4_addr( char const * s,
 FD_FN_CONST static inline int
 fd_ip4_addr_is_public( uint addr ) {
   uint addr_host = fd_uint_bswap( addr );
-  return !((addr_host >= fd_uint_bswap( IP4_PRIVATE_RANGE1_START_NET ) && addr_host <= fd_uint_bswap( IP4_PRIVATE_RANGE1_END_NET )) ||
+  return !((addr_host >= fd_uint_bswap( IP4_THIS_NET_START_NET       ) && addr_host <= fd_uint_bswap( IP4_THIS_NET_END_NET       )) ||
+           (addr_host >= fd_uint_bswap( IP4_PRIVATE_RANGE1_START_NET ) && addr_host <= fd_uint_bswap( IP4_PRIVATE_RANGE1_END_NET )) ||
            (addr_host >= fd_uint_bswap( IP4_PRIVATE_RANGE2_START_NET ) && addr_host <= fd_uint_bswap( IP4_PRIVATE_RANGE2_END_NET )) ||
            (addr_host >= fd_uint_bswap( IP4_PRIVATE_RANGE3_START_NET ) && addr_host <= fd_uint_bswap( IP4_PRIVATE_RANGE3_END_NET )) ||
+           (addr_host >= fd_uint_bswap( IP4_LINK_LOCAL_START_NET     ) && addr_host <= fd_uint_bswap( IP4_LINK_LOCAL_END_NET     )) ||
+           (addr_host >= fd_uint_bswap( IP4_CGNAT_START_NET          ) && addr_host <= fd_uint_bswap( IP4_CGNAT_END_NET          )) ||
+           (addr_host >= fd_uint_bswap( IP4_RESERVED_START_NET       ) && addr_host <= fd_uint_bswap( IP4_RESERVED_END_NET       )) ||
+           (addr_host >= fd_uint_bswap( IP4_TEST_NET_1_START_NET     ) && addr_host <= fd_uint_bswap( IP4_TEST_NET_1_END_NET     )) ||
+           (addr_host >= fd_uint_bswap( IP4_TEST_NET_2_START_NET     ) && addr_host <= fd_uint_bswap( IP4_TEST_NET_2_END_NET     )) ||
+           (addr_host >= fd_uint_bswap( IP4_TEST_NET_3_START_NET     ) && addr_host <= fd_uint_bswap( IP4_TEST_NET_3_END_NET     )) ||
+           (addr_host >= fd_uint_bswap( IP4_BENCH_START_NET          ) && addr_host <= fd_uint_bswap( IP4_BENCH_END_NET          )) ||
+           (addr_host >= fd_uint_bswap( IP4_PROTO_ASSIGN_START_NET   ) && addr_host <= fd_uint_bswap( IP4_PROTO_ASSIGN_END_NET   )) ||
+           (addr_host >= fd_uint_bswap( IP4_6TO4_RELAY_START_NET     ) && addr_host <= fd_uint_bswap( IP4_6TO4_RELAY_END_NET     )) ||
            fd_ip4_addr_is_loopback( addr ));
 }
 

--- a/src/util/net/test_ip4.c
+++ b/src/util/net/test_ip4.c
@@ -54,6 +54,11 @@ test_ip4_addr_is_public( void ) {
   // Loopback address should also return 0
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(127,   0,   0,   1) ) == 0 );
 
+  // "This network" 0.0.0.0/8 (RFC 791) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(  0,   0,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(  0,   0,   0,   1) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(  0, 255, 255, 255) ) == 0 );
+
   // More private addresses tests
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR( 10,   0,   0,   0) ) == 0 );
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR( 10, 255, 255, 255) ) == 0 );
@@ -61,6 +66,70 @@ test_ip4_addr_is_public( void ) {
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(172,  31, 255, 255) ) == 0 );
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192, 168,   0,   0) ) == 0 );
   FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192, 168, 255, 255) ) == 0 );
+
+  // Link-local addresses (169.254.0.0/16) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(169, 254,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(169, 254,   1,   1) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(169, 254, 255, 255) ) == 0 );
+
+  // CGNAT addresses (100.64.0.0/10) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(100,  64,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(100, 100, 100, 100) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(100, 127, 255, 255) ) == 0 );
+
+  // Boundary: just outside CGNAT should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(100, 128,   0,   0) ) == 1 );
+
+  // Boundary: just outside link-local should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(169, 253, 255, 255) ) == 1 );
+
+  // Reserved 240.0.0.0 – 255.255.255.254 should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(240,   0,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(250,   1,   2,   3) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(255, 255, 255, 254) ) == 0 );
+
+  // Broadcast is not caught by fd_ip4_addr_is_public (use fd_ip4_addr_is_bcast)
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(255, 255, 255, 255) ) == 1 );
+
+  // Boundary: just below reserved should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(239, 255, 255, 255) ) == 1 );
+
+  // Boundary: just above "this network" should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(  1,   0,   0,   0) ) == 1 );
+
+  // Documentation addresses (RFC 5737) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   2,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   2, 255) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(198,  51, 100,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(198,  51, 100, 255) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(203,   0, 113,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(203,   0, 113, 255) ) == 0 );
+
+  // Benchmarking addresses (RFC 2544) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(198,  18,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(198,  19, 255, 255) ) == 0 );
+
+  // Boundary: just outside documentation/benchmarking should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   3,   0) ) == 1 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(198,  20,   0,   0) ) == 1 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(203,   0, 114,   0) ) == 1 );
+
+  // IETF Protocol Assignments (192.0.0.0/24, RFC 6890) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   0,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   0, 128) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   0, 255) ) == 0 );
+
+  // Boundary: just outside IETF Protocol Assignments should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,   0,   1,   0) ) == 1 );
+
+  // 6to4 Relay Anycast (192.88.99.0/24, RFC 7526) should return 0
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,  88,  99,   0) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,  88,  99,   1) ) == 0 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,  88,  99, 255) ) == 0 );
+
+  // Boundary: just outside 6to4 Relay Anycast should return 1
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,  88,  98, 255) ) == 1 );
+  FD_TEST( fd_ip4_addr_is_public( FD_IP4_ADDR(192,  88, 100,   0) ) == 1 );
 }
 
 


### PR DESCRIPTION
Firedancer should filter reserved IP ranges for gossip snapshot download sources.