### PR TITLE
mlx5: multi tile support

### DIFF
--- a/src/app/firedancer-dev/commands/gossip.c
+++ b/src/app/firedancer-dev/commands/gossip.c
@@ -213,6 +213,7 @@ gossip_cmd_fn( args_t *   args,
 
   int const is_xdp = ( 0==strcmp( config->net.provider, "xdp" ) );
   if( is_xdp ) fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  else if( 0==strcmp( config->net.provider, "mlx5" ) ) fd_topo_install_mlx5( &config->topo );
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );
   fd_topo_fill( &config->topo );
 

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -843,6 +843,8 @@ repair_cmd_fn_catchup( args_t *   args,
   configure_cmd_fn( &configure_args, config );
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
   run_firedancer_init( config, 1, 0 );
 
@@ -973,6 +975,7 @@ repair_cmd_fn_eqvoc( args_t *   args,
   for( ulong i=0UL; STAGES[ i ]; i++ ) configure_args.configure.stages[ i ] = STAGES[ i ];
   configure_cmd_fn( &configure_args, config );
   if( 0==strcmp( config->net.provider, "xdp" ) ) fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  else if( 0==strcmp( config->net.provider, "mlx5" ) ) fd_topo_install_mlx5( &config->topo );
 
   run_firedancer_init( config, 1, 0 );
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -258,6 +258,8 @@ send_test_cmd_fn( args_t *   args ,
 
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
 
   fd_topo_join_workspaces( &config->topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -362,6 +362,11 @@ main_pid_namespace( void * _args ) {
     fd_topo_install_xdp( &config->topo, xdp_fds, &xdp_fds_cnt, config->net.bind_address_parsed, 0 );
   }
 
+  int need_mlx5_cmd_fd =
+      0==strcmp( config->net.provider, "mlx5" ) &&
+      fd_topo_tile_name_cnt( &config->topo, "mlx5" )>1UL;
+  if( need_mlx5_cmd_fd ) fd_topo_install_mlx5( &config->topo );
+
   initialize_accdb_fd( config );
   ulong snap_max                = 0UL;
   int   snapshot_upload_enabled = 0;
@@ -392,6 +397,13 @@ main_pid_namespace( void * _args ) {
             if( FD_UNLIKELY( -1==fcntl( xdp_fds[i].xsk_map_fd,   F_SETFD, 0 ) ) ) FD_LOG_ERR(( "fcntl(F_SETFD,0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
             if( FD_UNLIKELY( -1==fcntl( xdp_fds[i].prog_link_fd, F_SETFD, 0 ) ) ) FD_LOG_ERR(( "fcntl(F_SETFD,0) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
           }
+        }
+      }
+
+      if( need_mlx5_cmd_fd ) {
+        int cloexec = !!strcmp( tile->name, "mlx5" );
+        if( FD_UNLIKELY( -1==fcntl( FD_TOPO_MLX5_CMD_FD, F_SETFD, cloexec ? FD_CLOEXEC : 0 ) ) ) {
+          FD_LOG_ERR(( "fcntl(F_SETFD) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
         }
       }
 
@@ -476,6 +488,9 @@ main_pid_namespace( void * _args ) {
       if( FD_UNLIKELY( close( xdp_fds[i].xsk_map_fd ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       if( FD_UNLIKELY( close( xdp_fds[i].prog_link_fd ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     }
+  }
+  if( need_mlx5_cmd_fd ) {
+    if( FD_UNLIKELY( close( FD_TOPO_MLX5_CMD_FD ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   }
 
   if( FD_LIKELY( config->is_firedancer ) ) {

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -198,6 +198,8 @@ bench_cmd_fn( args_t *   args,
 
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
 
   initialize_accdb_fd( config );

--- a/src/app/shared_dev/commands/dev.c
+++ b/src/app/shared_dev/commands/dev.c
@@ -120,6 +120,8 @@ run_firedancer_threaded( config_t * config,
 
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
 
   initialize_accdb_fd( config );

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -327,6 +327,8 @@ pktgen_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   initialize_stacks( config );
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
   fd_topo_join_workspaces( topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );
 

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -111,6 +111,8 @@ udpecho_cmd_fn( args_t *   args,
   initialize_stacks( config );
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     fd_topo_install_xdp_simple( &config->topo, config->net.bind_address_parsed );
+  } else if( 0==strcmp( config->net.provider, "mlx5" ) ) {
+    fd_topo_install_mlx5( &config->topo );
   }
   fd_topo_join_workspaces( topo, FD_SHMEM_JOIN_MODE_READ_WRITE, FD_TOPO_CORE_DUMP_LEVEL_DISABLED );
 

--- a/src/disco/net/fd_net_tile.h
+++ b/src/disco/net/fd_net_tile.h
@@ -160,6 +160,18 @@ fd_topo_install_xdp( fd_topo_t const * topo,
 
 #define FD_TOPO_XDP_FDS_MAX (FD_NET_BOND_SLAVE_MAX+1)
 
+/* FD_TOPO_MLX5_CMD_FD is the fixed file descriptor number of the
+   Mellanox uverbs command fd shared across mlx tiles. */
+
+#define FD_TOPO_MLX5_CMD_FD (123480)
+
+/* fd_topo_install_mlx5 opens the uverbs command device at
+   FD_TOPO_MLX5_CMD_FD if the topology uses more than one mlx5 tile.
+   No-op otherwise. */
+
+void
+fd_topo_install_mlx5( fd_topo_t const * topo );
+
 /* fd_topo_install_xdp_simple is a convenience wrapper of the above. */
 
 FD_FN_UNUSED static void

--- a/src/disco/net/fd_net_tile_topo.c
+++ b/src/disco/net/fd_net_tile_topo.c
@@ -7,10 +7,13 @@
 #include "../../app/shared/fd_config.h" /* FIXME layering violation */
 #include "../../util/pod/fd_pod_format.h"
 #include "fd_linux_bond.h"
+#include "mlx5/fd_mlx5_private.h"
 #include "../../waltz/ip/fd_iproute.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <net/if.h>
+#include <sys/random.h>
 #include <unistd.h>
 
 char const *
@@ -238,10 +241,38 @@ fd_topos_net_tiles( fd_topo_t *             topo,
     fd_topob_tile_out( topo, "netlnk", 0UL, "iproute_out", 0UL );
     fd_netlink_topo_create( netlink_tile, topo, netlnk_max_routes, netlnk_max_peer_routes, netlnk_max_neighbors, net_cfg->interface );
 
-    if( FD_UNLIKELY( net_tile_cnt!=1UL ) ) {
-      FD_LOG_ERR(( "net.provider=\"mlx5\" requires layout.net_tile_count=1" ));
+    if( FD_UNLIKELY( net_tile_cnt>FD_MLX5_TILE_MAX ) ) {
+      FD_LOG_ERR(( "net.provider=\"mlx5\" supports at most %lu net tiles, but [layout.net_tile_count] is %lu",
+                   FD_MLX5_TILE_MAX, net_tile_cnt ));
     }
-    setup_mlx5_tile( topo, 0UL, netlink_tile, tile_to_cpu, net_cfg, netlnk_max_routes, netlnk_max_peer_routes );
+    for( ulong i=0UL; i<net_tile_cnt; i++ ) {
+      setup_mlx5_tile( topo, i, netlink_tile, tile_to_cpu, net_cfg,
+                       netlnk_max_routes, netlnk_max_peer_routes );
+    }
+
+    if( net_tile_cnt>1UL ) {
+      uint rss_seed;
+      do {
+        FD_TEST( sizeof(rss_seed)==getrandom( &rss_seed, sizeof(rss_seed), 0 ) );
+      } while( FD_UNLIKELY( !rss_seed ) );
+
+      for( ulong i=0UL; i<net_tile_cnt; i++ ) {
+        ulong tile_id = fd_topo_find_tile( topo, "mlx5", i );
+        FD_TEST( tile_id!=ULONG_MAX );
+        topo->tiles[ tile_id ].mlx5.rss_seed = rss_seed;
+      }
+      for( ulong i=0UL; i<net_tile_cnt; i++ ) {
+        ulong tile_id = fd_topo_find_tile( topo, "mlx5", i );
+        for( ulong j=0UL; j<net_tile_cnt; j++ ) {
+          if( i==j ) continue;
+          ulong peer_id = fd_topo_find_tile( topo, "mlx5", j );
+          fd_topob_tile_uses(
+              topo, &topo->tiles[ tile_id ],
+              &topo->objs[ topo->tiles[ peer_id ].tile_obj_id ],
+              FD_SHMEM_JOIN_MODE_READ_WRITE );
+        }
+      }
+    }
 
   } else {
     FD_LOG_ERR(( "invalid `net.provider`" ));
@@ -352,6 +383,32 @@ fd_topos_xdp_setup_mem( fd_topo_t *      topo,
   fd_pod_insertf_ulong( topo->props, cum_frame_cnt, "obj.%lu.depth", umem_obj_id );
   fd_pod_insertf_ulong( topo->props, 2UL,           "obj.%lu.burst", umem_obj_id ); /* 4096 byte padding */
   fd_pod_insertf_ulong( topo->props, 2048UL,        "obj.%lu.mtu",   umem_obj_id );
+}
+
+void
+fd_topo_install_mlx5( fd_topo_t const * topo ) {
+  if( fd_topo_tile_name_cnt( topo, "mlx5" )<=1UL ) return;
+  if( fcntl( FD_TOPO_MLX5_CMD_FD, F_GETFD )>=0 ) return; /* idempotent */
+
+  ulong mlx5_tile_idx = fd_topo_find_tile( topo, "mlx5", 0UL );
+  FD_TEST( mlx5_tile_idx!=ULONG_MAX );
+  char const * if_name = topo->tiles[ mlx5_tile_idx ].mlx5.if_name;
+
+  char rdma_name[ FD_MLX5_RDMA_NAME_MAX ];
+  uint port_num;
+  fd_mlx5_rdma_dev_find( rdma_name, &port_num, if_name );
+
+  int cmd_fd = fd_uverbs_open_cmd_fd( rdma_name );
+  if( FD_UNLIKELY( cmd_fd<0 ) ) {
+    FD_LOG_ERR(( "opening the uverbs device of `%s` (RDMA device `%s`) failed (%i-%s)",
+                 if_name, rdma_name, errno, fd_io_strerror( errno ) ));
+  }
+  if( FD_UNLIKELY( -1==dup2( cmd_fd, FD_TOPO_MLX5_CMD_FD ) ) ) {
+    FD_LOG_ERR(( "dup2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+  if( FD_UNLIKELY( -1==close( cmd_fd ) ) ) {
+    FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
 }
 
 void

--- a/src/disco/net/mlx5/fd_mlx5.c
+++ b/src/disco/net/mlx5/fd_mlx5.c
@@ -1,4 +1,5 @@
 #include "fd_mlx5_private.h"
+#include "../fd_linux_bond.h"
 #include "../../../util/log/fd_log.h"
 #include "../../../util/net/fd_eth.h"
 #include "../../../util/net/fd_ip4.h"
@@ -13,6 +14,7 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <net/if.h>
 #include <unistd.h>
 
 #include <linux/netlink.h>
@@ -121,20 +123,29 @@
 #define FD_MLX5_QP_ATTR_STATE (1U)    /* IB_QP_STATE */
 #define FD_MLX5_QP_ATTR_PORT  (1U<<5) /* IB_QP_PORT */
 
+#define FD_MLX5_WQS_RDY       (1U)    /* IB_WQS_RDY */
+#define FD_MLX5_WQ_ATTR_STATE (1U)    /* IB_WQ_STATE */
+
+#define FD_MLX5_RSS_HASH_FIELDS \
+  ( MLX5_RX_HASH_SRC_IPV4     | \
+    MLX5_RX_HASH_DST_IPV4     | \
+    MLX5_RX_HASH_SRC_PORT_UDP | \
+    MLX5_RX_HASH_DST_PORT_UDP )
+
+/* common Toeplitz hash key */
+static uchar const fd_mlx5_rss_key[ FD_MLX5_RSS_KEY_SZ ] = {
+  0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2,
+  0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3, 0x8f, 0xb0,
+  0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4,
+  0x77, 0xcb, 0x2d, 0xa3, 0x80, 0x30, 0xf2, 0x0c,
+  0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa
+};
+
 struct fd_mlx5_pd {
   fd_uverbs_ctx_t * ctx;    /* uverbs context */
   uint              handle; /* protection domain handle */
 };
 typedef struct fd_mlx5_pd fd_mlx5_pd_t;
-
-struct fd_mlx5_caps {
-  ulong max_mr_size;
-  uint  max_send_wqe; /* max_send_wqebb, SQ WQE capacity */
-  uint  max_recv_wr;
-  uint  max_cqe;
-  uchar eth_min_inline_hdr_sz;
-};
-typedef struct fd_mlx5_caps fd_mlx5_caps_t;
 
 /* fd_uverbs_* types define Linux uverbs requests and responses */
 struct fd_uverbs_ex_hdr {
@@ -306,6 +317,60 @@ struct fd_uverbs_modify_qp_req {
 typedef struct fd_uverbs_modify_qp_req fd_uverbs_modify_qp_req_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_modify_qp_req_t)==120UL, uverbs_modify_qp_req_sz );
 
+struct fd_uverbs_create_wq_req {
+  fd_uverbs_ex_hdr_t            hdr;
+  struct ib_uverbs_ex_create_wq core;
+  struct mlx5_ib_create_wq      mlx5;
+};
+typedef struct fd_uverbs_create_wq_req fd_uverbs_create_wq_req_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_wq_req_t)==112UL, uverbs_create_wq_req_sz );
+
+struct fd_uverbs_create_wq_resp {
+  struct ib_uverbs_ex_create_wq_resp core;
+  struct mlx5_ib_create_wq_resp      mlx5;
+};
+typedef struct fd_uverbs_create_wq_resp fd_uverbs_create_wq_resp_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_wq_resp_t)==32UL, uverbs_create_wq_resp_sz );
+
+struct fd_uverbs_modify_wq_req {
+  fd_uverbs_ex_hdr_t            hdr;
+  struct ib_uverbs_ex_modify_wq core;
+  struct mlx5_ib_modify_wq      mlx5;
+};
+typedef struct fd_uverbs_modify_wq_req fd_uverbs_modify_wq_req_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_modify_wq_req_t)==56UL, uverbs_modify_wq_req_sz );
+
+struct fd_uverbs_create_rqt_req {
+  fd_uverbs_ex_hdr_t hdr;
+  uint               comp_mask;
+  uint               log_ind_tbl_size;
+  uint               wq_handle[ FD_MLX5_RQT_SZ ];
+};
+typedef struct fd_uverbs_create_rqt_req fd_uverbs_create_rqt_req_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rqt_req_t)==544UL, uverbs_create_rqt_req_sz );
+
+struct fd_uverbs_create_rqt_resp {
+  struct ib_uverbs_ex_create_rwq_ind_table_resp core;
+  struct mlx5_ib_create_rwq_ind_tbl_resp        mlx5;
+};
+typedef struct fd_uverbs_create_rqt_resp fd_uverbs_create_rqt_resp_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rqt_resp_t)==24UL, uverbs_create_rqt_resp_sz );
+
+struct fd_uverbs_create_rss_qp_req {
+  fd_uverbs_ex_hdr_t            hdr;
+  struct ib_uverbs_ex_create_qp core;
+  struct mlx5_ib_create_qp_rss  mlx5;
+};
+typedef struct fd_uverbs_create_rss_qp_req fd_uverbs_create_rss_qp_req_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rss_qp_req_t)==240UL, uverbs_create_rss_qp_req_sz );
+
+struct fd_uverbs_create_rss_qp_resp {
+  struct ib_uverbs_ex_create_qp_resp core;
+  struct mlx5_ib_create_qp_resp      mlx5;
+};
+typedef struct fd_uverbs_create_rss_qp_resp fd_uverbs_create_rss_qp_resp_t;
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rss_qp_resp_t)==80UL, uverbs_create_rss_qp_resp_sz );
+
 struct fd_uverbs_create_udp_flow_req {
   fd_uverbs_ex_hdr_t                 hdr;
   uint                               comp_mask;
@@ -440,6 +505,99 @@ fd_mlx5_check_driver( char const * rdma_name ) {
     return -1;
   }
   return 0;
+}
+
+/* fd_mlx5_rdma_port_contains_if reports whether an RDMA device port is
+   backed by the given network interface. */
+static int
+fd_mlx5_rdma_port_contains_if( char const * rdma_name,
+                               uint         port_num,
+                               char const * if_name ) {
+  char dir_path[ FD_RDMA_PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( dir_path, sizeof(dir_path), NULL,
+                                 "/sys/class/infiniband/%s/ports/%u/gid_attrs/ndevs",
+                                 rdma_name, port_num ) );
+
+  DIR * netdev_dir = opendir( dir_path );
+  if( FD_UNLIKELY( !netdev_dir ) ) return 0;
+
+  int             netdev_found = 0;
+  struct dirent * netdev_entry;
+  while( !netdev_found && (netdev_entry=readdir( netdev_dir )) ) {
+    if( netdev_entry->d_name[0]=='.' ) continue;
+
+    char path[ FD_RDMA_PATH_MAX ];
+    char netdev_name[ IF_NAMESIZE+2UL ];
+    FD_TEST( fd_cstr_printf_check( path, sizeof(path), NULL, "%s/%s", dir_path, netdev_entry->d_name ) );
+    if( FD_UNLIKELY( fd_rdma_read_text( path, netdev_name, sizeof(netdev_name) ) ) ) continue;
+    netdev_found = !strcmp( netdev_name, if_name );
+  }
+  if( FD_UNLIKELY( closedir( netdev_dir ) ) ) return 0;
+  return netdev_found;
+}
+
+static int
+fd_mlx5_rdma_port_matches_if( char const * rdma_name,
+                              uint         port_num,
+                              char const * if_name ) {
+  if( fd_mlx5_rdma_port_contains_if( rdma_name, port_num, if_name ) ) return 1;
+  if( !fd_bonding_is_master( if_name ) ) return 0;
+
+  fd_bonding_slave_iter_t   iter_mem[1];
+  fd_bonding_slave_iter_t * iter = fd_bonding_slave_iter_init( iter_mem, if_name );
+  while( !fd_bonding_slave_iter_done( iter ) ) {
+    if( fd_mlx5_rdma_port_contains_if( rdma_name, port_num, fd_bonding_slave_iter_ele( iter ) ) ) return 1;
+    fd_bonding_slave_iter_next( iter );
+  }
+  return 0;
+}
+
+void
+fd_mlx5_rdma_dev_find( char         rdma_name[ FD_MLX5_RDMA_NAME_MAX ],
+                       uint *       port_num,
+                       char const * if_name ) {
+  DIR * infiniband_dir = opendir( "/sys/class/infiniband" );
+  if( FD_UNLIKELY( !infiniband_dir ) ) {
+    FD_LOG_ERR(( "opendir(/sys/class/infiniband) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  rdma_name[0] = '\0';
+  *port_num = 0U;
+
+  struct dirent * device_entry;
+  while( (device_entry=readdir( infiniband_dir )) ) {
+    if( device_entry->d_name[0]=='.' ) continue;
+
+    char device_ports_path[ FD_RDMA_PATH_MAX ];
+    FD_TEST( fd_cstr_printf_check( device_ports_path, sizeof(device_ports_path), NULL,
+                                   "/sys/class/infiniband/%s/ports", device_entry->d_name ) );
+    DIR * ports_dir = opendir( device_ports_path );
+    if( FD_UNLIKELY( !ports_dir ) ) continue;
+
+    struct dirent * port_entry;
+    while( (port_entry=readdir( ports_dir )) ) {
+      char * port_end;
+      ulong const port = strtoul( port_entry->d_name, &port_end, 10 );
+      if( !port || *port_end || port>(ulong)UCHAR_MAX ) continue;
+
+      if( !fd_mlx5_rdma_port_matches_if( device_entry->d_name, (uint)port, if_name ) ) continue;
+
+      if( FD_UNLIKELY( rdma_name[0] ) ) {
+        FD_LOG_ERR(( "multiple RDMA ports match interface `%s` (`%s` port %u and `%s` port %lu)",
+                     if_name, rdma_name, *port_num, device_entry->d_name, port ));
+      }
+      fd_cstr_ncpy( rdma_name, device_entry->d_name, FD_MLX5_RDMA_NAME_MAX );
+      *port_num = (uint)port;
+    }
+    closedir( ports_dir );
+  }
+
+  if( FD_UNLIKELY( closedir( infiniband_dir ) ) ) {
+    FD_LOG_ERR(( "closedir(/sys/class/infiniband) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+  if( FD_UNLIKELY( !rdma_name[0] ) ) {
+    FD_LOG_ERR(( "RDMA device port for interface `%s` not found", if_name ));
+  }
 }
 
 /* fd_uverbs_* helpers build and submit Linux uverbs commands */
@@ -680,39 +838,80 @@ fd_uverbs_query_port( fd_uverbs_ctx_t * ctx ) {
   return 0;
 }
 
+int
+fd_uverbs_open_cmd_fd( char const * rdma_name ) {
+  char uverbs_name[ FD_UVERBS_NAME_MAX ];
+  if( FD_UNLIKELY( fd_uverbs_resolve( uverbs_name, rdma_name ) ) ) return -1;
+
+  char path[ FD_RDMA_PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( path, sizeof(path), NULL, "/dev/infiniband/%s", uverbs_name ) );
+
+  int cmd_fd = open( path, O_RDWR ); /* not close-on-exec */
+  if( FD_UNLIKELY( cmd_fd<0 ) ) return -1;
+
+  struct stat cmd_fd_stat;
+  int err = 0;
+  if( FD_UNLIKELY( fstat( cmd_fd, &cmd_fd_stat ) ) ) err = errno;
+  else if( FD_UNLIKELY( !S_ISCHR( cmd_fd_stat.st_mode ) ) ) err = ENODEV;
+  if( FD_UNLIKELY( err ) ) {
+    close( cmd_fd );
+    errno = err;
+    return -1;
+  }
+  return cmd_fd;
+}
+
+fd_uverbs_ctx_t *
+fd_uverbs_join( fd_uverbs_ctx_t * uverbs,
+                int               cmd_fd,
+                uint              port_num ) {
+  if( FD_UNLIKELY( !uverbs || cmd_fd<0 || !port_num || port_num>(uint)UCHAR_MAX ) ) {
+    errno = EINVAL;
+    return NULL;
+  }
+  if( FD_UNLIKELY( fcntl( cmd_fd, F_GETFD )<0 ) ) {
+    errno = EBADF;
+    return NULL;
+  }
+  fd_memset( uverbs, 0, sizeof(*uverbs) );
+  uverbs->cmd_fd   = cmd_fd;
+  uverbs->async_fd = -1;
+  uverbs->port_num = port_num;
+  return uverbs;
+}
+
 static fd_uverbs_ctx_t *
 fd_uverbs_open_context( fd_uverbs_ctx_t * ctx,
                         fd_mlx5_caps_t *  caps,
                         char const *      rdma_name,
                         uint              port_num ) {
-  fd_memset( ctx, 0, sizeof(*ctx) );
   fd_memset( caps, 0, sizeof(*caps) );
-  ctx->cmd_fd   = -1;
-  ctx->async_fd = -1;
-  if( FD_UNLIKELY( !port_num || port_num>(uint)UCHAR_MAX ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  ctx->port_num = port_num;
 
-  char uverbs_name[ FD_UVERBS_NAME_MAX ];
-  if( FD_UNLIKELY( fd_uverbs_resolve( uverbs_name, rdma_name ) ) ) return NULL;
+  int cmd_fd = fd_uverbs_open_cmd_fd( rdma_name );
+  if( FD_UNLIKELY( cmd_fd<0 ) ) return NULL;
 
-  char path[ FD_RDMA_PATH_MAX ];
-  FD_TEST( fd_cstr_printf_check( path, sizeof(path), NULL, "/dev/infiniband/%s", uverbs_name ) );
-  ctx->cmd_fd = open( path, O_RDWR | O_CLOEXEC );
-  if( FD_UNLIKELY( ctx->cmd_fd<0 ) ) return NULL;
-
-  struct stat cmd_fd_stat;
-  if( FD_UNLIKELY( fstat( ctx->cmd_fd, &cmd_fd_stat ) ) ) return NULL;
-  if( FD_UNLIKELY( !S_ISCHR( cmd_fd_stat.st_mode ) ) ) {
-    errno = ENODEV;
+  if( FD_UNLIKELY( !fd_uverbs_join( ctx, cmd_fd, port_num ) ) ) {
+    int err = errno;
+    close( cmd_fd );
+    errno = err;
     return NULL;
   }
 
-  if( FD_UNLIKELY( fd_uverbs_get_context( ctx, caps )  ||
-                   fd_uverbs_query_device( ctx, caps ) ||
-                   fd_uverbs_query_port( ctx ) ) ) return NULL;
+  int cmd_fd_flags = fcntl( cmd_fd, F_GETFD );
+  if( FD_UNLIKELY(
+      cmd_fd_flags<0                                    ||
+      fcntl( cmd_fd, F_SETFD, cmd_fd_flags|FD_CLOEXEC ) ||
+      fd_uverbs_get_context( ctx, caps )                ||
+      fd_uverbs_query_device( ctx, caps )               ||
+      fd_uverbs_query_port( ctx ) ) ) {
+    int err = errno;
+    if( ctx->async_fd>=0 ) close( ctx->async_fd ); /* opened by get_context */
+    close( cmd_fd );
+    ctx->cmd_fd   = -1;
+    ctx->async_fd = -1;
+    errno = err;
+    return NULL;
+  }
   return ctx;
 }
 
@@ -968,12 +1167,18 @@ fd_uverbs_create_qp( fd_uverbs_ctx_t * uverbs,
                      fd_mlx5_pd_t *    pd,
                      uint              rx_cq_handle,
                      uint              tx_cq_handle,
-                     uint              uar_page_id ) {
-  if( FD_UNLIKELY( !uverbs || !qp || !qp->rx_cq || !qp->tx_cq || !qp->rq || !qp->sq ||
+                     uint              uar_page_id,
+                     int               send_only ) {
+  if( FD_UNLIKELY( !uverbs || !qp || !qp->tx_cq || !qp->sq ||
                    !qp->control || !pd || pd->ctx!=uverbs ) ) {
     errno = EINVAL;
     return NULL;
   }
+  if( FD_UNLIKELY( !send_only && (!qp->rx_cq || !qp->rq) ) ) {
+    errno = EINVAL;
+    return NULL;
+  }
+  uint const rq_depth = send_only ? 0U : qp->rx_depth;
 
   fd_uverbs_create_qp_req_t  req [1];
   fd_uverbs_create_qp_resp_t resp[1];
@@ -986,14 +1191,14 @@ fd_uverbs_create_qp( fd_uverbs_ctx_t * uverbs,
   req->send_cq_handle    = tx_cq_handle;
   req->recv_cq_handle    = rx_cq_handle;
   req->max_send_wr       = qp->tx_depth;
-  req->max_recv_wr       = qp->rx_depth;
+  req->max_recv_wr       = rq_depth;
   req->max_send_sge      = 1U;
-  req->max_recv_sge      = 1U;
+  req->max_recv_sge      = send_only ? 0U : 1U;
   req->qp_type           = IB_UVERBS_QPT_RAW_PACKET;
-  req->mlx5.buf_addr     = (ulong)qp->rq;
+  req->mlx5.buf_addr     = send_only ? (ulong)qp->sq : (ulong)qp->rq;
   req->mlx5.db_addr      = (ulong)qp->control;
   req->mlx5.sq_wqe_count = qp->tx_depth;
-  req->mlx5.rq_wqe_count = qp->rx_depth;
+  req->mlx5.rq_wqe_count = rq_depth;
   req->mlx5.rq_wqe_shift = (uint)fd_ulong_find_lsb( sizeof(fd_mlx5_rx_wqe_t) );
   req->mlx5.flags        = MLX5_QP_FLAG_UAR_PAGE_INDEX;
   req->mlx5.uidx         = 0U;
@@ -1006,10 +1211,10 @@ fd_uverbs_create_qp( fd_uverbs_ctx_t * uverbs,
   }
   if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return NULL;
 
-  if( FD_UNLIKELY( resp->core.max_send_wr <qp->tx_depth ||
-                   resp->core.max_recv_wr <qp->rx_depth ||
-                   resp->core.max_send_sge<1U           ||
-                   resp->core.max_recv_sge<1U           ||
+  if( FD_UNLIKELY( resp->core.max_send_wr <qp->tx_depth        ||
+                   resp->core.max_recv_wr <rq_depth            ||
+                   resp->core.max_send_sge<1U                  ||
+                   resp->core.max_recv_sge<(send_only ? 0U:1U) ||
                    resp->core.qpn>0xffffffU ) ) {
     FD_LOG_WARNING(( "invalid mlx5 QP response (max send WRs %u, max receive WRs %u, max send SGEs %u, "
                      "max receive SGEs %u, QPN %u)",
@@ -1031,6 +1236,150 @@ fd_uverbs_start_qp( fd_uverbs_ctx_t * uverbs,
                    fd_uverbs_modify_qp( uverbs, qp, FD_MLX5_QPS_RTR  ) ||
                    fd_uverbs_modify_qp( uverbs, qp, FD_MLX5_QPS_RTS  ) ) ) return NULL;
   return qp;
+}
+
+static int
+fd_uverbs_create_wq( fd_uverbs_ctx_t *    uverbs,
+                     uint                 pd_handle,
+                     uint                 rx_cq_handle,
+                     fd_mlx5_qp_t const * qp,
+                     uint *               wq_handle ) {
+  fd_uverbs_create_wq_req_t  req [1];
+  fd_uverbs_create_wq_resp_t resp[1];
+  fd_memset( req,  0, sizeof(req ) );
+  fd_memset( resp, 0, sizeof(resp) );
+
+  ulong const core_req_sz = offsetof( fd_uverbs_create_wq_req_t, mlx5 );
+  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr(
+      &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_WQ,
+      core_req_sz, sizeof(*req), resp,
+      sizeof(resp->core), sizeof(*resp) ) ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  req->core.user_handle  = (ulong)qp;
+  req->core.pd_handle    = pd_handle;
+  req->core.cq_handle    = rx_cq_handle;
+  req->core.wq_type      = IB_UVERBS_WQT_RQ;
+  req->core.max_wr       = qp->rx_depth;
+  req->core.max_sge      = 1U;
+  req->mlx5.buf_addr     = (ulong)qp->rq;
+  req->mlx5.db_addr      = (ulong)qp->control;
+  req->mlx5.rq_wqe_count = qp->rx_depth;
+  req->mlx5.rq_wqe_shift = (uint)fd_ulong_find_lsb( sizeof(fd_mlx5_rx_wqe_t) );
+  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  if( FD_UNLIKELY( resp->core.max_wr<qp->rx_depth || resp->core.max_sge<1U ) ) {
+    FD_LOG_WARNING(( "invalid mlx5 WQ response (max WRs %u, requested %u, max SGEs %u)",
+                     resp->core.max_wr, qp->rx_depth, resp->core.max_sge ));
+    errno = EPROTO;
+    return -1;
+  }
+
+  *wq_handle = resp->core.wq_handle;
+  return 0;
+}
+
+static int
+fd_uverbs_start_wq( fd_uverbs_ctx_t * uverbs,
+                    uint              wq_handle ) {
+  fd_uverbs_modify_wq_req_t req[1];
+  fd_memset( req, 0, sizeof(req) );
+
+  ulong const core_req_sz = offsetof( fd_uverbs_modify_wq_req_t, mlx5 );
+  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_MODIFY_WQ,
+                                          core_req_sz, sizeof(*req), NULL, 0UL, 0UL ) ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  req->core.attr_mask = FD_MLX5_WQ_ATTR_STATE;
+  req->core.wq_handle = wq_handle;
+  req->core.wq_state  = FD_MLX5_WQS_RDY;
+  return fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) );
+}
+
+int
+fd_uverbs_create_rqt( fd_uverbs_ctx_t * uverbs,
+                      uint const *      wq_handle,
+                      uint              wq_cnt,
+                      uint *            rqt_handle ) {
+  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !wq_handle || !wq_cnt ||
+                   wq_cnt>FD_MLX5_RQT_SZ || !rqt_handle ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fd_uverbs_create_rqt_req_t  req [1];
+  fd_uverbs_create_rqt_resp_t resp[1];
+  fd_memset( req,  0, sizeof(req ) );
+  fd_memset( resp, 0, sizeof(resp) );
+
+  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_RWQ_IND_TBL,
+                                          sizeof(*req), sizeof(*req), resp,
+                                          sizeof(resp->core), sizeof(*resp) ) ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  req->log_ind_tbl_size = FD_MLX5_RQT_LG_SZ;
+  for( ulong i=0UL; i<FD_MLX5_RQT_SZ; i++ ) req->wq_handle[ i ] = wq_handle[ i%wq_cnt ];
+  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  *rqt_handle = resp->core.ind_tbl_handle;
+  return 0;
+}
+
+int
+fd_uverbs_create_rss_qp( fd_uverbs_ctx_t * uverbs,
+                         uint              pd_handle,
+                         uint              rqt_handle,
+                         int               inner,
+                         uint *            qp_handle,
+                         uint *            qpn ) {
+  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !qp_handle || !qpn ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fd_uverbs_create_rss_qp_req_t  req [1];
+  fd_uverbs_create_rss_qp_resp_t resp[1];
+  fd_memset( req,  0, sizeof(req ) );
+  fd_memset( resp, 0, sizeof(resp) );
+
+  ulong const core_req_sz = offsetof( fd_uverbs_create_rss_qp_req_t, mlx5 );
+  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_QP,
+                                          core_req_sz, sizeof(*req), resp,
+                                          sizeof(resp->core), sizeof(*resp) ) ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  /* An RSS QP carries neither a send nor a receive queue of its own.  It
+     exists to name the indirection table in a flow rule, so every queue
+     size stays zero and Linux skips the completion queue lookups. */
+  req->core.pd_handle          = pd_handle;
+  req->core.qp_type            = IB_UVERBS_QPT_RAW_PACKET;
+  req->core.comp_mask          = IB_UVERBS_CREATE_QP_MASK_IND_TABLE;
+  req->core.rwq_ind_tbl_handle = rqt_handle;
+
+  req->mlx5.rx_hash_function   = MLX5_RX_HASH_FUNC_TOEPLITZ;
+  req->mlx5.rx_key_len         = (uchar)FD_MLX5_RSS_KEY_SZ;
+  fd_memcpy( req->mlx5.rx_hash_key, fd_mlx5_rss_key, FD_MLX5_RSS_KEY_SZ );
+  req->mlx5.rx_hash_fields_mask = FD_MLX5_RSS_HASH_FIELDS;
+  if( inner ) {
+    req->mlx5.rx_hash_fields_mask |= MLX5_RX_HASH_INNER;
+    req->mlx5.flags                = MLX5_QP_FLAG_TUNNEL_OFFLOADS;
+  }
+  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  if( FD_UNLIKELY( resp->core.base.qpn>0xffffffU ) ) {
+    FD_LOG_WARNING(( "invalid mlx5 RSS QP response (QPN %u)", resp->core.base.qpn ));
+    errno = EPROTO;
+    return -1;
+  }
+
+  *qp_handle = resp->core.base.qp_handle;
+  *qpn       = resp->core.base.qpn;
+  return 0;
 }
 
 static int
@@ -1069,20 +1418,21 @@ fd_uverbs_init_udp_flow_req( fd_uverbs_create_udp_flow_req_t *   req,
 }
 
 int
-fd_uverbs_create_udp_flow( fd_uverbs_ctx_t *    uverbs,
-                           fd_mlx5_qp_t const * qp,
-                           uint                 dst_ip,
-                           ushort               dst_port ) {
-  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !qp || !dst_port ) ) {
+fd_uverbs_create_udp_flow( fd_uverbs_ctx_t * uverbs,
+                           uint              qp_handle,
+                           uint              dst_ip,
+                           ushort            dst_port ) {
+  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !dst_port ) ) {
     errno = EINVAL;
     return -1;
   }
 
   fd_uverbs_create_udp_flow_req_t   req [1];
   struct ib_uverbs_create_flow_resp resp[1];
-  if( FD_UNLIKELY( fd_uverbs_init_udp_flow_req( req, resp, qp->handle,
-                                                uverbs->port_num, dst_ip,
-                                                dst_port ) ) ) {
+  if( FD_UNLIKELY( fd_uverbs_init_udp_flow_req(
+        req, resp, qp_handle,
+        uverbs->port_num, dst_ip,
+        dst_port ) ) ) {
     errno = EINVAL;
     return -1;
   }
@@ -1145,20 +1495,21 @@ fd_uverbs_init_gre_flow_req( fd_uverbs_create_gre_flow_req_t *   req,
 }
 
 int
-fd_uverbs_create_gre_udp_flow( fd_uverbs_ctx_t *    uverbs,
-                               fd_mlx5_qp_t const * qp,
-                               uint                 inner_dst_ip,
-                               ushort               inner_dst_port ) {
-  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !qp || !inner_dst_port ) ) {
+fd_uverbs_create_gre_udp_flow( fd_uverbs_ctx_t * uverbs,
+                               uint              qp_handle,
+                               uint              inner_dst_ip,
+                               ushort            inner_dst_port ) {
+  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !inner_dst_port ) ) {
     errno = EINVAL;
     return -1;
   }
 
   fd_uverbs_create_gre_flow_req_t   req [1];
   struct ib_uverbs_create_flow_resp resp[1];
-  if( FD_UNLIKELY( fd_uverbs_init_gre_flow_req( req, resp, qp->handle,
-                                                uverbs->port_num, inner_dst_ip,
-                                                inner_dst_port ) ) ) {
+  if( FD_UNLIKELY( fd_uverbs_init_gre_flow_req(
+        req, resp, qp_handle,
+        uverbs->port_num, inner_dst_ip,
+        inner_dst_port ) ) ) {
     errno = EINVAL;
     return -1;
   }
@@ -1201,10 +1552,90 @@ fd_uverbs_init( fd_uverbs_ctx_t * uverbs,
                    !fd_uverbs_create_cq( &tx_cq_handle, uverbs, tx_cq, uar_page_id, caps->max_cqe ) ||
                    !fd_uverbs_alloc_pd( pd, uverbs ) ||
                    !fd_uverbs_register_mr( &qp->lkey, pd, packet_memory, packet_memory_sz, caps->max_mr_size ) ||
-                   !fd_uverbs_create_qp( uverbs, qp, pd, rx_cq_handle, tx_cq_handle, uar_page_id ) ||
+                   !fd_uverbs_create_qp( uverbs, qp, pd, rx_cq_handle, tx_cq_handle, uar_page_id, 0 ) ||
                    !fd_uverbs_start_qp( uverbs, qp ) ) ) return NULL;
   qp->tx_inline_hdr_sz = caps->eth_min_inline_hdr_sz;
   return qp;
+}
+
+int
+fd_uverbs_open_shared( fd_uverbs_ctx_t * uverbs,
+                       fd_mlx5_caps_t *  caps,
+                       uint *            pd_handle ) {
+  if( FD_UNLIKELY( !uverbs || uverbs->cmd_fd<0 || !caps || !pd_handle ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  fd_memset( caps, 0, sizeof(*caps) );
+
+  if( FD_UNLIKELY(
+      fd_uverbs_get_context( uverbs, caps )  ||
+      fd_uverbs_query_device( uverbs, caps ) ||
+      fd_uverbs_query_port( uverbs ) ) ) return -1;
+
+  fd_mlx5_pd_t pd[1];
+  if( FD_UNLIKELY( !fd_uverbs_alloc_pd( pd, uverbs ) ) ) return -1;
+  *pd_handle = pd->handle;
+  return 0;
+}
+
+int
+fd_uverbs_init_rss_tile( fd_uverbs_ctx_t *      uverbs,
+                         fd_mlx5_caps_t const * caps,
+                         uint                   pd_handle,
+                         fd_mlx5_qp_t *         qp,
+                         void *                 packet_memory,
+                         ulong                  packet_memory_sz,
+                         uint *                 wq_handle ) {
+  if( FD_UNLIKELY(
+      !uverbs || !caps || !qp || !wq_handle ||
+      !qp->rx_cq || !qp->tx_cq ||
+      uverbs->cmd_fd<0 ||
+      qp->rx_depth!=qp->rx_cq->depth ||
+      qp->tx_depth!=qp->tx_cq->depth ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  if( FD_UNLIKELY(
+      !fd_uint_is_pow2( qp->rx_depth ) ||
+      !fd_uint_is_pow2( qp->tx_depth ) ||
+      qp->rx_depth    > caps->max_recv_wr  ||
+      qp->tx_depth    > caps->max_send_wqe ||
+      qp->rx_depth-1U > caps->max_cqe      ||
+      qp->tx_depth-1U > caps->max_cqe
+  ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fd_mlx5_pd_t pd[1] = {{ .ctx = uverbs, .handle = pd_handle }};
+
+  uint uar_page_id;
+  uint rx_cq_handle;
+  uint tx_cq_handle;
+  qp->sq_doorbell = fd_uverbs_map_uar( uverbs, &uar_page_id );
+  if( FD_UNLIKELY(
+      !qp->sq_doorbell ||
+      !fd_uverbs_create_cq( &rx_cq_handle, uverbs, qp->rx_cq, uar_page_id, caps->max_cqe ) ||
+      !fd_uverbs_create_cq( &tx_cq_handle, uverbs, qp->tx_cq, uar_page_id, caps->max_cqe ) ||
+      !fd_uverbs_register_mr( &qp->lkey, pd, packet_memory, packet_memory_sz, caps->max_mr_size ) ) ) {
+    return -1;
+  }
+
+  if( FD_UNLIKELY(
+      fd_uverbs_create_wq( uverbs, pd_handle, rx_cq_handle, qp, wq_handle ) ||
+      fd_uverbs_start_wq( uverbs, *wq_handle ) ) ) {
+    return -1;
+  }
+
+  if( FD_UNLIKELY(
+      !fd_uverbs_create_qp( uverbs, qp, pd, tx_cq_handle, tx_cq_handle, uar_page_id, 1 ) ||
+      !fd_uverbs_start_qp( uverbs, qp ) ) ) {
+    return -1;
+  }
+
+  qp->tx_inline_hdr_sz = caps->eth_min_inline_hdr_sz;
+  return 0;
 }
 
 #define FD_MLX5_NL_RECV_BUF_SZ (8192UL)

--- a/src/disco/net/mlx5/fd_mlx5.c
+++ b/src/disco/net/mlx5/fd_mlx5.c
@@ -147,52 +147,30 @@ struct fd_mlx5_pd {
 };
 typedef struct fd_mlx5_pd fd_mlx5_pd_t;
 
-/* fd_uverbs_* types define Linux uverbs requests and responses */
-struct fd_uverbs_ex_hdr {
-  struct ib_uverbs_cmd_hdr    cmd;
-  struct ib_uverbs_ex_cmd_hdr ex;
-};
-typedef struct fd_uverbs_ex_hdr fd_uverbs_ex_hdr_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_ex_hdr_t)==24UL, uverbs_ex_hdr_sz );
-
-struct fd_uverbs_get_context_req {
-  struct ib_uverbs_cmd_hdr             hdr;
-  ulong                                response;
-  struct mlx5_ib_alloc_ucontext_req_v2 mlx5;
-};
-typedef struct fd_uverbs_get_context_req fd_uverbs_get_context_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_get_context_req_t)==48UL, uverbs_get_context_req_sz );
-
-struct fd_uverbs_get_context_resp {
-  uint                               async_fd;
-  uint                               num_comp_vectors;
-  struct mlx5_ib_alloc_ucontext_resp mlx5;
-};
-typedef struct fd_uverbs_get_context_resp fd_uverbs_get_context_resp_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_get_context_resp_t)==80UL, uverbs_get_context_resp_sz );
+/* fd_uverbs_* types define Linux uverbs requests and responses.  Requests
+   of the uverbs core start with a response pointer that the ioctl
+   transport leaves unused, but that Linux still counts towards the
+   request size. */
 
 struct fd_uverbs_query_device_req {
-  struct ib_uverbs_cmd_hdr hdr;
-  ulong                    response;
+  ulong response;
 };
 typedef struct fd_uverbs_query_device_req fd_uverbs_query_device_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_query_device_req_t)==16UL, uverbs_query_device_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_query_device_req_t)==8UL, uverbs_query_device_req_sz );
 
 struct fd_uverbs_query_port_req {
-  struct ib_uverbs_cmd_hdr hdr;
-  ulong                    response;
-  uchar                    port_num;
-  uchar                    reserved[ 7 ];
+  ulong response;
+  uchar port_num;
+  uchar reserved[ 7 ];
 };
 typedef struct fd_uverbs_query_port_req fd_uverbs_query_port_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_query_port_req_t)==24UL, uverbs_query_port_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_query_port_req_t)==16UL, uverbs_query_port_req_sz );
 
 struct fd_uverbs_alloc_pd_req {
-  struct ib_uverbs_cmd_hdr hdr;
-  ulong                    response;
+  ulong response;
 };
 typedef struct fd_uverbs_alloc_pd_req fd_uverbs_alloc_pd_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_alloc_pd_req_t)==16UL, uverbs_alloc_pd_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_alloc_pd_req_t)==8UL, uverbs_alloc_pd_req_sz );
 
 struct fd_uverbs_alloc_pd_resp {
   uint                         pd_handle;
@@ -202,7 +180,6 @@ typedef struct fd_uverbs_alloc_pd_resp fd_uverbs_alloc_pd_resp_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_alloc_pd_resp_t)==8UL, uverbs_alloc_pd_resp_sz );
 
 struct fd_uverbs_reg_mr_req {
-  struct ib_uverbs_cmd_hdr hdr;
   ulong                    response;
   ulong                    start;
   ulong                    length;
@@ -211,7 +188,7 @@ struct fd_uverbs_reg_mr_req {
   uint                     access_flags;
 };
 typedef struct fd_uverbs_reg_mr_req fd_uverbs_reg_mr_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_reg_mr_req_t)==48UL, uverbs_reg_mr_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_reg_mr_req_t)==40UL, uverbs_reg_mr_req_sz );
 
 struct fd_uverbs_reg_mr_resp {
   uint mr_handle;
@@ -233,22 +210,17 @@ struct fd_uverbs_ioctl_hdr {
 typedef struct fd_uverbs_ioctl_hdr fd_uverbs_ioctl_hdr_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_ioctl_hdr_t)==24UL, uverbs_ioctl_hdr_sz );
 
-struct fd_uverbs_alloc_uar_req {
-  fd_uverbs_ioctl_hdr_t hdr;
-  struct ib_uverbs_attr attrs[ 5 ];
-};
-typedef struct fd_uverbs_alloc_uar_req fd_uverbs_alloc_uar_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_alloc_uar_req_t)==104UL, uverbs_alloc_uar_req_sz );
+/* FD_UVERBS_ATTR_MAX is the largest attribute count of any command that
+   this file submits. */
+#define FD_UVERBS_ATTR_MAX (5UL)
 
-struct fd_uverbs_destroy_uar_req {
+struct fd_uverbs_ioctl_req {
   fd_uverbs_ioctl_hdr_t hdr;
-  struct ib_uverbs_attr attrs[ 1 ];
+  struct ib_uverbs_attr attrs[ FD_UVERBS_ATTR_MAX ];
 };
-typedef struct fd_uverbs_destroy_uar_req fd_uverbs_destroy_uar_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_destroy_uar_req_t)==40UL, uverbs_destroy_uar_req_sz );
+typedef struct fd_uverbs_ioctl_req fd_uverbs_ioctl_req_t;
 
 struct fd_uverbs_create_cq_req {
-  struct ib_uverbs_cmd_hdr hdr;
   ulong                    response;
   ulong                    user_handle;
   uint                     cqe;
@@ -275,16 +247,14 @@ typedef struct fd_uverbs_create_cq_resp fd_uverbs_create_cq_resp_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_create_cq_resp_t)==16UL, uverbs_create_cq_resp_sz );
 
 struct fd_uverbs_destroy_cq_req {
-  struct ib_uverbs_cmd_hdr hdr;
-  ulong                    response;
-  uint                     cq_handle;
-  uint                     reserved;
+  ulong response;
+  uint  cq_handle;
+  uint  reserved;
 };
 typedef struct fd_uverbs_destroy_cq_req fd_uverbs_destroy_cq_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_destroy_cq_req_t)==24UL, uverbs_destroy_cq_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_destroy_cq_req_t)==16UL, uverbs_destroy_cq_req_sz );
 
 struct fd_uverbs_create_qp_req {
-  struct ib_uverbs_cmd_hdr hdr;
   ulong                    response;
   ulong                    user_handle;
   uint                     pd_handle;
@@ -310,20 +280,12 @@ struct fd_uverbs_create_qp_resp {
 };
 typedef struct fd_uverbs_create_qp_resp fd_uverbs_create_qp_resp_t;
 
-struct fd_uverbs_modify_qp_req {
-  struct ib_uverbs_cmd_hdr   hdr;
-  struct ib_uverbs_modify_qp core;
-};
-typedef struct fd_uverbs_modify_qp_req fd_uverbs_modify_qp_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_modify_qp_req_t)==120UL, uverbs_modify_qp_req_sz );
-
 struct fd_uverbs_create_wq_req {
-  fd_uverbs_ex_hdr_t            hdr;
   struct ib_uverbs_ex_create_wq core;
   struct mlx5_ib_create_wq      mlx5;
 };
 typedef struct fd_uverbs_create_wq_req fd_uverbs_create_wq_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_create_wq_req_t)==112UL, uverbs_create_wq_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_wq_req_t)==88UL, uverbs_create_wq_req_sz );
 
 struct fd_uverbs_create_wq_resp {
   struct ib_uverbs_ex_create_wq_resp core;
@@ -333,21 +295,19 @@ typedef struct fd_uverbs_create_wq_resp fd_uverbs_create_wq_resp_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_create_wq_resp_t)==32UL, uverbs_create_wq_resp_sz );
 
 struct fd_uverbs_modify_wq_req {
-  fd_uverbs_ex_hdr_t            hdr;
   struct ib_uverbs_ex_modify_wq core;
   struct mlx5_ib_modify_wq      mlx5;
 };
 typedef struct fd_uverbs_modify_wq_req fd_uverbs_modify_wq_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_modify_wq_req_t)==56UL, uverbs_modify_wq_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_modify_wq_req_t)==32UL, uverbs_modify_wq_req_sz );
 
 struct fd_uverbs_create_rqt_req {
-  fd_uverbs_ex_hdr_t hdr;
-  uint               comp_mask;
-  uint               log_ind_tbl_size;
-  uint               wq_handle[ FD_MLX5_RQT_SZ ];
+  uint comp_mask;
+  uint log_ind_tbl_size;
+  uint wq_handle[ FD_MLX5_RQT_SZ ];
 };
 typedef struct fd_uverbs_create_rqt_req fd_uverbs_create_rqt_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rqt_req_t)==544UL, uverbs_create_rqt_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rqt_req_t)==520UL, uverbs_create_rqt_req_sz );
 
 struct fd_uverbs_create_rqt_resp {
   struct ib_uverbs_ex_create_rwq_ind_table_resp core;
@@ -357,12 +317,11 @@ typedef struct fd_uverbs_create_rqt_resp fd_uverbs_create_rqt_resp_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rqt_resp_t)==24UL, uverbs_create_rqt_resp_sz );
 
 struct fd_uverbs_create_rss_qp_req {
-  fd_uverbs_ex_hdr_t            hdr;
   struct ib_uverbs_ex_create_qp core;
   struct mlx5_ib_create_qp_rss  mlx5;
 };
 typedef struct fd_uverbs_create_rss_qp_req fd_uverbs_create_rss_qp_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rss_qp_req_t)==240UL, uverbs_create_rss_qp_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rss_qp_req_t)==216UL, uverbs_create_rss_qp_req_sz );
 
 struct fd_uverbs_create_rss_qp_resp {
   struct ib_uverbs_ex_create_qp_resp core;
@@ -372,7 +331,6 @@ typedef struct fd_uverbs_create_rss_qp_resp fd_uverbs_create_rss_qp_resp_t;
 FD_STATIC_ASSERT( sizeof(fd_uverbs_create_rss_qp_resp_t)==80UL, uverbs_create_rss_qp_resp_sz );
 
 struct fd_uverbs_create_udp_flow_req {
-  fd_uverbs_ex_hdr_t                 hdr;
   uint                               comp_mask;
   uint                               qp_handle;
   uint                               type;
@@ -389,10 +347,9 @@ struct fd_uverbs_create_udp_flow_req {
   uint                               mlx5_reserved;
 };
 typedef struct fd_uverbs_create_udp_flow_req fd_uverbs_create_udp_flow_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_create_udp_flow_req_t)==144UL, uverbs_create_udp_flow_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_udp_flow_req_t)==120UL, uverbs_create_udp_flow_req_sz );
 
 struct fd_uverbs_create_gre_flow_req {
-  fd_uverbs_ex_hdr_t                 hdr;
   uint                               comp_mask;
   uint                               qp_handle;
   uint                               type;
@@ -411,7 +368,7 @@ struct fd_uverbs_create_gre_flow_req {
   uint                               mlx5_reserved;
 };
 typedef struct fd_uverbs_create_gre_flow_req fd_uverbs_create_gre_flow_req_t;
-FD_STATIC_ASSERT( sizeof(fd_uverbs_create_gre_flow_req_t)==200UL, uverbs_create_gre_flow_req_sz );
+FD_STATIC_ASSERT( sizeof(fd_uverbs_create_gre_flow_req_t)==176UL, uverbs_create_gre_flow_req_sz );
 
 #define FD_RDMA_PATH_MAX (256UL)
 
@@ -674,109 +631,165 @@ fd_uverbs_resolve( char         uverbs_name[ FD_UVERBS_NAME_MAX ],
   return 0;
 }
 
-static int
-fd_uverbs_init_cmd_hdr( struct ib_uverbs_cmd_hdr * hdr,
-                        uint                       command,
-                        ulong                      request_sz,
-                        ulong                      response_sz ) {
-  if( FD_UNLIKELY( !hdr || command>IB_USER_VERBS_CMD_COMMAND_MASK || request_sz<sizeof(*hdr) ) ) return -1;
+static void
+fd_uverbs_init_ioctl_attr( struct ib_uverbs_attr * attr,
+                           ushort                  attr_id,
+                           ushort                  len,
+                           ulong                   data ) {
+  fd_memset( attr, 0, sizeof(*attr) );
+  attr->attr_id = attr_id;
+  attr->len     = len;
+  attr->flags   = UVERBS_ATTR_F_MANDATORY;
+  attr->data    = data;
+}
 
-  hdr->command   = command;
-  hdr->in_words  = (ushort)(request_sz / 4UL);
-  hdr->out_words = (ushort)(response_sz / 4UL);
-  return 0;
+/* fd_uverbs_init_ioctl_in_attr sets an input attribute.  Linux reads
+   inputs of up to 8 bytes out of the attribute itself, and follows the
+   pointer for anything larger. */
+
+static void
+fd_uverbs_init_ioctl_in_attr( struct ib_uverbs_attr * attr,
+                              ushort                  attr_id,
+                              void const *            data,
+                              ulong                   data_sz ) {
+  ulong value = (ulong)data;
+  if( data_sz<=sizeof(value) ) {
+    value = 0UL;
+    fd_memcpy( &value, data, data_sz );
+  }
+  fd_uverbs_init_ioctl_attr( attr, attr_id, (ushort)data_sz, value );
 }
 
 static int
-fd_uverbs_init_ex_hdr( fd_uverbs_ex_hdr_t * hdr,
-                       uint                 command,
-                       ulong                core_request_sz,
-                       ulong                request_sz,
-                       void *               response,
-                       ulong                core_response_sz,
-                       ulong                response_sz ) {
-  ulong const hdr_sz = sizeof(*hdr);
-  if( FD_UNLIKELY( !hdr || command>IB_USER_VERBS_CMD_COMMAND_MASK ||
-                   core_request_sz<hdr_sz || request_sz<core_request_sz ||
-                   response_sz<core_response_sz || (response_sz && !response) ) ) return -1;
-
-  hdr->cmd.command           = IB_USER_VERBS_CMD_FLAG_EXTENDED | command;
-  hdr->cmd.in_words          = (ushort)((core_request_sz-hdr_sz) / 8UL);
-  hdr->cmd.out_words         = (ushort)(core_response_sz / 8UL);
-  hdr->ex.provider_in_words  = (ushort)((request_sz-core_request_sz) / 8UL);
-  hdr->ex.provider_out_words = (ushort)((response_sz-core_response_sz) / 8UL);
-  hdr->ex.response           = (ulong)response;
-  hdr->ex.cmd_hdr_reserved   = 0U;
-  return 0;
+fd_uverbs_ioctl( int                     cmd_fd,
+                 fd_uverbs_ioctl_req_t * req,
+                 uint                    object_id,
+                 uint                    method_id,
+                 ulong                   attr_cnt ) {
+  if( FD_UNLIKELY( cmd_fd<0 || attr_cnt>FD_UVERBS_ATTR_MAX ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+  req->hdr.length    = (ushort)( sizeof(req->hdr) + attr_cnt*sizeof(req->attrs[0]) );
+  req->hdr.object_id = (ushort)object_id;
+  req->hdr.method_id = (ushort)method_id;
+  req->hdr.num_attrs = (ushort)attr_cnt;
+  req->hdr.driver_id = RDMA_DRIVER_MLX5;
+  return ioctl( cmd_fd, RDMA_VERBS_IOCTL, &req->hdr );
 }
 
+/* fd_uverbs_cmd_t describes a uverbs command of the legacy write ABI.
+   core_in and core_out are the request and response of the uverbs core,
+   uhw_in and uhw_out the mlx5 driver payloads.  Linux tunnels these
+   commands through the ioctl ABI, which unlike write() is permitted after
+   the calling process changed credentials, as tiles do when they exec. */
+
+struct fd_uverbs_cmd {
+  uint         cmd;
+  void const * core_in;
+  ulong        core_in_sz;
+  void *       core_out;
+  ulong        core_out_sz;
+  void const * uhw_in;
+  ulong        uhw_in_sz;
+  void *       uhw_out;
+  ulong        uhw_out_sz;
+};
+typedef struct fd_uverbs_cmd fd_uverbs_cmd_t;
+
 static int
-fd_uverbs_write_cmd( int          cmd_fd,
-                     void const * req,
-                     ulong        req_sz ) {
-  ssize_t write_sz = write( cmd_fd, req, req_sz );
-  if( FD_UNLIKELY( write_sz<0 ) ) return -1;
-  if( FD_UNLIKELY( (ulong)write_sz!=req_sz ) ) {
+fd_uverbs_exec_cmd( int                     cmd_fd,
+                    fd_uverbs_cmd_t const * cmd ) {
+  if( FD_UNLIKELY( cmd->core_in_sz >USHORT_MAX || cmd->core_out_sz>USHORT_MAX ||
+                   cmd->uhw_in_sz  >USHORT_MAX || cmd->uhw_out_sz >USHORT_MAX ) ) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  fd_uverbs_ioctl_req_t req[1];
+  fd_memset( req, 0, sizeof(req) );
+
+  ulong attr_cnt = 0UL;
+  fd_uverbs_init_ioctl_attr( req->attrs+attr_cnt++, UVERBS_ATTR_WRITE_CMD, sizeof(ulong), cmd->cmd );
+  if( cmd->core_in )
+    fd_uverbs_init_ioctl_in_attr( req->attrs+attr_cnt++, UVERBS_ATTR_CORE_IN, cmd->core_in, cmd->core_in_sz );
+  if( cmd->core_out )
+    fd_uverbs_init_ioctl_attr( req->attrs+attr_cnt++, UVERBS_ATTR_CORE_OUT, (ushort)cmd->core_out_sz, (ulong)cmd->core_out );
+  if( cmd->uhw_in )
+    fd_uverbs_init_ioctl_in_attr( req->attrs+attr_cnt++, UVERBS_ATTR_UHW_IN, cmd->uhw_in, cmd->uhw_in_sz );
+  if( cmd->uhw_out )
+    fd_uverbs_init_ioctl_attr( req->attrs+attr_cnt++, UVERBS_ATTR_UHW_OUT,  (ushort)cmd->uhw_out_sz,  (ulong)cmd->uhw_out  );
+
+  return fd_uverbs_ioctl( cmd_fd, req, UVERBS_OBJECT_DEVICE, UVERBS_METHOD_INVOKE_WRITE, attr_cnt );
+}
+
+/* fd_uverbs_alloc_async_fd creates the file descriptor that reports
+   device and queue errors. */
+
+static int
+fd_uverbs_alloc_async_fd( fd_uverbs_ctx_t * ctx ) {
+  fd_uverbs_ioctl_req_t req[1];
+  fd_memset( req, 0, sizeof(req) );
+  fd_uverbs_init_ioctl_attr( req->attrs+0, UVERBS_ATTR_ASYNC_EVENT_ALLOC_FD_HANDLE, 0U, 0UL );
+  if( FD_UNLIKELY( fd_uverbs_ioctl( ctx->cmd_fd, req, UVERBS_OBJECT_ASYNC_EVENT,
+                                    UVERBS_METHOD_ASYNC_EVENT_ALLOC, 1UL ) ) ) return -1;
+
+  long const async_fd = (long)req->attrs[0].data_s64;
+  if( FD_UNLIKELY( async_fd<0L || async_fd>(long)INT_MAX ) ) {
     errno = EPROTO;
     return -1;
   }
+  ctx->async_fd = (int)async_fd;
   return 0;
 }
 
 static int
 fd_uverbs_get_context( fd_uverbs_ctx_t * ctx,
                        fd_mlx5_caps_t *  caps ) {
-  fd_uverbs_get_context_req_t req [1];
-  fd_uverbs_get_context_resp_t resp[1];
+  struct mlx5_ib_alloc_ucontext_req_v2 req [1];
+  struct mlx5_ib_alloc_ucontext_resp   resp[1];
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  req->response                    = (ulong)resp;
-  req->mlx5.total_num_bfregs       = 16U;
-  req->mlx5.num_low_latency_bfregs = 4U;
-  req->mlx5.max_cqe_version        = 1U;
-  req->mlx5.lib_caps               = MLX5_LIB_CAP_4K_UAR | MLX5_LIB_CAP_DYN_UAR;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_GET_CONTEXT,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( ctx->cmd_fd, req, sizeof(req) ) ) ) return -1;
-  if( FD_UNLIKELY( resp->async_fd>(uint)INT_MAX ) ) {
-    errno = EPROTO;
-    return -1;
-  }
+  req->total_num_bfregs       = 16U;
+  req->num_low_latency_bfregs = 4U;
+  req->max_cqe_version        = 1U;
+  req->lib_caps               = MLX5_LIB_CAP_4K_UAR | MLX5_LIB_CAP_DYN_UAR;
 
-  ctx->async_fd = (int)resp->async_fd;
-  int fd_flags = fcntl( ctx->async_fd, F_GETFD );
-  if( FD_UNLIKELY( fd_flags<0 || fcntl( ctx->async_fd, F_SETFD, fd_flags | FD_CLOEXEC ) ) ) return -1;
+  fd_uverbs_ioctl_req_t ioctl_req[1];
+  fd_memset( ioctl_req, 0, sizeof(ioctl_req) );
+  fd_uverbs_init_ioctl_in_attr( ioctl_req->attrs+0, UVERBS_ATTR_UHW_IN, req, sizeof(req) );
+  fd_uverbs_init_ioctl_attr( ioctl_req->attrs+1, UVERBS_ATTR_UHW_OUT, (ushort)sizeof(resp), (ulong)resp );
+  if( FD_UNLIKELY( fd_uverbs_ioctl( ctx->cmd_fd, ioctl_req, UVERBS_OBJECT_DEVICE,
+                                    UVERBS_METHOD_GET_CONTEXT, 2UL ) ) ) return -1;
+  if( FD_UNLIKELY( fd_uverbs_alloc_async_fd( ctx ) ) ) return -1;
 
   ulong const uar_resp_sz = offsetof( struct mlx5_ib_alloc_ucontext_resp, num_uars_per_page )+
-                            sizeof(resp->mlx5.num_uars_per_page);
-  if( FD_UNLIKELY( resp->mlx5.response_length<uar_resp_sz                              ||
-                   resp->mlx5.cqe_version>1U                                           ||
-                   resp->mlx5.max_sq_desc_sz<sizeof(fd_mlx5_tx_wqe_t)                  ||
-                   resp->mlx5.max_rq_desc_sz<sizeof(fd_mlx5_rx_wqe_t)                  ||
-                   resp->mlx5.log_uar_size!=(uint)fd_ulong_find_lsb( FD_MLX5_PAGE_SZ ) ||
-                   resp->mlx5.num_uars_per_page!=1U                                    ||
-                   resp->mlx5.tot_bfregs ) ) {
+                            sizeof(resp->num_uars_per_page);
+  if( FD_UNLIKELY( resp->response_length<uar_resp_sz                              ||
+                   resp->cqe_version>1U                                           ||
+                   resp->max_sq_desc_sz<sizeof(fd_mlx5_tx_wqe_t)                  ||
+                   resp->max_rq_desc_sz<sizeof(fd_mlx5_rx_wqe_t)                  ||
+                   resp->log_uar_size!=(uint)fd_ulong_find_lsb( FD_MLX5_PAGE_SZ ) ||
+                   resp->num_uars_per_page!=1U                                    ||
+                   resp->tot_bfregs ) ) {
     FD_LOG_WARNING(( "unsupported mlx5 context capabilities (response length %u, CQE version %u, "
                      "max SQ descriptor %u, max RQ descriptor %u, log UAR size %u, UARs per page %u, "
                      "legacy BF registers %u)",
-                     resp->mlx5.response_length, (uint)resp->mlx5.cqe_version,
-                     (uint)resp->mlx5.max_sq_desc_sz, (uint)resp->mlx5.max_rq_desc_sz,
-                     resp->mlx5.log_uar_size, resp->mlx5.num_uars_per_page, resp->mlx5.tot_bfregs ));
+                     resp->response_length, (uint)resp->cqe_version,
+                     (uint)resp->max_sq_desc_sz, (uint)resp->max_rq_desc_sz,
+                     resp->log_uar_size, resp->num_uars_per_page, resp->tot_bfregs ));
     errno = EPROTONOSUPPORT;
     return -1;
   }
 
-  caps->max_send_wqe = resp->mlx5.max_send_wqebb;
-  caps->max_recv_wr  = resp->mlx5.max_recv_wr;
-  switch( resp->mlx5.eth_min_inline ) {
+  caps->max_send_wqe = resp->max_send_wqebb;
+  caps->max_recv_wr  = resp->max_recv_wr;
+  switch( resp->eth_min_inline ) {
   case MLX5_USER_INLINE_MODE_NONE: caps->eth_min_inline_hdr_sz = 0U;                        break;
   case MLX5_USER_INLINE_MODE_L2:   caps->eth_min_inline_hdr_sz = FD_MLX5_ETH_INLINE_HDR_SZ; break;
   default:
-    FD_LOG_WARNING(( "unsupported mlx5 minimum inline mode %u", (uint)resp->mlx5.eth_min_inline ));
+    FD_LOG_WARNING(( "unsupported mlx5 minimum inline mode %u", (uint)resp->eth_min_inline ));
     errno = EPROTONOSUPPORT;
     return -1;
   }
@@ -791,13 +804,12 @@ fd_uverbs_query_device( fd_uverbs_ctx_t * ctx,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  req->response = (ulong)resp;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_QUERY_DEVICE,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( ctx->cmd_fd, req, sizeof(req) ) ) ) return -1;
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_QUERY_DEVICE,
+    .core_in     = req,  .core_in_sz  = sizeof(req ),
+    .core_out    = resp, .core_out_sz = sizeof(resp)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( ctx->cmd_fd, &cmd ) ) ) return -1;
 
   caps->max_mr_size = resp->max_mr_size;
   caps->max_cqe     = resp->max_cqe;
@@ -820,14 +832,13 @@ fd_uverbs_query_port( fd_uverbs_ctx_t * ctx ) {
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  req->response = (ulong)resp;
   req->port_num = (uchar)ctx->port_num;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_QUERY_PORT,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( ctx->cmd_fd, req, sizeof(req) ) ) ) return -1;
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_QUERY_PORT,
+    .core_in     = req,  .core_in_sz  = sizeof(req ),
+    .core_out    = resp, .core_out_sz = sizeof(resp)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( ctx->cmd_fd, &cmd ) ) ) return -1;
 
   if( FD_UNLIKELY( resp->link_layer!=FD_MLX5_LINK_LAYER_ETHERNET ) ) {
     FD_LOG_WARNING(( "unsupported mlx5 link layer %u, expected Ethernet (%u)",
@@ -932,13 +943,13 @@ fd_uverbs_alloc_pd( fd_mlx5_pd_t *      pd,
   fd_uverbs_alloc_pd_resp_t resp[1];
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
-  req->response = (ulong)resp;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_ALLOC_PD,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( ctx->cmd_fd, req, sizeof(req) ) ) ) return NULL;
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_ALLOC_PD,
+    .core_in     = req,              .core_in_sz  = sizeof(req),
+    .core_out    = &resp->pd_handle, .core_out_sz = sizeof(resp->pd_handle),
+    .uhw_out     = &resp->mlx5,      .uhw_out_sz  = sizeof(resp->mlx5)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( ctx->cmd_fd, &cmd ) ) ) return NULL;
 
   pd->ctx    = ctx;
   pd->handle = resp->pd_handle;
@@ -962,78 +973,29 @@ fd_uverbs_register_mr( uint *         lkey,
   fd_uverbs_reg_mr_resp_t resp[1];
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
-  req->response     = (ulong)resp;
   req->start        = memory_addr;
   req->length       = memory_sz;
   req->hca_va       = memory_addr;
   req->pd_handle    = pd->handle;
   req->access_flags = IB_UVERBS_ACCESS_LOCAL_WRITE;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_REG_MR,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( pd->ctx->cmd_fd, req, sizeof(req) ) ) ) return NULL;
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_REG_MR,
+    .core_in     = req,  .core_in_sz  = sizeof(req ),
+    .core_out    = resp, .core_out_sz = sizeof(resp)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( pd->ctx->cmd_fd, &cmd ) ) ) return NULL;
 
   *lkey = resp->lkey;
   return lkey;
 }
 
-static void
-fd_uverbs_init_ioctl_attr( struct ib_uverbs_attr * attr,
-                           ushort                  attr_id,
-                           ushort                  len,
-                           ulong                   data ) {
-  fd_memset( attr, 0, sizeof(*attr) );
-  attr->attr_id = attr_id;
-  attr->len     = len;
-  attr->flags   = UVERBS_ATTR_F_MANDATORY;
-  attr->data    = data;
-}
-
-static int
-fd_uverbs_init_alloc_uar_req( fd_uverbs_alloc_uar_req_t * req,
-                              ulong *                     mmap_offset,
-                              uint *                      mmap_sz,
-                              uint *                      page_id ) {
-  if( FD_UNLIKELY( !req || !mmap_offset || !mmap_sz || !page_id ) ) return -1;
-  fd_memset( req, 0, sizeof(*req) );
-  req->hdr.length    = (ushort)sizeof(*req);
-  req->hdr.object_id = MLX5_IB_OBJECT_UAR;
-  req->hdr.method_id = MLX5_IB_METHOD_UAR_OBJ_ALLOC;
-  req->hdr.num_attrs = 5U;
-  req->hdr.driver_id = RDMA_DRIVER_MLX5;
-  fd_uverbs_init_ioctl_attr( req->attrs+0, MLX5_IB_ATTR_UAR_OBJ_ALLOC_HANDLE,      0U, 0UL );
-  fd_uverbs_init_ioctl_attr( req->attrs+1, MLX5_IB_ATTR_UAR_OBJ_ALLOC_TYPE,        8U, MLX5_IB_UAPI_UAR_ALLOC_TYPE_NC );
-  fd_uverbs_init_ioctl_attr( req->attrs+2, MLX5_IB_ATTR_UAR_OBJ_ALLOC_MMAP_OFFSET, 8U, (ulong)mmap_offset );
-  fd_uverbs_init_ioctl_attr( req->attrs+3, MLX5_IB_ATTR_UAR_OBJ_ALLOC_MMAP_LENGTH, 4U, (ulong)mmap_sz );
-  fd_uverbs_init_ioctl_attr( req->attrs+4, MLX5_IB_ATTR_UAR_OBJ_ALLOC_PAGE_ID,     4U, (ulong)page_id );
-  return 0;
-}
-
-static int
-fd_uverbs_init_destroy_uar_req( fd_uverbs_destroy_uar_req_t * req,
-                                uint                          handle ) {
-  if( FD_UNLIKELY( !req ) ) return -1;
-  fd_memset( req, 0, sizeof(*req) );
-  req->hdr.length    = (ushort)sizeof(*req);
-  req->hdr.object_id = MLX5_IB_OBJECT_UAR;
-  req->hdr.method_id = MLX5_IB_METHOD_UAR_OBJ_DESTROY;
-  req->hdr.num_attrs = 1U;
-  req->hdr.driver_id = RDMA_DRIVER_MLX5;
-  fd_uverbs_init_ioctl_attr( req->attrs, MLX5_IB_ATTR_UAR_OBJ_DESTROY_HANDLE, 0U, handle );
-  return 0;
-}
-
 static int
 fd_uverbs_destroy_uar( fd_uverbs_ctx_t * ctx,
                        uint              handle ) {
-  fd_uverbs_destroy_uar_req_t req[1];
-  if( FD_UNLIKELY( fd_uverbs_init_destroy_uar_req( req, handle ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-  return ioctl( ctx->cmd_fd, RDMA_VERBS_IOCTL, &req->hdr );
+  fd_uverbs_ioctl_req_t req[1];
+  fd_memset( req, 0, sizeof(req) );
+  fd_uverbs_init_ioctl_attr( req->attrs+0, MLX5_IB_ATTR_UAR_OBJ_DESTROY_HANDLE, 0U, handle );
+  return fd_uverbs_ioctl( ctx->cmd_fd, req, MLX5_IB_OBJECT_UAR, MLX5_IB_METHOD_UAR_OBJ_DESTROY, 1UL );
 }
 
 static volatile uchar *
@@ -1051,12 +1013,15 @@ fd_uverbs_map_uar( fd_uverbs_ctx_t * ctx,
   ulong mmap_offset = 0UL;
   uint  mmap_sz     = 0U;
   uint  uar_page_id = 0U;
-  fd_uverbs_alloc_uar_req_t req[1];
-  if( FD_UNLIKELY( fd_uverbs_init_alloc_uar_req( req, &mmap_offset, &mmap_sz, &uar_page_id ) ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  if( FD_UNLIKELY( ioctl( ctx->cmd_fd, RDMA_VERBS_IOCTL, &req->hdr ) ) ) return NULL;
+  fd_uverbs_ioctl_req_t req[1];
+  fd_memset( req, 0, sizeof(req) );
+  fd_uverbs_init_ioctl_attr( req->attrs+0, MLX5_IB_ATTR_UAR_OBJ_ALLOC_HANDLE,      0U, 0UL );
+  fd_uverbs_init_ioctl_attr( req->attrs+1, MLX5_IB_ATTR_UAR_OBJ_ALLOC_TYPE,        8U, MLX5_IB_UAPI_UAR_ALLOC_TYPE_NC );
+  fd_uverbs_init_ioctl_attr( req->attrs+2, MLX5_IB_ATTR_UAR_OBJ_ALLOC_MMAP_OFFSET, 8U, (ulong)&mmap_offset );
+  fd_uverbs_init_ioctl_attr( req->attrs+3, MLX5_IB_ATTR_UAR_OBJ_ALLOC_MMAP_LENGTH, 4U, (ulong)&mmap_sz );
+  fd_uverbs_init_ioctl_attr( req->attrs+4, MLX5_IB_ATTR_UAR_OBJ_ALLOC_PAGE_ID,     4U, (ulong)&uar_page_id );
+  if( FD_UNLIKELY( fd_uverbs_ioctl( ctx->cmd_fd, req, MLX5_IB_OBJECT_UAR,
+                                    MLX5_IB_METHOD_UAR_OBJ_ALLOC, 5UL ) ) ) return NULL;
 
   ulong handle_raw = req->attrs[0].data;
   if( FD_UNLIKELY( handle_raw>UINT_MAX || mmap_sz!=FD_MLX5_PAGE_SZ ||
@@ -1103,7 +1068,6 @@ fd_uverbs_create_cq( uint *               handle,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  req->response                = (ulong)resp;
   req->user_handle             = (ulong)cq;
   req->cqe                     = cq->depth-1U;
   req->comp_channel            = -1;
@@ -1112,24 +1076,28 @@ fd_uverbs_create_cq( uint *               handle,
   req->mlx5.fields.cqe_size    = sizeof(fd_mlx5_cqe_t);
   req->mlx5.fields.flags       = MLX5_IB_CREATE_CQ_FLAGS_UAR_PAGE_INDEX;
   req->mlx5.uar.uar_page_index = (ushort)page_id;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_CREATE_CQ,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( ctx->cmd_fd, req, sizeof(req) ) ) ) return NULL;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_CREATE_CQ,
+    .core_in     = req,              .core_in_sz  = offsetof( fd_uverbs_create_cq_req_t, mlx5 ),
+    .core_out    = resp,             .core_out_sz = offsetof( fd_uverbs_create_cq_resp_t, mlx5 ),
+    .uhw_in      = &req->mlx5,       .uhw_in_sz   = sizeof(req->mlx5 ),
+    .uhw_out     = &resp->mlx5,      .uhw_out_sz  = sizeof(resp->mlx5)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( ctx->cmd_fd, &cmd ) ) ) return NULL;
   if( FD_UNLIKELY( resp->cqe!=cq->depth-1U ) ) {
     fd_uverbs_destroy_cq_req_t       destroy[1];
     struct ib_uverbs_destroy_cq_resp destroy_resp[1];
     fd_memset( destroy,      0, sizeof(destroy)      );
     fd_memset( destroy_resp, 0, sizeof(destroy_resp) );
 
-    destroy->response  = (ulong)destroy_resp;
     destroy->cq_handle = resp->cq_handle;
-    if( !fd_uverbs_init_cmd_hdr( &destroy->hdr, IB_USER_VERBS_CMD_DESTROY_CQ,
-                                 sizeof(destroy), sizeof(destroy_resp) ) ) {
-      fd_uverbs_write_cmd( ctx->cmd_fd, destroy, sizeof(destroy) );
-    }
+    fd_uverbs_cmd_t const destroy_cmd = {
+      .cmd         = IB_USER_VERBS_CMD_DESTROY_CQ,
+      .core_in     = destroy,      .core_in_sz  = sizeof(destroy     ),
+      .core_out    = destroy_resp, .core_out_sz = sizeof(destroy_resp)
+    };
+    fd_uverbs_exec_cmd( ctx->cmd_fd, &destroy_cmd );
     FD_LOG_WARNING(( "invalid mlx5 CQ response (CQEs %u, requested %u)", resp->cqe, cq->depth-1U ));
     errno = EPROTO;
     return NULL;
@@ -1143,22 +1111,20 @@ static int
 fd_uverbs_modify_qp( fd_uverbs_ctx_t * uverbs,
                      fd_mlx5_qp_t *    qp,
                      uint              state ) {
-  fd_uverbs_modify_qp_req_t req[1];
+  struct ib_uverbs_modify_qp req[1];
   fd_memset( req, 0, sizeof(req) );
-  req->core.qp_handle = qp->handle;
-  req->core.attr_mask = FD_MLX5_QP_ATTR_STATE;
-  req->core.qp_state  = (uchar)state;
+  req->qp_handle = qp->handle;
+  req->attr_mask = FD_MLX5_QP_ATTR_STATE;
+  req->qp_state  = (uchar)state;
   if( state==FD_MLX5_QPS_INIT ) {
-    req->core.attr_mask |= FD_MLX5_QP_ATTR_PORT;
-    req->core.port_num   = (uchar)uverbs->port_num;
+    req->attr_mask |= FD_MLX5_QP_ATTR_PORT;
+    req->port_num   = (uchar)uverbs->port_num;
   }
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_MODIFY_QP,
-                                           sizeof(req), 0UL ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
-  return 0;
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_MODIFY_QP,
+    .core_in     = req, .core_in_sz = sizeof(req)
+  };
+  return fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd );
 }
 
 static fd_mlx5_qp_t *
@@ -1185,7 +1151,6 @@ fd_uverbs_create_qp( fd_uverbs_ctx_t * uverbs,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  req->response          = (ulong)resp;
   req->user_handle       = (ulong)qp;
   req->pd_handle         = pd->handle;
   req->send_cq_handle    = tx_cq_handle;
@@ -1199,17 +1164,20 @@ fd_uverbs_create_qp( fd_uverbs_ctx_t * uverbs,
   req->mlx5.db_addr      = (ulong)qp->control;
   req->mlx5.sq_wqe_count = qp->tx_depth;
   req->mlx5.rq_wqe_count = rq_depth;
-  req->mlx5.rq_wqe_shift = (uint)fd_ulong_find_lsb( sizeof(fd_mlx5_rx_wqe_t) );
+  req->mlx5.rq_wqe_shift = send_only ? 0U : (uint)fd_ulong_find_lsb( sizeof(fd_mlx5_rx_wqe_t) );
   req->mlx5.flags        = MLX5_QP_FLAG_UAR_PAGE_INDEX;
   req->mlx5.uidx         = 0U;
   req->mlx5.bfreg_index  = uar_page_id;
   req->mlx5.sq_buf_addr  = (ulong)qp->sq;
-  if( FD_UNLIKELY( fd_uverbs_init_cmd_hdr( &req->hdr, IB_USER_VERBS_CMD_CREATE_QP,
-                                           sizeof(req), sizeof(resp) ) ) ) {
-    errno = EINVAL;
-    return NULL;
-  }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return NULL;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_CREATE_QP,
+    .core_in     = req,         .core_in_sz  = offsetof( fd_uverbs_create_qp_req_t, mlx5 ),
+    .core_out    = &resp->core, .core_out_sz = sizeof(resp->core),
+    .uhw_in      = &req->mlx5,  .uhw_in_sz   = sizeof(req->mlx5  ),
+    .uhw_out     = &resp->mlx5, .uhw_out_sz  = sizeof(resp->mlx5 )
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd ) ) ) return NULL;
 
   if( FD_UNLIKELY( resp->core.max_send_wr <qp->tx_depth        ||
                    resp->core.max_recv_wr <rq_depth            ||
@@ -1249,14 +1217,6 @@ fd_uverbs_create_wq( fd_uverbs_ctx_t *    uverbs,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  ulong const core_req_sz = offsetof( fd_uverbs_create_wq_req_t, mlx5 );
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr(
-      &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_WQ,
-      core_req_sz, sizeof(*req), resp,
-      sizeof(resp->core), sizeof(*resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
   req->core.user_handle  = (ulong)qp;
   req->core.pd_handle    = pd_handle;
   req->core.cq_handle    = rx_cq_handle;
@@ -1267,7 +1227,15 @@ fd_uverbs_create_wq( fd_uverbs_ctx_t *    uverbs,
   req->mlx5.db_addr      = (ulong)qp->control;
   req->mlx5.rq_wqe_count = qp->rx_depth;
   req->mlx5.rq_wqe_shift = (uint)fd_ulong_find_lsb( sizeof(fd_mlx5_rx_wqe_t) );
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_CREATE_WQ,
+    .core_in     = req,         .core_in_sz  = offsetof( fd_uverbs_create_wq_req_t, mlx5 ),
+    .core_out    = &resp->core, .core_out_sz = sizeof(resp->core),
+    .uhw_in      = &req->mlx5,  .uhw_in_sz   = sizeof(req->mlx5  ),
+    .uhw_out     = &resp->mlx5, .uhw_out_sz  = sizeof(resp->mlx5 )
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd ) ) ) return -1;
 
   if( FD_UNLIKELY( resp->core.max_wr<qp->rx_depth || resp->core.max_sge<1U ) ) {
     FD_LOG_WARNING(( "invalid mlx5 WQ response (max WRs %u, requested %u, max SGEs %u)",
@@ -1286,16 +1254,16 @@ fd_uverbs_start_wq( fd_uverbs_ctx_t * uverbs,
   fd_uverbs_modify_wq_req_t req[1];
   fd_memset( req, 0, sizeof(req) );
 
-  ulong const core_req_sz = offsetof( fd_uverbs_modify_wq_req_t, mlx5 );
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_MODIFY_WQ,
-                                          core_req_sz, sizeof(*req), NULL, 0UL, 0UL ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
   req->core.attr_mask = FD_MLX5_WQ_ATTR_STATE;
   req->core.wq_handle = wq_handle;
   req->core.wq_state  = FD_MLX5_WQS_RDY;
-  return fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) );
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_MODIFY_WQ,
+    .core_in     = req,        .core_in_sz = offsetof( fd_uverbs_modify_wq_req_t, mlx5 ),
+    .uhw_in      = &req->mlx5, .uhw_in_sz  = sizeof(req->mlx5)
+  };
+  return fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd );
 }
 
 int
@@ -1314,15 +1282,16 @@ fd_uverbs_create_rqt( fd_uverbs_ctx_t * uverbs,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_RWQ_IND_TBL,
-                                          sizeof(*req), sizeof(*req), resp,
-                                          sizeof(resp->core), sizeof(*resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
   req->log_ind_tbl_size = FD_MLX5_RQT_LG_SZ;
   for( ulong i=0UL; i<FD_MLX5_RQT_SZ; i++ ) req->wq_handle[ i ] = wq_handle[ i%wq_cnt ];
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_CREATE_RWQ_IND_TBL,
+    .core_in     = req,         .core_in_sz  = sizeof(req),
+    .core_out    = &resp->core, .core_out_sz = sizeof(resp->core),
+    .uhw_out     = &resp->mlx5, .uhw_out_sz  = sizeof(resp->mlx5)
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd ) ) ) return -1;
 
   *rqt_handle = resp->core.ind_tbl_handle;
   return 0;
@@ -1345,14 +1314,6 @@ fd_uverbs_create_rss_qp( fd_uverbs_ctx_t * uverbs,
   fd_memset( req,  0, sizeof(req ) );
   fd_memset( resp, 0, sizeof(resp) );
 
-  ulong const core_req_sz = offsetof( fd_uverbs_create_rss_qp_req_t, mlx5 );
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_QP,
-                                          core_req_sz, sizeof(*req), resp,
-                                          sizeof(resp->core), sizeof(*resp) ) ) ) {
-    errno = EINVAL;
-    return -1;
-  }
-
   /* An RSS QP carries neither a send nor a receive queue of its own.  It
      exists to name the indirection table in a flow rule, so every queue
      size stays zero and Linux skips the completion queue lookups. */
@@ -1369,7 +1330,15 @@ fd_uverbs_create_rss_qp( fd_uverbs_ctx_t * uverbs,
     req->mlx5.rx_hash_fields_mask |= MLX5_RX_HASH_INNER;
     req->mlx5.flags                = MLX5_QP_FLAG_TUNNEL_OFFLOADS;
   }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_CREATE_QP,
+    .core_in     = req,         .core_in_sz  = offsetof( fd_uverbs_create_rss_qp_req_t, mlx5 ),
+    .core_out    = &resp->core, .core_out_sz = sizeof(resp->core),
+    .uhw_in      = &req->mlx5,  .uhw_in_sz   = sizeof(req->mlx5  ),
+    .uhw_out     = &resp->mlx5, .uhw_out_sz  = sizeof(resp->mlx5 )
+  };
+  if( FD_UNLIKELY( fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd ) ) ) return -1;
 
   if( FD_UNLIKELY( resp->core.base.qpn>0xffffffU ) ) {
     FD_LOG_WARNING(( "invalid mlx5 RSS QP response (QPN %u)", resp->core.base.qpn ));
@@ -1383,21 +1352,14 @@ fd_uverbs_create_rss_qp( fd_uverbs_ctx_t * uverbs,
 }
 
 static int
-fd_uverbs_init_udp_flow_req( fd_uverbs_create_udp_flow_req_t *   req,
-                             struct ib_uverbs_create_flow_resp * resp,
-                             uint                                qp_handle,
-                             uint                                port_num,
-                             uint                                dst_ip,
-                             ushort                              dst_port ) {
-  if( FD_UNLIKELY( !req || !resp || !port_num || port_num>UCHAR_MAX || !dst_port ) ) return -1;
+fd_uverbs_init_udp_flow_req( fd_uverbs_create_udp_flow_req_t * req,
+                             uint                              qp_handle,
+                             uint                              port_num,
+                             uint                              dst_ip,
+                             ushort                            dst_port ) {
+  if( FD_UNLIKELY( !req || !port_num || port_num>UCHAR_MAX || !dst_port ) ) return -1;
 
-  fd_memset( req,  0, sizeof(*req ) );
-  fd_memset( resp, 0, sizeof(*resp) );
-  ulong const core_req_sz = offsetof( fd_uverbs_create_udp_flow_req_t, mlx5_ncounters_data );
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_FLOW,
-                                          core_req_sz, sizeof(*req), resp,
-                                          sizeof(*resp), sizeof(*resp) ) ) ) return -1;
-
+  fd_memset( req, 0, sizeof(*req) );
   req->qp_handle           = qp_handle;
   req->size                = sizeof(req->eth)+sizeof(req->ipv4)+sizeof(req->udp);
   req->num_of_specs        = 3U;
@@ -1429,33 +1391,32 @@ fd_uverbs_create_udp_flow( fd_uverbs_ctx_t * uverbs,
 
   fd_uverbs_create_udp_flow_req_t   req [1];
   struct ib_uverbs_create_flow_resp resp[1];
-  if( FD_UNLIKELY( fd_uverbs_init_udp_flow_req(
-        req, resp, qp_handle,
-        uverbs->port_num, dst_ip,
-        dst_port ) ) ) {
+  fd_memset( resp, 0, sizeof(resp) );
+  if( FD_UNLIKELY( fd_uverbs_init_udp_flow_req( req, qp_handle, uverbs->port_num,
+                                                dst_ip, dst_port ) ) ) {
     errno = EINVAL;
     return -1;
   }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
-  return 0;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_CREATE_FLOW,
+    .core_in     = req,  .core_in_sz  = offsetof( fd_uverbs_create_udp_flow_req_t, mlx5_ncounters_data ),
+    .core_out    = resp, .core_out_sz = sizeof(resp),
+    .uhw_in      = &req->mlx5_ncounters_data,
+    .uhw_in_sz   = sizeof(*req)-offsetof( fd_uverbs_create_udp_flow_req_t, mlx5_ncounters_data )
+  };
+  return fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd );
 }
 
 static int
-fd_uverbs_init_gre_flow_req( fd_uverbs_create_gre_flow_req_t *   req,
-                             struct ib_uverbs_create_flow_resp * resp,
-                             uint                                qp_handle,
-                             uint                                port_num,
-                             uint                                inner_dst_ip,
-                             ushort                              inner_dst_port ) {
-  if( FD_UNLIKELY( !req || !resp || !port_num || port_num>UCHAR_MAX || !inner_dst_port ) ) return -1;
+fd_uverbs_init_gre_flow_req( fd_uverbs_create_gre_flow_req_t * req,
+                             uint                              qp_handle,
+                             uint                              port_num,
+                             uint                              inner_dst_ip,
+                             ushort                            inner_dst_port ) {
+  if( FD_UNLIKELY( !req || !port_num || port_num>UCHAR_MAX || !inner_dst_port ) ) return -1;
 
-  fd_memset( req,  0, sizeof(*req ) );
-  fd_memset( resp, 0, sizeof(*resp) );
-  ulong const core_req_sz = offsetof( fd_uverbs_create_gre_flow_req_t, mlx5_ncounters_data );
-  if( FD_UNLIKELY( fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_FLOW,
-                                          core_req_sz, sizeof(*req), resp,
-                                          sizeof(*resp), sizeof(*resp) ) ) ) return -1;
-
+  fd_memset( req, 0, sizeof(*req) );
   req->qp_handle    = qp_handle;
   req->size         = sizeof(req->eth)+sizeof(req->outer_ipv4)+sizeof(req->gre)+
                       sizeof(req->inner_ipv4)+sizeof(req->inner_udp);
@@ -1506,15 +1467,21 @@ fd_uverbs_create_gre_udp_flow( fd_uverbs_ctx_t * uverbs,
 
   fd_uverbs_create_gre_flow_req_t   req [1];
   struct ib_uverbs_create_flow_resp resp[1];
-  if( FD_UNLIKELY( fd_uverbs_init_gre_flow_req(
-        req, resp, qp_handle,
-        uverbs->port_num, inner_dst_ip,
-        inner_dst_port ) ) ) {
+  fd_memset( resp, 0, sizeof(resp) );
+  if( FD_UNLIKELY( fd_uverbs_init_gre_flow_req( req, qp_handle, uverbs->port_num,
+                                                inner_dst_ip, inner_dst_port ) ) ) {
     errno = EINVAL;
     return -1;
   }
-  if( FD_UNLIKELY( fd_uverbs_write_cmd( uverbs->cmd_fd, req, sizeof(req) ) ) ) return -1;
-  return 0;
+
+  fd_uverbs_cmd_t const cmd = {
+    .cmd         = IB_USER_VERBS_CMD_FLAG_EXTENDED | IB_USER_VERBS_EX_CMD_CREATE_FLOW,
+    .core_in     = req,  .core_in_sz  = offsetof( fd_uverbs_create_gre_flow_req_t, mlx5_ncounters_data ),
+    .core_out    = resp, .core_out_sz = sizeof(resp),
+    .uhw_in      = &req->mlx5_ncounters_data,
+    .uhw_in_sz   = sizeof(*req)-offsetof( fd_uverbs_create_gre_flow_req_t, mlx5_ncounters_data )
+  };
+  return fd_uverbs_exec_cmd( uverbs->cmd_fd, &cmd );
 }
 
 fd_mlx5_qp_t *

--- a/src/disco/net/mlx5/fd_mlx5_private.h
+++ b/src/disco/net/mlx5/fd_mlx5_private.h
@@ -24,6 +24,17 @@
 #define FD_MLX5_PAGE_SZ       (4096UL)
 #define FD_MLX5_RDMA_NAME_MAX (64UL)
 
+/* FD_MLX5_TILE_MAX is the max number of mlx5 tiles sharing one device. */
+#define FD_MLX5_TILE_MAX      (32UL)
+
+/* FD_MLX5_RQT_LG_SZ selects the size of the receive queue indirection
+   table (RSS). */
+#define FD_MLX5_RQT_LG_SZ     (7)
+#define FD_MLX5_RQT_SZ        (1UL<<FD_MLX5_RQT_LG_SZ)
+
+/* FD_MLX5_RSS_KEY_SZ is the length of the Toeplitz hash key. */
+#define FD_MLX5_RSS_KEY_SZ    (40UL)
+
 struct __attribute__((aligned(FD_MLX5_TX_WQE_SZ))) fd_mlx5_tx_wqe {
   uchar bytes[ FD_MLX5_TX_WQE_SZ ];
 };
@@ -108,6 +119,17 @@ struct fd_mlx5_qp {
 };
 typedef struct fd_mlx5_qp fd_mlx5_qp_t;
 
+/* fd_mlx5_caps_t holds the device and context limits that constrain
+   queue depths and memory region sizes. */
+struct fd_mlx5_caps {
+  ulong max_mr_size;
+  uint  max_send_wqe; /* max_send_wqebb, SQ WQE capacity */
+  uint  max_recv_wr;
+  uint  max_cqe;
+  uchar eth_min_inline_hdr_sz;
+};
+typedef struct fd_mlx5_caps fd_mlx5_caps_t;
+
 /* fd_netlink_rdma_ctx stores the state used to request one QP-bound counter
    through Linux NETLINK_RDMA. */
 struct fd_netlink_rdma_ctx {
@@ -118,6 +140,10 @@ struct fd_netlink_rdma_ctx {
   uint seq;        /* matches each netlink reply to its request. */
 };
 typedef struct fd_netlink_rdma_ctx fd_netlink_rdma_ctx_t;
+
+/* FD_MLX5_RSS_TIMEOUT_NS bounds how long one mlx5 tile waits on mlx5:0
+   to do RSS setup during boot.  This is practically instant. */
+#define FD_MLX5_RSS_TIMEOUT_NS (30e9) /* 30 seconds */
 
 FD_PROTOTYPES_BEGIN
 
@@ -135,20 +161,92 @@ fd_uverbs_init( fd_uverbs_ctx_t * uverbs,
                 void *            packet_memory,
                 ulong             packet_memory_sz );
 
-/* fd_uverbs_create_udp_flow and fd_uverbs_create_gre_udp_flow steer matching
-   IPv4 traffic to qp.  The GRE destination IP and port select the inner
-   packet.  A zero destination IP matches every IPv4 address. */
-int
-fd_uverbs_create_udp_flow( fd_uverbs_ctx_t *    uverbs,
-                           fd_mlx5_qp_t const * qp,
-                           uint                 dst_ip,
-                           ushort               dst_port );
+/* fd_uverbs_create_udp_flow and fd_uverbs_create_gre_udp_flow steer
+   matching IPv4 traffic to the queue pair named by qp_handle, which is
+   either a raw packet QP or an RSS QP.  The GRE destination IP and port
+   select the inner packet.  A zero destination IP matches every IPv4
+   address. */
 
 int
-fd_uverbs_create_gre_udp_flow( fd_uverbs_ctx_t *    uverbs,
-                               fd_mlx5_qp_t const * qp,
-                               uint                 inner_dst_ip,
-                               ushort               inner_dst_port );
+fd_uverbs_create_udp_flow( fd_uverbs_ctx_t * uverbs,
+                           uint              qp_handle,
+                           uint              dst_ip,
+                           ushort            dst_port );
+
+int
+fd_uverbs_create_gre_udp_flow( fd_uverbs_ctx_t * uverbs,
+                               uint              qp_handle,
+                               uint              inner_dst_ip,
+                               ushort            inner_dst_port );
+
+/* fd_mlx5_rdma_dev_find maps a network interface, or one of its bond
+   slaves, to Linux's RDMA device name and port number.  Dies if no port
+   matches or if more than one does. */
+
+void
+fd_mlx5_rdma_dev_find( char         rdma_name[ FD_MLX5_RDMA_NAME_MAX ],
+                       uint *       port_num,
+                       char const * if_name );
+
+/* fd_uverbs_open_cmd_fd opens the uverbs command device belonging to
+   rdma_name without creating a context on it.  Returns a file
+   descriptor, or -1 on failure. */
+
+int
+fd_uverbs_open_cmd_fd( char const * rdma_name );
+
+/* fd_uverbs_join wraps an already open command fd. */
+
+fd_uverbs_ctx_t *
+fd_uverbs_join( fd_uverbs_ctx_t * uverbs,
+                int               cmd_fd,
+                uint              port_num );
+
+/* fd_uverbs_open_shared creates the uverbs context and protection
+   domain that every tile on this command fd will use.  Called by mlx5:0. */
+
+int
+fd_uverbs_open_shared( fd_uverbs_ctx_t * uverbs,
+                       fd_mlx5_caps_t *  caps,
+                       uint *            pd_handle );
+
+/* fd_uverbs_init_rss_tile creates one tile's queues on a shared command
+   fd: a UAR, the RX and TX CQs, a memory region over the tile's own
+   packet memory, a work queue over its own RQ memory, and a send-only
+   raw packet QP.  The work queue is left in the ready state and its
+   handle is returned in wq_handle for the indirection table. */
+
+int
+fd_uverbs_init_rss_tile( fd_uverbs_ctx_t *      uverbs,
+                         fd_mlx5_caps_t const * caps,
+                         uint                   pd_handle,
+                         fd_mlx5_qp_t *         qp,
+                         void *                 packet_memory,
+                         ulong                  packet_memory_sz,
+                         uint *                 wq_handle );
+
+/* fd_uverbs_create_rqt builds the receive queue indirection table over
+   wq_cnt work queues, repeating them to fill FD_MLX5_RQT_SZ entries. */
+
+int
+fd_uverbs_create_rqt( fd_uverbs_ctx_t * uverbs,
+                      uint const *      wq_handle,
+                      uint              wq_cnt,
+                      uint *            rqt_handle );
+
+/* fd_uverbs_create_rss_qp creates the RSS queue pair that spreads
+   packets over rqt_handle using a Toeplitz hash of the IPv4 addresses
+   and UDP ports.  When inner is set the hash covers the tunnelled
+   headers instead of the outer ones, which callers use for GRE and may
+   fail on older firmware.  Returns 0 on success, -1 on failure. */
+
+int
+fd_uverbs_create_rss_qp( fd_uverbs_ctx_t * uverbs,
+                         uint              pd_handle,
+                         uint              rqt_handle,
+                         int               inner,
+                         uint *            qp_handle,
+                         uint *            qpn );
 
 /* fd_mlx5_netlink_rdma_init binds a manual RDMA counter to qpn. */
 fd_netlink_rdma_ctx_t *

--- a/src/disco/net/mlx5/fd_mlx5_tile.c
+++ b/src/disco/net/mlx5/fd_mlx5_tile.c
@@ -1158,8 +1158,8 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   return FD_LAYOUT_FINI( layout, scratch_align() );
 }
 
-/* fd_mlx5_tile_rx_dst_port_add maps an IPv4 UDP destination port to the
-   first output link with the requested name.  Published fragments encode
+/* fd_mlx5_tile_rx_dst_port_add maps an IPv4 UDP destination port to this
+   tile's output link with the requested name.  Published fragments encode
    dst_proto in their netmux signatures. */
 static void
 fd_mlx5_tile_rx_dst_port_add( fd_mlx5_tile_t *       ctx,
@@ -1170,7 +1170,7 @@ fd_mlx5_tile_rx_dst_port_add( fd_mlx5_tile_t *       ctx,
                               ushort                 dst_port,
                               int                    required ) {
   if( FD_UNLIKELY( !dst_port ) ) return;
-  ulong out_idx = fd_topo_find_tile_out_link( topo, tile, out_link, 0UL );
+  ulong out_idx = fd_topo_find_tile_out_link( topo, tile, out_link, tile->kind_id );
 
   if( FD_UNLIKELY( out_idx==ULONG_MAX ) ) {
     if( FD_UNLIKELY( required ) ) {
@@ -1206,7 +1206,7 @@ fd_mlx5_tile_rx_dst_ports_init( fd_mlx5_tile_t *       ctx,
   fd_mlx5_tile_rx_dst_port_add( ctx, topo, tile, DST_PROTO_SEND,     "net_txsend", tile->mlx5.net.txsend_src_port,                1 );
 
   if( tile->mlx5.net.repair_client_listen_port ) {
-    ulong out_idx = fd_topo_find_tile_out_link( topo, tile, "net_repair", 0UL );
+    ulong out_idx = fd_topo_find_tile_out_link( topo, tile, "net_repair", tile->kind_id );
     if( FD_UNLIKELY( out_idx==ULONG_MAX ) ) {
       FD_LOG_ERR(( "mlx5 output link `net_repair` is missing for repair pings" ));
     }

--- a/src/disco/net/mlx5/fd_mlx5_tile.c
+++ b/src/disco/net/mlx5/fd_mlx5_tile.c
@@ -144,6 +144,18 @@ struct fd_mlx5_tile {
 
   uint batch_size; /* used for both SQ/RQ and TX/RX CQ batching */
 
+  uint tile_id;
+  uint tile_cnt;
+
+  struct {
+    uint           seed;
+    fd_mlx5_caps_t caps;      /* published by mlx5:0 */
+    uint           pd_handle; /* published by mlx5:0 */
+    uint           pd_ready;
+    uint           wq_handle;
+    uint           wq_ready;
+  } rss;
+
   /* RQ batching */
   uint rq_pending_chunk[ FD_MLX5_BATCH_SIZE ];
   uint rq_pending_cnt;
@@ -797,6 +809,9 @@ before_frag( fd_mlx5_tile_t * ctx,
   ulong dst_proto = fd_disco_netmux_sig_proto( sig );
   if( FD_UNLIKELY( dst_proto!=DST_PROTO_OUTGOING ) ) return 1;
 
+  uint const tx_hash = (uint)fd_disco_netmux_sig_hash( sig );
+  if( FD_UNLIKELY( tx_hash%ctx->tile_cnt!=ctx->tile_id ) ) return 1;
+
   uint dst_ip = fd_disco_netmux_sig_ip( sig );
   if( FD_UNLIKELY( !fd_net_tx_route( &ctx->router, dst_ip, &ctx->tx_route ) ) ) return 1;
   if( FD_UNLIKELY( ctx->tx_route.use_gre ) ) {
@@ -1036,27 +1051,10 @@ fd_mlx5_tile_gre_tunnels_refresh( fd_mlx5_tile_t * ctx ) {
 }
 
 static inline void
-during_housekeeping( fd_mlx5_tile_t * ctx ) {
-  /* Refresh the mlx5 out_of_buffer QP counter periodically */
-  long const now_ticks = fd_tickcount();
-  if( FD_UNLIKELY( now_ticks>ctx->next_stats_refresh_ticks ) ) {
-    ctx->next_stats_refresh_ticks = now_ticks+ctx->stats_interval_ticks;
-
-    ulong rx_out_of_buffer_cnt;
-    if( FD_UNLIKELY( fd_mlx5_netlink_rdma_qp_counter_read( &ctx->netlink_rdma, &rx_out_of_buffer_cnt ) ) ) {
-      FD_LOG_ERR(( "reading mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-    }
-
-    ulong const rx_out_of_buffer_delta = rx_out_of_buffer_cnt>=ctx->rx_out_of_buffer_prev_cnt
-                                         ? rx_out_of_buffer_cnt-ctx->rx_out_of_buffer_prev_cnt
-                                         : rx_out_of_buffer_cnt;
-
-    ctx->metrics.rx_out_of_buffer_cnt += rx_out_of_buffer_delta;
-    ctx->rx_out_of_buffer_prev_cnt     = rx_out_of_buffer_cnt;
-  }
-
-  /* Drain pending uverbs async events. */
+fd_mlx5_tile_drain_async_events( fd_mlx5_tile_t * ctx ) {
   int const async_event_fd = ctx->uverbs.async_fd;
+  if( FD_UNLIKELY( async_event_fd<0 ) ) return;
+
   for(;;) {
     struct ib_uverbs_async_event_desc async_event;
     ssize_t async_event_read_sz;
@@ -1081,6 +1079,29 @@ during_housekeeping( fd_mlx5_tile_t * ctx ) {
     }
     FD_LOG_INFO(( "mlx5 async event %u on element %lu", async_event_type, async_event_element ));
   }
+}
+
+static inline void
+during_housekeeping( fd_mlx5_tile_t * ctx ) {
+  long const now_ticks = fd_tickcount();
+  if( FD_UNLIKELY( ctx->netlink_rdma.fd>=0 && now_ticks>ctx->next_stats_refresh_ticks ) ) {
+    ctx->next_stats_refresh_ticks = now_ticks+ctx->stats_interval_ticks;
+
+    ulong rx_out_of_buffer_cnt;
+    if( FD_UNLIKELY( fd_mlx5_netlink_rdma_qp_counter_read( &ctx->netlink_rdma, &rx_out_of_buffer_cnt ) ) ) {
+      FD_LOG_ERR(( "reading mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+
+    ulong const rx_out_of_buffer_delta =
+        rx_out_of_buffer_cnt >= ctx->rx_out_of_buffer_prev_cnt ?
+        rx_out_of_buffer_cnt -  ctx->rx_out_of_buffer_prev_cnt :
+        rx_out_of_buffer_cnt;
+
+    ctx->metrics.rx_out_of_buffer_cnt += rx_out_of_buffer_delta;
+    ctx->rx_out_of_buffer_prev_cnt     = rx_out_of_buffer_cnt;
+  }
+
+  fd_mlx5_tile_drain_async_events( ctx );
 
   /* Refresh the netdev snapshot when its shared state is stable */
   if( FD_LIKELY( !fd_seqlock_locked_hint( &ctx->router.netdev_shared.hdr->seqlock ) ) ) {
@@ -1135,112 +1156,6 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   layout = FD_LAYOUT_APPEND( layout, fd_fib4_align(),         fd_fib4_footprint( tile->mlx5.route_max, tile->mlx5.route_peer_max ) );
 
   return FD_LAYOUT_FINI( layout, scratch_align() );
-}
-
-static int
-fd_mlx5_tile_rdma_port_contains_if( char const * rdma_name,
-                                    uint         port,
-                                    char const * if_name ) {
-  char netdev_dir_path[ PATH_MAX ];
-  int path_sz = snprintf( netdev_dir_path, sizeof(netdev_dir_path),
-                          "/sys/class/infiniband/%s/ports/%u/gid_attrs/ndevs", rdma_name, port );
-  if( FD_UNLIKELY( path_sz<=0 || (ulong)path_sz>=sizeof(netdev_dir_path) ) ) return 0;
-
-  DIR * netdev_dir = opendir( netdev_dir_path );
-  if( FD_UNLIKELY( !netdev_dir ) ) return 0;
-
-  struct dirent * netdev_entry;
-  int netdev_found = 0;
-  while( !netdev_found && (netdev_entry=readdir( netdev_dir )) ) {
-    if( netdev_entry->d_name[0]=='.' ) continue;
-    char netdev_name_path[ PATH_MAX ];
-    int netdev_name_path_sz = snprintf( netdev_name_path, sizeof(netdev_name_path),
-                                        "%s/%s", netdev_dir_path, netdev_entry->d_name );
-    if( FD_UNLIKELY( netdev_name_path_sz<=0 || (ulong)netdev_name_path_sz>=sizeof(netdev_name_path) ) ) continue;
-    int netdev_fd = open( netdev_name_path, O_RDONLY );
-    if( FD_UNLIKELY( netdev_fd<0 ) ) continue;
-
-    char netdev_name[ IF_NAMESIZE+1 ];
-    ssize_t read_sz = read( netdev_fd, netdev_name, IF_NAMESIZE );
-    close( netdev_fd );
-
-    if( FD_UNLIKELY( read_sz<=0 ) ) continue;
-    while( read_sz>0 && (netdev_name[read_sz-1]=='\n' || netdev_name[read_sz-1]=='\r') ) read_sz--;
-    netdev_name[read_sz] = '\0';
-    netdev_found = !strcmp( netdev_name, if_name );
-  }
-  closedir( netdev_dir );
-  return netdev_found;
-}
-
-static int
-fd_mlx5_tile_rdma_port_matches_if( char const * rdma_name,
-                                   uint         port,
-                                   char const * if_name ) {
-  if( fd_mlx5_tile_rdma_port_contains_if( rdma_name, port, if_name ) ) return 1;
-  if( !fd_bonding_is_master( if_name ) ) return 0;
-
-  fd_bonding_slave_iter_t   iter_mem[1];
-  fd_bonding_slave_iter_t * iter = fd_bonding_slave_iter_init( iter_mem, if_name );
-  while( !fd_bonding_slave_iter_done( iter ) ) {
-    char const * slave_if_name = fd_bonding_slave_iter_ele( iter );
-    if( fd_mlx5_tile_rdma_port_contains_if( rdma_name, port, slave_if_name ) ) return 1;
-    fd_bonding_slave_iter_next( iter );
-  }
-
-  return 0;
-}
-
-/* fd_mlx5_tile_rdma_dev_find maps the configured network interface or
-   one of its bond slaves to Linux's RDMA device and numbered port. */
-static void
-fd_mlx5_tile_rdma_dev_find( char                   rdma_device_name[ FD_MLX5_RDMA_NAME_MAX ],
-                            uint *                 rdma_port_num,
-                            fd_topo_tile_t const * tile ) {
-  char const * interface_name = tile->mlx5.if_name;
-  DIR * infiniband_dir = opendir( "/sys/class/infiniband" );
-  if( FD_UNLIKELY( !infiniband_dir ) ) {
-    FD_LOG_ERR(( "opendir(/sys/class/infiniband) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  }
-
-  rdma_device_name[0] = '\0';
-  *rdma_port_num = 0U;
-
-  struct dirent * device_entry;
-  while( (device_entry=readdir( infiniband_dir )) ) {
-    if( device_entry->d_name[0]=='.' ) continue;
-
-    char device_ports_path[ PATH_MAX ];
-    int const device_ports_path_sz = snprintf( device_ports_path, sizeof(device_ports_path),
-                                               "/sys/class/infiniband/%s/ports", device_entry->d_name );
-    if( FD_UNLIKELY( device_ports_path_sz<=0 || (ulong)device_ports_path_sz>=sizeof(device_ports_path) ) ) continue;
-    DIR * ports_dir = opendir( device_ports_path );
-    if( FD_UNLIKELY( !ports_dir ) ) continue;
-
-    struct dirent * port_entry;
-    while( (port_entry=readdir( ports_dir )) ) {
-      char * port_end;
-      ulong const port_num = strtoul( port_entry->d_name, &port_end, 10 );
-      if( !port_num || *port_end || port_num>(ulong)UCHAR_MAX ) continue;
-
-      if( !fd_mlx5_tile_rdma_port_matches_if( device_entry->d_name, (uint)port_num, interface_name ) ) continue;
-
-      if( FD_UNLIKELY( rdma_device_name[0] ) ) {
-        FD_LOG_ERR(( "multiple RDMA ports match interface `%s` (`%s` port %u and `%s` port %lu)",
-                     interface_name, rdma_device_name, *rdma_port_num, device_entry->d_name, port_num ));
-      }
-      fd_cstr_ncpy( rdma_device_name, device_entry->d_name, FD_MLX5_RDMA_NAME_MAX );
-      *rdma_port_num = (uint)port_num;
-    }
-    closedir( ports_dir );
-  }
-
-  if( FD_UNLIKELY( closedir( infiniband_dir ) ) ) {
-    FD_LOG_ERR(( "closedir(/sys/class/infiniband) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  }
-  if( FD_UNLIKELY( !rdma_device_name[0] ) ) {
-    FD_LOG_ERR(( "RDMA device port for interface `%s` not found", interface_name ));
-  }
 }
 
 /* fd_mlx5_tile_rx_dst_port_add maps an IPv4 UDP destination port to the
@@ -1299,6 +1214,114 @@ fd_mlx5_tile_rx_dst_ports_init( fd_mlx5_tile_t *       ctx,
   }
 }
 
+struct fd_mlx5_tile_steer {
+  uint udp_qp_handle;
+  uint gre_qp_handle;
+  uint counter_qpn;
+};
+typedef struct fd_mlx5_tile_steer fd_mlx5_tile_steer_t;
+
+static fd_mlx5_tile_t *
+fd_mlx5_tile_peer( fd_topo_t const * topo,
+                   ulong             kind_id ) {
+  ulong tile_idx = fd_topo_find_tile( topo, "mlx5", kind_id );
+  if( FD_UNLIKELY( tile_idx==ULONG_MAX ) ) FD_LOG_ERR(( "tile mlx5:%lu not found", kind_id ));
+  return fd_topo_obj_laddr( topo, topo->tiles[ tile_idx ].tile_obj_id );
+}
+
+/* fd_mlx5_tile_rss_wait waits for a remote mlx5 tile's flow steering
+   config to be configured. */
+
+static void
+fd_mlx5_tile_rss_wait( uint volatile const * ready,
+                       uint                  seed,
+                       char const *          what,
+                       ulong                 which ) {
+  long const deadline = fd_log_wallclock()+(long)FD_MLX5_RSS_TIMEOUT_NS;
+  while( FD_VOLATILE_CONST( *ready )!=seed ) {
+    if( FD_UNLIKELY( fd_log_wallclock()>deadline ) ) {
+      FD_LOG_ERR(( "timed out waiting for mlx5:%lu to publish %s", which, what ));
+    }
+    FD_YIELD();
+  }
+  FD_COMPILER_MFENCE();
+}
+
+static void
+fd_mlx5_tile_rss_init( fd_mlx5_tile_t *       ctx,
+                       fd_topo_t const *      topo,
+                       void *                 packet_memory,
+                       ulong                  packet_memory_sz,
+                       uint                   rdma_port_num,
+                       fd_mlx5_tile_steer_t * steer ) {
+  ulong const tile_id  = ctx->tile_id;
+  ulong const tile_cnt = ctx->tile_cnt;
+  uint  const seed     = ctx->rss.seed;
+  if( FD_UNLIKELY( !seed ) ) FD_LOG_ERR(( "mlx5 receive side scaling seed is unset (topology bug)" ));
+
+  if( FD_UNLIKELY( !fd_uverbs_join( &ctx->uverbs, FD_TOPO_MLX5_CMD_FD, rdma_port_num ) ) ) {
+    FD_LOG_ERR(( "adopting the shared mlx5 command fd failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  fd_mlx5_tile_t * leader = fd_mlx5_tile_peer( topo, 0UL );
+  fd_mlx5_caps_t   caps[1];
+  if( FD_LIKELY( !tile_id ) ) {
+    if( FD_UNLIKELY( fd_uverbs_open_shared( &ctx->uverbs, caps, &ctx->rss.pd_handle ) ) ) {
+      FD_LOG_ERR(( "opening the shared mlx5 context failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+    ctx->rss.caps = *caps;
+    FD_COMPILER_MFENCE();
+    FD_VOLATILE( ctx->rss.pd_ready ) = seed;
+    FD_COMPILER_MFENCE();
+  } else {
+    fd_mlx5_tile_rss_wait( &leader->rss.pd_ready, seed, "the shared protection domain", 0UL );
+    *caps = leader->rss.caps;
+  }
+
+  if( FD_UNLIKELY( fd_uverbs_init_rss_tile( &ctx->uverbs, caps, leader->rss.pd_handle,
+                                            &ctx->qp,
+                                            packet_memory, packet_memory_sz,
+                                            &ctx->rss.wq_handle ) ) ) {
+    FD_LOG_ERR(( "direct mlx5 setup failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( ctx->rss.wq_ready ) = seed;
+  FD_COMPILER_MFENCE();
+
+  *steer = (fd_mlx5_tile_steer_t){0};
+  if( FD_UNLIKELY( tile_id ) ) return;
+
+  uint wq_handle[ FD_MLX5_TILE_MAX ];
+  wq_handle[ 0 ] = ctx->rss.wq_handle;
+  for( ulong i=1UL; i<tile_cnt; i++ ) {
+    fd_mlx5_tile_t const * peer = fd_mlx5_tile_peer( topo, i );
+    fd_mlx5_tile_rss_wait( &peer->rss.wq_ready, seed, "its receive work queue", i );
+    wq_handle[ i ] = peer->rss.wq_handle;
+  }
+
+  uint rqt_handle;
+  if( FD_UNLIKELY( fd_uverbs_create_rqt( &ctx->uverbs, wq_handle, (uint)tile_cnt, &rqt_handle ) ) ) {
+    FD_LOG_ERR(( "creating the mlx5 receive queue indirection table failed (%i-%s)",
+                 errno, fd_io_strerror( errno ) ));
+  }
+
+  uint qpn; /* unused */
+  if( FD_UNLIKELY( fd_uverbs_create_rss_qp(
+      &ctx->uverbs, ctx->rss.pd_handle, rqt_handle, 0,
+      &steer->udp_qp_handle, &qpn ) ) ) {
+    FD_LOG_ERR(( "creating the mlx5 RSS queue pair failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  }
+
+  if( FD_UNLIKELY( fd_uverbs_create_rss_qp(
+      &ctx->uverbs, ctx->rss.pd_handle, rqt_handle, 1,
+      &steer->gre_qp_handle, &qpn ) ) ) {
+    FD_LOG_WARNING(( "creating the mlx5 inner hash RSS queue pair failed (%i-%s); "
+                     "all GRE traffic will arrive on tile mlx5:0",
+                     errno, fd_io_strerror( errno ) ));
+    steer->gre_qp_handle = steer->udp_qp_handle;
+  }
+}
+
 FD_FN_UNUSED static void
 privileged_init( fd_topo_t const *      topo,
                  fd_topo_tile_t const * tile ) {
@@ -1337,35 +1360,51 @@ privileged_init( fd_topo_t const *      topo,
   ctx->pkt_buf_chunk0    = (uint)pkt_buf_chunk0;
   ctx->pkt_buf_wmark     = (uint)pkt_buf_wmark;
 
-  if( FD_UNLIKELY( tile->kind_id!=0 ) ) {
-    /* FIXME support receive side scaling */
-    FD_LOG_ERR(( "Sorry, net.provider='mlx5' currently only supports layout.net_tile_count=1" ));
-  }
+  ctx->tile_id         = (uint)tile->kind_id;
+  ctx->tile_cnt        = (uint)fd_topo_tile_name_cnt( topo, "mlx5" );
+  ctx->rss.seed        = tile->mlx5.rss_seed;
+  ctx->netlink_rdma.fd = -1;
 
   /* Open the device and create its uverbs resources */
   char rdma_device_name[ FD_MLX5_RDMA_NAME_MAX ];
   uint rdma_port_num;
-  fd_mlx5_tile_rdma_dev_find( rdma_device_name, &rdma_port_num, tile );
+  fd_mlx5_rdma_dev_find( rdma_device_name, &rdma_port_num, tile->mlx5.if_name );
   FD_LOG_INFO(( "Opening direct mlx5 device `%s` port %u", rdma_device_name, rdma_port_num ));
-  if( FD_UNLIKELY( !fd_uverbs_init( &ctx->uverbs, &ctx->rx_cq, &ctx->tx_cq, &ctx->qp,
-                                    rdma_device_name, rdma_port_num, packet_dcache, frame_region_sz ) ) ) {
-    FD_LOG_ERR(( "direct mlx5 setup failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  fd_mlx5_tile_steer_t steer[1];
+  if( FD_LIKELY( ctx->tile_cnt==1U ) ) {
+    if( FD_UNLIKELY( !fd_uverbs_init( &ctx->uverbs, &ctx->rx_cq, &ctx->tx_cq, &ctx->qp,
+                                      rdma_device_name, rdma_port_num, packet_dcache, frame_region_sz ) ) ) {
+      FD_LOG_ERR(( "direct mlx5 setup failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+    *steer = (fd_mlx5_tile_steer_t){
+      .udp_qp_handle = ctx->qp.handle,
+      .gre_qp_handle = ctx->qp.handle,
+      .counter_qpn   = ctx->qp.qpn
+    };
+  } else {
+    fd_mlx5_tile_rss_init( ctx, topo, packet_dcache, frame_region_sz, rdma_port_num, steer );
   }
-  if( FD_UNLIKELY( !fd_mlx5_netlink_rdma_init( &ctx->netlink_rdma, rdma_device_name,
-                                               rdma_port_num, ctx->qp.qpn ) ) ) {
-    FD_LOG_ERR(( "initializing mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
-  }
-  if( FD_UNLIKELY( fd_mlx5_netlink_rdma_qp_counter_read( &ctx->netlink_rdma,
-                                                         &ctx->rx_out_of_buffer_prev_cnt ) ) ) {
-    FD_LOG_ERR(( "reading mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  if( FD_LIKELY( steer->counter_qpn ) ) {
+    if( FD_UNLIKELY( !fd_mlx5_netlink_rdma_init( &ctx->netlink_rdma, rdma_device_name,
+                                                 rdma_port_num, steer->counter_qpn ) ) ) {
+      FD_LOG_ERR(( "initializing mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+    if( FD_UNLIKELY( fd_mlx5_netlink_rdma_qp_counter_read( &ctx->netlink_rdma,
+                                                           &ctx->rx_out_of_buffer_prev_cnt ) ) ) {
+      FD_LOG_ERR(( "reading mlx5 QP counters failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
   }
 
   /* Configure asynchronous device events */
-  int const async_event_fd    = ctx->uverbs.async_fd;
-  int const async_event_flags = fcntl( async_event_fd, F_GETFL );
-  if( FD_UNLIKELY( async_event_flags<0 ||
-                   fcntl( async_event_fd, F_SETFL, async_event_flags|O_NONBLOCK )<0 ) ) {
-    FD_LOG_ERR(( "making mlx5 async fd non-blocking failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+  int const async_event_fd = ctx->uverbs.async_fd;
+  if( FD_LIKELY( async_event_fd>=0 ) ) {
+    int const async_event_flags = fcntl( async_event_fd, F_GETFL );
+    if( FD_UNLIKELY( async_event_flags<0 ||
+                     fcntl( async_event_fd, F_SETFL, async_event_flags|O_NONBLOCK )<0 ) ) {
+      FD_LOG_ERR(( "making mlx5 async fd non-blocking failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
   }
 
   /* Resolve the netdev and install RX flow steering */
@@ -1378,22 +1417,28 @@ privileged_init( fd_topo_t const *      topo,
   ctx->router.default_address = fd_mlx5_tile_if_ip4_addr( tile->mlx5.if_name );
 
   fd_mlx5_tile_rx_dst_ports_init( ctx, topo, tile );
+
+  /* Only mlx5:0 installs RSS and flow steering */
+  if( FD_UNLIKELY( !steer->udp_qp_handle ) ) return;
   for( ulong flow_idx=0UL; flow_idx<ctx->dst_port_cnt; flow_idx++ ) {
-    if( FD_UNLIKELY( fd_uverbs_create_udp_flow( &ctx->uverbs, &ctx->qp,
-                                                tile->mlx5.net.bind_address,
-                                                ctx->dst_ports[ flow_idx ] ) ) ) {
+    if( FD_UNLIKELY( fd_uverbs_create_udp_flow(
+        &ctx->uverbs, steer->udp_qp_handle,
+        tile->mlx5.net.bind_address,
+        ctx->dst_ports[ flow_idx ] ) ) ) {
       FD_LOG_ERR(( "fd_uverbs_create_udp_flow failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     }
-    if( FD_UNLIKELY( fd_uverbs_create_gre_udp_flow( &ctx->uverbs, &ctx->qp,
-                                                    tile->mlx5.net.bind_address,
-                                                    ctx->dst_ports[ flow_idx ] ) ) ) {
+    if( FD_UNLIKELY( fd_uverbs_create_gre_udp_flow(
+        &ctx->uverbs, steer->gre_qp_handle,
+        tile->mlx5.net.bind_address,
+        ctx->dst_ports[ flow_idx ] ) ) ) {
       FD_LOG_ERR(( "fd_uverbs_create_gre_udp_flow failed (%i-%s)", errno, fd_io_strerror( errno ) ));
     }
     FD_LOG_DEBUG(( "Created flow rule for ip4.dst_ip=" FD_IP4_ADDR_FMT " udp.dst_port:%hu",
                    FD_IP4_ADDR_FMT_ARGS( tile->mlx5.net.bind_address ),
                    ctx->dst_ports[ flow_idx ] ));
   }
-  FD_LOG_INFO(( "Installed %u direct mlx5 flow rules", 2U*ctx->dst_port_cnt ));
+  FD_LOG_INFO(( "Installed %u direct mlx5 flow rules across %u tiles",
+                2U*ctx->dst_port_cnt, ctx->tile_cnt ));
 }
 
 FD_FN_UNUSED static void
@@ -1539,8 +1584,8 @@ populate_allowed_fds( fd_topo_t const *      topo,
   out_fds[ out_cnt++ ] = 2;
   if( FD_LIKELY( fd_log_private_logfile_fd()!=-1 ) ) out_fds[ out_cnt++ ] = fd_log_private_logfile_fd();
   out_fds[ out_cnt++ ] = ctx->uverbs.cmd_fd;
-  out_fds[ out_cnt++ ] = ctx->uverbs.async_fd;
-  out_fds[ out_cnt++ ] = ctx->netlink_rdma.fd;
+  if( FD_LIKELY( ctx->uverbs.async_fd!=-1 ) ) out_fds[ out_cnt++ ] = ctx->uverbs.async_fd;
+  if( FD_LIKELY( ctx->netlink_rdma.fd!=-1 ) ) out_fds[ out_cnt++ ] = ctx->netlink_rdma.fd;
   return out_cnt;
 }
 

--- a/src/disco/net/mlx5/test_mlx5_tile.c
+++ b/src/disco/net/mlx5/test_mlx5_tile.c
@@ -7,6 +7,7 @@
 #include "fd_mlx5_tile.c"
 #include "../fd_net_tile.h"
 #include "../../../disco/topo/fd_topob.h"
+#include "../../../app/shared/fd_config.h" /* FIXME layering violation */
 
 #include <errno.h>
 #include <signal.h>
@@ -114,8 +115,8 @@ test_hardware( char const * rdma_name,
   FD_TEST( rx_cq_entries[ 0U ].op_own==(uchar)(FD_MLX5_CQE_OP_INVALID<<4) );
   FD_TEST( tx_cq_entries[ 0U ].op_own==(uchar)(FD_MLX5_CQE_OP_INVALID<<4) );
 
-  FD_TEST( !fd_uverbs_create_udp_flow( &tile->uverbs, &tile->qp, 0U, 65535U ) );
-  FD_TEST( !fd_uverbs_create_gre_udp_flow( &tile->uverbs, &tile->qp,
+  FD_TEST( !fd_uverbs_create_udp_flow( &tile->uverbs, tile->qp.handle, 0U, 65535U ) );
+  FD_TEST( !fd_uverbs_create_gre_udp_flow( &tile->uverbs, tile->qp.handle,
                                            FD_IP4_ADDR( 192,0,2,1 ), 65535U ) );
 
   ulong out_of_buffer;
@@ -178,6 +179,65 @@ test_rx_routes( void ) {
   FD_TEST( proto==DST_PROTO_SEND );
   FD_TEST( !fd_mlx5_tile_rx_dst_port_lookup( tile, 9999U, 64UL, &out_idx, &proto ) );
 }
+
+/* test_rss_topology checks the shape of an mlx5 topology: every tile knows
+   how many tiles there are, and when receive side scaling is in play they
+   all reach the one handshake object they exchange uverbs handles
+   through. */
+static void
+test_rss_topology( ulong net_tile_cnt ) {
+  static fd_topo_t topo[1];
+  FD_TEST( fd_topob_new( topo, "test_mlx5_rss_topo" ) );
+  fd_topob_wksp( topo, "metric_in" );
+
+  fd_config_net_t net_cfg[1];
+  fd_memset( net_cfg, 0, sizeof(net_cfg) );
+  fd_cstr_ncpy( net_cfg->provider,  "mlx5", sizeof(net_cfg->provider)  );
+  fd_cstr_ncpy( net_cfg->interface, "eth0", sizeof(net_cfg->interface) );
+  net_cfg->mlx5.rx_queue_size = 1024U;
+  net_cfg->mlx5.tx_queue_size = 1024U;
+
+  ulong tile_to_cpu[ FD_TILE_MAX ];
+  for( ulong i=0UL; i<FD_TILE_MAX; i++ ) tile_to_cpu[ i ] = ULONG_MAX;
+
+  fd_topos_net_tiles( topo, net_tile_cnt, net_cfg, 64UL, 64UL, 64UL, 0, tile_to_cpu );
+  FD_TEST( fd_topo_tile_name_cnt( topo, "mlx5" )==net_tile_cnt );
+
+  uint rss_seed = 0U;
+  for( ulong i=0UL; i<net_tile_cnt; i++ ) {
+    ulong tile_idx = fd_topo_find_tile( topo, "mlx5", i );
+    FD_TEST( tile_idx!=ULONG_MAX );
+    fd_topo_tile_t const * mlx5_tile = &topo->tiles[ tile_idx ];
+
+    /* One tile handles its own device and needs no handshake. */
+    if( net_tile_cnt<=1UL ) {
+      FD_TEST( !mlx5_tile->mlx5.rss_seed );
+      continue;
+    }
+
+    FD_TEST( mlx5_tile->mlx5.rss_seed );
+    if( !i ) rss_seed = mlx5_tile->mlx5.rss_seed;
+    else     FD_TEST( mlx5_tile->mlx5.rss_seed==rss_seed );
+
+    /* Each tile must declare read-write use of every peer's tile object,
+       which is how it reads the peer's published uverbs handles. */
+    for( ulong j=0UL; j<net_tile_cnt; j++ ) {
+      if( i==j ) continue;
+      ulong peer_idx = fd_topo_find_tile( topo, "mlx5", j );
+      FD_TEST( peer_idx!=ULONG_MAX );
+      ulong peer_obj_id = topo->tiles[ peer_idx ].tile_obj_id;
+
+      int uses_peer = 0;
+      for( ulong k=0UL; k<mlx5_tile->uses_obj_cnt; k++ ) {
+        if( mlx5_tile->uses_obj_id[ k ]!=peer_obj_id ) continue;
+        FD_TEST( mlx5_tile->uses_obj_mode[ k ]==FD_SHMEM_JOIN_MODE_READ_WRITE );
+        uses_peer = 1;
+      }
+      FD_TEST( uses_peer );
+    }
+  }
+}
+
 #define SHRED_PORT ((ushort)4242)
 
 #define IF_IDX_LO   1U
@@ -429,6 +489,9 @@ main( int     argc,
   fd_boot( &argc, &argv );
   test_queue_footprint();
   test_rx_routes();
+  test_rss_topology( 1UL );
+  test_rss_topology( 2UL );
+  test_rss_topology( 5UL );
   test_rx_cqe_normal();
   test_tx_wqe();
   test_tx_cqe_normal();
@@ -489,6 +552,7 @@ main( int     argc,
   FD_TEST( tile );
   memset( tile, 0, sizeof(fd_mlx5_tile_t) );
   tile->batch_size    = batch_size;
+  tile->tile_cnt      = 1U;
   topo->objs[ topo_tile->tile_obj_id ].offset = (ulong)tile - (ulong)wksp;
   FD_TEST( fd_topo_obj_laddr( topo, topo_tile->tile_obj_id )==tile );
   FD_TEST( rx_link->mcache );
@@ -973,6 +1037,27 @@ main( int     argc,
   /* TX packet targeting default gateway */
   memset( &tile->tx_route, 0, sizeof(tile->tx_route) );
   tx_sig = fd_disco_netmux_sig( 0U, 0, FD_IP4_ADDR( 1,1,1,1 ), DST_PROTO_OUTGOING, 0UL );
+  FD_TEST( 0==before_frag( tile, 0UL, tx_seq, tx_sig ) );
+
+  /* Every mlx5 tile is subscribed to every TX link, so exactly one of them
+     must claim each outgoing packet. */
+  for( uint claim_tile_cnt=1U; claim_tile_cnt<=8U; claim_tile_cnt++ ) {
+    tile->tile_cnt = claim_tile_cnt;
+    for( ushort claim_port=1; claim_port<=32; claim_port++ ) {
+      ulong const claim_sig = fd_disco_netmux_sig( neigh2_ip4_addr, claim_port, neigh2_ip4_addr,
+                                                   DST_PROTO_OUTGOING, 0UL );
+      uint claim_cnt = 0U;
+      for( uint claim_tile_id=0U; claim_tile_id<claim_tile_cnt; claim_tile_id++ ) {
+        tile->tile_id = claim_tile_id;
+        memset( &tile->tx_route, 0, sizeof(tile->tx_route) );
+        claim_cnt += (uint)( 0==before_frag( tile, 0UL, tx_seq, claim_sig ) );
+      }
+      FD_TEST( claim_cnt==1U );
+    }
+  }
+  tile->tile_cnt = 1U;
+  tile->tile_id  = 0U;
+  memset( &tile->tx_route, 0, sizeof(tile->tx_route) );
   FD_TEST( 0==before_frag( tile, 0UL, tx_seq, tx_sig ) );
 
   /* TX packet with no free buffer */

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -211,6 +211,7 @@ struct fd_topo_tile {
       uint  rx_queue_size;
       uint  tx_queue_size;
       uint  batch_size;
+      uint  rss_seed;
 
       ulong netdev_tbl_obj_id;
       ulong route_max;


### PR DESCRIPTION
- add uverbs uapi for creating indirection tables
- move uverbs command fd creation to run.c and inherit across
  tiles
- adds receive side scaling support (with opportunistic GRE RX
  load balancing)
- adds TX load balancing support
- create a master (mlx5:0) / slave (mlx5:1+i) bootstrapping
  mechanism where mlx5:0 is responsible for creating QPs and RSS
  state, which the other tiles join
