### PR TITLE
config: simplify version header generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,3 @@ venv
 
 # Version derive
 src/util/fd_version_generated.h
-src/util/fd_version_generated1.h

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@
 
 ### Bootstrap the Makefile environment
 
+include config/make_version.mk
+
 # Remove pollution from unwanted default Make variables, such as $(CC)
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables

--- a/book/guide/internals/supply_chain.md
+++ b/book/guide/internals/supply_chain.md
@@ -44,8 +44,6 @@ manager (dnf or apt) when running `./deps.sh check`. These include:
 - C/C++ compiler: GCC or Clang
 - pkgconf
 - GNU coreutils
-- GNU diffutils
-- GNU patch
 - Perl (for building OpenSSL)
 
 ## Vendored

--- a/config/make_version.mk
+++ b/config/make_version.mk
@@ -1,0 +1,17 @@
+ifndef MAKE_VERSION
+$(error This Makefile requires GNU Make 4.2 or newer. Try invoking 'gmake')
+endif
+
+_gnumake_version_words := $(subst ., ,$(MAKE_VERSION))
+_gnumake_major := $(word 1,$(_gnumake_version_words))
+_gnumake_minor := $(word 2,$(_gnumake_version_words))
+
+# Reject GNU Make < 4.2.
+ifneq ($(filter 0 1 2 3,$(_gnumake_major)),)
+$(error GNU Make 4.2 or newer is required; found GNU Make $(MAKE_VERSION))
+endif
+ifeq ($(_gnumake_major),4)
+ifeq ($(filter-out 0 1,$(_gnumake_minor)),)
+$(error GNU Make 4.2 or newer is required; found GNU Make $(MAKE_VERSION))
+endif
+endif

--- a/src/app/fdctl/.gitignore
+++ b/src/app/fdctl/.gitignore
@@ -1,2 +1,1 @@
 version.h
-version2.h

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -5,12 +5,9 @@ define FDCTL_VERSION2_H
 #define FDCTL_PATCH_VERSION $(FIREDANCER_VERSION_PATCH)
 #define FDCTL_VERSION_CSTR "$(FIREDANCER_VERSION_CSTR)"
 endef
-$(file >src/app/fdctl/version2.h,$(FDCTL_VERSION2_H))
-
 # Update version.h only if version changed or doesn't exist
-ifneq ($(shell cmp -s src/app/fdctl/version.h src/app/fdctl/version2.h && echo "same"),same)
-src/app/fdctl/version.h: src/app/fdctl/version2.h
-	cp -f src/app/fdctl/version2.h $@
+ifneq ($(if $(wildcard src/app/fdctl/version.h),$(file <src/app/fdctl/version.h)),$(FDCTL_VERSION2_H))
+$(file >src/app/fdctl/version.h,$(FDCTL_VERSION2_H))
 endif
 
 $(OBJDIR)/info: src/app/fdctl/version.h

--- a/src/util/Local.mk
+++ b/src/util/Local.mk
@@ -27,10 +27,9 @@ define FD_VERSION_GENERATED_H
 #define FD_VERSION_MINOR $(FD_VERSION_MINOR)
 #define FD_VERSION_PATCH $(FD_VERSION_PATCH)
 endef
-$(file >src/util/fd_version_generated1.h,$(FD_VERSION_GENERATED_H))
-ifneq ($(shell cmp -s src/util/fd_version_generated.h src/util/fd_version_generated1.h && echo "same"),same)
-src/util/fd_version_generated.h: src/util/fd_version_generated1.h
-	cp -f src/util/fd_version_generated1.h $@
+# $(file <...) requires GNU Make 4.2
+ifneq ($(if $(wildcard src/util/fd_version_generated.h),$(file <src/util/fd_version_generated.h)),$(FD_VERSION_GENERATED_H))
+$(file >src/util/fd_version_generated.h,$(FD_VERSION_GENERATED_H))
 endif
 $(OBJDIR)/info: src/util/fd_version_generated.h
 $(OBJDIR)/obj/util/fd_version.o:     src/util/fd_version_generated.h


### PR DESCRIPTION
Remove dependency on diffutils, instead use a GNU Make 4.2
feature.  This Make version is supported on all Firedancer targets
(including Ubuntu 20.04 and RHEL 8).
