### PR TITLE
backup: fix torn reads from disk

### DIFF
--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -1667,8 +1667,9 @@ fd_gui_printf_accounts_stats( fd_gui_t * gui ) {
              with zeroed utilization so the row visually clears once its
              data has been moved out. */
           int    is_compacted   = info->compaction_state==0 &&
-                                  info->write_offset>0UL &&
-                                  info->compaction_offset>=info->write_offset;
+                                  ( ( info->write_offset>0UL &&
+                                      info->compaction_offset>=info->write_offset ) ||
+                                    ( !info->write_offset && info->bytes_written>0UL ) );
           ulong  tier           = is_compacted ? 255UL : (ulong)info->layer;
           double utilization    = (!is_compacted && partition_sz)
             ? (double)info->write_offset / (double)partition_sz : 0.0;

--- a/src/discof/backup/fd_snapmk_tile.c
+++ b/src/discof/backup/fd_snapmk_tile.c
@@ -1739,7 +1739,10 @@ snaprd_frag( fd_snapmk_t *       ctx,
       FD_CHECK_ERR( !parse->ps_cnt, "prestaged batch outlived its frag" );
       if( FD_UNLIKELY( fd_frag_meta_ctl_eom( ctl ) ) ) {
         if( FD_UNLIKELY( parse->meta_sz || parse->acc_active || parse->pub_pending ) ) {
-          FD_LOG_CRIT(( "snaprd stream ended mid-account record" ));
+          FD_LOG_CRIT(( "snaprd stream ended mid-account record at accdb offset %lu "
+                        "(meta_sz=%u acc_active=%i acc_off=%u acc_sz=%u pub_pending=%i)",
+                        parse->src_off, parse->meta_sz, parse->acc_active,
+                        parse->acc_off, parse->acc_sz, parse->pub_pending ));
         }
         ctx->disk_out_idx = -1;
         barrier_install( ctx, stem );

--- a/src/discof/backup/fd_snaprd_tile.c
+++ b/src/discof/backup/fd_snaprd_tile.c
@@ -6,7 +6,6 @@
 #include "../../disco/topo/fd_topo.h"
 #include "../../flamenco/accdb/fd_accdb.h"
 #include "../../flamenco/accdb/fd_accdb_shmem.h"
-#include "../../flamenco/accdb/fd_accdb_private.h"
 #include "../../tango/fseq/fd_fseq.h"
 #include <errno.h>
 #include <unistd.h>
@@ -22,7 +21,6 @@
 
 #define STEM_BURST 64UL /* 64 * 64KiB -> 4MiB */
 #define SNAPRD_PART_MAX (1UL<<13)
-#define BARRIER_WORDS   (FD_ACCDB_MAX_JOINERS/64UL)
 
 struct fd_snaprd {
   uint state;
@@ -46,7 +44,7 @@ struct fd_snaprd {
   ulong part_sz;       /* byte size of partition */
   ulong part_file_off; /* accdb file offset of partition */
 
-  ulong barrier[ BARRIER_WORDS ]; /* writers whose pwritev2 has yet to land */
+  fd_accdb_shmem_writer_barrier_t barrier[ 1 ]; /* writers whose pwritev2 has yet to land */
 
   struct {
     void * mem;
@@ -167,13 +165,15 @@ next_partition( fd_snaprd_t * ctx ) {
 
 static int
 backup_disk_capture( fd_snaprd_t * ctx ) {
+  FD_CHECK_CRIT( fd_accdb_snapshot_sync_state( fd_accdb_shmem_snapshot_sync( ctx->accdb ) )==FD_ACCDB_SNAPSHOT_SYNC_RUNNING,
+                 "backup capture outside snapshot_sync RUNNING" );
+
   ulong part_max = fd_accdb_shmem_partition_max( ctx->accdb );
   if( FD_UNLIKELY( part_max>SNAPRD_PART_MAX ) ) {
     FD_LOG_ERR(( "accdb partition count %lu exceeds snaprd capacity %lu", part_max, SNAPRD_PART_MAX ));
   }
 
   ulong part_sz = fd_accdb_shmem_partition_sz( ctx->accdb );
-  fd_accdb_partition_t const * pool = (fd_accdb_partition_t const *)( (uchar const *)ctx->accdb + ctx->accdb->partition_pool_off );
 
   ctx->part_cnt = 0UL;
   ulong export_total_bytes = 0UL;
@@ -183,18 +183,15 @@ backup_disk_capture( fd_snaprd_t * ctx ) {
        rooted accounts will have been saved from cache, and non-rooted
        accounts are ignored regardless) */
 
-    ulong sz = ULONG_MAX;
-    for( ulong k=0UL; k<FD_ACCDB_COMPACTION_LAYER_CNT; k++ ) {
-      if( !FD_VOLATILE_CONST( ctx->accdb->has_partition[ k ] ) ) continue;
-      accdb_offset_t whead = { .val = FD_VOLATILE_CONST( ctx->accdb->whead[ k ].val ) };
-      if( packed_partition_idx( &whead )!=i ) continue;
-      sz = packed_partition_offset( &whead );
-      if( FD_UNLIKELY( sz>ctx->accdb->partition_sz ) ) return 0;
-      break;
-    }
-    if( sz==ULONG_MAX ) sz = FD_VOLATILE_CONST( partition_pool_ele_const( pool, i )->write_offset );
+    fd_accdb_shmem_partition_info_t info[ 1 ];
+    fd_accdb_shmem_partition_info( ctx->accdb, i, info );
+
+    ulong sz = info->write_offset_raw;
+    if( FD_UNLIKELY( info->is_write_head && sz>part_sz ) ) return 0; /* mid-rotation, retry */
+    FD_CHECK_CRIT( sz<=part_sz, "accdb partition write_offset exceeds partition size" );
 
     if( !sz ) continue;
+    if( FD_UNLIKELY( info->compaction_offset>=sz ) ) continue; /* already compacted, partition effectively dead */
     ctx->part[ ctx->part_cnt ].file_off = i*part_sz;
     ctx->part[ ctx->part_cnt ].sz       = sz;
     ctx->part_cnt++;
@@ -204,12 +201,7 @@ backup_disk_capture( fd_snaprd_t * ctx ) {
   ctx->metrics.export_total_bytes    = export_total_bytes;
 
   /* need to wait for these writers to complete */
-  memset( ctx->barrier, 0, sizeof(ctx->barrier) );
-  ulong joiner_cnt = FD_VOLATILE_CONST( ctx->accdb->joiner_cnt );
-  for( ulong t=0UL; t<joiner_cnt; t++ ) {
-    if( FD_VOLATILE_CONST( ctx->accdb->joiner_epochs[ t ].val )==ULONG_MAX ) continue;
-    ctx->barrier[ t/64UL ] |= 1UL<<(t%64UL);
-  }
+  fd_accdb_shmem_writer_barrier_capture( ctx->accdb, ctx->barrier );
   return 1;
 }
 
@@ -218,19 +210,7 @@ backup_disk_capture( fd_snaprd_t * ctx ) {
 
 static void
 backup_disk_drain( fd_snaprd_t * ctx ) {
-  ulong remain = 0UL;
-  for( ulong w=0UL; w<BARRIER_WORDS; w++ ) {
-    ulong bits = ctx->barrier[ w ];
-    while( bits ) {
-      ulong b = (ulong)fd_ulong_find_lsb( bits );
-      bits &= bits-1UL;
-      if( FD_VOLATILE_CONST( ctx->accdb->joiner_epochs[ w*64UL+b ].val )==ULONG_MAX ) {
-        ctx->barrier[ w ] &= ~(1UL<<b);
-      }
-    }
-    remain |= ctx->barrier[ w ];
-  }
-  if( FD_UNLIKELY( remain ) ) return;
+  if( FD_UNLIKELY( fd_accdb_shmem_writer_barrier_poll( ctx->accdb, ctx->barrier ) ) ) return;
 
   /* An accdb with no data on disk yields an empty stream, which snapmk
      still has to see terminated (a zero size frag carrying eom). */
@@ -281,6 +261,8 @@ after_credit( fd_snaprd_t *       ctx,
 
   FD_CHECK_CRIT( *stem->cr_avail <= UINT_MAX, "cr_avail underflow" );
   FD_CHECK_CRIT( ctx->part_cur <= ctx->part_sz, "partition cursor overflow" );
+  FD_CHECK_CRIT( fd_accdb_snapshot_sync_state( fd_accdb_shmem_snapshot_sync( ctx->accdb ) )==FD_ACCDB_SNAPSHOT_SYNC_RUNNING,
+                 "accdb resumed compaction while backup read in progress" );
 
   ulong burst_rem = STEM_BURST;
   while( ctx->state==SNAPRD_STATE_READ && stem->cr_avail[ 0 ] && burst_rem-- ) {

--- a/src/discof/backup/fd_snaprd_tile.c
+++ b/src/discof/backup/fd_snaprd_tile.c
@@ -6,6 +6,7 @@
 #include "../../disco/topo/fd_topo.h"
 #include "../../flamenco/accdb/fd_accdb.h"
 #include "../../flamenco/accdb/fd_accdb_shmem.h"
+#include "../../flamenco/accdb/fd_accdb_private.h"
 #include "../../tango/fseq/fd_fseq.h"
 #include <errno.h>
 #include <unistd.h>
@@ -13,12 +14,15 @@
 #include <time.h>
 #include "generated/fd_snaprd_tile_seccomp.h"
 
-#define SNAPRD_STATE_IDLE 0
-#define SNAPRD_STATE_READ 1
-#define SNAPRD_STATE_DONE 2
+#define SNAPRD_STATE_IDLE    0
+#define SNAPRD_STATE_READ    1
+#define SNAPRD_STATE_DONE    2
+#define SNAPRD_STATE_CAPTURE 3 /* sampling accdb partition bounds */
+#define SNAPRD_STATE_DRAIN   4 /* waiting for in-flight accdb writes to land */
 
 #define STEM_BURST 64UL /* 64 * 64KiB -> 4MiB */
 #define SNAPRD_PART_MAX (1UL<<13)
+#define BARRIER_WORDS   (FD_ACCDB_MAX_JOINERS/64UL)
 
 struct fd_snaprd {
   uint state;
@@ -41,6 +45,8 @@ struct fd_snaprd {
   ulong part_cur;      /* cursor in [0,part_sz] */
   ulong part_sz;       /* byte size of partition */
   ulong part_file_off; /* accdb file offset of partition */
+
+  ulong barrier[ BARRIER_WORDS ]; /* writers whose pwritev2 has yet to land */
 
   struct {
     void * mem;
@@ -156,30 +162,75 @@ next_partition( fd_snaprd_t * ctx ) {
   return 0;
 }
 
-static void
-backup_disk_begin( fd_snaprd_t * ctx ) {
+/* backup_disk_capture determines which accdb partition ranges must be
+   read to produce a snapshot. */
+
+static int
+backup_disk_capture( fd_snaprd_t * ctx ) {
   ulong part_max = fd_accdb_shmem_partition_max( ctx->accdb );
   if( FD_UNLIKELY( part_max>SNAPRD_PART_MAX ) ) {
     FD_LOG_ERR(( "accdb partition count %lu exceeds snaprd capacity %lu", part_max, SNAPRD_PART_MAX ));
   }
 
+  ulong part_sz = fd_accdb_shmem_partition_sz( ctx->accdb );
+  fd_accdb_partition_t const * pool = (fd_accdb_partition_t const *)( (uchar const *)ctx->accdb + ctx->accdb->partition_pool_off );
+
   ctx->part_cnt = 0UL;
   ulong export_total_bytes = 0UL;
   for( ulong i=0UL; i<part_max; i++ ) {
-    fd_accdb_shmem_partition_info_t info[1];
-    fd_accdb_shmem_partition_info( ctx->accdb, i, info );
     /* the accdb partitions might grow after we save offsets into
        ctx->part, but we can safely ignore any future data (newly added
        rooted accounts will have been saved from cache, and non-rooted
        accounts are ignored regardless) */
-    if( !info->write_offset ) continue;
-    ctx->part[ ctx->part_cnt ].file_off = info->file_offset;
-    ctx->part[ ctx->part_cnt ].sz       = info->write_offset;
+
+    ulong sz = ULONG_MAX;
+    for( ulong k=0UL; k<FD_ACCDB_COMPACTION_LAYER_CNT; k++ ) {
+      if( !FD_VOLATILE_CONST( ctx->accdb->has_partition[ k ] ) ) continue;
+      accdb_offset_t whead = { .val = FD_VOLATILE_CONST( ctx->accdb->whead[ k ].val ) };
+      if( packed_partition_idx( &whead )!=i ) continue;
+      sz = packed_partition_offset( &whead );
+      if( FD_UNLIKELY( sz>ctx->accdb->partition_sz ) ) return 0;
+      break;
+    }
+    if( sz==ULONG_MAX ) sz = FD_VOLATILE_CONST( partition_pool_ele_const( pool, i )->write_offset );
+
+    if( !sz ) continue;
+    ctx->part[ ctx->part_cnt ].file_off = i*part_sz;
+    ctx->part[ ctx->part_cnt ].sz       = sz;
     ctx->part_cnt++;
-    export_total_bytes += info->write_offset;
+    export_total_bytes += sz;
   }
   ctx->metrics.export_progress_bytes = 0UL;
   ctx->metrics.export_total_bytes    = export_total_bytes;
+
+  /* need to wait for these writers to complete */
+  memset( ctx->barrier, 0, sizeof(ctx->barrier) );
+  ulong joiner_cnt = FD_VOLATILE_CONST( ctx->accdb->joiner_cnt );
+  for( ulong t=0UL; t<joiner_cnt; t++ ) {
+    if( FD_VOLATILE_CONST( ctx->accdb->joiner_epochs[ t ].val )==ULONG_MAX ) continue;
+    ctx->barrier[ t/64UL ] |= 1UL<<(t%64UL);
+  }
+  return 1;
+}
+
+/* backup_disk_drain waits out the writes that were in flight when
+   backup_disk_capture sampled the partition bounds. */
+
+static void
+backup_disk_drain( fd_snaprd_t * ctx ) {
+  ulong remain = 0UL;
+  for( ulong w=0UL; w<BARRIER_WORDS; w++ ) {
+    ulong bits = ctx->barrier[ w ];
+    while( bits ) {
+      ulong b = (ulong)fd_ulong_find_lsb( bits );
+      bits &= bits-1UL;
+      if( FD_VOLATILE_CONST( ctx->accdb->joiner_epochs[ w*64UL+b ].val )==ULONG_MAX ) {
+        ctx->barrier[ w ] &= ~(1UL<<b);
+      }
+    }
+    remain |= ctx->barrier[ w ];
+  }
+  if( FD_UNLIKELY( remain ) ) return;
 
   /* An accdb with no data on disk yields an empty stream, which snapmk
      still has to see terminated (a zero size frag carrying eom). */
@@ -203,8 +254,8 @@ before_credit( fd_snaprd_t *       ctx,
 
   /* new backup job */
   ctx->in_ctl_seq = ctl_cur;
-  backup_disk_begin( ctx );
-  ctx->idle_cnt = 0UL;
+  ctx->state      = SNAPRD_STATE_CAPTURE;
+  ctx->idle_cnt   = 0UL;
   *charge_busy = 1;
 }
 
@@ -213,6 +264,19 @@ after_credit( fd_snaprd_t *       ctx,
               fd_stem_context_t * stem,
               int *               opt_poll_in,
               int *               charge_busy ) {
+  if( FD_UNLIKELY( ctx->state==SNAPRD_STATE_CAPTURE ) ) {
+    *charge_busy = 1;
+    if( FD_UNLIKELY( !backup_disk_capture( ctx ) ) ) return;
+    ctx->state = SNAPRD_STATE_DRAIN;
+    return;
+  }
+
+  if( FD_UNLIKELY( ctx->state==SNAPRD_STATE_DRAIN ) ) {
+    *charge_busy = 1;
+    backup_disk_drain( ctx );
+    return;
+  }
+
   if( FD_UNLIKELY( ctx->state!=SNAPRD_STATE_READ ) ) return;
 
   FD_CHECK_CRIT( *stem->cr_avail <= UINT_MAX, "cr_avail underflow" );

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -601,6 +601,7 @@ fd_accdb_snapshot_revert_whead( fd_accdb_t *                         accdb,
     if( FD_UNLIKELY( part->queued ) ) {
       compaction_dlist_ele_remove( accdb->compaction_dlist[ part->layer ], part, accdb->partition_pool );
     }
+    FD_VOLATILE( part->write_offset ) = 0UL;
     partition_pool_ele_release( accdb->partition_pool, part );
   }
 
@@ -1856,6 +1857,7 @@ background_compact( fd_accdb_t * accdb,
     spin_lock_acquire( &accdb->shmem->partition_lock );
     deferred_free_dlist_ele_pop_head( accdb->deferred_free_dlist, accdb->partition_pool );
     FD_ATOMIC_FETCH_AND_SUB( &accdb->shmem->shmetrics->disk_current_bytes, accdb->shmem->partition_sz );
+    FD_VOLATILE( p->write_offset ) = 0UL;
     partition_pool_ele_release( accdb->partition_pool, p );
     spin_lock_release( &accdb->shmem->partition_lock );
   }
@@ -3854,6 +3856,12 @@ background_preevict( fd_accdb_t * accdb,
       line->key.generation = UINT_MAX;
       if( FD_UNLIKELY( !line->persisted && acc_idx!=UINT_MAX ) ) {
         fd_accdb_accmeta_t * accmeta = &accdb->acc_pool[ acc_idx ];
+
+        /* advertise to external observers that write is in progress */
+        FD_COMPILER_MFENCE();
+        FD_VOLATILE( *accdb->my_epoch_slot ) = FD_VOLATILE_CONST( accdb->shmem->epoch );
+        FD_HW_MFENCE();
+
         fd_racesan_hook( "preevict:pre_synth" );
 #if FD_TMPL_USE_HANDHOLDING
         FD_TEST( line_gen==accmeta->key.generation &&
@@ -3913,6 +3921,9 @@ background_preevict( fd_accdb_t * accdb,
 
         accdb->metrics->accounts_preevicted++;
         accdb->metrics->accounts_preevicted_per_class[ c ]++;
+
+        FD_COMPILER_MFENCE();
+        FD_VOLATILE( *accdb->my_epoch_slot ) = ULONG_MAX;
       }
 
       line->persisted      = 1;

--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -444,6 +444,8 @@ fd_accdb_reset( fd_accdb_t * accdb ) {
 
 void
 fd_accdb_snapshot_load_begin( fd_accdb_t * accdb ) {
+  FD_CHECK_CRIT( fd_accdb_snapshot_sync_state( &accdb->shmem->snapshot_sync )==FD_ACCDB_SNAPSHOT_SYNC_IDLE,
+                 "snapshot load started while snapshot production active" );
   accdb->snapshot_loading = 1;
   FD_VOLATILE( accdb->shmem->snapshot_loading ) = 1;
 }
@@ -1666,6 +1668,7 @@ change_partition( fd_accdb_t *           accdb,
   ulong new_partition_idx = partition_pool_idx( accdb->partition_pool, partition );
   int had_partition = *has_partition;
   *out_offset   = accdb_offset( new_partition_idx, 0UL );
+  FD_COMPILER_MFENCE();
   *has_partition = 1;
 
   /* Now that the write head has been rotated away from the old
@@ -4312,11 +4315,15 @@ fd_accdb_background( fd_accdb_t * accdb,
       fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_IDLE );
       break;
     case FD_ACCDB_SNAPSHOT_SYNC_START_FULL:
+      FD_CHECK_CRIT( !FD_VOLATILE_CONST( shmem->snapshot_loading ),
+                     "snapshot production requested during snapshot load" );
       delta_reset( accdb );
       fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
       *charge_busy = 1;
       return;
     case FD_ACCDB_SNAPSHOT_SYNC_START_INCR:
+      FD_CHECK_CRIT( !FD_VOLATILE_CONST( shmem->snapshot_loading ),
+                     "snapshot production requested during snapshot load" );
       if( delta_is_valid( accdb->shmem ) ) {
         fd_accdb_snapshot_sync_advance( snap_sync_p, FD_ACCDB_SNAPSHOT_SYNC_RUNNING );
       } else {

--- a/src/flamenco/accdb/fd_accdb_shmem.c
+++ b/src/flamenco/accdb/fd_accdb_shmem.c
@@ -333,6 +333,9 @@ fd_accdb_shmem_new( void * shmem,
 
   fd_accdb_partition_t * partition_pool = partition_pool_join( partition_pool_new( _partition_pool, partition_cnt ) );
   FD_TEST( partition_pool );
+  for( ulong i=0UL; i<partition_cnt; i++ ) {
+    partition_pool_ele( partition_pool, i )->write_offset = 0UL;
+  }
 
   for( ulong k=0UL; k<FD_ACCDB_COMPACTION_LAYER_CNT; k++ ) {
     compaction_dlist_t * dlist = compaction_dlist_join( compaction_dlist_new( _compaction_dlists[ k ] ) );
@@ -548,12 +551,13 @@ fd_accdb_shmem_partition_info( fd_accdb_shmem_t const *          accdb,
      layer, partition->write_offset is stale (it's only updated at
      handoff in change_partition).  The live tip lives in whead[layer].
      Surface the live value so the GUI shows real-time fill, not the
-     "0 until rolled" snapshot. */
+     "0 until rolled" snapshot.  The tip is a reservation that can
+     briefly overrun the partition, so clamp rather than show >100%. */
   for( ulong k=0UL; k<FD_ACCDB_COMPACTION_LAYER_CNT; k++ ) {
     if( !FD_VOLATILE_CONST( accdb->has_partition[ k ] ) ) continue;
     accdb_offset_t whead = { .val = FD_VOLATILE_CONST( accdb->whead[ k ].val ) };
     if( packed_partition_idx( &whead )==partition_idx ) {
-      out->write_offset  = packed_partition_offset( &whead );
+      out->write_offset  = fd_ulong_min( packed_partition_offset( &whead ), accdb->partition_sz );
       out->is_write_head = 1;
       break;
     }

--- a/src/flamenco/accdb/fd_accdb_shmem.c
+++ b/src/flamenco/accdb/fd_accdb_shmem.c
@@ -545,7 +545,6 @@ fd_accdb_shmem_partition_info( fd_accdb_shmem_t const *          accdb,
   fd_accdb_partition_t const * p              = partition_pool_ele_const( partition_pool, partition_idx );
 
   out->file_offset       = partition_idx * accdb->partition_sz;
-  out->write_offset      = FD_VOLATILE_CONST( p->write_offset );
   out->is_write_head     = 0;
   /* If this partition is currently the active write head for any
      layer, partition->write_offset is stale (it's only updated at
@@ -553,14 +552,22 @@ fd_accdb_shmem_partition_info( fd_accdb_shmem_t const *          accdb,
      Surface the live value so the GUI shows real-time fill, not the
      "0 until rolled" snapshot.  The tip is a reservation that can
      briefly overrun the partition, so clamp rather than show >100%. */
+  ulong head_off = ULONG_MAX;
   for( ulong k=0UL; k<FD_ACCDB_COMPACTION_LAYER_CNT; k++ ) {
     if( !FD_VOLATILE_CONST( accdb->has_partition[ k ] ) ) continue;
     accdb_offset_t whead = { .val = FD_VOLATILE_CONST( accdb->whead[ k ].val ) };
     if( packed_partition_idx( &whead )==partition_idx ) {
-      out->write_offset  = fd_ulong_min( packed_partition_offset( &whead ), accdb->partition_sz );
+      head_off           = packed_partition_offset( &whead );
       out->is_write_head = 1;
       break;
     }
+  }
+  if( FD_UNLIKELY( out->is_write_head ) ) {
+    out->write_offset_raw = head_off;
+    out->write_offset     = fd_ulong_min( head_off, accdb->partition_sz );
+  } else {
+    out->write_offset_raw = FD_VOLATILE_CONST( p->write_offset );
+    out->write_offset     = out->write_offset_raw;
   }
   out->bytes_freed       = FD_VOLATILE_CONST( p->bytes_freed );
   out->compaction_offset = FD_VOLATILE_CONST( p->compaction_offset );
@@ -574,4 +581,40 @@ fd_accdb_shmem_partition_info( fd_accdb_shmem_t const *          accdb,
   uchar compacting       = FD_VOLATILE_CONST( p->compacting_now );
   uchar queued           = FD_VOLATILE_CONST( p->queued );
   out->compaction_state  = compacting ? 2 : ( queued ? 1 : 0 );
+}
+
+FD_STATIC_ASSERT( sizeof(((fd_accdb_shmem_writer_barrier_t *)0)->bits)*8UL==FD_ACCDB_MAX_JOINERS, barrier_width );
+
+void
+fd_accdb_shmem_writer_barrier_capture( fd_accdb_shmem_t const *          accdb,
+                                       fd_accdb_shmem_writer_barrier_t * barrier ) {
+  memset( barrier->bits, 0, sizeof(barrier->bits) );
+  ulong joiner_cnt = FD_VOLATILE_CONST( accdb->joiner_cnt );
+  for( ulong t=0UL; t<joiner_cnt; t++ ) {
+    if( FD_VOLATILE_CONST( accdb->joiner_epochs[ t ].val )==ULONG_MAX ) continue;
+    barrier->bits[ t/64UL ] |= 1UL<<(t%64UL);
+  }
+}
+
+ulong
+fd_accdb_shmem_writer_barrier_poll( fd_accdb_shmem_t const *          accdb,
+                                    fd_accdb_shmem_writer_barrier_t * barrier ) {
+  ulong remain = 0UL;
+  for( ulong w=0UL; w<sizeof(barrier->bits)/sizeof(ulong); w++ ) {
+    ulong bits = barrier->bits[ w ];
+    while( bits ) {
+      ulong b = (ulong)fd_ulong_find_lsb( bits );
+      bits &= bits-1UL;
+      if( FD_VOLATILE_CONST( accdb->joiner_epochs[ w*64UL+b ].val )==ULONG_MAX ) {
+        barrier->bits[ w ] &= ~(1UL<<b);
+      }
+    }
+    remain |= barrier->bits[ w ];
+  }
+  return remain;
+}
+
+ulong const *
+fd_accdb_shmem_snapshot_sync( fd_accdb_shmem_t const * accdb ) {
+  return &accdb->snapshot_sync;
 }

--- a/src/flamenco/accdb/fd_accdb_shmem.h
+++ b/src/flamenco/accdb/fd_accdb_shmem.h
@@ -136,6 +136,7 @@ fd_accdb_shmem_try_enqueue_compaction( fd_accdb_shmem_t * accdb,
 struct fd_accdb_shmem_partition_info {
   ulong file_offset;        /* byte offset of partition start in the accdb file */
   ulong write_offset;       /* current write head within the partition          */
+  ulong write_offset_raw;   /* active head's reservation tip, may exceed the partition size */
   ulong bytes_freed;        /* bytes marked freed within the partition          */
   ulong compaction_offset;  /* current compaction read offset within partition  */
   ulong read_ops;
@@ -162,6 +163,27 @@ void
 fd_accdb_shmem_partition_info( fd_accdb_shmem_t const *          accdb,
                                ulong                             partition_idx,
                                fd_accdb_shmem_partition_info_t * out );
+
+/* Writer barrier.  Write heads advance when space is reserved, not
+   when the write lands, so a sampled offset may cover in-flight
+   writes.  capture records which joiners are mid-write; poll until it
+   returns 0, and everything below offsets sampled before capture is
+   on disk. */
+
+struct fd_accdb_shmem_writer_barrier { ulong bits[ 4UL ]; };
+
+typedef struct fd_accdb_shmem_writer_barrier fd_accdb_shmem_writer_barrier_t;
+
+void
+fd_accdb_shmem_writer_barrier_capture( fd_accdb_shmem_t const *          accdb,
+                                       fd_accdb_shmem_writer_barrier_t * barrier );
+
+ulong
+fd_accdb_shmem_writer_barrier_poll( fd_accdb_shmem_t const *          accdb,
+                                    fd_accdb_shmem_writer_barrier_t * barrier );
+
+ulong const *
+fd_accdb_shmem_snapshot_sync( fd_accdb_shmem_t const * accdb );
 
 FD_PROTOTYPES_END
 


### PR DESCRIPTION
Fixes a data race where the snapshot producer reads accdb
partition offsets from disk that have been allocated but not yet
written.

This is done by letting pre-evict hold onto epochs while writing,
then making snaprd drain epochs before reading.

Closes https://github.com/firedancer-io/firedancer/issues/10965