### PR TITLE
accdb: stop on generation overflow

### DIFF
--- a/src/flamenco/accdb/fd_accdb.c
+++ b/src/flamenco/accdb/fd_accdb.c
@@ -777,6 +777,8 @@ fd_accdb_attach_child( fd_accdb_t *       accdb,
      live + deferred forks <= max_live_slots. */
   wait_cmd( accdb );
 
+  if( FD_UNLIKELY( accdb->shmem->generation==UINT_MAX ) ) FD_LOG_ERR(( "accdb ran out of generation sequence numbers, restart required" ));
+
   fd_accdb_fork_shmem_t * acquired = fork_pool_acquire( accdb->fork_shmem_pool );
   if( FD_UNLIKELY( !acquired ) ) {
     submit_cmd( accdb, FD_ACCDB_CMD_DRAIN_DEFERRED, USHORT_MAX );


### PR DESCRIPTION
Possibly slop, the generation counter takes decades to overflow
at 200ms slots.  However if someone wants to launch an appchain
with 10ms slots based on Firedancer, they can realistically run
into an overflow in a year or so.  So, I thought it'd be worth
adding.
