### PR TITLE
rpc: reject getMinimumBalanceForRentExemption for giant accounts

### DIFF
--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -1853,6 +1853,11 @@ getMinimumBalanceForRentExemption( fd_rpc_tile_t * ctx,
     CSTR_JSON( id, id_cstr );
     return PRINTF_JSON( ctx, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params: invalid type: %s, expected usize.\"},\"id\":%s}\n", fd_rpc_cjson_type_to_cstr( acct_sz ), id_cstr );
   }
+  if( FD_UNLIKELY( acct_sz->valuedouble>(double)FD_RUNTIME_ACC_SZ_MAX ) ) {
+    CSTR_JSON( id, id_cstr );
+    return PRINTF_JSON( ctx, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid request\"},\"id\":%s}\n", id_cstr );
+  }
+  ulong acct_sz_value = (ulong)acct_sz->valuedouble;
 
   bank_info_t const * bank = &ctx->banks[ bank_idx ];
 
@@ -1861,7 +1866,7 @@ getMinimumBalanceForRentExemption( fd_rpc_tile_t * ctx,
     .exemption_threshold = bank->rent.exemption_threshold,
     .burn_percent = bank->rent.burn_percent,
   };
-  ulong minimum = fd_rent_exempt_minimum_balance( &rent, acct_sz->valueulong );
+  ulong minimum = fd_rent_exempt_minimum_balance( &rent, acct_sz_value );
   CSTR_JSON( id, id_cstr );
   return PRINTF_JSON( ctx, "{\"jsonrpc\":\"2.0\",\"result\":%lu,\"id\":%s}\n", minimum, id_cstr );
 }

--- a/src/discof/rpc/test_rpc_tile.c
+++ b/src/discof/rpc/test_rpc_tile.c
@@ -570,6 +570,12 @@ main( int     argc,
   char req_buf[8192];
   char res_buf[4096];
 
+  FD_TEST( fd_cstr_printf_check( req_buf, sizeof(req_buf), NULL,
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getMinimumBalanceForRentExemption\",\"params\":[%lu]}",
+      FD_RUNTIME_ACC_SZ_MAX+1UL ) );
+  expect_rpc_response( ctx, req_buf,
+      "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid request\"},\"id\":1}" );
+
   expect_rpc_response( ctx,
       "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getMultipleAccounts\",\"params\":[\"not-an-array\"]}",
       "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params: invalid type: string \\\"not-an-array\\\", expected a sequence.\"},\"id\":1}" );

--- a/src/discof/rpc/test_rpc_tile.py
+++ b/src/discof/rpc/test_rpc_tile.py
@@ -676,6 +676,15 @@ GET_MINIMUM_BALANCE_FOR_RENT_EXEMPTION = [
         },
         "description": f"getMinimumBalanceForRentExemption success",
     },
+    {
+        "payload": {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "getMinimumBalanceForRentExemption",
+            "params": [10 * 1024 * 1024 + 1],
+        },
+        "description": "getMinimumBalanceForRentExemption rejects oversized account",
+    },
 ]
 
 GET_SLOT = [


### PR DESCRIPTION
Match Agave, returning "Invalid request" for requests with
oversize account data size.
