### PR TITLE
config: match Agave's full/incremental interval

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -439,7 +439,7 @@ telemetry = true
     # creations.  0 disables incremental snapshot production.
     # Snapshots may be skipped if production cannot keep up with the
     # schedule or max_incremental_snapshot_accounts is exceeded.
-    incremental_snapshot_interval_slots = 100
+    incremental_snapshot_interval_slots = 200
 
     # Maximum number of changed-account pubkeys retained between full
     # snapshots for incremental snapshot creation.  Each entry uses 36
@@ -495,7 +495,9 @@ telemetry = true
         # set higher than the incremental age because, as full snapshots
         # are much larger than incremental snapshots, the time penalty
         # for downloading a full snapshot is much higher.
-        max_local_full_effective_age = 1000
+        # This should exceed [snapshots].full_snapshot_interval_slots to
+        # leave enough time for the next full snapshot to be created.
+        max_local_full_effective_age = 125000
         max_local_incremental_age = 50
 
         # If any HTTP server URLs are listed, the following paths will

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -258,6 +258,13 @@ fd_topo_initialize( config_t * config ) {
     FD_CHECK_ERR( !config->firedancer.snapshots.incremental_snapshot_interval_slots ||
                   config->firedancer.snapshots.max_incremental_snapshots_to_keep,
                   "[snapshots.max_incremental_snapshots_to_keep] must be nonzero when incremental snapshot production is enabled" );
+    if( FD_UNLIKELY( config->firedancer.snapshots.full_snapshot_interval_slots &&
+                     config->firedancer.snapshots.sources.max_local_full_effective_age<=config->firedancer.snapshots.full_snapshot_interval_slots ) ) {
+      FD_LOG_WARNING(( "[snapshots.sources.max_local_full_effective_age] is %u slots, not greater than [snapshots.full_snapshot_interval_slots] of %lu slots.\n"
+                       "This leaves no slack for full snapshot creation and can prevent startup from locally produced snapshots.",
+                       config->firedancer.snapshots.sources.max_local_full_effective_age,
+                       config->firedancer.snapshots.full_snapshot_interval_slots ));
+    }
   }
 
   fd_topo_t * topo = fd_topob_new( &config->topo, config->name );

--- a/src/app/shared/test_config_json.c
+++ b/src/app/shared/test_config_json.c
@@ -56,6 +56,9 @@ main( int     argc,
   static fd_config_t config[1];
   fd_config_load( 1, 0, default_config, strlen( default_config ), NULL, NULL, 0UL, NULL, 0UL, NULL, config, 0 );
 
+  /* default config checks */
+  FD_TEST( config->firedancer.snapshots.sources.max_local_full_effective_age>config->firedancer.snapshots.full_snapshot_interval_slots );
+
   strcpy( config->tiles.bundle.url, "https://user:hunter2@mainnet.example.com:443/v1/txns?api-key=SECRET#frag" );
   strcpy( config->tiles.event.url,  "https://events.example.com/submit" );
 


### PR DESCRIPTION
- default.toml: produce full snapshots every 100k slots
- default.toml: produce incremental snapshots every 200 slots
- default.toml: raise max full snapshot age to 125k slots
- log a warning if the max full snap age is less than the full
  snap creation interval
