### PR TITLE
progcache: keep free recs write-locked

### DIFF
--- a/src/flamenco/progcache/README.md
+++ b/src/flamenco/progcache/README.md
@@ -137,8 +137,9 @@ Each record access considers the following slot numbers:
 ### Record life cycle
 
 Records have the following states:
+- free: descriptor is in the record pool with its write lock held
 - hidden: resources allocated, but invisible (cannot be referenced by
-  any thread)
+  any thread); inherits the write lock from the pool
 - published: owned by a fork, visible to users
 - rooted: finalized by consensus (not owned by a fork), visible
 
@@ -157,6 +158,11 @@ The record descriptor itself is reclaimed according to these rules:
 - Records that are part of a transaction defer reclamation to rooting/
   cancellation (replay tile)
 - Records that are already rooted are immediately reclaimed
+
+Reclamation leaves the descriptor write locked when returning it to the
+record pool.  Allocation inherits that lock and keeps it held through
+initialization and publication.  This prevents stale speculative readers
+from acquiring a recycled descriptor between generations.
 
 ### Cache replacement policy
 

--- a/src/flamenco/progcache/fd_progcache.c
+++ b/src/flamenco/progcache/fd_progcache.c
@@ -132,8 +132,8 @@ fd_progcache_shmem_new( void * shmem,
 
   FD_TEST( FD_SCRATCH_ALLOC_FINI( l, fd_progcache_shmem_align() ) == (ulong)pc + fd_progcache_shmem_footprint( txn_max, rec_max ) );
 
-  fd_memset( pc,      0, offsetof(fd_progcache_shmem_t, spill) );
-  fd_memset( rec_ele, 0, rec_max * sizeof(fd_progcache_rec_t)  );
+  fd_memset( pc, 0, offsetof(fd_progcache_shmem_t, spill) );
+  for( ulong i=0UL; i<rec_max; i++ ) fd_progcache_rec_new( &rec_ele[ i ] );
 
   pc->wksp_tag = wksp_tag;
   pc->seed     = seed;

--- a/src/flamenco/progcache/fd_progcache.h
+++ b/src/flamenco/progcache/fd_progcache.h
@@ -15,7 +15,7 @@
 /* fd_progcache_shmem_t is the top-level shared memory data structure
    of the progcache. */
 
-#define FD_PROGCACHE_SHMEM_MAGIC (0xf17eda2ce7fc2c03UL)
+#define FD_PROGCACHE_SHMEM_MAGIC (0xf17eda2ce7fc2c04UL)
 
 #define FD_PROGCACHE_SPAD_MAX (FD_MAX_INSTRUCTION_STACK_DEPTH * (20UL<<20))
 

--- a/src/flamenco/progcache/fd_progcache_admin.c
+++ b/src/flamenco/progcache/fd_progcache_admin.c
@@ -357,6 +357,11 @@ reset_rec_map( fd_progcache_join_t * cache ) {
       fd_progcache_rec_t * rec = fd_prog_recm_iter_ele( iter );
       ulong next = fd_prog_recm_private_idx( rec->map_next );
 
+      /* Free pool records are write locked.  reset does not support
+         concurrent use, so this acquisition cannot block on a live
+         user. */
+      fd_rwlock_write( &rec->lock );
+
       if( rec->exists ) {
         fd_prog_recm_query_t rec_query[1];
         int err = fd_prog_recm_remove( cache->rec.map, &rec->pair, NULL, rec_query, FD_MAP_FLAG_BLOCKING );

--- a/src/flamenco/progcache/fd_progcache_rec.h
+++ b/src/flamenco/progcache/fd_progcache_rec.h
@@ -61,6 +61,27 @@ struct __attribute__((aligned(64))) fd_progcache_rec {
 
 FD_STATIC_ASSERT( sizeof(fd_progcache_rec_t)==128, layout );
 
+/* fd_progcache_rec_reset clears all record state except lock */
+
+static inline fd_progcache_rec_t *
+fd_progcache_rec_reset( fd_progcache_rec_t * rec ) {
+  FD_TEST( atomic_load_explicit( &rec->lock.value, memory_order_relaxed )==FD_RWLOCK_WRITE_LOCK );
+  memset( rec,            0, offsetof(fd_progcache_rec_t, txn_idx)                              );
+  memset( &rec->next_idx, 0, offsetof(fd_progcache_rec_t, lock)-offsetof(fd_progcache_rec_t, next_idx) );
+  atomic_store_explicit( &rec->txn_idx, UINT_MAX, memory_order_relaxed );
+  rec->reclaim_next = UINT_MAX;
+  return rec;
+}
+
+/* fd_progcache_rec_new formats a descriptor into the free, write-locked
+   state.  Only valid when the descriptor is not concurrently visible. */
+
+static inline fd_progcache_rec_t *
+fd_progcache_rec_new( fd_progcache_rec_t * rec ) {
+  atomic_store_explicit( &rec->lock.value, FD_RWLOCK_WRITE_LOCK, memory_order_relaxed );
+  return fd_progcache_rec_reset( rec );
+}
+
 FD_PROTOTYPES_BEGIN
 
 /* Accessors */

--- a/src/flamenco/progcache/fd_progcache_reclaim.c
+++ b/src/flamenco/progcache/fd_progcache_reclaim.c
@@ -41,8 +41,8 @@ rec_reclaim( fd_progcache_join_t * join,
   }
   fd_racesan_hook( "prog_reclaim:post_unlink" );
 
-  /* Drain existing users
-     Leave record in locked state (lock is reset when allocating) */
+  /* Drain existing users.  Transfer the write lock with the record to
+     the pool; the next allocator inherits it. */
 
   if( FD_UNLIKELY( !fd_rwlock_trywrite( &rec->lock ) ) ) return 0;
 

--- a/src/flamenco/progcache/fd_progcache_user.c
+++ b/src/flamenco/progcache/fd_progcache_user.c
@@ -395,8 +395,7 @@ fd_progcache_spill_open( fd_progcache_t *        cache,
   uint rec_idx = shmem->spill.rec_used++;
   shmem->spill.spad_off[ rec_idx ] = shmem->spill.spad_used;
   fd_progcache_rec_t * rec = &shmem->spill.rec[ rec_idx ];
-  memset( rec, 0, sizeof(fd_progcache_rec_t) );
-  rec->lock.value   = 1; /* read lock; no concurrency, don't need CAS */
+  fd_progcache_rec_new( rec );
   rec->exists       = 1;
   rec->feature_slot = params->feature_slot;
   rec->deploy_slot  = params->deploy_slot;
@@ -430,6 +429,7 @@ fd_progcache_spill_open( fd_progcache_t *        cache,
   cache->metrics->spill_cnt++;
   cache->metrics->spill_tot_sz += rec->rodata_sz;
 
+  fd_rwlock_demote( &rec->lock );
   FD_TEST( rec->exists );
   return rec;
 }
@@ -466,12 +466,11 @@ fd_progcache_insert( fd_progcache_t *        cache,
       return fd_progcache_spill_open( cache, params );
     }
   }
-  memset( rec, 0, sizeof(fd_progcache_rec_t) );
+  fd_progcache_rec_reset( rec );
   rec->exists       = 1;
   rec->feature_slot = feature_slot;
   rec->deploy_slot  = params->deploy_slot;
-  rec->txn_idx      = UINT_MAX;
-  rec->reclaim_next = UINT_MAX;
+  fd_racesan_hook( "prog_insert:post_reset" );
 
   if( FD_LIKELY( peek_err==FD_SBPF_ELF_SUCCESS ) ) {
     ulong val_align     = fd_progcache_val_align();
@@ -492,10 +491,7 @@ fd_progcache_insert( fd_progcache_t *        cache,
 
   /* Publish cache entry to index */
 
-  /* Acquires rec->lock before txn.rwlock (inverse of the documented
-     lock order).  Safe because the record was just allocated and is not
-     yet visible to other threads. */
-  fd_rwlock_write( &rec->lock );
+  /* rec->lock was inherited write locked from the record pool. */
   fd_racesan_hook( "prog_insert:pre_push" );
   fd_rwlock_read( &ljoin->shmem->txn.rwlock );
   ulong txn_idx = cache->lineage->tip_txn_idx;
@@ -506,7 +502,6 @@ fd_progcache_insert( fd_progcache_t *        cache,
   fd_rwlock_unwrite( &txn->lock );
   if( FD_UNLIKELY( !push_ok ) ) {
     fd_rwlock_unread( &ljoin->shmem->txn.rwlock );
-    fd_rwlock_unwrite( &rec->lock );
     fd_progcache_val_free( rec, ljoin );
     fd_prog_recp_release( ljoin->rec.pool, rec );
     return NULL;

--- a/src/flamenco/progcache/test_progcache_racesan.c
+++ b/src/flamenco/progcache/test_progcache_racesan.c
@@ -1029,6 +1029,68 @@ FD_UNIT_TEST( delete_reclaim_reuse_pair ) {
   test_progcache_shmem_delete( shmem );
 }
 
+/* A speculative reader may retain a record pointer after map removal.
+   Reclamation and reuse must keep the descriptor write locked so that
+   reader cannot acquire the next record generation during reset. */
+
+FD_UNIT_TEST( peek_reclaim_reuse_lock ) {
+  fd_progcache_shmem_t * shmem = test_progcache_shmem_new();
+
+  fd_pubkey_t key1 = test_key( 1UL );
+  fd_pubkey_t key2 = test_key( 2UL );
+  fd_prog_load_env_t load_env = { .features = g_features, .feature_slot = 0UL };
+
+  test_account_t acc1, acc2;
+  test_account_init( &acc1, &key1, &fd_solana_bpf_loader_deprecated_program_id, 1, valid_program_data, valid_program_data_sz );
+  test_account_init( &acc2, &key2, &fd_solana_bpf_loader_deprecated_program_id, 1, valid_program_data, valid_program_data_sz );
+
+  fd_progcache_join_t admin[1]; FD_TEST( fd_progcache_shmem_join( admin, shmem ) );
+  fd_progcache_fork_id_t xid1 = fd_progcache_attach_child( admin, fd_progcache_fork_id_initial() );
+
+  fd_progcache_rec_t * rec_old;
+  {
+    fd_progcache_t tmp[1];
+    FD_TEST( fd_progcache_join( tmp, shmem, g_fiber[ 2 ].scratch, FD_PROGCACHE_SCRATCH_FOOTPRINT ) );
+    rec_old = fd_progcache_pull( tmp, xid1, &key1, &load_env, acc1.entry );
+    FD_TEST( rec_old );
+    fd_progcache_rec_close( tmp, rec_old );
+    fd_progcache_leave( tmp, NULL );
+  }
+
+  fd_racesan_async_t * peek = fiber_peek( &g_fiber[ 0 ], shmem, xid1, &key1 );
+  FD_TEST( fd_racesan_async_step_until( peek, "prog_search_chain:pre_tryread", STEP_MAX )==FD_RACESAN_ASYNC_RET_HOOK );
+
+  FD_TEST( fd_prog_delete_rec( admin, rec_old )>=0L );
+  FD_TEST( fd_prog_reclaim_work( admin )==1UL );
+  FD_TEST( atomic_load_explicit( &rec_old->lock.value, memory_order_relaxed )==FD_RWLOCK_WRITE_LOCK );
+
+  fd_racesan_async_t * pull = fiber_pull( &g_fiber[ 1 ], shmem, xid1, &key2, &load_env, acc2.entry );
+  FD_TEST( fd_racesan_async_step_until( pull, "prog_insert:post_reset", STEP_MAX )==FD_RACESAN_ASYNC_RET_HOOK );
+  FD_TEST( atomic_load_explicit( &rec_old->lock.value, memory_order_relaxed )==FD_RWLOCK_WRITE_LOCK );
+
+  for(;;) {
+    int ret = fd_racesan_async_step( peek );
+    if( ret==FD_RACESAN_ASYNC_RET_EXIT ) break;
+    FD_TEST( ret==FD_RACESAN_ASYNC_RET_HOOK );
+  }
+  fiber_delete( &g_fiber[ 0 ] );
+
+  for(;;) {
+    int ret = fd_racesan_async_step( pull );
+    if( ret==FD_RACESAN_ASYNC_RET_EXIT ) break;
+    FD_TEST( ret==FD_RACESAN_ASYNC_RET_HOOK );
+  }
+  fiber_delete( &g_fiber[ 1 ] );
+
+  FD_TEST( query_rec_exact( admin, xid1, &key2 )==rec_old );
+  FD_TEST( atomic_load_explicit( &rec_old->lock.value, memory_order_relaxed )==0U );
+  FD_TEST( !fd_progcache_verify( admin ) );
+
+  fd_progcache_cancel_fork( admin, xid1 );
+  FD_TEST( fd_progcache_shmem_leave( admin, NULL ) );
+  test_progcache_shmem_delete( shmem );
+}
+
 FD_UNIT_TEST( cancel_reclaim_reuse_next ) {
   fd_progcache_shmem_t * shmem = test_progcache_shmem_new();
 
@@ -1071,10 +1133,8 @@ FD_UNIT_TEST( cancel_reclaim_reuse_next ) {
 
   fd_progcache_rec_t * rec_reuse = fd_prog_recp_acquire( admin->rec.pool );
   FD_TEST( rec_reuse==rec1 );
-  memset( rec_reuse, 0, sizeof(fd_progcache_rec_t) );
+  fd_progcache_rec_reset( rec_reuse );
   rec_reuse->exists       = 1;
-  rec_reuse->txn_idx      = UINT_MAX;
-  rec_reuse->reclaim_next = UINT_MAX;
   FD_TEST( rec_reuse->next_idx==0U );
 
   int done = 0;


### PR DESCRIPTION
Fixes a correctness issue: progcache rec locks were changed with
non-atomic memset.  Practically not a problem on x86, but only
because the compiler emitted a regular memset instead of a
'rep stosb'.

Instead, let rwlocks outlive rec allocation state and keep rwlock
write-locked while recs are free.
