### PR TITLE
fd_zle, a fast zero-run compressor

### DIFF
--- a/src/flamenco/accdb/Local.mk
+++ b/src/flamenco/accdb/Local.mk
@@ -21,3 +21,10 @@ endif
 
 endif
 endif
+
+$(call add-hdrs,fd_zle.h)
+$(call add-objs,fd_zle,fd_flamenco)
+
+$(call make-unit-test,test_zle,test_zle,fd_flamenco fd_util)
+$(call run-unit-test,test_zle)
+$(call make-unit-test,bench_zle,bench_zle,fd_flamenco fd_util)

--- a/src/flamenco/accdb/bench_zle.c
+++ b/src/flamenco/accdb/bench_zle.c
@@ -1,0 +1,71 @@
+#include "fd_zle.h"
+#include "../../util/fd_util.h"
+
+/* bench_zle: single-thread cache-hot encode/decode throughput on
+   account-shaped inputs. */
+
+#define MAX_SZ (8UL<<20)
+
+static uchar in  [ MAX_SZ ];
+static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ];
+static uchar out [ MAX_SZ ];
+
+static ulong volatile sink;
+
+static void
+bench( char const * name,
+       ulong        sz ) {
+  ulong comp_sz = fd_zle_compress( comp, in, sz );
+  FD_TEST( fd_zle_decompress( out, sz, comp, comp_sz )==(long)sz );
+  FD_TEST( 0==memcmp( out, in, sz ) );
+
+  ulong iter = 1UL + (1UL<<30)/sz;
+
+  for( ulong i=0UL; i<iter/8UL+1UL; i++ ) sink += fd_zle_compress( comp, in, sz );
+
+  long t0 = fd_log_wallclock();
+  for( ulong i=0UL; i<iter; i++ ) sink += fd_zle_compress( comp, in, sz );
+  long t1 = fd_log_wallclock();
+  for( ulong i=0UL; i<iter; i++ ) sink += (ulong)fd_zle_decompress( out, sz, comp, comp_sz );
+  long t2 = fd_log_wallclock();
+
+  double bytes = (double)sz*(double)iter;
+  FD_LOG_NOTICE(( "%-24s sz %8lu -> %6.2f%%  enc %6.2f GB/s (%6.3f ns/B)  dec %6.2f GB/s",
+                  name, sz, 100.*(double)comp_sz/(double)sz,
+                  bytes/(double)(t1-t0), (double)(t1-t0)/bytes,
+                  bytes/(double)(t2-t1) ));
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  uint seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 42U );
+
+  fd_rng_t _rng[1];
+  fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, seed, 0UL ) );
+  FD_TEST( rng );
+
+  /* SPL-Token-shaped: mint+owner+amount random, COption fields zero */
+  fd_memset( in, 0, 165UL );
+  for( ulong j=0UL; j<72UL; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
+  in[108] = 1;
+  bench( "spl-token 165 B", 165UL );
+
+  /* Serum-shaped: 256 KiB orderbook, ~99.6% zero */
+  fd_memset( in, 0, 256UL<<10 );
+  for( ulong j=0UL; j<1024UL; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
+  bench( "serum 256 KiB", 256UL<<10 );
+
+  /* uniform random: a stray zero every ~256 bytes, none elidable */
+  for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = (uchar)fd_rng_uint( rng );
+  bench( "uniform random 8 MiB", MAX_SZ );
+
+  fd_memset( in, 0, MAX_SZ );
+  bench( "all-zero 8 MiB", MAX_SZ );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+  fd_halt();
+  return 0;
+}

--- a/src/flamenco/accdb/fd_zle.c
+++ b/src/flamenco/accdb/fd_zle.c
@@ -1,5 +1,9 @@
 #include "fd_zle.h"
 
+#if FD_HAS_AVX512
+#include <immintrin.h>
+#endif
+
 /* Wire format: a stream of frames, each producing L literal bytes then
    Z zero bytes.
 
@@ -66,6 +70,50 @@ fd_zle_frame_sz( ulong L,
   return 1UL + fd_zle_ext( L ) + L + fd_zle_ext( Z );
 }
 
+#if FD_HAS_AVX512
+
+/* fd_zle_zmask returns the zero-byte mask of the 64 byte word at
+   src+(w<<6).  Bits at positions >=n read as non-zero so runs terminate
+   at n. */
+
+static inline ulong
+fd_zle_zmask( uchar const * s,
+              ulong         w,
+              ulong         n ) {
+  ulong off = w<<6;
+  if( FD_LIKELY( off+64UL<=n ) )
+    return _cvtmask64_u64( _mm512_cmpeq_epi8_mask( _mm512_loadu_si512( (void const *)( s+off ) ), _mm512_setzero_si512() ) );
+  ulong   tail = ~0UL>>( 64UL-( n-off ) );
+  __m512i v    = _mm512_maskz_loadu_epi8( _cvtu64_mask64( tail ), s+off );
+  return _cvtmask64_u64( _mm512_cmpeq_epi8_mask( v, _mm512_setzero_si512() ) ) & tail;
+}
+
+/* exact-length copy: full 64 B vectors + one masked tail */
+
+static inline void
+fd_zle_copy( uchar *       FD_RESTRICT d,
+             uchar const * FD_RESTRICT s,
+             ulong                     sz ) {
+  ulong k = 0UL;
+  for( ; k+64UL<=sz; k+=64UL )
+    _mm512_storeu_si512( (void *)( d+k ), _mm512_loadu_si512( (void const *)( s+k ) ) );
+  if( k<sz ) {
+    __mmask64 m = _cvtu64_mask64( ~0UL>>( 64UL-( sz-k ) ) );
+    _mm512_mask_storeu_epi8( (void *)( d+k ), m, _mm512_maskz_loadu_epi8( m, s+k ) );
+  }
+}
+
+#else
+
+static inline void
+fd_zle_copy( uchar * FD_RESTRICT       d,
+             uchar const * FD_RESTRICT s,
+             ulong                     sz ) {
+  if( sz ) fd_memcpy( d, s, sz );
+}
+
+#endif
+
 static uchar *
 fd_zle_emit( uchar *                   o,
              uchar const * FD_RESTRICT lit,
@@ -75,11 +123,113 @@ fd_zle_emit( uchar *                   o,
   ulong zn = Z<15UL ? Z : 15UL;
   *o++ = (uchar)( (ln<<4) | zn );
   if( L>=15UL ) o += fd_zle_vput( o, L-15UL );
-  if( L       ) fd_memcpy( o, lit, L );
+  fd_zle_copy( o, lit, L );
   o += L;
   if( Z>=15UL ) o += fd_zle_vput( o, Z-15UL );
   return o;
 }
+
+#if FD_HAS_AVX512
+
+/* extend a zero run beyond word *pw; leaves *pw and *pm at the run end */
+
+static inline ulong
+fd_zle_spill( uchar const * s,
+              ulong         n,
+              ulong         words,
+              ulong *       pw,
+              ulong *       pm,
+              ulong         len ) {
+  ulong w = *pw+1UL;
+  while( ( w<<6 )+256UL<=n ) {
+    ulong m0 = fd_zle_zmask( s, w,     n );
+    ulong m1 = fd_zle_zmask( s, w+1UL, n );
+    ulong m2 = fd_zle_zmask( s, w+2UL, n );
+    ulong m3 = fd_zle_zmask( s, w+3UL, n );
+    if( ( m0&m1&m2&m3 )!=~0UL ) break;
+    w += 4UL; len += 256UL;
+  }
+  for(;;) {
+    if( w>=words ) { *pw = w; *pm = 0UL; return len; }
+    ulong t = fd_zle_zmask( s, w, n );
+    if( t!=~0UL ) {
+      ulong ext = (ulong)__builtin_ctzll( ~t );
+      *pw = w;
+      *pm = t & ~( ( 1UL<<ext )-1UL );
+      return len+ext;
+    }
+    w++; len += 64UL;
+  }
+}
+
+ulong
+fd_zle_compress( void *       FD_RESTRICT comp,
+                 void const * FD_RESTRICT data,
+                 ulong                    data_sz ) {
+  uchar *       dst = (uchar *)comp;
+  uchar const * src = (uchar const *)data;
+  ulong         n   = data_sz;
+
+  if( FD_UNLIKELY( !n ) ) return 0UL;
+
+  ulong esc_sz = 1UL + fd_zle_ext( n ) + n;
+  ulong words  = ( n+63UL )>>6;
+
+  uchar * o  = dst;
+  ulong   fs = 0UL;
+  ulong   w  = 0UL;
+  ulong   m  = fd_zle_zmask( src, 0UL, n );
+  for(;;) {
+    while( !m ) {
+      w++;
+      while( ( w<<6 )+256UL<=n ) {
+        ulong m0 = fd_zle_zmask( src, w,     n );
+        ulong m1 = fd_zle_zmask( src, w+1UL, n );
+        ulong m2 = fd_zle_zmask( src, w+2UL, n );
+        ulong m3 = fd_zle_zmask( src, w+3UL, n );
+        if( m0|m1|m2|m3 ) break;
+        w += 4UL;
+      }
+      while( w<words && !( m = fd_zle_zmask( src, w, n ) ) ) w++;
+      if( w>=words ) goto trailing;
+    }
+    ulong b  = (ulong)__builtin_ctzll( m );
+    ulong zs = ( w<<6 )+b;
+    ulong hi = m>>b;
+    ulong len;
+    if( ~hi ) {
+      len = (ulong)__builtin_ctzll( ~hi );
+      m &= ~( ( ( 1UL<<len )-1UL )<<b );
+      if( b+len==64UL ) len = fd_zle_spill( src, n, words, &w, &m, len );
+    } else {                             /* run fills rest of word */
+      m   = 0UL;
+      len = fd_zle_spill( src, n, words, &w, &m, 64UL-b );
+    }
+    if( len>=FD_ZLE_MIN_Z ) {
+      ulong L   = zs-fs;
+      ulong cur = (ulong)( o-dst );
+      if( FD_UNLIKELY( cur+L+15UL>=esc_sz ) &&
+          cur+fd_zle_frame_sz( L, len )>=esc_sz ) goto escape;
+      o  = fd_zle_emit( o, src+fs, L, len );
+      fs = zs+len;
+    }
+    if( !m && w>=words ) break;
+  }
+trailing:
+  if( fs<n ) {
+    ulong L   = n-fs;
+    ulong cur = (ulong)( o-dst );
+    if( FD_UNLIKELY( cur+L+15UL>=esc_sz ) &&
+        cur+fd_zle_frame_sz( L, 0UL )>=esc_sz ) goto escape;
+    o = fd_zle_emit( o, src+fs, L, 0UL );
+  }
+  return (ulong)( o-dst );
+
+escape:
+  return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
+}
+
+#else
 
 ulong
 fd_zle_compress( void *       FD_RESTRICT comp,
@@ -125,6 +275,8 @@ escape:
   return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
 }
 
+#endif /* FD_HAS_AVX512 */
+
 long
 fd_zle_decompress( void *       FD_RESTRICT data,
                    ulong                    data_sz,
@@ -146,7 +298,7 @@ fd_zle_decompress( void *       FD_RESTRICT data,
     }
     if( FD_UNLIKELY( L>comp_sz-i ) ) return FD_ZLE_ERR_CORRUPT;
     if( FD_UNLIKELY( L>data_sz-o ) ) return FD_ZLE_ERR_SPACE;
-    fd_memcpy( d+o, s+i, L );
+    fd_zle_copy( d+o, s+i, L );
     i += L;
     o += L;
     if( Z==15UL ) {

--- a/src/flamenco/accdb/fd_zle.c
+++ b/src/flamenco/accdb/fd_zle.c
@@ -1,0 +1,173 @@
+#include "fd_zle.h"
+
+/* Wire format: a stream of frames, each producing L literal bytes then
+   Z zero bytes.
+
+     token     1 byte = (min(L,15)<<4) | min(Z,15)
+     lit_ext   varint( L-15 )  only if L>=15
+     literals  L bytes verbatim
+     zero_ext  varint( Z-15 )  only if Z>=15
+
+   The token 0x00 is invalid.  The greedy encoder breaks the open
+   literal frame iff a zero run is >=FD_ZLE_MIN_Z long, and falls back
+   to a single all-literal frame if that did not win, bounding overhead
+   at 1+varint(data_sz-15) <= FD_ZLE_OVERHEAD bytes. */
+
+#define FD_ZLE_MIN_Z (2UL)
+
+static inline ulong
+fd_zle_vput( uchar * p,
+             ulong   v ) {
+  ulong k = 0UL;
+  do {
+    p[k] = (uchar)( v & 0x7fUL );
+    v >>= 7;
+    if( v ) p[k] = (uchar)( p[k] | 0x80 );
+    k++;
+  } while( v );
+  return k;
+}
+
+static inline int
+fd_zle_vget( uchar const * s,
+             ulong         slen,
+             ulong *       pi,
+             ulong *       out ) {
+  ulong v  = 0UL;
+  ulong i  = *pi;
+  int   sh = 0;
+  for(;;) {
+    if( FD_UNLIKELY( (i>=slen) | (sh>42) ) ) return 0;
+    uchar b = s[i++];
+    v |= (ulong)( b & 0x7f )<<sh;
+    if( !(b & 0x80) ) break;
+    sh += 7;
+  }
+  *pi  = i;
+  *out = v;
+  return 1;
+}
+
+static inline ulong
+fd_zle_vlen( ulong v ) {
+  ulong k = 1UL;
+  while( v>=128UL ) { v >>= 7; k++; }
+  return k;
+}
+
+static inline ulong
+fd_zle_ext( ulong v ) {
+  return v>=15UL ? fd_zle_vlen( v-15UL ) : 0UL;
+}
+
+static inline ulong
+fd_zle_frame_sz( ulong L,
+                 ulong Z ) {
+  return 1UL + fd_zle_ext( L ) + L + fd_zle_ext( Z );
+}
+
+static uchar *
+fd_zle_emit( uchar *                   o,
+             uchar const * FD_RESTRICT lit,
+             ulong                     L,
+             ulong                     Z ) {
+  ulong ln = L<15UL ? L : 15UL;
+  ulong zn = Z<15UL ? Z : 15UL;
+  *o++ = (uchar)( (ln<<4) | zn );
+  if( L>=15UL ) o += fd_zle_vput( o, L-15UL );
+  if( L       ) fd_memcpy( o, lit, L );
+  o += L;
+  if( Z>=15UL ) o += fd_zle_vput( o, Z-15UL );
+  return o;
+}
+
+ulong
+fd_zle_compress( void *       FD_RESTRICT comp,
+                 void const * FD_RESTRICT data,
+                 ulong                    data_sz ) {
+  uchar *       dst = (uchar *)comp;
+  uchar const * src = (uchar const *)data;
+  ulong         n   = data_sz;
+
+  if( FD_UNLIKELY( !n ) ) return 0UL;
+
+  /* escape as soon as a frame would reach the escape size, keeps writes
+     within FD_ZLE_COMPRESS_BOUND( data_sz ). */
+
+  ulong esc_sz = 1UL + fd_zle_ext( n ) + n;
+
+  uchar * o   = dst;
+  ulong   pos = 0UL;
+  ulong   fs  = 0UL;
+  while( pos<n ) {
+    ulong zs = pos;
+    while( (zs<n) &&  src[zs] ) zs++;
+    if( zs==n ) break;
+    ulong ze = zs;
+    while( (ze<n) && !src[ze] ) ze++;
+    if( ze-zs>=FD_ZLE_MIN_Z ) {
+      ulong L = zs-fs;
+      ulong Z = ze-zs;
+      if( FD_UNLIKELY( (ulong)( o-dst )+fd_zle_frame_sz( L, Z )>=esc_sz ) ) goto escape;
+      o  = fd_zle_emit( o, src+fs, L, Z );
+      fs = ze;
+    }
+    pos = ze;
+  }
+  if( fs<n ) {
+    ulong L = n-fs;
+    if( FD_UNLIKELY( (ulong)( o-dst )+fd_zle_frame_sz( L, 0UL )>=esc_sz ) ) goto escape;
+    o = fd_zle_emit( o, src+fs, L, 0UL );
+  }
+  return (ulong)( o-dst );
+
+escape:
+  return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
+}
+
+long
+fd_zle_decompress( void *       FD_RESTRICT data,
+                   ulong                    data_sz,
+                   void const * FD_RESTRICT comp,
+                   ulong                    comp_sz ) {
+  uchar *       d = (uchar *)data;
+  uchar const * s = (uchar const *)comp;
+  ulong i = 0UL;
+  ulong o = 0UL;
+  while( i<comp_sz ) {
+    uchar t = s[i++];
+    if( FD_UNLIKELY( !t ) ) return FD_ZLE_ERR_CORRUPT;
+    ulong L = (ulong)( t>>4 );
+    ulong Z = (ulong)( t&15 );
+    ulong e;
+    if( L==15UL ) {
+      if( FD_UNLIKELY( !fd_zle_vget( s, comp_sz, &i, &e ) ) ) return FD_ZLE_ERR_CORRUPT;
+      L += e;
+    }
+    if( FD_UNLIKELY( L>comp_sz-i ) ) return FD_ZLE_ERR_CORRUPT;
+    if( FD_UNLIKELY( L>data_sz-o ) ) return FD_ZLE_ERR_SPACE;
+    fd_memcpy( d+o, s+i, L );
+    i += L;
+    o += L;
+    if( Z==15UL ) {
+      if( FD_UNLIKELY( !fd_zle_vget( s, comp_sz, &i, &e ) ) ) return FD_ZLE_ERR_CORRUPT;
+      Z += e;
+    }
+    if( FD_UNLIKELY( Z>data_sz-o ) ) return FD_ZLE_ERR_SPACE;
+    fd_memset( d+o, 0, Z );
+    o += Z;
+  }
+  return (long)o;
+}
+
+char const *
+fd_zle_strerror( long res ) {
+  switch( res ) {
+  case FD_ZLE_ERR_SPACE:   return "out of buffer space";
+  case FD_ZLE_ERR_CORRUPT: return "malformed compressed data";
+  case 0L:                 return "empty";
+  default:
+    if( FD_UNLIKELY( res>0L ) ) return "ok";
+    return "unknown";
+  }
+}

--- a/src/flamenco/accdb/fd_zle.h
+++ b/src/flamenco/accdb/fd_zle.h
@@ -1,0 +1,50 @@
+#ifndef HEADER_fd_flamenco_accdb_fd_zle_h
+#define HEADER_fd_flamenco_accdb_fd_zle_h
+
+/* fd_zle.h is a fast compression algorithm based on zero run length
+   coding.
+
+   fd_zle was designed for and tuned on compressing Solana mainnet
+   account data (individually), and is about an order of magnitude
+   faster than LZ4 and Zstandard at this task, without compromising on
+   compression ratio. */
+
+#include "../../util/fd_util_base.h"
+
+#define FD_ZLE_OVERHEAD (8UL)
+#define FD_ZLE_COMPRESS_BOUND( in_sz ) (FD_ZLE_OVERHEAD + (in_sz))
+
+#define FD_ZLE_ERR_SPACE   (-1L) /* out of buffer space */
+#define FD_ZLE_ERR_CORRUPT (-2L) /* malformed compressed data */
+
+FD_PROTOTYPES_BEGIN
+
+/* fd_zle_compress compresses data_sz bytes at data.  Writes up to
+   FD_ZLE_COMPRESS_BOUND( data_sz ) compressed bytes to comp.  Returns
+   the number of compressed bytes written. */
+
+ulong
+fd_zle_compress( void *       FD_RESTRICT comp,
+                 void const * FD_RESTRICT data,
+                 ulong                    data_sz );
+
+/* fd_zle_decompress takes an fd_zle compressed blob at comp.  Writes up
+   to data_sz decompressed bytes to data.  Returns the number of bytes
+   decompressed (>=0) on success, or a negative FD_ZLE_ERR_* number on
+   failure. */
+
+long
+fd_zle_decompress( void *       FD_RESTRICT data,
+                   ulong                    data_sz,
+                   void const * FD_RESTRICT comp,
+                   ulong                    comp_sz );
+
+/* fd_zle_strerror returns a static-lifetime cstr describing the error
+   code returned by fd_zle_decompress(). */
+
+char const *
+fd_zle_strerror( long res );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_flamenco_accdb_fd_zle_h */

--- a/src/flamenco/accdb/test_zle.c
+++ b/src/flamenco/accdb/test_zle.c
@@ -1,0 +1,134 @@
+#include "fd_zle.h"
+#include "../../util/fd_util.h"
+
+#define MAX_SZ (1UL<<20)
+
+static uchar in  [ MAX_SZ ];
+static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ];
+static uchar out [ MAX_SZ ];
+
+static ulong
+round_trip( ulong sz ) {
+  fd_memset( comp, 0xcc, sizeof(comp) );
+  ulong comp_sz = fd_zle_compress( comp, in, sz );
+  FD_TEST( comp_sz<=FD_ZLE_COMPRESS_BOUND( sz ) );
+  fd_memset( out, 0xcc, sizeof(out) );
+  long res = fd_zle_decompress( out, sz, comp, comp_sz );
+  FD_TEST( res==(long)sz );
+  FD_TEST( 0==memcmp( out, in, sz ) );
+  return comp_sz;
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  fd_rng_t _rng[1]; fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
+
+  /* empty input */
+
+  FD_TEST( fd_zle_compress( comp, in, 0UL )==0UL );
+  FD_TEST( fd_zle_decompress( out, 0UL, comp, 0UL )==0L );
+
+  /* known vectors */
+
+  fd_memcpy( in, "AB\0\0\0CD", 7UL );
+  FD_TEST( round_trip( 7UL )==6UL );
+  FD_TEST( 0==memcmp( comp, "\x23" "AB" "\x20" "CD", 6UL ) );
+
+  /* 00 00 -> single (L=0,Z=2) frame */
+  fd_memset( in, 0, 2UL );
+  FD_TEST( round_trip( 2UL )==1UL );
+  FD_TEST( comp[0]==0x02 );
+
+  /* all zeros -> token + varint(85) */
+  fd_memset( in, 0, 100UL );
+  FD_TEST( round_trip( 100UL )==2UL );
+  FD_TEST( comp[0]==0x0f && comp[1]==85 );
+
+  /* single zero byte -> escape, 2 bytes */
+  in[0] = 0;
+  FD_TEST( round_trip( 1UL )==2UL );
+  FD_TEST( comp[0]==0x10 && comp[1]==0x00 );
+
+  /* all zeros, various sizes */
+
+  fd_memset( in, 0, MAX_SZ );
+  for( ulong sz=2UL; sz<=MAX_SZ; sz<<=1 ) FD_TEST( round_trip( sz )<=4UL );
+
+  /* zero-free input escapes with bounded overhead */
+
+  for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = (uchar)( 1U+( fd_rng_uint( rng )%255U ) );
+  for( ulong sz=1UL; sz<=MAX_SZ; sz<<=1 ) FD_TEST( round_trip( sz )<=FD_ZLE_COMPRESS_BOUND( sz ) );
+
+  /* max frame density: 00 00 X repeated */
+
+  for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = ( j%3UL==2UL ) ? (uchar)0xff : (uchar)0;
+  FD_TEST( round_trip( MAX_SZ )<=( MAX_SZ*2UL )/3UL+8UL );
+
+  /* SPL-token-shaped: 165 bytes, zero runs interleaved with pubkeys */
+
+  fd_memset( in, 0, 165UL );
+  for( ulong j= 0UL; j< 32UL; j++ ) in[j] = (uchar)fd_rng_uint( rng );
+  for( ulong j=32UL; j< 64UL; j++ ) in[j] = (uchar)fd_rng_uint( rng );
+  in[64] = 1; in[105] = 1;
+  FD_TEST( round_trip( 165UL )<165UL );
+
+  /* random fuzz: random sizes, random zero density */
+
+  for( ulong iter=0UL; iter<50000UL; iter++ ) {
+    ulong sz     = 1UL+fd_rng_ulong_roll( rng, 4096UL );
+    uint  thresh = fd_rng_uint( rng )%256U;  /* zero probability */
+    for( ulong j=0UL; j<sz; j++ )
+      in[j] = ( ( fd_rng_uint( rng )&255U )<thresh ) ? (uchar)0 : (uchar)( fd_rng_uint( rng ) | 1U );
+    ulong comp_sz = round_trip( sz );
+
+    /* truncated streams must not round-trip cleanly */
+    if( comp_sz>1UL ) {
+      long res = fd_zle_decompress( out, sz, comp, comp_sz-1UL );
+      FD_TEST( res<(long)sz );
+    }
+
+    /* bit flips must never crash and never overflow the output */
+    ulong bit = fd_rng_ulong_roll( rng, comp_sz*8UL );
+    comp[ bit/8UL ] = (uchar)( comp[ bit/8UL ] ^ (uchar)( 1U<<( bit%8UL ) ) );
+    long res = fd_zle_decompress( out, sz, comp, comp_sz );
+    FD_TEST( res<=(long)sz );
+  }
+
+  /* invalid inputs */
+
+  comp[0] = 0x00;                                       /* empty frame */
+  FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 1UL )==FD_ZLE_ERR_CORRUPT );
+
+  comp[0] = 0x1f; comp[1] = 0x00;                       /* L=1 but no literal bytes... */
+  comp[0] = 0x10;                                       /* L=1, truncated */
+  FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 1UL )==FD_ZLE_ERR_CORRUPT );
+
+  comp[0] = 0xf0;                                       /* L>=15, missing varint */
+  FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 1UL )==FD_ZLE_ERR_CORRUPT );
+
+  comp[0] = 0xf0;
+  for( ulong j=1UL; j<9UL; j++ ) comp[j] = 0x80;        /* unterminated varint */
+  FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 9UL )==FD_ZLE_ERR_CORRUPT );
+
+  comp[0] = 0x0f; comp[1] = 0xff; comp[2] = 0x7f;     /* zero run larger than dst */
+  FD_TEST( fd_zle_decompress( out, 16UL, comp, 3UL )==FD_ZLE_ERR_SPACE );
+
+  comp[0] = 0x21; comp[1] = 0x41; comp[2] = 0x42;    /* output exceeds capacity */
+  FD_TEST( fd_zle_decompress( out, 2UL, comp, 3UL )==FD_ZLE_ERR_SPACE );
+
+  /* strerror */
+
+  FD_TEST( 0==strcmp( fd_zle_strerror( 0L                 ), "empty"                     ) );
+  FD_TEST( 0==strcmp( fd_zle_strerror( 1L                 ), "ok"                        ) );
+  FD_TEST( 0==strcmp( fd_zle_strerror( FD_ZLE_ERR_SPACE   ), "out of buffer space"       ) );
+  FD_TEST( 0==strcmp( fd_zle_strerror( FD_ZLE_ERR_CORRUPT ), "malformed compressed data" ) );
+
+  fd_rng_delete( fd_rng_leave( rng ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
fd_zle is a custom vectorized zero-run length compressor.

It was designed from scratch to individually compress Solana accounts (for random access in the account database).

For this use-case, on a AMD Zen 5 core, fd_zle outperforms LZ4 and Zstandard on speed and compression ratio:

Mean account size 318 bytes, median account size 165 bytes (also the p25, p50, p75), 342.6 GB input data, 1,077,456,076 accounts/records total.

| lib | compress throughput | decompress throughput | ratio |
|---|--:|--:|---|
| fd_zle | 7.07GB/s | 11.52GB/s | 30.29% (103.78GB compressed) |
| Zstandard lvl=1 | 0.19GB/s | 2.51GB/s | 33.24% (+10.11GB worse) |
| LZ4 lvl=1 | 1.75GB/s | 6.78GB/s | 32.94% (+9.08GB worse) | 

Note that these numbers are for compression of many individual accounts. 
This use case is more suitable for the online account database, than the offline snapshot format.