### PR TITLE
zle: further optimizations

### DIFF
--- a/src/flamenco/accdb/Local.mk
+++ b/src/flamenco/accdb/Local.mk
@@ -28,3 +28,7 @@ $(call add-objs,fd_zle,fd_flamenco)
 $(call make-unit-test,test_zle,test_zle,fd_flamenco fd_util)
 $(call run-unit-test,test_zle)
 $(call make-unit-test,bench_zle,bench_zle,fd_flamenco fd_util)
+ifdef FD_HAS_HOSTED
+$(call make-fuzz-test,fuzz_zle_diff,fuzz_zle_diff,fd_flamenco fd_util)
+$(call make-fuzz-test,fuzz_zle_decompress,fuzz_zle_decompress,fd_flamenco fd_util)
+endif

--- a/src/flamenco/accdb/bench_zle.c
+++ b/src/flamenco/accdb/bench_zle.c
@@ -2,24 +2,389 @@
 #include "../../util/fd_util.h"
 
 /* bench_zle: single-thread cache-hot encode/decode throughput on
-   account-shaped inputs. */
+   account shaped inputs, weighted to match mainnet.
+
+   (This file is mostly AI-generated.)
+
+   Workload was fit on full snapshot data at slot 442,351,854 (Aug 2026,
+   1.076 B accounts, 343 GB of raw account data).  This file generates
+   random account data that matches mainnet account distribution and
+   fd_zle compression behavior within <0.1% margin of error.
+
+   Solana mainnet's account distribution is dominated by a few types of
+   programs, whose account data patterns are handwritten below.  (Since
+   fd_zle is a zero length compressor, the account data patterns merely
+   need to reconstruct where the zeros are, and can kill the rest with
+   random bytes.)
+
+   run[] alternates literal and zero run lengths starting with a literal
+   run (a leading 0 means the account starts with zeros) and sums to
+   data_len.  These are then randomized to prevent branch predictor
+   overfitting. */
 
 #define MAX_SZ (8UL<<20)
 
-static uchar in  [ MAX_SZ ] __attribute__((aligned(64)));
+#define BENCH_WORK_SZ          ( 1UL<<30)
+#define ALL_ZERO_BENCH_WORK_SZ (12UL<<30)
+
+static uchar in  [ MAX_SZ+64UL ] __attribute__((aligned(64)));
 static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ] __attribute__((aligned(64)));
 static uchar out [ MAX_SZ ] __attribute__((aligned(64)));
 
 static ulong volatile sink;
 
+/* Metaplex edition: a discriminator and a u64 supply. */
+static uint const run_metaplex_edition[] = { 1, 8, 1, 10 };
+/* pump.fun bonding curve: a discriminator, five u64 reserves and a
+      complete flag.  Short literals split by the high zero bytes of little
+      endian integers, right at the point where zero coding stops paying. */
+static uint const run_pumpfun_curve[] = {
+      15,      1,      5,      3,      7,      1,      1,      8,      6,      2 };
+/* Metaplex token record: one pubkey sized blob, half of it unset. */
+static uint const run_token_record[] = { 9, 23 };
+/* A one byte account.  The floor case: 1 byte in, 2 bytes out. */
+static uint const run_wormhole_1b[] = { 1 };
+/* SPL Token account: mint and owner, the amount, then the delegate,
+      state, is_native, delegated_amount and close_authority COptions,
+      nearly all of them unset.  The most common account on Solana. */
+static uint const run_spl_token_acct[] = { 70, 38, 1, 56 };
+/* Token-2022 token account: the 165 byte SPL layout plus an account
+      type discriminator and an empty TLV extension header. */
+static uint const run_t22_acct[] = { 67, 41, 1, 56, 2, 3 };
+/* SPL Token mint, the 61% that carry a freeze authority: barely
+      compressible. */
+static uint const run_spl_token_mint[] = { 1, 3, 33, 8, 2, 3, 32 };
+/* SPL Token mint, the other 39%: no mint or freeze authority, so both
+      COption bodies are zero. */
+static uint const run_spl_token_mint_nofz[] = { 0, 4, 32, 1, 6, 1, 2, 36 };
+/* PumpSwap AMM record: a short header, then all zeros. */
+static uint const run_pumpswap_amm[] = { 40, 97 };
+/* Stake account: meta, authorized, lockup and delegation.  Bimodal at
+      66% and 81% of raw; this is the more common mode. */
+static uint const run_stake_acct[] = {
+       1,      3,      3,      5,     64,     48,     38,      2,      2,      6,      8,      6,      6,      8 };
+/* Metaplex Token Metadata, the two dominant record versions.  Long
+      trailing zero runs: name, symbol and uri are fixed width and mostly
+      empty, and the v1.3 record over allocates. */
+static uint const run_metaplex_md[] = {
+      66,      3,     15,     17,      1,      3,      3,      7,      1,      3,     63,    137,      4,      3,
+      33,      1,     32,      1,      5,    209 };
+static uint const run_metaplex_md_v3[] = {
+      66,      3,     14,     18,      1,      3,      3,      7,      1,      3,    116,     87,      6,      2,
+       1,    348 };
+/* Metaplex edition marker: a 248 byte bitmap that is almost always
+      empty. */
+static uint const run_metaplex_marker[] = { 1, 8, 1, 272 };
+/* Address Lookup Table: densely packed pubkeys, 94% of raw.  The shape
+      zero coding cannot help with. */
+static uint const run_alt[] = {
+       1,      3,     12,      5,     33,      2,     64,     32,     94,      1,     24,      1,     35,      4,
+     129,      1,    127 };
+/* Raydium AMM v4 AmmInfo: ~75 runs of densely packed u64 fields.  The
+      worst common shape for a run coder, both for ratio and for the
+      unpredictable branch per frame. */
+static uint const run_raydium_amm[] = {
+       1,      7,      1,      7,      1,      7,      1,      7,      1,      7,      1,      7,      1,     16,
+       3,      4,      2,      6,      3,      5,      3,      5,      3,      5,      1,      8,      3,      5,
+       3,      4,      1,      7,      2,      6,      1,      7,      2,      6,      1,      7,      1,      7,
+       1,      7,      2,     22,      4,      4,      5,      3,      4,     28,      7,      9,      5,     11,
+       4,      4,      5,     11,      7,      9,      6,      2,    123,      4,    161,     64,     34,      1,
+       2,     11,      2,     14 };
+/* OpenBook v1 queue: a live header over an empty ring. */
+static uint const run_openbook_q[] = {
+       6,      7,     64,     32,     16,   3088,      3,      5,      7 };
+/* Meteora DAMM v2 pool: dense fixed point fields. */
+static uint const run_meteora_damm[] = {
+      11,     37,      1,      1,      1,    117,     59,      4,     65,     32,     32,     32,      4,      4,
+       1,     23,      3,      1,      1,     11,     12,      4,      8,      8,      4,      4,      1,      4,
+       1,      2,      7,     25,      4,     44,      4,     12,      1,     15,      4,      4,      1,     23,
+       1,     15,     32,     16,      1,    415 };
+/* Raydium AMM v4 pool state: a header over an unused tail. */
+static uint const run_raydium_pool[] = { 32, 993, 4, 13, 6, 1144, 16 };
+/* Serum v3 (defunct): a 5+5 byte magic sandwich around a slab that was
+      never used.  99.9% zero, and 95 GB of chain state looks like this. */
+static uint const run_serum_slab[] = { 6, 14511, 7 };
+/* Meteora DLMM BinArray: ~70 bins of a few live bytes each followed by
+      a fixed zero tail, i.e. a long stream of short frames.  Stresses the
+      per frame cost rather than the copy loops. */
+static uint const run_dlmm_bins[] = {
+       9,      7,      1,      7,     32,     16,     11,    133,     11,    133,     11,    133,     11,    133,
+      11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,     69,      8,     56,
+      11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,
+       8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,
+      11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,
+       8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,
+      11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,
+       8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,
+      11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,
+       8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,
+      11,     69,      8,     56,     11,     69,      8,     56,     11,     69,      8,     56,     11,     69,
+       8,     56,     11,     69,      8,     56,     11,     53,      5,     11,      8,     56,     11,    133,
+      11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,
+      11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,
+      11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,     11,    133,
+      11,    133,     11,    133,     11,    133,     11,    117 };
+/* Raydium CLMM TickArrayState: a handful of initialized ticks in a
+      10 KiB array. */
+static uint const run_clmm_ticks[] = { 44, 672, 4, 9405, 2, 113 };
+static uint const run_serum_q_64k[] = { 6, 65487, 7 };
+static uint const run_serum_slab_64k[] = { 6, 65535, 7 };
+static uint const run_serum_q_256k[] = { 6, 262143, 7 };
+struct shape {
+  char const * name;
+  ulong        acct;      /* accounts on chain with this layout */
+  uint const * run;
+  ulong        run_cnt;
+};
+
+typedef struct shape shape_t;
+
+#define SHAPE( name, acct, run ) { (name), (acct), (run), sizeof(run)/sizeof(uint) }
+
+static shape_t const shape[] = {
+  SHAPE( "metaplex edition"       ,     22921472UL, run_metaplex_edition     ),
+  SHAPE( "pump.fun curve"         ,      9347776UL, run_pumpfun_curve        ),
+  SHAPE( "metaplex token record"  ,      3567168UL, run_token_record         ),
+  SHAPE( "wormhole 1 B"           ,      1570816UL, run_wormhole_1b          ),
+  SHAPE( "spl-token account"      ,    615273088UL, run_spl_token_acct       ),
+  SHAPE( "token-2022 account"     ,     84784704UL, run_t22_acct             ),
+  SHAPE( "spl-token mint"         ,     45047074UL, run_spl_token_mint       ),
+  SHAPE( "spl-token mint nofz"    ,     29217565UL, run_spl_token_mint_nofz  ),
+  SHAPE( "pumpswap amm"           ,      7725696UL, run_pumpswap_amm         ),
+  SHAPE( "stake account"          ,      1442496UL, run_stake_acct           ),
+  SHAPE( "metaplex metadata"      ,     42464896UL, run_metaplex_md          ),
+  SHAPE( "metaplex metadata v1.3" ,      8667712UL, run_metaplex_md_v3       ),
+  SHAPE( "metaplex edition marker",      2572480UL, run_metaplex_marker      ),
+  SHAPE( "address lookup table"   ,       149056UL, run_alt                  ),
+  SHAPE( "raydium amm v4 info"    ,       709184UL, run_raydium_amm          ),
+  SHAPE( "openbook v1 queue"      ,      1618048UL, run_openbook_q           ),
+  SHAPE( "meteora damm v2 pool"   ,      1436096UL, run_meteora_damm         ),
+  SHAPE( "raydium amm v4 pool"    ,       705600UL, run_raydium_pool         ),
+  SHAPE( "serum v3 slab"          ,      1050688UL, run_serum_slab           ),
+  SHAPE( "meteora dlmm bins"      ,       450752UL, run_dlmm_bins            ),
+  SHAPE( "raydium clmm ticks"     ,       424128UL, run_clmm_ticks           ),
+  SHAPE( "serum v3 queue 64K"     ,        62848UL, run_serum_q_64k          ),
+  SHAPE( "serum v3 slab 64K"      ,       288640UL, run_serum_slab_64k       ),
+  SHAPE( "serum v3 queue 256K"    ,       141504UL, run_serum_q_256k         )
+};
+
+#define SHAPE_CNT (sizeof(shape)/sizeof(shape_t))
+
+/* Band tails.  Each table is (literal run, zero run, cumulative weight
+   in permille) sampled from the pooled interior texture of every
+   unnamed account in that band. */
+
+static uint const pair_tail0[][3] = {
+  {      4,      4,   86 }, {      9,      3,  167 }, {      3,      5,  239 }, {     40,      1,  298 },
+  {      4,      3,  348 }, {     12,      4,  399 }, {      5,      3,  445 }, {      8,      1,  490 },
+  {     43,      5,  531 }, {      1,      3,  568 }, {      8,      8,  604 }, {     45,      4,  639 },
+  {     41,      3,  673 }, {      3,      4,  705 }, {     45,      3,  737 }, {     10,      7,  769 },
+  {     44,      4,  798 }, {     40,      8,  818 }, {      9,      1,  837 }, {     12,      5,  856 },
+  {     12,      8,  874 }, {      1,      1,  888 }, {     45,      5,  902 }, {     13,      4,  916 },
+  {     11,      5,  928 }, {      1,      8,  939 }, {      6,      2,  950 }, {      2,      1,  961 },
+  {     44,      8,  971 }, {      1,      7,  982 }, {      9,      7,  991 }, {     36,      1, 1000 }
+};
+static uint const pair_tail1[][3] = {
+  {      1,      3,   86 }, {      1,      1,  162 }, {      4,      4,  237 }, {      2,      3,  303 },
+  {      6,      1,  369 }, {      6,      2,  430 }, {      1,     29,  477 }, {      1,      8,  522 },
+  {      8,      1,  567 }, {      5,      4,  606 }, {      2,      6,  644 }, {      5,      3,  681 },
+  {      3,      5,  708 }, {      7,      1,  735 }, {     15,      1,  760 }, {      2,      7,  779 },
+  {     67,      3,  798 }, {     77,      4,  816 }, {      4,      5,  834 }, {     64,     29,  852 },
+  {      1,      7,  867 }, {      4,      3,  882 }, {     32,      1,  896 }, {      3,      4,  910 },
+  {      1,      4,  922 }, {     40,     16,  935 }, {     11,      3,  947 }, {      9,      1,  958 },
+  {      3,     29,  969 }, {      9,      3,  980 }, {     12,      4,  990 }, {     32,      8, 1000 }
+};
+static uint const pair_tail2[][3] = {
+  {      1,      1,  175 }, {      4,      4,  296 }, {      1,      3,  363 }, {     33,     33,  425 },
+  {      2,     36,  481 }, {      2,      1,  534 }, {      1,      7,  574 }, {      5,      3,  609 },
+  {      6,     36,  643 }, {      4,      3,  670 }, {     32,      1,  692 }, {      2,      3,  713 },
+  {      4,     36,  732 }, {     65,      1,  750 }, {      2,      6,  768 }, {      3,      1,  785 },
+  {     67,      3,  802 }, {      3,      5,  819 }, {      6,      3,  834 }, {     32,     34,  849 },
+  {     80,      3,  864 }, {      6,      2,  879 }, {      7,      3,  894 }, {     33,      1,  907 },
+  {      7,     36,  921 }, {     10,      6,  934 }, {      9,      3,  947 }, {      8,     36,  958 },
+  {      2,      2,  969 }, {      1,      8,  980 }, {      6,      1,  990 }, {      7,      1, 1000 }
+};
+static uint const pair_tail3[][3] = {
+  {      4,      4,  225 }, {      5,      3,  336 }, {     20,      4,  408 }, {      6,      2,  474 },
+  {      2,      2,  529 }, {      9,      7,  569 }, {      8,      8,  605 }, {      1,      1,  638 },
+  {      4,     12,  669 }, {      7,      9,  695 }, {      5,     11,  720 }, {      1,      3,  745 },
+  {      3,     13,  768 }, {     10,      6,  788 }, {      1,      7,  807 }, {      6,     10,  825 },
+  {      1,     15,  842 }, {      2,      1,  857 }, {      2,      6,  872 }, {      8,     15,  886 },
+  {      3,      5,  899 }, {     16,     15,  910 }, {     64,     15,  921 }, {      6,      7,  932 },
+  {      2,     14,  943 }, {     12,      4,  953 }, {     11,      5,  961 }, {     32,     15,  970 },
+  {      5,      4,  978 }, {      3,     15,  985 }, {      4,      1,  993 }, {      4,      3, 1000 }
+};
+static uint const pair_tail4[][3] = {
+  {      8,     24,  152 }, {      8,     36,  297 }, {      9,      7,  381 }, {      8,      8,  461 },
+  {     11,      5,  518 }, {     12,      4,  551 }, {      7,      9,  581 }, {      9,     35,  611 },
+  {      1,      3,  641 }, {      4,      4,  670 }, {      2,      2,  695 }, {      1,      1,  719 },
+  {     10,      6,  742 }, {      6,     36,  764 }, {      2,      6,  786 }, {      2,     36,  806 },
+  {      1,      7,  824 }, {     12,     32,  843 }, {      1,     36,  860 }, {      3,      5,  877 },
+  {      7,     36,  891 }, {      3,      8,  906 }, {      7,     25,  918 }, {      9,     23,  929 },
+  {      2,      1,  940 }, {      3,     13,  950 }, {      4,     36,  960 }, {      4,      1,  969 },
+  {    220,      4,  977 }, {      4,     12,  985 }, {      1,      5,  993 }, {     32,      1, 1000 }
+};
+static uint const pair_tail5[][3] = {
+  {      2,      2,  178 }, {      1,      3,  318 }, {      2,      6,  436 }, {      4,      4,  523 },
+  {      1,      1,  602 }, {      3,      5,  656 }, {      8,     24,  705 }, {      1,      7,  733 },
+  {      9,      7,  760 }, {     12,     24,  785 }, {      6,      2,  805 }, {      3,      1,  821 },
+  {     11,     24,  836 }, {     63,     24,  851 }, {      8,      8,  865 }, {      1,      5,  879 },
+  {      6,      6,  891 }, {      5,      3,  902 }, {      6,      3,  912 }, {      2,     10,  921 },
+  {      2,      4,  930 }, {     12,      4,  939 }, {      5,      4,  947 }, {      2,      1,  955 },
+  {      9,     23,  962 }, {     32,     24,  968 }, {      2,      3,  974 }, {     11,     21,  980 },
+  {      8,      1,  985 }, {     10,      6,  990 }, {      1,      2,  995 }, {     11,      5, 1000 }
+};
+static uint const pair_tail6[][3] = {
+  {      2,      2,  247 }, {      4,      4,  395 }, {      2,      6,  537 }, {      1,      3,  656 },
+  {      3,      5,  760 }, {      1,      6,  804 }, {      1,      1,  833 }, {      6,      6,  858 },
+  {      3,      1,  880 }, {      1,      5,  899 }, {      3,      6,  916 }, {      6,      2,  932 },
+  {      8,      4,  944 }, {      2,      4,  954 }, {      7,      5,  959 }, {      5,      3,  964 },
+  {      2,      1,  969 }, {      1,      4,  973 }, {     63,      6,  978 }, {     32,      6,  981 },
+  {      5,      6,  984 }, {      5,      1,  987 }, {      4,      6,  989 }, {      2,      3,  991 },
+  {      9,      6,  993 }, {     10,      6,  994 }, {     34,      6,  995 }, {      1,      2,  997 },
+  {     11,      5,  998 }, {      7,      1,  999 }, {      2,      5, 1000 }, {     42,      6, 1001 }
+};
+static uint const pair_tail7[][3] = {
+  {      2,      2,  179 }, {      4,      4,  335 }, {      1,      3,  481 }, {      2,      6,  606 },
+  {      3,      5,  713 }, {      1,      7,  746 }, {      6,      6,  773 }, {      3,      1,  798 },
+  {     63,      7,  822 }, {      1,      1,  846 }, {      6,      2,  862 }, {      3,      7,  878 },
+  {      8,      4,  891 }, {      1,      5,  905 }, {     42,      6,  917 }, {      4,      7,  928 },
+  {      2,      4,  938 }, {     10,      6,  948 }, {      5,      3,  953 }, {      7,      5,  959 },
+  {      1,      4,  964 }, {      2,      1,  969 }, {     18,      7,  973 }, {      5,      7,  977 },
+  {     16,      7,  981 }, {     14,      7,  984 }, {     41,      7,  987 }, {     21,      7,  990 },
+  {     12,      7,  993 }, {      2,      7,  996 }, {     17,      7,  998 }, {     19,      7, 1000 }
+};
+
+struct synth {
+  char const * name;
+  ulong        acct;      /* accounts on chain this case stands for */
+  ulong        sz;        /* mean data_len of the band tail */
+  ulong        code_sz;   /* sampled prefix; the rest is one zero run */
+  uint const   (* pair)[3];
+  ulong        pair_cnt;
+};
+
+typedef struct synth synth_t;
+
+#define SYNTH( name, acct, sz, code, tbl ) \
+  { (name), (acct), (sz), (code), (tbl), sizeof(tbl)/sizeof(tbl[0]) }
+
+static synth_t const synth[] = {
+  SYNTH( "tail 1-64"     ,     39997696UL,       29UL,       23UL, pair_tail0 ),
+  SYNTH( "tail 65-256"   ,    111374912UL,      140UL,       81UL, pair_tail1 ),
+  SYNTH( "tail 257-1K"   ,     35740800UL,      456UL,      310UL, pair_tail2 ),
+  SYNTH( "tail 1K-4K"    ,      4929344UL,     2175UL,      489UL, pair_tail3 ),
+  SYNTH( "tail 4K-16K"   ,      2348352UL,     7771UL,     3015UL, pair_tail4 ),
+  SYNTH( "tail 16K-64K"  ,        41856UL,    29668UL,    14285UL, pair_tail5 ),
+  SYNTH( "tail 64K-1M"   ,        90944UL,   237237UL,    90209UL, pair_tail6 ),
+  SYNTH( "tail >1M"      ,         4160UL,  1958702UL,   784949UL, pair_tail7 )
+};
+
+#define SYNTH_CNT (sizeof(synth)/sizeof(synth_t))
+
+/* The snapshot itself, per band, for the fit report. */
+
+struct ref {
+  char const * name;
+  ulong        acct;
+  ulong        raw;
+  ulong        comp;
+};
+
+static struct ref const chain[] = {
+  { "1-64"    ,      77404928UL,      2189840832UL,      1513895168UL },
+  { "65-256"  ,     894865536UL,    138967900928UL,     67748377024UL },
+  { "257-1K"  ,      90304128UL,     49319376576UL,     20453432448UL },
+  { "1K-4K"   ,       8689088UL,     19099444736UL,      2356349184UL },
+  { "4K-16K"  ,       4273920UL,     42421981440UL,      3532961792UL },
+  { "16K-64K" ,        104704UL,      5358324928UL,       319812416UL },
+  { "64K-1M"  ,        521088UL,     77591140672UL,      4857884224UL },
+  { ">1M"     ,          4160UL,      8148198720UL,      2169811200UL }
+};
+
+#define BAND_CNT (sizeof(chain)/sizeof(struct ref))
+
+static ulong
+band_of( ulong sz ) {
+  ulong b = 0UL;
+  static ulong const edge[] = { 64UL, 256UL, 1024UL, 4096UL, 16384UL, 65536UL, 1UL<<20 };
+  for( ulong i=0UL; i<sizeof(edge)/sizeof(ulong); i++ ) b += (ulong)( sz>edge[i] );
+  return b;
+}
+
+/* fill_runs writes a run length sequence into in, literal runs filled
+   with non-zero random bytes.  Returns the total size.  The pad up to
+   the next 64 byte boundary is poisoned, so a pad byte leaking into the
+   output would break the round trip check in bench(). */
+
+static ulong
+fill_runs( fd_rng_t *   rng,
+           uint const * run,
+           ulong        run_cnt ) {
+  ulong j = 0UL;
+  for( ulong i=0UL; i<run_cnt; i++ ) {
+    ulong len = run[ i ];
+    if( i & 1UL ) { fd_memset( in+j, 0, len ); j += len; }
+    else          { for( ulong k=0UL; k<len; k++ ) in[ j++ ] = (uchar)( fd_rng_uint( rng ) | 1U ); }
+  }
+  fd_memset( in+j, 0xff, fd_ulong_align_up( j, 64UL )+64UL-j );
+  return j;
+}
+
+/* fill_synth resamples a band tail's run texture, then closes the
+   account with one zero run.  Pair selection walks a Weyl sequence
+   rather than the rng: the draws have to be reproducible outside this
+   file, because code_sz was calibrated against them so that the case
+   lands on its band tail's real compression ratio. */
+
+static ulong
+fill_synth( fd_rng_t *      rng,
+            synth_t const * s ) {
+  ulong j = 0UL;
+  for( ulong d=1UL; j<s->code_sz; d++ ) {
+    ulong wgt = ( ( d*2654435761UL )>>8 ) % 1000UL;
+    ulong i   = 0UL; while( i<s->pair_cnt-1UL && s->pair[i][2]<=wgt ) i++;
+    ulong lit = s->pair[i][0];
+    ulong zer = s->pair[i][1];
+    for( ulong k=0UL; k<lit && j<s->code_sz; k++ ) in[ j++ ] = (uchar)( fd_rng_uint( rng ) | 1U );
+    for( ulong k=0UL; k<zer && j<s->code_sz; k++ ) in[ j++ ] = 0;
+  }
+  fd_memset( in+j,      0,    s->sz-j );
+  fd_memset( in+s->sz,  0xff, 64UL    );
+  return s->sz;
+}
+
+/* Column rules and headers are dimmed so the numbers read first;
+   fd_log strips the escapes from the log file. */
+
+#define DIM (fd_log_style_dim())
+#define RST (fd_log_style_normal())
+
 static void
+hdr_cases( void ) {
+  FD_LOG_NOTICE(( "%s%-24s %10s %14s | %8s | %8s %8s | %8s %8s%s",
+                  DIM, "case", "size", "accounts", "ratio",
+                  "enc GB/s", "enc ns/B", "dec GB/s", "dec ns/B", RST ));
+}
+
+/* bench times one input and returns its compressed size.  For the small
+   shapes the per account cost matters more than the throughput, since
+   the fixed cost of a call dominates there. */
+
+static ulong
 bench( char const * name,
-       ulong        sz ) {
+       ulong        sz,
+       ulong        acct,
+       ulong        work_sz,
+       double *     opt_enc_ns,
+       double *     opt_dec_ns ) {
   ulong comp_sz = fd_zle_compress( comp, in, sz );
   FD_TEST( fd_zle_decompress( out, sz, comp, comp_sz )==(long)sz );
   FD_TEST( 0==memcmp( out, in, sz ) );
 
-  ulong iter = 1UL + (1UL<<30)/sz;
+  ulong iter = 1UL + work_sz/sz;
+  /* The 1-byte Wormhole case otherwise makes over a billion calls. */
+  if( FD_UNLIKELY( sz==1UL ) ) iter = 1UL<<24;
 
   for( ulong i=0UL; i<iter/8UL+1UL; i++ ) sink += fd_zle_compress( comp, in, sz );
 
@@ -29,11 +394,19 @@ bench( char const * name,
   for( ulong i=0UL; i<iter; i++ ) sink += (ulong)fd_zle_decompress( out, sz, comp, comp_sz );
   long t2 = fd_log_wallclock();
 
-  double bytes = (double)sz*(double)iter;
-  FD_LOG_NOTICE(( "%-24s sz %8lu -> %6.2f%%  enc %6.2f GB/s (%6.3f ns/B)  dec %6.2f GB/s",
-                  name, sz, 100.*(double)comp_sz/(double)sz,
-                  bytes/(double)(t1-t0), (double)(t1-t0)/bytes,
-                  bytes/(double)(t2-t1) ));
+  double bytes  = (double)sz*(double)iter;
+  double enc_ns = (double)(t1-t0)/(double)iter;
+  double dec_ns = (double)(t2-t1)/(double)iter;
+
+  FD_LOG_NOTICE(( "%-24s %10lu %14lu %s|%s %7.2f%% %s|%s %8.2f %8.4f %s|%s %8.2f %8.4f",
+                  name, sz, acct, DIM, RST,
+                  100.*(double)comp_sz/(double)sz, DIM, RST,
+                  bytes/(double)(t1-t0), enc_ns/(double)sz, DIM, RST,
+                  bytes/(double)(t2-t1), dec_ns/(double)sz ));
+
+  if( opt_enc_ns ) *opt_enc_ns = enc_ns;
+  if( opt_dec_ns ) *opt_dec_ns = dec_ns;
+  return comp_sz;
 }
 
 int
@@ -42,37 +415,86 @@ main( int     argc,
   fd_boot( &argc, &argv );
 
   uint seed = fd_env_strip_cmdline_uint( &argc, &argv, "--seed", NULL, 42U );
+  int  do_synth = !fd_env_strip_cmdline_contains( &argc, &argv, "--no-synth" );
 
   fd_rng_t _rng[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, seed, 0UL ) );
   FD_TEST( rng );
 
-  /* SPL-Token-shaped: mint+owner+amount random, COption fields zero */
-  fd_memset( in, 0, 165UL );
-  for( ulong j=0UL; j<72UL; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
-  in[108] = 1;
-  bench( "spl-token 165 B", 165UL );
+  double b_acct[ BAND_CNT ], b_raw[ BAND_CNT ], b_comp[ BAND_CNT ];
+  double b_enc [ BAND_CNT ], b_dec[ BAND_CNT ];
+  for( ulong b=0UL; b<BAND_CNT; b++ ) b_acct[b] = b_raw[b] = b_comp[b] = b_enc[b] = b_dec[b] = 0.;
 
-  /* Serum-shaped: 256 KiB orderbook, ~99.6% zero */
-  fd_memset( in, 0, 256UL<<10 );
-  for( ulong j=0UL; j<1024UL; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
-  bench( "serum 256 KiB", 256UL<<10 );
+  hdr_cases();
 
-  /* stake/vote-shaped: short random fields split by short zero runs */
-  for( ulong j=0UL; j<(64UL<<10); ) {
-    ulong lit = 4UL+fd_rng_ulong_roll( rng, 20UL );
-    ulong run = 2UL+fd_rng_ulong_roll( rng, 10UL );
-    for( ulong k=0UL; k<lit && j<(64UL<<10); k++ ) in[j++] = (uchar)( fd_rng_uint( rng ) | 1U );
-    for( ulong k=0UL; k<run && j<(64UL<<10); k++ ) in[j++] = 0;
+  for( ulong i=0UL; i<SHAPE_CNT+SYNTH_CNT; i++ ) {
+    char const * name;
+    ulong        acct, sz;
+    if( i<SHAPE_CNT ) {
+      shape_t const * s = shape+i;
+      name = s->name; acct = s->acct; sz = fill_runs( rng, s->run, s->run_cnt );
+    } else {
+      synth_t const * s = synth+(i-SHAPE_CNT);
+      name = s->name; acct = s->acct; sz = fill_synth( rng, s );
+    }
+
+    double enc_ns, dec_ns;
+    ulong  comp_sz = bench( name, sz, acct, BENCH_WORK_SZ, &enc_ns, &dec_ns );
+
+    ulong  b = band_of( sz );
+    double n = (double)acct;
+    b_acct[b] += n;
+    b_raw [b] += n*(double)sz;
+    b_comp[b] += n*(double)comp_sz;
+    b_enc [b] += n*enc_ns;
+    b_dec [b] += n*dec_ns;
   }
-  bench( "dense mixed 64 KiB", 64UL<<10 );
 
-  /* uniform random: a stray zero every ~256 bytes, none elidable */
-  for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = (uchar)fd_rng_uint( rng );
-  bench( "uniform random 8 MiB", MAX_SZ );
+  /* Synthetic bounds.  Neither shape occurs on chain and neither is in
+     the mix; they bracket what the coder can do. */
 
-  fd_memset( in, 0, MAX_SZ );
-  bench( "all-zero 8 MiB", MAX_SZ );
+  if( do_synth ) {
+
+    FD_LOG_NOTICE(( "%s-- synthetic bounds (not in the mix) --%s", DIM, RST ));
+
+    for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = (uchar)fd_rng_uint( rng );
+    bench( "uniform random 8 MiB", MAX_SZ, 0UL, BENCH_WORK_SZ, NULL, NULL );
+
+    fd_memset( in, 0, MAX_SZ+64UL );
+    bench( "all-zero 64 B",     64UL,     0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 256 B",   256UL,     0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 1 KiB",     1UL<<10, 0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 4 KiB",     4UL<<10, 0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 16 KiB",   16UL<<10, 0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 64 KiB",   64UL<<10, 0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 1 MiB",     1UL<<20, 0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+    bench( "all-zero 8 MiB", MAX_SZ,      0UL, ALL_ZERO_BENCH_WORK_SZ, NULL, NULL );
+
+  }
+
+  /* How well the mix reproduces the snapshot, band by band. */
+
+  double ta = 0., tr = 0., tc = 0., te = 0., td = 0.;
+  double ca = 0., cr = 0., cc = 0.;
+  FD_LOG_NOTICE(( "%s-- band fit vs snapshot --%s", DIM, RST ));
+  FD_LOG_NOTICE(( "%s%-8s %14s %14s %9s %9s %9s %9s%s", DIM, "band", "accounts", "raw bytes",
+                  "acct err", "byte err", "mix ratio", "chain", RST ));
+  for( ulong b=0UL; b<BAND_CNT; b++ ) {
+    FD_LOG_NOTICE(( "%-8s %14.0f %14.0f %8.2f%% %8.2f%% %8.2f%% %8.2f%%",
+                    chain[b].name, b_acct[b], b_raw[b],
+                    100.*(b_acct[b]-(double)chain[b].acct)/(double)chain[b].acct,
+                    100.*(b_raw [b]-(double)chain[b].raw )/(double)chain[b].raw,
+                    100.*b_comp[b]/b_raw[b],
+                    100.*(double)chain[b].comp/(double)chain[b].raw ));
+    ta += b_acct[b]; tr += b_raw[b]; tc += b_comp[b]; te += b_enc[b]; td += b_dec[b];
+    ca += (double)chain[b].acct; cr += (double)chain[b].raw; cc += (double)chain[b].comp;
+  }
+  FD_LOG_NOTICE(( "%s%-8s%s %14.0f %14.0f %8.2f%% %8.2f%% %8.2f%% %8.2f%%",
+                  fd_log_style_bold(), "TOTAL", RST, ta, tr, 100.*(ta-ca)/ca, 100.*(tr-cr)/cr,
+                  100.*tc/tr, 100.*cc/cr ));
+  FD_LOG_NOTICE(( "%smix%s: %.2f%% of raw, enc %.4f ns/B (%.2f GB/s), dec %.4f ns/B (%.2f GB/s)",
+                  fd_log_style_bold(), RST,
+                  100.*tc/tr, te/tr, tr/te, td/tr, tr/td ));
 
   fd_rng_delete( fd_rng_leave( rng ) );
   fd_halt();

--- a/src/flamenco/accdb/bench_zle.c
+++ b/src/flamenco/accdb/bench_zle.c
@@ -6,9 +6,9 @@
 
 #define MAX_SZ (8UL<<20)
 
-static uchar in  [ MAX_SZ ];
-static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ];
-static uchar out [ MAX_SZ ];
+static uchar in  [ MAX_SZ ] __attribute__((aligned(64)));
+static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ] __attribute__((aligned(64)));
+static uchar out [ MAX_SZ ] __attribute__((aligned(64)));
 
 static ulong volatile sink;
 
@@ -57,6 +57,15 @@ main( int     argc,
   fd_memset( in, 0, 256UL<<10 );
   for( ulong j=0UL; j<1024UL; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
   bench( "serum 256 KiB", 256UL<<10 );
+
+  /* stake/vote-shaped: short random fields split by short zero runs */
+  for( ulong j=0UL; j<(64UL<<10); ) {
+    ulong lit = 4UL+fd_rng_ulong_roll( rng, 20UL );
+    ulong run = 2UL+fd_rng_ulong_roll( rng, 10UL );
+    for( ulong k=0UL; k<lit && j<(64UL<<10); k++ ) in[j++] = (uchar)( fd_rng_uint( rng ) | 1U );
+    for( ulong k=0UL; k<run && j<(64UL<<10); k++ ) in[j++] = 0;
+  }
+  bench( "dense mixed 64 KiB", 64UL<<10 );
 
   /* uniform random: a stray zero every ~256 bytes, none elidable */
   for( ulong j=0UL; j<MAX_SZ; j++ ) in[j] = (uchar)fd_rng_uint( rng );

--- a/src/flamenco/accdb/fd_zle.c
+++ b/src/flamenco/accdb/fd_zle.c
@@ -1,7 +1,7 @@
 #include "fd_zle.h"
 
 #if FD_HAS_AVX512
-#include <immintrin.h>
+#include "../../util/simd/fd_avx512.h"
 #endif
 
 /* Wire format: a stream of frames, each producing L literal bytes then
@@ -15,7 +15,12 @@
    The token 0x00 is invalid.  The greedy encoder breaks the open
    literal frame iff a zero run is >=FD_ZLE_MIN_Z long, and falls back
    to a single all-literal frame if that did not win, bounding overhead
-   at 1+varint(data_sz-15) <= FD_ZLE_OVERHEAD bytes. */
+   at 1+varint(data_sz-15) <= FD_ZLE_OVERHEAD bytes.
+
+   Note that fd_zle makes assumptions on memory protection setup
+   surrounding the input buffer for performance (fd_zle deliberately
+   reads slightly out of bounds to omit expensive tail access
+   specialization, see API docs in fd_zle.h). */
 
 #define FD_ZLE_MIN_Z (2UL)
 
@@ -73,34 +78,65 @@ fd_zle_frame_sz( ulong L,
 #if FD_HAS_AVX512
 
 /* fd_zle_zmask returns the zero-byte mask of the 64 byte word at
-   src+(w<<6).  Bits at positions >=n read as non-zero so runs terminate
-   at n. */
+   s+(w<<6), for w<(n+63)/64.  Bits at positions >=n read as non-zero so
+   runs terminate at n. */
 
 static inline ulong
 fd_zle_zmask( uchar const * s,
               ulong         w,
               ulong         n ) {
   ulong off = w<<6;
-  if( FD_LIKELY( off+64UL<=n ) )
-    return _cvtmask64_u64( _mm512_cmpeq_epi8_mask( _mm512_loadu_si512( (void const *)( s+off ) ), _mm512_setzero_si512() ) );
-  ulong   tail = ~0UL>>( 64UL-( n-off ) );
-  __m512i v    = _mm512_maskz_loadu_epi8( _cvtu64_mask64( tail ), s+off );
-  return _cvtmask64_u64( _mm512_cmpeq_epi8_mask( v, _mm512_setzero_si512() ) ) & tail;
+  ulong m   = wwb_eq( wwb_ldu( s+off ), wwb_zero() );
+  if( FD_LIKELY( off+64UL<=n ) ) return m;
+  return m & ( ~0UL>>( 64UL-( n-off ) ) );
 }
 
-/* exact-length copy: full 64 B vectors + one masked tail */
+/* fd_zle_cand marks where a zero run of FD_ZLE_MIN_Z bytes starts.
+   Output bit i survives only when src[i]==src[i+1]==0.  nz==1 implies
+   first byte in next 64 byte block is zero (if unknown set it to 1). */
+
+FD_STATIC_ASSERT( FD_ZLE_MIN_Z==2UL, unit );
+
+static inline ulong
+fd_zle_cand( ulong m,
+             ulong nz ) {
+  return m & ( ( m>>1 ) | ( nz<<63 ) );
+}
+
+/* inline-friendly memcpy/memset */
 
 static inline void
 fd_zle_copy( uchar *       FD_RESTRICT d,
              uchar const * FD_RESTRICT s,
              ulong                     sz ) {
   ulong k = 0UL;
-  for( ; k+64UL<=sz; k+=64UL )
-    _mm512_storeu_si512( (void *)( d+k ), _mm512_loadu_si512( (void const *)( s+k ) ) );
+  for( ; k+64UL<=sz; k+=64UL ) {
+    wwb_stu( d+k, wwb_ldu( s+k ) );
+  }
   if( k<sz ) {
     __mmask64 m = _cvtu64_mask64( ~0UL>>( 64UL-( sz-k ) ) );
     _mm512_mask_storeu_epi8( (void *)( d+k ), m, _mm512_maskz_loadu_epi8( m, s+k ) );
   }
+}
+
+#define FD_ZLE_ZERO_THRESH (512UL)
+
+static inline void
+fd_zle_zero( uchar * d,
+             ulong   sz ) {
+  wwb_t z = wwb_zero();
+  if( FD_LIKELY( sz<=64UL ) ) {
+    /* _bzhi_u64 saturates at 64, so sz==64 yields the full mask */
+    _mm512_mask_storeu_epi8( (void *)d, _cvtu64_mask64( _bzhi_u64( ~0UL, sz ) ), z );
+    return;
+  }
+  if( FD_LIKELY( sz<FD_ZLE_ZERO_THRESH ) ) {
+    ulong k = 0UL;
+    do { wwb_stu( d+k, z ); k += 64UL; } while( k+64UL<=sz );
+    wwb_stu( d+sz-64UL, z );  /* overlaps, stays in range */
+    return;
+  }
+  fd_memset( d, 0, sz );
 }
 
 #else
@@ -110,6 +146,12 @@ fd_zle_copy( uchar * FD_RESTRICT       d,
              uchar const * FD_RESTRICT s,
              ulong                     sz ) {
   if( sz ) fd_memcpy( d, s, sz );
+}
+
+static inline void
+fd_zle_zero( uchar * d,
+             ulong   sz ) {
+  fd_memset( d, 0, sz );
 }
 
 #endif
@@ -131,7 +173,8 @@ fd_zle_emit( uchar *                   o,
 
 #if FD_HAS_AVX512
 
-/* extend a zero run beyond word *pw; leaves *pw and *pm at the run end */
+/* fd_zle_spill extends a zero run past the end of word *pw, returning
+   the run length and leaving *pw / *pm at the word where it ended. */
 
 static inline ulong
 fd_zle_spill( uchar const * s,
@@ -141,25 +184,251 @@ fd_zle_spill( uchar const * s,
               ulong *       pm,
               ulong         len ) {
   ulong w = *pw+1UL;
-  while( ( w<<6 )+256UL<=n ) {
-    ulong m0 = fd_zle_zmask( s, w,     n );
-    ulong m1 = fd_zle_zmask( s, w+1UL, n );
-    ulong m2 = fd_zle_zmask( s, w+2UL, n );
-    ulong m3 = fd_zle_zmask( s, w+3UL, n );
-    if( ( m0&m1&m2&m3 )!=~0UL ) break;
-    w += 4UL; len += 256UL;
-  }
   for(;;) {
     if( w>=words ) { *pw = w; *pm = 0UL; return len; }
     ulong t = fd_zle_zmask( s, w, n );
-    if( t!=~0UL ) {
+    if( FD_UNLIKELY( t!=~0UL ) ) {
       ulong ext = (ulong)__builtin_ctzll( ~t );
       *pw = w;
       *pm = t & ~( ( 1UL<<ext )-1UL );
       return len+ext;
     }
     w++; len += 64UL;
+    while( ( w<<6 )+256UL<=n ) {
+      uchar const * p = s+( w<<6 );
+      wwb_t v = wwb_or( wwb_or( wwb_ldu( p       ), wwb_ldu( p+ 64UL ) ),
+                        wwb_or( wwb_ldu( p+128UL ), wwb_ldu( p+192UL ) ) );
+      if( FD_UNLIKELY( _mm512_test_epi8_mask( v, v ) ) ) break;
+      w += 4UL; len += 256UL;
+    }
   }
+}
+
+/* L and Z fit in 256 bytes here. */
+
+static inline uchar *
+fd_zle_vput_small( uchar * o,
+                   ulong   v ) {
+  ulong big = (ulong)( v>=128UL );
+  o[0] = (uchar)( ( v & 0x7fUL ) | ( big<<7 ) );
+  o[1] = (uchar)( v>>7 );
+  return o+1UL+big;
+}
+
+static inline uchar *
+fd_zle_emit_small( uchar *                   o,
+                   uchar const * FD_RESTRICT lit,
+                   ulong                     L,
+                   ulong                     Z ) {
+  ulong ln = L<15UL ? L : 15UL;
+  ulong zn = Z<15UL ? Z : 15UL;
+  *o++ = (uchar)( (ln<<4) | zn );
+  if( L>=15UL ) o = fd_zle_vput_small( o, L-15UL );
+  if( FD_LIKELY( L<=64UL ) ) {   /* the common case is a single vector */
+    /* masked load partially OOB */
+    __mmask64 m = _cvtu64_mask64( _bzhi_u64( ~0UL, (uint)L ) );
+    _mm512_mask_storeu_epi8( (void *)o, m, _mm512_maskz_loadu_epi8( m, lit ) );
+  } else fd_zle_copy( o, lit, L );
+  o += L;
+  if( Z>=15UL ) o = fd_zle_vput_small( o, Z-15UL );
+  return o;
+}
+
+/* FD_ZLE_EXT extends a zero run that reached the end of the previous
+   64-byte word.  Count consecutive zero bytes from the start of m, add
+   them to len, and remove their bits from m.  Set full if all 64 bytes
+   were zero, meaning the run may continue into the following word. */
+
+#define FD_ZLE_EXT( m ) do {                                           \
+    ulong _e = ~(m) ? (ulong)__builtin_ctzll( ~(m) ) : 64UL;           \
+    len  += _e;                                                        \
+    (m)   = _e<64UL ? ( (m) & ~( ( 1UL<<_e )-1UL ) ) : 0UL;            \
+    full  = _e==64UL;                                                  \
+  } while(0)
+
+/* FD_ZLE_WALK scans zero-byte mask m and emits a frame for each zero
+   run of at least FD_ZLE_MIN_Z bytes.  wb is the input offset
+   represented by bit 0.  EXT continues a run past bit 63 into
+   subsequent mask words. */
+
+#define FD_ZLE_WALK( m, wb, EXT ) do {                                 \
+    while( m ) {                                                       \
+      ulong b   = (ulong)__builtin_ctzll( m );                         \
+      ulong zs  = (wb)+b;                                              \
+      ulong hi  = (m)>>b;                                              \
+      ulong len;                                                       \
+      ulong full FD_FN_UNUSED = 0UL;                                   \
+      if( ~hi ) {                                                      \
+        len = (ulong)__builtin_ctzll( ~hi );                           \
+        (m) &= ~( ( ( 1UL<<len )-1UL )<<b );                           \
+      } else {                          /* run fills rest of word */   \
+        len = 64UL-b;                                                  \
+        (m) = 0UL;                                                     \
+      }                                                                \
+      if( b+len==64UL ) { EXT; }                                       \
+      if( len>=FD_ZLE_MIN_Z ) {                                        \
+        o  = fd_zle_emit_small( o, src+fs, zs-fs, len );               \
+        fs = zs+len;                                                   \
+      }                                                                \
+    }                                                                  \
+  } while(0)
+
+/* fd_zle_fini closes the open literal frame and applies the deferred
+   escape test. */
+
+static inline ulong
+fd_zle_fini( uchar *       FD_RESTRICT dst,
+             uchar *                   o,
+             uchar const * FD_RESTRICT src,
+             ulong                     n,
+             ulong                     fs ) {
+  if( fs<n ) o = fd_zle_emit_small( o, src+fs, n-fs, 0UL );
+  ulong sz = (ulong)( o-dst );
+  if( FD_UNLIKELY( sz>=1UL+fd_zle_ext( n )+n ) ) return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
+  return sz;
+}
+
+/* fd_zle_w1..fd_zle_w4 encode inputs of exactly 1..4 mask words, i.e.
+   64*(k-1)<n<=64*k.  A compile time word count keeps each body
+   straight-line with its mask words in registers, which is what these
+   lengths are bound by. */
+
+static ulong
+fd_zle_w1( uchar *       FD_RESTRICT dst,
+           uchar const * FD_RESTRICT src,
+           ulong                     n ) {
+  ulong   m0 = fd_zle_zmask( src, 0UL, n );
+  uchar * o  = dst;
+  ulong   fs = 0UL;                    /* start of the open literal frame */
+  FD_ZLE_WALK( m0, 0UL, (void)0 );
+  return fd_zle_fini( dst, o, src, n, fs );
+}
+
+static ulong
+fd_zle_w2( uchar *       FD_RESTRICT dst,
+           uchar const * FD_RESTRICT src,
+           ulong                     n ) {
+  ulong   m0 = fd_zle_zmask( src, 0UL, n );
+  ulong   m1 = fd_zle_zmask( src, 1UL, n );
+  uchar * o  = dst;
+  ulong   fs = 0UL;
+  FD_ZLE_WALK( m0,  0UL, FD_ZLE_EXT( m1 ) );
+  FD_ZLE_WALK( m1, 64UL, (void)0 );
+  return fd_zle_fini( dst, o, src, n, fs );
+}
+
+static ulong
+fd_zle_w3( uchar *       FD_RESTRICT dst,
+           uchar const * FD_RESTRICT src,
+           ulong                     n ) {
+  ulong   m0 = fd_zle_zmask( src, 0UL, n );
+  ulong   m1 = fd_zle_zmask( src, 1UL, n );
+  ulong   m2 = fd_zle_zmask( src, 2UL, n );
+  uchar * o  = dst;
+  ulong   fs = 0UL;
+  FD_ZLE_WALK( m0,   0UL, { FD_ZLE_EXT( m1 ); if( full ) FD_ZLE_EXT( m2 ); } );
+  FD_ZLE_WALK( m1,  64UL, FD_ZLE_EXT( m2 ) );
+  FD_ZLE_WALK( m2, 128UL, (void)0 );
+  return fd_zle_fini( dst, o, src, n, fs );
+}
+
+static ulong
+fd_zle_w4( uchar *       FD_RESTRICT dst,
+           uchar const * FD_RESTRICT src,
+           ulong                     n ) {
+  ulong   m0 = fd_zle_zmask( src, 0UL, n );
+  ulong   m1 = fd_zle_zmask( src, 1UL, n );
+  ulong   m2 = fd_zle_zmask( src, 2UL, n );
+  ulong   m3 = fd_zle_zmask( src, 3UL, n );
+  uchar * o  = dst;
+  ulong   fs = 0UL;
+  FD_ZLE_WALK( m0,   0UL, { FD_ZLE_EXT( m1 ); if( full ) { FD_ZLE_EXT( m2 ); if( full ) FD_ZLE_EXT( m3 ); } } );
+  FD_ZLE_WALK( m1,  64UL, { FD_ZLE_EXT( m2 ); if( full ) FD_ZLE_EXT( m3 ); } );
+  FD_ZLE_WALK( m2, 128UL, FD_ZLE_EXT( m3 ) );
+  FD_ZLE_WALK( m3, 192UL, (void)0 );
+  return fd_zle_fini( dst, o, src, n, fs );
+}
+
+#undef FD_ZLE_WALK
+#undef FD_ZLE_EXT
+
+/* fd_zle_big is the general encoder */
+
+static ulong __attribute__((noinline))
+fd_zle_big( uchar *       FD_RESTRICT dst,
+            uchar const * FD_RESTRICT src,
+            ulong                     n ) {
+
+  /* if a frame reaches esc_sz bytes, use a plaintext frame */
+
+  ulong esc_sz = 1UL + fd_zle_ext( n ) + n;
+  ulong lim    = (ulong)dst + esc_sz;
+  ulong words  = ( n+63UL )>>6;
+
+  uchar * o  = dst;
+  ulong   fs = 0UL;
+  ulong   w  = 0UL;
+  ulong   m  = fd_zle_zmask( src, 0UL, n );
+  ulong   d  = fd_zle_cand( m, 1UL );
+
+  for(;;) {
+
+    if( !d ) {
+
+      w++;
+      for(;;) {
+        if( FD_UNLIKELY( w>=words ) ) goto trailing;
+        m = fd_zle_zmask( src, w, n );
+        d = fd_zle_cand( m, 1UL );
+        if( d ) break;
+        w++;
+        while( ( w<<6 )+257UL<=n ) {
+          uchar const * p  = src+( w<<6 );
+          wwb_t a0 = wwb_or( wwb_ldu( p       ), wwb_ldu( p+  1UL ) );
+          wwb_t a1 = wwb_or( wwb_ldu( p+ 64UL ), wwb_ldu( p+ 65UL ) );
+          wwb_t a2 = wwb_or( wwb_ldu( p+128UL ), wwb_ldu( p+129UL ) );
+          wwb_t a3 = wwb_or( wwb_ldu( p+192UL ), wwb_ldu( p+193UL ) );
+          wwb_t t  = _mm512_min_epu8( _mm512_min_epu8( a0, a1 ), _mm512_min_epu8( a2, a3 ) );
+          if( FD_UNLIKELY( _mm512_testn_epi8_mask( t, t ) ) ) break;
+          w += 4UL;
+        }
+      }
+    }
+
+    /* ctz(d+lo) gives the index of the zero run's final byte */
+
+    ulong lo = d & ( ~d+1UL ); /* lowest candidate */
+    ulong b  = (ulong)__builtin_ctzll( d );
+    ulong zs = ( w<<6 )+b;
+    ulong x  = d + lo;
+    ulong len;
+    if( FD_LIKELY( x ) ) {
+      len = (ulong)__builtin_ctzll( x )-b+1UL;
+      d   = x & ( x-1UL );
+    } else { /* x==0: run hit the word end */
+      len = fd_zle_spill( src, n, words, &w, &m, 64UL-b );
+      d   = fd_zle_cand( m, 1UL );
+    }
+    if( FD_LIKELY( len>=FD_ZLE_MIN_Z ) ) {
+      ulong L = zs-fs;
+      if( FD_UNLIKELY( (ulong)o+L+15UL>=lim ) &&
+          (ulong)o+fd_zle_frame_sz( L, len )>=lim ) goto escape;
+      o  = fd_zle_emit( o, src+fs, L, len );
+      fs = zs+len;
+    }
+  }
+
+trailing:
+  if( fs<n ) {
+    ulong L = n-fs;
+    if( FD_UNLIKELY( (ulong)o+L+15UL>=lim ) &&
+        (ulong)o+fd_zle_frame_sz( L, 0UL )>=lim ) goto escape;
+    o = fd_zle_emit( o, src+fs, L, 0UL );
+  }
+  return (ulong)( o-dst );
+
+escape:
+  return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
 }
 
 ulong
@@ -168,65 +437,12 @@ fd_zle_compress( void *       FD_RESTRICT comp,
                  ulong                    data_sz ) {
   uchar *       dst = (uchar *)comp;
   uchar const * src = (uchar const *)data;
-  ulong         n   = data_sz;
-
-  if( FD_UNLIKELY( !n ) ) return 0UL;
-
-  ulong esc_sz = 1UL + fd_zle_ext( n ) + n;
-  ulong words  = ( n+63UL )>>6;
-
-  uchar * o  = dst;
-  ulong   fs = 0UL;
-  ulong   w  = 0UL;
-  ulong   m  = fd_zle_zmask( src, 0UL, n );
-  for(;;) {
-    while( !m ) {
-      w++;
-      while( ( w<<6 )+256UL<=n ) {
-        ulong m0 = fd_zle_zmask( src, w,     n );
-        ulong m1 = fd_zle_zmask( src, w+1UL, n );
-        ulong m2 = fd_zle_zmask( src, w+2UL, n );
-        ulong m3 = fd_zle_zmask( src, w+3UL, n );
-        if( m0|m1|m2|m3 ) break;
-        w += 4UL;
-      }
-      while( w<words && !( m = fd_zle_zmask( src, w, n ) ) ) w++;
-      if( w>=words ) goto trailing;
-    }
-    ulong b  = (ulong)__builtin_ctzll( m );
-    ulong zs = ( w<<6 )+b;
-    ulong hi = m>>b;
-    ulong len;
-    if( ~hi ) {
-      len = (ulong)__builtin_ctzll( ~hi );
-      m &= ~( ( ( 1UL<<len )-1UL )<<b );
-      if( b+len==64UL ) len = fd_zle_spill( src, n, words, &w, &m, len );
-    } else {                             /* run fills rest of word */
-      m   = 0UL;
-      len = fd_zle_spill( src, n, words, &w, &m, 64UL-b );
-    }
-    if( len>=FD_ZLE_MIN_Z ) {
-      ulong L   = zs-fs;
-      ulong cur = (ulong)( o-dst );
-      if( FD_UNLIKELY( cur+L+15UL>=esc_sz ) &&
-          cur+fd_zle_frame_sz( L, len )>=esc_sz ) goto escape;
-      o  = fd_zle_emit( o, src+fs, L, len );
-      fs = zs+len;
-    }
-    if( !m && w>=words ) break;
-  }
-trailing:
-  if( fs<n ) {
-    ulong L   = n-fs;
-    ulong cur = (ulong)( o-dst );
-    if( FD_UNLIKELY( cur+L+15UL>=esc_sz ) &&
-        cur+fd_zle_frame_sz( L, 0UL )>=esc_sz ) goto escape;
-    o = fd_zle_emit( o, src+fs, L, 0UL );
-  }
-  return (ulong)( o-dst );
-
-escape:
-  return (ulong)( fd_zle_emit( dst, src, n, 0UL )-dst );
+  if( FD_UNLIKELY( !data_sz        ) ) return 0UL;
+  if( FD_LIKELY  ( data_sz<= 64UL  ) ) return fd_zle_w1 ( dst, src, data_sz );
+  if( FD_LIKELY  ( data_sz<=128UL  ) ) return fd_zle_w2 ( dst, src, data_sz );
+  if( FD_LIKELY  ( data_sz<=192UL  ) ) return fd_zle_w3 ( dst, src, data_sz );
+  if( FD_LIKELY  ( data_sz<=256UL  ) ) return fd_zle_w4 ( dst, src, data_sz );
+  return                                      fd_zle_big( dst, src, data_sz );
 }
 
 #else
@@ -306,7 +522,7 @@ fd_zle_decompress( void *       FD_RESTRICT data,
       Z += e;
     }
     if( FD_UNLIKELY( Z>data_sz-o ) ) return FD_ZLE_ERR_SPACE;
-    fd_memset( d+o, 0, Z );
+    fd_zle_zero( d+o, Z );
     o += Z;
   }
   return (long)o;

--- a/src/flamenco/accdb/fd_zle.h
+++ b/src/flamenco/accdb/fd_zle.h
@@ -14,6 +14,11 @@
 #define FD_ZLE_OVERHEAD (8UL)
 #define FD_ZLE_COMPRESS_BOUND( in_sz ) (FD_ZLE_OVERHEAD + (in_sz))
 
+/* FD_ZLE_MAX_SZ is the largest input fd_zle_compress accepts (approx
+   512 TiB). */
+
+#define FD_ZLE_MAX_SZ ((1UL<<49)+14UL)
+
 #define FD_ZLE_ERR_SPACE   (-1L) /* out of buffer space */
 #define FD_ZLE_ERR_CORRUPT (-2L) /* malformed compressed data */
 
@@ -21,7 +26,11 @@ FD_PROTOTYPES_BEGIN
 
 /* fd_zle_compress compresses data_sz bytes at data.  Writes up to
    FD_ZLE_COMPRESS_BOUND( data_sz ) compressed bytes to comp.  Returns
-   the number of compressed bytes written. */
+   the number of compressed bytes written.  data_sz<=FD_ZLE_MAX_SZ.
+
+   data has no alignment requirement, but the readable span starting at
+   data must cover fd_ulong_align_up( data_sz, 64 ) bytes.  The tail
+   padding does not affect the output. */
 
 ulong
 fd_zle_compress( void *       FD_RESTRICT comp,
@@ -31,7 +40,11 @@ fd_zle_compress( void *       FD_RESTRICT comp,
 /* fd_zle_decompress takes an fd_zle compressed blob at comp.  Writes up
    to data_sz decompressed bytes to data.  Returns the number of bytes
    decompressed (>=0) on success, or a negative FD_ZLE_ERR_* number on
-   failure. */
+   failure.  data, data_sz have no alignment requirements.  comp and
+   comp_sz have no alignment requirements, no OOB reads at comp are
+   done.  Safe (but possibly slow) given arbitrary input.
+
+   The caller assumes all data_sz output bytes are invalidated. */
 
 long
 fd_zle_decompress( void *       FD_RESTRICT data,

--- a/src/flamenco/accdb/fuzz_zle_decompress.c
+++ b/src/flamenco/accdb/fuzz_zle_decompress.c
@@ -1,0 +1,86 @@
+/* fuzz_zle_decompress attacks the decompression function. */
+
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include "fd_zle.h"
+#include "../../util/fd_util.h"
+#include "../../util/sanitize/fd_fuzz.h"
+
+#include <stdlib.h>
+
+#define MAX_SZ (1UL<<20)
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  fd_log_level_core_set( 3 ); /* crash on warning log */
+  return 0;
+}
+
+static void
+decode_at( uchar const * comp,
+           ulong         comp_sz,
+           ulong         data_sz ) {
+
+  /* exact sized allocations, no slack for an overrun to hide in */
+
+  uchar * cbuf = malloc( fd_ulong_max( comp_sz, 1UL ) );
+  uchar * data = malloc( fd_ulong_max( data_sz, 1UL ) );
+  FD_TEST( cbuf && data );
+  if( comp_sz ) memcpy( cbuf, comp, comp_sz );
+  memset( data, 0xcc, fd_ulong_max( data_sz, 1UL ) );
+
+  long res = fd_zle_decompress( data, data_sz, cbuf, comp_sz );
+  FD_TEST( res<=(long)data_sz );
+  FD_TEST( ( res>=0L ) | ( res==FD_ZLE_ERR_SPACE ) | ( res==FD_ZLE_ERR_CORRUPT ) );
+  FD_TEST( fd_zle_strerror( res ) );
+
+  if( FD_LIKELY( res>=0L ) ) {
+    ulong   n     = (ulong)res;
+    ulong   span  = fd_ulong_align_up( fd_ulong_max( n, 1UL ), 64UL );
+    uchar * pad   = aligned_alloc( 64UL, span );
+    uchar * comp2 = malloc( FD_ZLE_COMPRESS_BOUND( n ) );
+    uchar * out2  = malloc( fd_ulong_max( n, 1UL ) );
+    FD_TEST( pad && comp2 && out2 );
+    if( n ) memcpy( pad, data, n );
+    memset( pad+n, 0xff, span-n );
+
+    ulong csz = fd_zle_compress( comp2, pad, n );
+    FD_TEST( csz<=FD_ZLE_COMPRESS_BOUND( n ) );
+    FD_TEST( fd_zle_decompress( out2, n, comp2, csz )==(long)n );
+    FD_TEST( 0==memcmp( out2, data, n ) );
+
+    free( out2 ); free( comp2 ); free( pad );
+  }
+
+  free( data ); free( cbuf );
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         data_sz ) {
+  if( FD_UNLIKELY( data_sz>MAX_SZ ) ) data_sz = MAX_SZ;
+
+  /* the first byte picks the output capacity so that both the
+     ERR_SPACE and the success paths get explored */
+
+  ulong cap;
+  if( FD_UNLIKELY( !data_sz ) ) cap = 0UL;
+  else switch( data[0] & 3U ) {
+    case 0:  cap = 0UL;                          break;
+    case 1:  cap = (ulong)data[ data_sz-1UL ];   break;
+    case 2:  cap = data_sz;                      break;
+    default: cap = MAX_SZ;                       break;
+  }
+
+  decode_at( data, data_sz, cap );
+
+  FD_FUZZ_MUST_BE_COVERED;
+  return 0;
+}

--- a/src/flamenco/accdb/fuzz_zle_diff.c
+++ b/src/flamenco/accdb/fuzz_zle_diff.c
@@ -1,0 +1,147 @@
+#if !FD_HAS_HOSTED
+#error "This target requires FD_HAS_HOSTED"
+#endif
+
+#include "fd_zle.h"
+#include "../../util/fd_util.h"
+#include "../../util/sanitize/fd_fuzz.h"
+
+#include <stdlib.h>
+
+/* fuzz_zle_diff differentially fuzzes fd_zle_compress against a scalar
+   transcription of the wire format.  The fuzzer input is the data to
+   compress. */
+
+#define MAX_SZ (1UL<<20)
+
+/* fd_zle reference implementation */
+
+static ulong
+ref_vput( uchar * p,
+          ulong   v ) {
+  ulong k = 0UL;
+  do {
+    p[k] = (uchar)( v & 0x7fUL );
+    v >>= 7;
+    if( v ) p[k] = (uchar)( p[k] | 0x80 );
+    k++;
+  } while( v );
+  return k;
+}
+
+static ulong
+ref_ext( ulong v ) {
+  if( v<15UL ) return 0UL;
+  v -= 15UL;
+  ulong k = 1UL;
+  while( v>=128UL ) { v >>= 7; k++; }
+  return k;
+}
+
+static uchar *
+ref_emit( uchar *       o,
+          uchar const * lit,
+          ulong         L,
+          ulong         Z ) {
+  ulong ln = L<15UL ? L : 15UL;
+  ulong zn = Z<15UL ? Z : 15UL;
+  *o++ = (uchar)( (ln<<4) | zn );
+  if( L>=15UL ) o += ref_vput( o, L-15UL );
+  if( L ) memcpy( o, lit, L );
+  o += L;
+  if( Z>=15UL ) o += ref_vput( o, Z-15UL );
+  return o;
+}
+
+static ulong
+ref_compress( uchar *       dst,
+              uchar const * src,
+              ulong         n ) {
+  if( !n ) return 0UL;
+  ulong   esc_sz = 1UL + ref_ext( n ) + n;
+  uchar * o      = dst;
+  ulong   pos    = 0UL;
+  ulong   fs     = 0UL;
+  while( pos<n ) {
+    ulong zs = pos;
+    while( (zs<n) &&  src[zs] ) zs++;
+    if( zs==n ) break;
+    ulong ze = zs;
+    while( (ze<n) && !src[ze] ) ze++;
+    if( ze-zs>=2UL ) {
+      ulong L = zs-fs;
+      ulong Z = ze-zs;
+      if( (ulong)( o-dst )+1UL+ref_ext( L )+L+ref_ext( Z )>=esc_sz ) goto escape;
+      o  = ref_emit( o, src+fs, L, Z );
+      fs = ze;
+    }
+    pos = ze;
+  }
+  if( fs<n ) {
+    ulong L = n-fs;
+    if( (ulong)( o-dst )+1UL+ref_ext( L )+L>=esc_sz ) goto escape;
+    o = ref_emit( o, src+fs, L, 0UL );
+  }
+  return (ulong)( o-dst );
+escape:
+  return (ulong)( ref_emit( dst, src, n, 0UL )-dst );
+}
+
+static uchar ref[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ];
+static uchar out[ MAX_SZ ];
+
+int
+LLVMFuzzerInitialize( int  *   argc,
+                      char *** argv ) {
+  putenv( "FD_LOG_BACKTRACE=0" );
+  setenv( "FD_LOG_PATH", "", 0 );
+  fd_boot( argc, argv );
+  atexit( fd_halt );
+  fd_log_level_core_set( 3 ); /* crash on warning log */
+  return 0;
+}
+
+static void
+check_at( uchar const * data,
+          ulong         sz,
+          ulong         off ) {
+
+  ulong   span = off + fd_ulong_align_up( fd_ulong_max( sz, 1UL ), 64UL );
+  uchar * buf  = aligned_alloc( 64UL, fd_ulong_align_up( span, 64UL ) );
+  FD_TEST( buf );
+  uchar * src = buf+off;
+  memcpy( src, data, sz );
+  memset( src+sz, 0xff, span-off-sz );   /* pad must not affect the output */
+
+  ulong   bound = FD_ZLE_COMPRESS_BOUND( sz );
+  uchar * comp  = malloc( bound );
+  FD_TEST( comp );
+
+  ulong csz = fd_zle_compress( comp, src, sz );
+  FD_TEST( csz<=bound );
+
+  ulong rsz = ref_compress( ref, src, sz );
+  if( FD_UNLIKELY( ( csz!=rsz ) || ( csz && memcmp( comp, ref, csz ) ) ) )
+    FD_LOG_ERR(( "encoder mismatch at sz %lu off %lu (got %lu bytes, ref %lu bytes)",
+                 sz, off, csz, rsz ));
+
+  long res = fd_zle_decompress( out, sz, comp, csz );
+  FD_TEST( res==(long)sz );
+  FD_TEST( 0==memcmp( out, src, sz ) );
+
+  free( comp );
+  free( buf  );
+}
+
+int
+LLVMFuzzerTestOneInput( uchar const * data,
+                        ulong         data_sz ) {
+  if( FD_UNLIKELY( data_sz>MAX_SZ ) ) data_sz = MAX_SZ;
+
+  ulong hash = fd_ulong_hash( data_sz ^ ( data_sz ? ( ( (ulong)data[0]<<8 ) | (ulong)data[data_sz-1] ) : 0UL ) );
+  check_at( data, data_sz, 0UL         );
+  check_at( data, data_sz, hash & 63UL );   /* fd_zle.h permits an unaligned input */
+
+  FD_FUZZ_MUST_BE_COVERED;
+  return 0;
+}

--- a/src/flamenco/accdb/test_zle.c
+++ b/src/flamenco/accdb/test_zle.c
@@ -1,11 +1,108 @@
 #include "fd_zle.h"
 #include "../../util/fd_util.h"
+#include <unistd.h>
 
 #define MAX_SZ (1UL<<20)
 
-static uchar in  [ MAX_SZ ];
-static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ];
-static uchar out [ MAX_SZ ];
+static uchar in  [ MAX_SZ ] __attribute__((aligned(64)));
+static uchar comp[ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ] __attribute__((aligned(64)));
+static uchar out [ MAX_SZ ] __attribute__((aligned(64)));
+static uchar ref [ FD_ZLE_COMPRESS_BOUND( MAX_SZ ) ] __attribute__((aligned(64)));
+
+/* fd_zle reference implementation */
+
+static ulong
+ref_vput( uchar * p,
+          ulong   v ) {
+  ulong k = 0UL;
+  do {
+    p[k] = (uchar)( v & 0x7fUL );
+    v >>= 7;
+    if( v ) p[k] = (uchar)( p[k] | 0x80 );
+    k++;
+  } while( v );
+  return k;
+}
+
+static ulong
+ref_ext( ulong v ) {
+  if( v<15UL ) return 0UL;
+  v -= 15UL;
+  ulong k = 1UL;
+  while( v>=128UL ) { v >>= 7; k++; }
+  return k;
+}
+
+static ulong
+ref_frame_sz( ulong L,
+              ulong Z ) {
+  return 1UL + ref_ext( L ) + L + ref_ext( Z );
+}
+
+static uchar *
+ref_emit( uchar *       o,
+          uchar const * lit,
+          ulong         L,
+          ulong         Z ) {
+  ulong ln = L<15UL ? L : 15UL;
+  ulong zn = Z<15UL ? Z : 15UL;
+  *o++ = (uchar)( (ln<<4) | zn );
+  if( L>=15UL ) o += ref_vput( o, L-15UL );
+  if( L        ) memcpy( o, lit, L );
+  o += L;
+  if( Z>=15UL ) o += ref_vput( o, Z-15UL );
+  return o;
+}
+
+static ulong
+ref_compress( uchar *       dst,
+              uchar const * src,
+              ulong         n ) {
+  if( !n ) return 0UL;
+  ulong   esc_sz = 1UL + ref_ext( n ) + n;
+  uchar * o      = dst;
+  ulong   pos    = 0UL;
+  ulong   fs     = 0UL;
+  while( pos<n ) {
+    ulong zs = pos;
+    while( (zs<n) &&  src[zs] ) zs++;
+    if( zs==n ) break;
+    ulong ze = zs;
+    while( (ze<n) && !src[ze] ) ze++;
+    if( ze-zs>=2UL ) {
+      ulong L = zs-fs;
+      ulong Z = ze-zs;
+      if( (ulong)( o-dst )+ref_frame_sz( L, Z )>=esc_sz ) return (ulong)( ref_emit( dst, src, n, 0UL )-dst );
+      o  = ref_emit( o, src+fs, L, Z );
+      fs = ze;
+    }
+    pos = ze;
+  }
+  if( fs<n ) {
+    ulong L = n-fs;
+    if( (ulong)( o-dst )+ref_frame_sz( L, 0UL )>=esc_sz ) return (ulong)( ref_emit( dst, src, n, 0UL )-dst );
+    o = ref_emit( o, src+fs, L, 0UL );
+  }
+  return (ulong)( o-dst );
+}
+
+/* diff_case asserts, for src[0,sz), that the encoder matches the oracle
+   byte for byte, stays inside FD_ZLE_COMPRESS_BOUND, and round trips. */
+
+static void
+diff_case( uchar const * src,
+           ulong         sz ) {
+  fd_memset( comp, 0xcc, FD_ZLE_COMPRESS_BOUND( sz )+1UL );
+  ulong comp_sz = fd_zle_compress( comp, src, sz );
+  ulong ref_sz  = ref_compress( ref, src, sz );
+  FD_TEST( comp_sz<=FD_ZLE_COMPRESS_BOUND( sz ) );
+  FD_TEST( comp[ FD_ZLE_COMPRESS_BOUND( sz ) ]==0xcc ); /* no write past bound */
+  FD_TEST( comp_sz==ref_sz );
+  FD_TEST( 0==memcmp( comp, ref, comp_sz ) );
+  fd_memset( out, 0xcc, sz );
+  FD_TEST( fd_zle_decompress( out, sz, comp, comp_sz )==(long)sz );
+  FD_TEST( 0==memcmp( out, src, sz ) );
+}
 
 static ulong
 round_trip( ulong sz ) {
@@ -90,7 +187,7 @@ main( int     argc,
       FD_TEST( res<(long)sz );
     }
 
-    /* bit flips must never crash and never overflow the output */
+    /* a bit flip must decode within sz bytes or report an error */
     ulong bit = fd_rng_ulong_roll( rng, comp_sz*8UL );
     comp[ bit/8UL ] = (uchar)( comp[ bit/8UL ] ^ (uchar)( 1U<<( bit%8UL ) ) );
     long res = fd_zle_decompress( out, sz, comp, comp_sz );
@@ -102,7 +199,9 @@ main( int     argc,
   comp[0] = 0x00;                                       /* empty frame */
   FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 1UL )==FD_ZLE_ERR_CORRUPT );
 
-  comp[0] = 0x1f; comp[1] = 0x00;                       /* L=1 but no literal bytes... */
+  comp[0] = 0x1f; comp[1] = 0x00;                       /* L=1, Z=15, no literal or zero_ext */
+  FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 2UL )==FD_ZLE_ERR_CORRUPT );
+
   comp[0] = 0x10;                                       /* L=1, truncated */
   FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 1UL )==FD_ZLE_ERR_CORRUPT );
 
@@ -118,6 +217,108 @@ main( int     argc,
 
   comp[0] = 0x21; comp[1] = 0x41; comp[2] = 0x42;    /* output exceeds capacity */
   FD_TEST( fd_zle_decompress( out, 2UL, comp, 3UL )==FD_ZLE_ERR_SPACE );
+
+  /* the decompressor accepts a wider variety of encodings than the
+     compress function emits */
+
+  do {
+    static uchar const alt[][8] = {
+      { 0x20, 0x41, 0x42             }, /* canonical  "AB" */
+      { 0x10, 0x41, 0x10, 0x42       }, /* split into two frames */
+      { 0x11, 0x41, 0x10, 0x42, 0x00 }, /* fails: trailing 0x00 token */
+    };
+    static ulong const alt_sz[] = { 3UL, 4UL, 5UL };
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, alt[0], alt_sz[0] )==2L && out[0]=='A' && out[1]=='B' );
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, alt[1], alt_sz[1] )==2L && out[0]=='A' && out[1]=='B' );
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, alt[2], alt_sz[2] )==FD_ZLE_ERR_CORRUPT );
+
+    /* non-minimal varints are accepted (up to the 7 byte cap) */
+    comp[0] = 0xf0; comp[1] = 0x00;
+    for( ulong j=0UL; j<15UL; j++ ) comp[2UL+j] = (uchar)( 'a'+j );
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 17UL )==15L );
+    comp[0] = 0xf0; comp[1] = 0x80; comp[2] = 0x80; comp[3] = 0x00;
+    for( ulong j=0UL; j<15UL; j++ ) comp[4UL+j] = (uchar)( 'a'+j );
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 19UL )==15L );
+    FD_TEST( 0==memcmp( out, "abcdefghijklmno", 15UL ) );
+
+    /* a varint longer than 7 bytes is rejected, which is what keeps
+       FD_ZLE_OVERHEAD at 8 consistent with FD_ZLE_MAX_SZ */
+    comp[0] = 0xf0;
+    for( ulong j=1UL; j<8UL; j++ ) comp[j] = 0x80;
+    comp[8] = 0x01;
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 9UL )==FD_ZLE_ERR_CORRUPT );
+
+    /* Z=1 is below FD_ZLE_MIN_Z but still decodes */
+    comp[0] = 0x01; comp[1] = 0x01; comp[2] = 0x01; comp[3] = 0x01;
+    FD_TEST( fd_zle_decompress( out, MAX_SZ, comp, 4UL )==4L );
+    FD_TEST( !out[0] && !out[1] && !out[2] && !out[3] );
+
+    /* decompress writes only what it returns: the tail is untouched */
+    fd_memset( out, 0xcc, 64UL );
+    comp[0] = 0x20; comp[1] = 0x41; comp[2] = 0x42;
+    FD_TEST( fd_zle_decompress( out, 64UL, comp, 3UL )==2L );
+    for( ulong j=2UL; j<64UL; j++ ) FD_TEST( out[j]==0xcc );
+  } while(0);
+
+  /* randomised differential battery against the scalar oracle */
+
+  {
+    /* every size 0..4096 at a spread of zero densities, so that runs
+       land on and straddle both the 64 B word and the 256 B block
+       boundary at every possible phase */
+
+    static uint const dens[] = { 0U, 1U, 8U, 64U, 128U, 192U, 248U, 255U, 256U };
+    for( ulong sz=0UL; sz<=4096UL; sz++ ) {
+      for( ulong k=0UL; k<sizeof(dens)/sizeof(dens[0]); k++ ) {
+        for( ulong j=0UL; j<sz; j++ )
+          in[j] = ( fd_rng_uint( rng )&255U )<dens[k] ? (uchar)0 : (uchar)( fd_rng_uint( rng ) | 1U );
+        diff_case( in, sz );
+      }
+    }
+
+    /* one long run, swept across every offset and length that can touch
+       a word or block boundary, plus the very first and very last byte */
+
+    for( ulong sz=1UL; sz<=1024UL; sz++ ) {
+      for( ulong off=0UL; off<sz; off++ ) {
+        ulong len = sz-off;
+        if( !( ( off%64UL )<=1UL || ( off%64UL )>=63UL || ( off%256UL )<=1UL || ( off%256UL )>=255UL ||
+               off==0UL || off==sz-1UL ) ) continue;
+        for( ulong j=0UL; j<sz; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
+        for( ulong j=off; j<off+len && j<sz; j++ ) in[j] = 0;
+        diff_case( in, sz );
+        if( len>1UL ) {                    /* and a bounded run, not a suffix */
+          for( ulong j=0UL; j<sz; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
+          ulong e = off+( len>320UL ? 320UL : len )-1UL;
+          for( ulong j=off; j<e; j++ ) in[j] = 0;
+          diff_case( in, sz );
+        }
+      }
+    }
+
+    /* larger sizes, random shapes */
+
+    for( ulong t=0UL; t<300UL; t++ ) {
+      ulong sz = 1UL + (ulong)( fd_rng_uint( rng )%100000U );
+      uint  d  = fd_rng_uint( rng )%257U;
+      ulong j  = 0UL;
+      while( j<sz ) {                      /* run structured, not i.i.d. */
+        ulong run = 1UL + (ulong)( fd_rng_uint( rng )%600U );
+        int   z   = ( fd_rng_uint( rng )&255U )<d;
+        for( ulong q=0UL; q<run && j<sz; q++, j++ ) in[j] = z ? (uchar)0 : (uchar)( fd_rng_uint( rng ) | 1U );
+      }
+      diff_case( in, sz );
+    }
+
+    /* all-zero and all-nonzero at the interesting sizes */
+
+    for( ulong sz=0UL; sz<=8192UL; sz++ ) {
+      fd_memset( in, 0, sz );
+      diff_case( in, sz );
+      for( ulong j=0UL; j<sz; j++ ) in[j] = (uchar)( fd_rng_uint( rng ) | 1U );
+      diff_case( in, sz );
+    }
+  }
 
   /* strerror */
 


### PR DESCRIPTION
mainnet compression profile on AMD EPYC 9555P (sunburst)

```
case                           size       accounts |    ratio | enc GB/s enc ns/B | dec GB/s dec ns/B
metaplex edition                 20       22921472 |   20.00% |     3.73   0.2682 |     4.67   0.2143
pump.fun curve                   49        9347776 |   81.63% |     4.44   0.2252 |     7.76   0.1289
metaplex token record            32        3567168 |   34.38% |     8.47   0.1180 |    11.50   0.0870
wormhole 1 B                      1        1570816 |  200.00% |     0.31   3.2304 |     0.39   2.5406
spl-token account               165      615273088 |   46.06% |    15.82   0.0632 |    24.76   0.0404
token-2022 account              170       84784704 |   44.71% |    14.52   0.0689 |    17.22   0.0581
spl-token mint                   82       45047074 |   90.24% |     7.18   0.1392 |     9.60   0.1042
spl-token mint nofz              82       29217565 |   56.10% |     7.65   0.1306 |    17.46   0.0573
pumpswap amm                    137        7725696 |   31.39% |    18.86   0.0530 |    40.65   0.0246
stake account                   200        1442496 |   66.00% |    11.15   0.0897 |    11.81   0.0847
metaplex metadata               607       42464896 |   39.70% |    16.83   0.0594 |    27.79   0.0360
metaplex metadata v1.3          679        8667712 |   32.70% |    18.36   0.0545 |    29.68   0.0337
metaplex edition marker         282        2572480 |    2.13% |    24.00   0.0417 |    37.35   0.0268
address lookup table            568         149056 |   94.19% |    18.64   0.0536 |    29.51   0.0339
raydium amm v4 info             752         709184 |   60.24% |     7.12   0.1404 |    11.12   0.0899
openbook v1 queue              3228        1618048 |    3.28% |   119.49   0.0084 |   138.11   0.0072
meteora damm v2 pool           1112        1436096 |   26.98% |    13.67   0.0731 |    22.38   0.0447
raydium amm v4 pool            2208         705600 |    3.08% |    84.67   0.0118 |   153.16   0.0065
serum v3 slab                 14524        1050688 |    0.12% |   397.94   0.0025 |   258.75   0.0039
meteora dlmm bins             10136         450752 |   12.95% |    19.03   0.0525 |    35.96   0.0278
raydium clmm ticks            10240         424128 |    0.58% |   265.92   0.0038 |   246.83   0.0041
serum v3 queue 64K            65500          62848 |    0.03% |   189.05   0.0053 |   195.29   0.0051
serum v3 slab 64K             65548         288640 |    0.03% |   187.99   0.0053 |   197.79   0.0051
serum v3 queue 256K          262156         141504 |    0.01% |   203.21   0.0049 |   203.81   0.0049
tail 1-64                        29       39997696 |   86.21% |     6.91   0.1446 |    10.25   0.0976
tail 65-256                     140      111374912 |   60.00% |    17.05   0.0586 |    36.58   0.0273
tail 257-1K                     456       35740800 |   48.25% |     9.17   0.1090 |    16.47   0.0607
tail 1K-4K                     2175        4929344 |   15.91% |    19.58   0.0511 |    33.16   0.0302
tail 4K-16K                    7771        2348352 |   15.88% |    21.56   0.0464 |    34.59   0.0289
tail 16K-64K                  29668          41856 |   25.67% |     9.55   0.1047 |    12.21   0.0819
tail 64K-1M                  237237          90944 |   22.48% |     7.34   0.1363 |     9.50   0.1053
tail >1M                    1958702           4160 |   26.63% |     8.80   0.1136 |    10.81   0.0925
-- synthetic bounds (not in the mix) --
uniform random 8 MiB        8388608              0 |  100.00% |    22.23   0.0450 |    48.75   0.0205
all-zero 64 B                    64              0 |    3.12% |    17.70   0.0565 |    25.19   0.0397
all-zero 256 B                  256              0 |    1.17% |    40.14   0.0249 |    63.28   0.0158
all-zero 1 KiB                 1024              0 |    0.29% |   108.59   0.0092 |   190.58   0.0052
all-zero 4 KiB                 4096              0 |    0.07% |   272.47   0.0037 |   255.31   0.0039
all-zero 16 KiB               16384              0 |    0.02% |   439.75   0.0023 |   276.59   0.0036
all-zero 64 KiB               65536              0 |    0.01% |   191.11   0.0052 |   197.07   0.0051
all-zero 1 MiB              1048576              0 |    0.00% |   190.62   0.0052 |   186.42   0.0054
all-zero 8 MiB              8388608              0 |    0.00% |   133.66   0.0075 |   100.26   0.0100
-- band fit vs snapshot --
band           accounts      raw bytes  acct err  byte err mix ratio     chain
1-64           77404928     2192123840     0.00%     0.10%    68.79%    69.13%
65-256        894865535   138962566830    -0.00%    -0.00%    48.76%    48.75%
257-1K         90304128    49302782656     0.00%    -0.03%    41.45%    41.47%
1K-4K           8689088    19099285696     0.00%    -0.00%    12.33%    12.34%
4K-16K          4273920    42421128896     0.00%    -0.00%     8.33%     8.33%
16K-64K          104704     5358327808     0.00%     0.00%     5.97%     5.97%
64K-1M           521088    77591179072     0.00%     0.00%     6.26%     6.26%
>1M                4160     8148200320     0.00%     0.00%    26.63%    26.63%
TOTAL        1076167551   343075595118    -0.00%    -0.01%    30.01%    30.01%
mix: 30.01% of raw, enc 0.0570 ns/B (17.55 GB/s), dec 0.0379 ns/B (26.38 GB/s)
```