### PR TITLE
mlx5: support odd tile counts

### DIFF
--- a/src/app/shared/fd_config_auto.c
+++ b/src/app/shared/fd_config_auto.c
@@ -253,7 +253,6 @@ mlx5_check( fd_config_t    const * config,
             fd_auto_info_t const * info ) {
   if( strcmp( config->net.provider, "auto" ) ) return 0;
   if( !info->has_mlx5_rdma_port ) return 0;
-  if( !fd_ulong_is_pow2( config->layout.net_tile_count ) ) return 0;
   return 1;
 }
 

--- a/src/app/shared/test_config_auto.c
+++ b/src/app/shared/test_config_auto.c
@@ -30,8 +30,8 @@ main( int     argc,
       char ** argv ) {
   fd_boot( &argc, &argv );
 
-  /* Auto selects mlx5 only for a supported driver, kernel, RDMA port,
-     and tile count.  Otherwise it falls back to XDP. */
+  /* Auto selects mlx5 only for a supported driver, kernel, and RDMA port.
+     Otherwise it falls back to XDP. */
 
   fd_auto_info_t info1 = { .linux_major=7, .linux_minor=0, .driver="mlx5_core", .has_mlx5_rdma_port=1 };
 
@@ -41,7 +41,7 @@ main( int     argc,
 
   reset_provider_auto( 3U );
   fd_auto_net( config, &info1 );
-  FD_TEST( 0==strcmp( config->net.provider, "xdp" ) );
+  FD_TEST( 0==strcmp( config->net.provider, "mlx5" ) );
 
   reset_provider_auto( 1U );
   fd_auto_info_t info_old_mlx5 = { .linux_major=5, .linux_minor=13, .driver="mlx5_core" };

--- a/src/disco/net/fd_net_tile_topo.c
+++ b/src/disco/net/fd_net_tile_topo.c
@@ -238,9 +238,6 @@ fd_topos_net_tiles( fd_topo_t *             topo,
     fd_topob_tile_out( topo, "netlnk", 0UL, "iproute_out", 0UL );
     fd_netlink_topo_create( netlink_tile, topo, netlnk_max_routes, netlnk_max_peer_routes, netlnk_max_neighbors, net_cfg->interface );
 
-    if( FD_UNLIKELY( !fd_ulong_is_pow2( net_tile_cnt ) ) ) {
-      FD_LOG_ERR(( "net.provider=\"mlx5\" requires layout.net_tile_count to be a power of two" ));
-    }
     for( ulong i=0UL; i<net_tile_cnt; i++ ) {
       setup_mlx5_tile( topo, i, netlink_tile, tile_to_cpu, net_cfg, netlnk_max_routes, netlnk_max_peer_routes );
     }

--- a/src/disco/net/mlx5/fd_mlx5.c
+++ b/src/disco/net/mlx5/fd_mlx5.c
@@ -149,6 +149,7 @@
                                         FD_MLX5_RX_HASH_SRC_PORT_UDP | FD_MLX5_RX_HASH_DST_PORT_UDP )
 #define FD_MLX5_QP_TUNNEL_OFFLOADS    (1U<<2)   /* MLX5_QP_FLAG_TUNNEL_OFFLOADS */
 #define FD_MLX5_TUNNEL_OFFLOADS_GRE   (1U<<1)   /* MLX5_IB_TUNNELED_OFFLOADS_GRE */
+#define FD_MLX5_INDIRECTION_MIN       (1UL<<8)
 #define FD_MLX5_INDIRECTION_MAX       (1UL<<13) /* 1UL << IB_USER_VERBS_MAX_LOG_IND_TBL_SIZE */
 
 static int
@@ -1334,18 +1335,21 @@ fd_uverbs_create_rwq_ind_table( uint *                        handle,
                                 fd_uverbs_ctx_t *             uverbs,
                                 fd_mlx5_uverbs_tile_t const * tiles,
                                 ulong                         tile_cnt ) {
-  if( FD_UNLIKELY( !fd_ulong_is_pow2( tile_cnt ) || tile_cnt>FD_MLX5_INDIRECTION_MAX ) ) {
+  if( FD_UNLIKELY( !tile_cnt || tile_cnt>FD_MLX5_INDIRECTION_MAX ) ) {
     errno = EINVAL;
     return NULL;
   }
-  ulong const req_sz = fd_ulong_align_up( sizeof(fd_uverbs_create_rwq_ind_table_req_t)+tile_cnt*sizeof(uint), 8UL );
+  ulong const indirection_cnt = fd_ulong_max( FD_MLX5_INDIRECTION_MIN, fd_ulong_pow2_up( tile_cnt ) );
+  ulong const req_sz = fd_ulong_align_up( sizeof(fd_uverbs_create_rwq_ind_table_req_t)+indirection_cnt*sizeof(uint), 8UL );
   fd_uverbs_create_rwq_ind_table_req_t * req = aligned_alloc( 8UL, req_sz );
   if( FD_UNLIKELY( !req ) ) return NULL;
   struct ib_uverbs_ex_create_rwq_ind_table_resp resp[1];
   fd_memset( req,  0, req_sz );
   fd_memset( resp, 0, sizeof(resp) );
-  req->log_ind_tbl_size = (uint)fd_ulong_find_lsb( tile_cnt );
-  for( ulong i=0UL; i<tile_cnt; i++ ) req->wq_handles[ i ] = tiles[ i ].rx_wq->handle;
+  req->log_ind_tbl_size = (uint)fd_ulong_find_lsb( indirection_cnt );
+  for( ulong i=0UL; i<indirection_cnt; i++ ) {
+    req->wq_handles[ i ] = tiles[ i%tile_cnt ].rx_wq->handle;
+  }
   FD_TEST( !fd_uverbs_init_ex_hdr( &req->hdr, IB_USER_VERBS_EX_CMD_CREATE_RWQ_IND_TBL,
                                    req_sz, req_sz, resp,
                                    sizeof(resp), sizeof(resp) ) );
@@ -1535,8 +1539,8 @@ fd_uverbs_init( fd_uverbs_ctx_t *       uverbs,
                 fd_mlx5_rss_qp_t *      gre_rss_qp,
                 char const *            rdma_name,
                 uint                    port_num ) {
-  if( FD_UNLIKELY( !uverbs || !tiles || !tile_cnt || !fd_ulong_is_pow2( tile_cnt ) ||
-                   tile_cnt>FD_MLX5_INDIRECTION_MAX || !outer_rss_qp || !gre_rss_qp ) ) {
+  if( FD_UNLIKELY( !uverbs || !tiles || !tile_cnt || tile_cnt>FD_MLX5_INDIRECTION_MAX ||
+                   !outer_rss_qp || !gre_rss_qp ) ) {
     errno = EINVAL;
     return NULL;
   }

--- a/src/disco/net/mlx5/fd_mlx5_private.h
+++ b/src/disco/net/mlx5/fd_mlx5_private.h
@@ -159,9 +159,8 @@ FD_PROTOTYPES_BEGIN
 /* fd_uverbs_init creates one shared context, PD, receive indirection table,
    and two RSS QPs, one hashing outer headers and one hashing inner tunnel
    headers.  It creates an MR, UAR, RX CQ, TX CQ, receive WQ, and send-only QP
-   for each entry in tiles.  tile_cnt must be a power of two.  On failure,
-   process-scoped resources can remain live.  Callers must exit rather than
-   retry initialization. */
+   for each entry in tiles.  On failure, process-scoped resources can remain
+   live.  Callers must exit rather than retry initialization. */
 fd_mlx5_rss_qp_t *
 fd_uverbs_init( fd_uverbs_ctx_t *         uverbs,
                 fd_mlx5_uverbs_tile_t *   tiles,

--- a/src/disco/net/mlx5/fd_mlx5_tile.c
+++ b/src/disco/net/mlx5/fd_mlx5_tile.c
@@ -1235,8 +1235,8 @@ void
 fd_topo_install_mlx5( fd_topo_t *     topo,
                       fd_mlx5_fds_t * fds ) {
   ulong const tile_cnt = fd_topo_tile_name_cnt( topo, "mlx5" );
-  if( FD_UNLIKELY( !fd_ulong_is_pow2( tile_cnt ) || tile_cnt>FD_TOPO_MAX_TILES ) ) {
-    FD_LOG_ERR(( "mlx5 tile count must be a power of two" ));
+  if( FD_UNLIKELY( !tile_cnt || tile_cnt>FD_TOPO_MAX_TILES ) ) {
+    FD_LOG_ERR(( "mlx5 tile count %lu must be in [1,%lu]", tile_cnt, FD_TOPO_MAX_TILES ));
   }
 
   fd_mlx5_tile_t *       ctxs  [ FD_TOPO_MAX_TILES ];

--- a/src/disco/net/mlx5/test_mlx5_tile.c
+++ b/src/disco/net/mlx5/test_mlx5_tile.c
@@ -81,12 +81,12 @@ test_hardware( char const * rdma_name,
                uint         rx_depth,
                uint         tx_depth,
                ulong        tile_cnt ) {
-  FD_TEST( tile_cnt==1UL || tile_cnt==2UL );
+  FD_TEST( tile_cnt && tile_cnt<=FD_TOPO_MAX_TILES );
   ulong queue_footprint = fd_mlx5_queue_footprint( rx_depth, tx_depth );
   FD_TEST( queue_footprint );
-  fd_mlx5_tile_t        tile  [2];
-  fd_mlx5_uverbs_tile_t queues[2];
-  fd_memset( tile, 0, sizeof(tile) );
+  fd_mlx5_tile_t *        tile   = calloc( tile_cnt, sizeof(fd_mlx5_tile_t       ) );
+  fd_mlx5_uverbs_tile_t * queues = calloc( tile_cnt, sizeof(fd_mlx5_uverbs_tile_t) );
+  FD_TEST( tile && queues );
   for( ulong i=0UL; i<tile_cnt; i++ ) {
     void * queue_memory = mmap( NULL, queue_footprint, PROT_READ | PROT_WRITE,
                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0 );


### PR DESCRIPTION
- always use an indir table 256 or larger
- remove pow2 assumption on tile counts

Closes #11108