### PR TITLE
wsample: avoid out-of-bounds sentinel indexing

### DIFF
--- a/src/ballet/wsample/fd_wsample.c
+++ b/src/ballet/wsample/fd_wsample.c
@@ -141,10 +141,10 @@ struct __attribute__((aligned(64UL))) fd_wsample_private {
      implemented as a memcpy.
 
      The tree itself is surrounded by two dummy elements, dummy, and
-     tree[internal_node_cnt], that aren't actually used.  This is
-     because searching the tree branchlessly involves some out of bounds
-     reads, and although the value is immediately discarded, it's better
-     to know where exactly those reads might go. */
+     tree[internal_node_cnt].  Branchless searches historically used
+     these as physical sentinels, but that still accesses outside the
+     left_sum array subobject.  Loads now stay in bounds; the padding is
+     retained to preserve the existing workspace layout. */
   tree_ele_t        dummy;
   tree_ele_t        tree[];
 };
@@ -443,24 +443,11 @@ fd_wsample_map_sample_i( fd_wsample_t const * sampler,
 #endif
 
     /* See the note at the top of this file for the explanation of l[i]
-       and l[i-1].  Because this is fd_ulong_if and not a ternary, these
-       can read/write out of what you would think the appropriate bounds
-       are.  The dummy elements, as described along with tree makes this
-       safe. */
-#if 0
-    ulong li  = fd_ulong_if( child_idx<R-1UL, e->left_sum[ child_idx     ], S   );
-    ulong lm1 = fd_ulong_if( child_idx>0UL,   e->left_sum[ child_idx-1UL ], 0UL );
-#elif 0
-    ulong li  = fd_ulong_if_force( child_idx<R-1UL, e->left_sum[ child_idx     ], S   );
-    ulong lm1 = fd_ulong_if_force( child_idx>0UL,   e->left_sum[ child_idx-1UL ], 0UL );
-#else
-    ulong * temp = (ulong *)e->left_sum;
-    ulong orig_m1 = temp[ -1 ];    ulong orig_Rm1 = temp[ R-1UL ];
-    temp[ -1 ] = 0UL;              temp[ R-1UL ] = S;
-    ulong li  = temp[ child_idx     ];
-    ulong lm1 = temp[ child_idx-1UL ];
-    temp[ -1 ] = orig_m1;          temp[ R-1UL ] = orig_Rm1;
-#endif
+       and l[i-1].  fd_ulong_if evaluates both candidates, so clamp the
+       physical loads to left_sum before the muxes select the conceptual
+       sentinel values. */
+    ulong li  = fd_ulong_if( child_idx<R-1UL, e->left_sum[ fd_ulong_min( child_idx, R-2UL ) ], S   );
+    ulong lm1 = fd_ulong_if( child_idx>0UL,   e->left_sum[ child_idx-(ulong)!!child_idx     ], 0UL );
 
     query -= lm1;
     S = li - lm1;
@@ -533,8 +520,10 @@ fd_wsample_find_weight( fd_wsample_t const * sampler,
 
     /* If child_idx < R-1, we can compute the weight easily.  If
        child_idx==R-1, the computation is S - left_sum[ R-2 ], but we
-       don't know S, so we need to continue up the tree. */
-    lm1  += fd_ulong_if( child_idx>0UL, tree[ parent ].left_sum[ child_idx-1UL ], 0UL );
+       don't know S, so we need to continue up the tree.  fd_ulong_if
+       evaluates both candidates, so keep the predecessor load in bounds
+       even when child_idx is zero. */
+    lm1  += fd_ulong_if( child_idx>0UL, tree[ parent ].left_sum[ child_idx-(ulong)!!child_idx ], 0UL );
     if( FD_LIKELY( child_idx<R-1UL ) ) {
       li = tree[ parent ].left_sum[ child_idx ];
       break;

--- a/src/ballet/wsample/test_wsample.c
+++ b/src/ballet/wsample/test_wsample.c
@@ -314,6 +314,9 @@ test_remove_idx( void ) {
   fd_wsample_t * sample = fd_wsample_join( fd_wsample_new_fini( fd_wsample_new_add( fd_wsample_new_add( partial, 2UL ), 1UL ), 0UL ) );
   FD_TEST( sample );
 
+  fd_wsample_remove_idx( sample, 0UL );
+  FD_TEST( fd_wsample_restore_all( sample ) );
+
   fd_wsample_remove_idx( sample, 1UL );
 
   for( ulong j=0UL; j<10UL; j++ ) FD_TEST( fd_wsample_sample( sample ) != 1UL );


### PR DESCRIPTION
## Problem
Weighted-sampler traversal treated conceptual sentinel values as physical left_sum elements. The sampling path accessed indices outside the array at both ends, while fd_wsample_find_weight evaluated child_idx-1 even when child_idx was zero. These accesses are undefined even when padding surrounds the array and the selected value is later discarded.

## Fix
Clamp both sampling loads to valid left_sum indices before selecting the conceptual zero and S sentinels. Apply the same safe predecessor index in fd_wsample_find_weight, with the existing remove-index test exercising child zero. Workspace layout, sampling behavior, and branchless execution remain unchanged.