### PR TITLE
util: make signed saturating arithmetic UBSan-clean

### DIFF
--- a/src/util/bits/fd_sat.h
+++ b/src/util/bits/fd_sat.h
@@ -60,26 +60,26 @@ fd_long_sat_add( long x, long y ) {
   long res;
   int cf = __builtin_saddl_overflow ( x, y, &res );
   /* https://stackoverflow.com/a/56531252
-     x + y overflows => x, y have the same sign
-     we can use either to determine the result,
-     with the trick described in the SO answer.
-     We chose x because it works also for sub.
-     It is not UB because we compile with -fwrapv. */
-  return fd_long_if( cf, (long)((ulong)x >> 63) + LONG_MAX, res );
+     x+y overflows only when x and y have the same sign, so x selects
+     the saturation direction for addition and subtraction.  Select
+     the limits directly because fd_long_if evaluates both candidates;
+     constructing LONG_MIN as LONG_MAX+1 is still diagnosed by UBSan
+     despite -fwrapv. */
+  return fd_long_if( cf, fd_long_if( x<0L, LONG_MIN, LONG_MAX ), res );
 }
 
 FD_FN_CONST static inline long
 fd_long_sat_sub( long x, long y ) {
   long res;
   int cf = __builtin_ssubl_overflow ( x, y, &res );
-  return fd_long_if( cf, (long)((ulong)x >> 63) + LONG_MAX, res );
+  return fd_long_if( cf, fd_long_if( x<0L, LONG_MIN, LONG_MAX ), res );
 }
 
 FD_FN_CONST static inline long
 fd_long_sat_mul( long x, long y ) {
   long res;
   int cf = __builtin_smull_overflow ( x, y, &res );
-  return fd_long_if( cf, (long)((ulong)(x ^ y) >> 63) + LONG_MAX, res );
+  return fd_long_if( cf, fd_long_if( (x<0L) ^ (y<0L), LONG_MIN, LONG_MAX ), res );
 }
 
 FD_FN_CONST static inline uint

--- a/src/util/bits/test_sat.c
+++ b/src/util/bits/test_sat.c
@@ -240,9 +240,11 @@ main( int     argc,
     TEST(add,0,LONG_MAX);
     TEST(add,LONG_MAX,10);
     TEST(add,LONG_MAX - 10,LONG_MAX - 10);
+    TEST(add,LONG_MIN,-1);
     TEST(sub,0,LONG_MAX);
     TEST(add,LONG_MAX,10);
     TEST(sub,LONG_MAX - 10,LONG_MAX - 10);
+    TEST(sub,LONG_MIN,1);
     TEST(mul,0,LONG_MAX);
     TEST(mul,LONG_MAX,10);
     TEST(mul,LONG_MAX - 10,LONG_MAX - 10);


### PR DESCRIPTION
## Problem
The signed saturating add, subtract, and multiply helpers constructed LONG_MIN by evaluating signed 1+LONG_MAX. Function arguments are evaluated before fd_long_if selects a result, so the overflowing expression ran even when saturation was not selected. Signed overflow is undefined and defeats the purpose of these safety helpers.

## Fix
Select LONG_MIN or LONG_MAX directly from the operand signs after the compiler overflow builtins report overflow. This preserves branchless saturation without evaluating an overflowing boundary expression.