### PR TITLE
shred: make FEC signature keys unaligned-safe

### DIFF
--- a/src/disco/shred/fd_fec_resolver.c
+++ b/src/disco/shred/fd_fec_resolver.c
@@ -5,10 +5,10 @@
 #include "../metrics/fd_metrics.h"
 #include "fd_fec_resolver.h"
 
-typedef union {
+typedef struct {
   fd_ed25519_sig_t u;
-  ulong            l;
 } wrapped_sig_t;
+FD_STATIC_ASSERT( alignof(wrapped_sig_t)==1UL, wrapped_sig_t_align );
 
 typedef struct __attribute__((packed)) {
   ulong slot;
@@ -68,7 +68,7 @@ typedef struct set_ctx set_ctx_t;
 #define MAP_PREV              map_prev
 #define MAP_ELE_T             set_ctx_t
 #define MAP_KEY_EQ(k0,k1)    (!memcmp( (k0)->u, (k1)->u, FD_ED25519_SIG_SZ ))
-#define MAP_KEY_HASH(key,s)  (fd_ulong_hash( (key)->l ^ (s) ))
+#define MAP_KEY_HASH(key,s)  (fd_ulong_hash( FD_LOAD( ulong, (key)->u ) ^ (s) ))
 #define MAP_OPTIMIZE_RANDOM_ACCESS_REMOVAL 1
 #include "../../util/tmpl/fd_map_chain.c"
 

--- a/src/disco/shred/test_fec_resolver.c
+++ b/src/disco/shred/test_fec_resolver.c
@@ -204,6 +204,8 @@ test_interleaved( void ) {
   fd_fec_set_t * set1 = fd_shredder_next_fec_set( shredder, _set+1UL, chained_merkle_root );
   FD_TEST( fd_shredder_fini_batch( shredder ) );
 
+  FD_TEST( !fd_ulong_is_aligned( (ulong)set0->data_shreds[ 1 ].s, alignof(ulong) ) );
+
   fd_fec_set_t const * out_fec[1];
   fd_shred_t const   * out_shred[1];
   fd_bmtree_node_t     out_merkle_root[1];


### PR DESCRIPTION
## Problem
The FEC signature key wrapper was a union containing ulong, which required eight-byte alignment. Resolver keys can point into byte-aligned shred storage, so map lookup formed and accessed a misaligned typed key. This is undefined even on CPUs that tolerate unaligned loads and may fault on stricter architectures.

## Fix
Make the wrapper byte-aligned and load the hash word with FD_LOAD. Key comparison remains byte-based, and a static assertion protects the required alignment contract.