### PR TITLE
tls: skip zero-length serde copies

### DIFF
--- a/src/waltz/tls/fd_tls_serde.h
+++ b/src/waltz/tls/fd_tls_serde.h
@@ -42,7 +42,8 @@
 
 #define FD_TLS_SERDE_DECODE( IDX, FIELD, FIELD_TYPE, FIELD_CNT ) \
   do {                                                           \
-    memcpy( (FIELD), (void const *)_field_##IDX##_laddr, _field_##IDX##_sz ); \
+    if( _field_##IDX##_sz )                                      \
+      memcpy( (FIELD), (void const *)_field_##IDX##_laddr, _field_##IDX##_sz ); \
     FIELD_TYPE * _field_##IDX##_ptr = (FIELD);                   \
     for( ulong i=0; i < (FIELD_CNT); i++ ) {                     \
       *((_field_##IDX##_ptr)++) = __extension__                  \
@@ -53,7 +54,8 @@
 #define FD_TLS_SERDE_ENCODE( IDX, FIELD, FIELD_TYPE, FIELD_CNT ) \
   do {                                                           \
     uchar * dest = (uchar *)_field_##IDX##_laddr;                \
-    memcpy( dest, (FIELD), _field_##IDX##_sz );                  \
+    if( _field_##IDX##_sz )                                      \
+      memcpy( dest, (FIELD), _field_##IDX##_sz );                \
     for( ulong i=0; i<(FIELD_CNT); i++ ) {                       \
       FIELD_TYPE temp;                                           \
       memcpy( &temp, dest, sizeof(FIELD_TYPE) );                 \


### PR DESCRIPTION
## Problem
The root TLS encode and decode macros called memcpy unconditionally. Variable-length fields can legitimately have a zero count and a null backing pointer, which violates the library pointer contract even when the byte count is zero. Repairing only one caller would leave the shared serialization contract broken.

## Fix
Call memcpy only when the computed field size is nonzero in both encode and decode. Nonempty fields retain the same copy and byte-order loops.