### PR TITLE
genesis: make output bounds checks pointer-safe

### DIFF
--- a/src/flamenco/genesis/fd_genesis_create.c
+++ b/src/flamenco/genesis/fd_genesis_create.c
@@ -49,36 +49,36 @@ typedef struct fd_genesis_account_pair fd_genesis_account_pair_t;
 
 static inline uchar *
 emit_u8( uchar * p, uchar * end, uchar v ) {
-  if( FD_UNLIKELY( p+1>end ) ) return NULL;
+  if( FD_UNLIKELY( (ulong)end-(ulong)p<1UL ) ) return NULL;
   *p = v;
   return p+1;
 }
 
 static inline uchar *
 emit_u32( uchar * p, uchar * end, uint v ) {
-  if( FD_UNLIKELY( p+4>end ) ) return NULL;
+  if( FD_UNLIKELY( (ulong)end-(ulong)p<4UL ) ) return NULL;
   FD_STORE( uint, p, v );
   return p+4;
 }
 
 static inline uchar *
 emit_u64( uchar * p, uchar * end, ulong v ) {
-  if( FD_UNLIKELY( p+8>end ) ) return NULL;
+  if( FD_UNLIKELY( (ulong)end-(ulong)p<8UL ) ) return NULL;
   FD_STORE( ulong, p, v );
   return p+8;
 }
 
 static inline uchar *
 emit_f64( uchar * p, uchar * end, double v ) {
-  if( FD_UNLIKELY( p+8>end ) ) return NULL;
+  if( FD_UNLIKELY( (ulong)end-(ulong)p<8UL ) ) return NULL;
   FD_STORE( double, p, v );
   return p+8;
 }
 
 static inline uchar *
 emit_bytes( uchar * p, uchar * end, void const * src, ulong n ) {
-  if( FD_UNLIKELY( p+n>end ) ) return NULL;
-  fd_memcpy( p, src, n );
+  if( FD_UNLIKELY( (ulong)end-(ulong)p<n ) ) return NULL;
+  if( FD_LIKELY( n ) ) fd_memcpy( p, src, n );
   return p+n;
 }
 
@@ -111,6 +111,8 @@ static ulong
 genesis_encode( genesis_solana_t const * g,
                 uchar *                  buf,
                 ulong                    bufsz ) {
+  if( FD_UNLIKELY( !buf ) ) return 0UL;
+
   uchar * p   = buf;
   uchar * end = buf + bufsz;
 

--- a/src/flamenco/genesis/test_genesis_create.c
+++ b/src/flamenco/genesis/test_genesis_create.c
@@ -38,6 +38,8 @@ main( int     argc,
   /* Buffer too small */
 
   FD_TEST( !fd_genesis_create( NULL, 0UL, options ) );
+  uchar tiny_buf[ 7 ];
+  FD_TEST( !fd_genesis_create( tiny_buf, sizeof(tiny_buf), options ) );
 
   /* No more warnings expected */
 


### PR DESCRIPTION
## Problem
Genesis encoding formed buf+bufsz for a null zero-sized output and formed p+n before checking whether an undersized buffer had n bytes remaining. Those expressions can leave the array object before the function returns failure, so the bounds checks themselves invoke undefined pointer arithmetic.

## Fix
Reject a null output before pointer use, compare the available address range before forming each advanced pointer, and skip zero-byte copies. The emitter API and successful serialization path remain unchanged.