### PR TITLE
zstd: align dstream test backing memory

### DIFF
--- a/src/ballet/zstd/test_zstd.c
+++ b/src/ballet/zstd/test_zstd.c
@@ -31,7 +31,7 @@ test_decompress( void ) {
 
   ulong window_sz = 1UL<<21;
   ulong mem_sz    = fd_zstd_dstream_footprint( window_sz );
-  uchar mem[mem_sz];  /* Use VLA to assist AddressSanitizer */
+  uchar mem[mem_sz] __attribute__((aligned(FD_ZSTD_DSTREAM_ALIGN)));  /* Use VLA to assist AddressSanitizer */
 
   fd_zstd_dstream_t * dstream = fd_zstd_dstream_new( mem, window_sz );
   FD_TEST( dstream );


### PR DESCRIPTION
## Problem
The zstd decompression test placed dstream backing storage in a byte VLA without the 32-byte alignment required by fd_zstd_dstream_new. Stack placement happened to satisfy the requirement with one compiler but not another. Casting and dereferencing an under-aligned buffer is undefined and makes the test layout-dependent.

## Fix
Give the existing VLA FD_ZSTD_DSTREAM_ALIGN alignment. No production code or allocation behavior changes.