### PR TITLE
util: make allocator test patterns unaligned-safe

### DIFF
--- a/src/util/alloc/test_alloc.c
+++ b/src/util/alloc/test_alloc.c
@@ -115,7 +115,7 @@ test_main( int     argc,
 
       pat[j] = (tile_idx<<32) | i;
       ulong b;
-      for( b=0UL; (b+7UL)<sz[j]; b+=8UL ) *((ulong *)(mem[j]+b)) = pat[j];
+      for( b=0UL; (b+7UL)<sz[j]; b+=8UL ) FD_STORE( ulong, mem[j]+b, pat[j] );
       for( ; b<sz[j]; b++ ) mem[j][b] = ((uchar)tile_idx);
 
       /* This allocation is now outstanding */
@@ -132,7 +132,7 @@ test_main( int     argc,
 
       ulong b;
       for( b=0UL; (b+7UL)<sz[k]; b+=8UL )
-        if( (*(ulong *)(mem[k]+b))!=pat[k] ) FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx ));
+        if( FD_LOAD( ulong, mem[k]+b )!=pat[k] ) FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx ));
       for( ; b<sz[k]; b++ ) if( mem[k][b]!=((uchar)tile_idx) ) FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx ));
 
       /* Free the allocation */
@@ -262,7 +262,7 @@ test2_main( int     argc,
 
       ulong pat = (tile_idx<<32) | i;
       ulong b;
-      for( b=0UL; (b+7UL)<sz; b+=8UL ) *((ulong *)(mem+b)) = pat;
+      for( b=0UL; (b+7UL)<sz; b+=8UL ) FD_STORE( ulong, mem+b, pat );
       for( ; b<sz; b++ ) mem[b] = ((uchar)tile_idx);
 
       /* This allocation is now outstanding */
@@ -282,7 +282,7 @@ test2_main( int     argc,
 
       ulong b;
       for( b=0UL; (b+7UL)<sz; b+=8UL )
-        if( (*(ulong *)(mem+b))!=pat ) { FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx )); break; }
+        if( FD_LOAD( ulong, mem+b )!=pat ) { FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx )); break; }
       for( ; b<sz; b++ ) if( mem[b]!=((uchar)src) ) { FD_LOG_ERR(( "On tile %lu, memory corruption detected", tile_idx )); break; }
 
       /* Free the allocation */

--- a/src/util/wksp/test_wksp.c
+++ b/src/util/wksp/test_wksp.c
@@ -124,7 +124,7 @@ test_main( int     argc,
 
       pat[j] = (tile_idx<<32) | i;
       ulong b;
-      for( b=0UL; (b+7UL)<sz[j]; b+=8UL ) *((ulong *)(mem[j]+b)) = pat[j];
+      for( b=0UL; (b+7UL)<sz[j]; b+=8UL ) FD_STORE( ulong, mem[j]+b, pat[j] );
       for( ; b<sz[j]; b++ ) mem[j][b] = ((uchar)tile_idx);
 
       #if FD_HAS_DEEPASAN
@@ -145,7 +145,7 @@ test_main( int     argc,
       /* Validate the bit pattern was preserved between alloc and free */
 
       ulong b;
-      for( b=0UL; (b+7UL)<sz[k]; b+=8UL ) FD_TEST( (*(ulong *)(mem[k]+b))==pat[k] );
+      for( b=0UL; (b+7UL)<sz[k]; b+=8UL ) FD_TEST( FD_LOAD( ulong, mem[k]+b )==pat[k] );
       for( ; b<sz[k]; b++ ) FD_TEST( mem[k][b]==((uchar)tile_idx) );
 
       /* Check the tag */


### PR DESCRIPTION
## Problem
The allocator and workspace tests request alignments as small as one, two, and four bytes, then read and write returned memory through ulong pointers. Several valid allocations are therefore under-aligned for ulong, making the tests themselves undefined while they check allocator correctness.

## Fix
Use FD_STORE and FD_LOAD for all six ulong pattern accesses, including the allocator paired=0 path. The byte pattern and test workload are unchanged.