### PR TITLE
vm: handle empty instruction test input

### DIFF
--- a/src/flamenco/vm/test_vm_instr.c
+++ b/src/flamenco/vm/test_vm_instr.c
@@ -401,9 +401,9 @@ run_input( test_input_t const * input,
 
   /* Set up VM */
 
-  uchar * input_copy = malloc( input->input_sz );
+  uchar * input_copy = malloc( input->input_sz ? input->input_sz : 1UL );
   FD_TEST( input_copy );
-  memcpy( input_copy, input->input, input->input_sz );
+  if( input->input_sz ) memcpy( input_copy, input->input, input->input_sz );
 
   /* Turn input into a single memory region */
   fd_vm_input_region_t input_region[32];


### PR DESCRIPTION
## Problem
The VM instruction test passed a zero size to malloc and then unconditionally called memcpy with the returned pointer and a possibly null input pointer. A zero-size allocation may return null, and the copy still violates the builtin pointer contract at size zero. This makes valid empty-input fixtures depend on allocator behavior.

## Fix
Allocate at least one byte for empty input and skip memcpy when input_sz is zero. Nonempty inputs keep the same allocation and copy path.