### PR TITLE
ballet: make r43x6 wrapping references UBSan-clean

### DIFF
--- a/src/ballet/ed25519/avx512/test_r43x6.c
+++ b/src/ballet/ed25519/avx512/test_r43x6.c
@@ -280,7 +280,7 @@ fd_r43x6_approx_mod_unsigned_ref( fd_r43x6_t x ) {
 FD_FN_CONST static fd_r43x6_t
 fd_r43x6_add_fast_ref( fd_r43x6_t x,
                        fd_r43x6_t y ) {
-  union { __m512i v; long lane[8]; } xx, yy, zz;
+  union { __m512i v; ulong lane[8]; } xx, yy, zz;
   xx.v = x; /* Arb */
   yy.v = y; /* Arb */
   for( ulong i=0UL; i<8UL; i++ ) zz.lane[i] = xx.lane[i] + yy.lane[i];
@@ -290,7 +290,7 @@ fd_r43x6_add_fast_ref( fd_r43x6_t x,
 FD_FN_CONST static fd_r43x6_t
 fd_r43x6_sub_fast_ref( fd_r43x6_t x,
                        fd_r43x6_t y ) {
-  union { __m512i v; long lane[8]; } xx, yy, zz, pp;
+  union { __m512i v; ulong lane[8]; } xx, yy, zz, pp;
   xx.v = x; /* Arb */
   yy.v = y; /* Arb */
   pp.v = fd_r43x6_p();


### PR DESCRIPTION
## Problem
The AVX-512 r43x6 test implemented reference add and subtract with signed long lanes. Random inputs can overflow those scalar operations even though the SIMD instructions intentionally wrap modulo 2^64. Signed overflow makes the reference undefined and allows it to diverge from the operation it checks.

## Fix
Use ulong lanes in the reference unions. Unsigned arithmetic exactly models the SIMD wraparound while preserving every lane bit.