### PR TITLE
util: short-circuit signed fd_is_pow2 inputs

### DIFF
--- a/src/util/bits/fd_bits_tg.h
+++ b/src/util/bits/fd_bits_tg.h
@@ -117,7 +117,7 @@
 
 #define fd_is_pow2( x ) (__extension__({                                                      \
     __typeof__((x)) _fd_bits_x = (x);                                                         \
-    ((_fd_bits_x > (__typeof__((x)))0) &                                                      \
+    ((_fd_bits_x > (__typeof__((x)))0) &&                                                     \
       !fd_tg_and( _fd_bits_x, fd_tg_sub( _fd_bits_x, (__typeof__((x)))1 ) ));                 \
   }))
 


### PR DESCRIPTION
## Problem
The generic fd_is_pow2 macro used bitwise conjunction between the positive-value check and the x-1 test. Both sides were always evaluated, so signed minimum values reached an overflowing subtraction despite already being nonpositive. Signed subtract-one at the minimum value is undefined.

## Fix
Use logical short-circuit conjunction so nonpositive signed values never evaluate x-1. Positive and unsigned inputs keep the same predicate result.