### PR TITLE
sbpf, vm: read program text with FD_LOAD

### DIFF
--- a/src/ballet/sbpf/fd_sbpf_loader.c
+++ b/src/ballet/sbpf/fd_sbpf_loader.c
@@ -178,7 +178,10 @@ fd_sbpf_program_new( void *                     prog_mem,
     .info            = *elf_info,
     .rodata          = rodata,
     .rodata_sz       = 0UL,
-    .text            = (ulong *)((ulong)rodata + elf_info->text_off), /* FIXME: WHAT IF MISALIGNED */
+    /* text_off is .text's sh_addr, so text need not be 8 byte aligned.
+       Agave accepts these, so rejecting would diverge.
+       https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/ebpf.rs#L675-L684 */
+    .text            = (ulong *)((ulong)rodata + elf_info->text_off),
     .entry_pc        = ULONG_MAX,
     .calldests_shmem = NULL,
     .calldests       = NULL,

--- a/src/ballet/sbpf/fd_sbpf_loader.h
+++ b/src/ballet/sbpf/fd_sbpf_loader.h
@@ -255,7 +255,8 @@ struct __attribute__((aligned(32UL))) fd_sbpf_program {
   void * rodata;     /* rodata segment data */
   ulong  rodata_sz;  /* size of read-only data */
 
-  /* text section within rodata segment */
+  /* text section within rodata segment.  Not necessarily 8 byte
+     aligned; read words with FD_LOAD. */
   ulong * text;
   ulong   entry_pc;  /* entrypoint PC (at text[ entry_pc ]). ULONG_MAX if not set. */
 

--- a/src/ballet/sbpf/test_sbpf_loader.c
+++ b/src/ballet/sbpf/test_sbpf_loader.c
@@ -93,6 +93,84 @@ void test_zero_text_cnt( void ) {
   FD_TEST( prog->entry_pc==0UL );
 }
 
+/* .text at an odd sh_addr.  The lenient path takes text_off straight
+   from sh_addr, so prog->text lands misaligned; Agave accepts these,
+   so this must load. */
+
+#define TEXT_ADDR (321UL)  /* == sh_offset, deliberately odd */
+#define TEXT_SZ    (16UL)  /* mov64 r0, 1 ; exit */
+#define SHOFF     (128UL)
+#define SHSTRTAB  "\0.text\0.shstrtab"
+
+static ulong
+build_unaligned_text_elf( uchar bin[ 512 ] ) {
+  ulong shstrtab_off = TEXT_ADDR + TEXT_SZ;
+  fd_memset( bin, 0, 512UL );
+
+  fd_elf64_ehdr ehdr = {
+    .e_ident     = { 0x7f, 'E', 'L', 'F', FD_ELF_CLASS_64, FD_ELF_DATA_LE, 1, FD_ELF_OSABI_NONE },
+    .e_type      = FD_ELF_ET_DYN,
+    .e_machine   = FD_ELF_EM_BPF,
+    .e_version   = 1,
+    .e_entry     = TEXT_ADDR,
+    .e_shoff     = SHOFF,
+    .e_flags     = FD_SBPF_V0,
+    .e_ehsize    = sizeof(fd_elf64_ehdr),
+    .e_phentsize = sizeof(fd_elf64_phdr),
+    .e_shentsize = sizeof(fd_elf64_shdr),
+    .e_shnum     = 3,
+    .e_shstrndx  = 2
+  };
+  fd_elf64_shdr shdr[3] = {
+    { 0 },
+    { .sh_name = 1U, .sh_type = FD_ELF_SHT_PROGBITS,           /* .text */
+      .sh_flags = FD_ELF_SHF_ALLOC | FD_ELF_SHF_EXECINSTR,
+      .sh_addr = TEXT_ADDR, .sh_offset = TEXT_ADDR, .sh_size = TEXT_SZ, .sh_addralign = 1UL },
+    { .sh_name = 7U, .sh_type = FD_ELF_SHT_STRTAB,             /* .shstrtab */
+      .sh_offset = shstrtab_off, .sh_size = sizeof(SHSTRTAB), .sh_addralign = 1UL }
+  };
+  uchar const text[ TEXT_SZ ] = {
+    0xb7, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,  /* mov64 r0, 1 */
+    0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00   /* exit        */
+  };
+
+  fd_memcpy( bin,                   &ehdr, sizeof(ehdr)     );
+  fd_memcpy( bin + SHOFF,            shdr, sizeof(shdr)     );
+  fd_memcpy( bin + TEXT_ADDR,        text, sizeof(text)     );
+  fd_memcpy( bin + shstrtab_off, SHSTRTAB, sizeof(SHSTRTAB) );
+
+  return shstrtab_off + sizeof(SHSTRTAB);
+}
+
+void test_unaligned_text( void ) {
+  fd_scratch_push();
+  fd_sbpf_elf_info_t info;
+
+  uchar bin[ 512 ];
+  ulong bin_sz = build_unaligned_text_elf( bin );
+
+  fd_sbpf_loader_config_t config = { 0 };
+  config.elf_deploy_checks = 1;
+  config.sbpf_min_version = FD_SBPF_V0;
+  config.sbpf_max_version = FD_SBPF_V3;
+
+  FD_TEST( fd_sbpf_elf_peek( &info, bin, bin_sz, &config )==FD_SBPF_ELF_SUCCESS );
+  FD_TEST( info.text_off==TEXT_ADDR );
+
+  void * rodata = fd_scratch_alloc( FD_SBPF_PROG_RODATA_ALIGN, info.bin_sz );
+  FD_TEST( rodata );
+
+  fd_sbpf_program_t * prog = fd_sbpf_program_new( fd_scratch_alloc( fd_sbpf_program_align(), fd_sbpf_program_footprint( &info ) ), &info, rodata );
+
+  fd_sbpf_syscalls_t * syscalls = fd_sbpf_syscalls_new( fd_scratch_alloc( fd_sbpf_syscalls_align(), fd_sbpf_syscalls_footprint() ) );
+
+  void * scratch = fd_scratch_alloc( 1UL, bin_sz );
+  int res = fd_sbpf_program_load( prog, bin, bin_sz, syscalls, &config, scratch, bin_sz );
+
+  FD_TEST( res == 0 );
+  FD_TEST( prog->entry_pc==0UL );
+  FD_TEST( !fd_ulong_is_aligned( (ulong)prog->text, 8UL ) );
+}
 
 int
 main(   int argc,
@@ -106,6 +184,7 @@ main(   int argc,
   // testing here
   test_duplicate_entrypoint_entry();
   test_zero_text_cnt();
+  test_unaligned_text();
 
   fd_scratch_detach( NULL );
   fd_halt();

--- a/src/flamenco/progcache/fd_progcache_rec.c
+++ b/src/flamenco/progcache/fd_progcache_rec.c
@@ -133,7 +133,8 @@ fd_progcache_rec_load( fd_progcache_rec_t *            rec,
   fd_sbpf_program_t prog[1] = {{
     .info     = *elf_info,
     .rodata   = rodata_mem,
-    .text     = (ulong *)((ulong)rodata_mem + elf_info->text_off), /* FIXME: WHAT IF MISALIGNED */
+    /* Not necessarily 8 byte aligned; see fd_sbpf_program_new. */
+    .text     = (ulong *)((ulong)rodata_mem + elf_info->text_off),
     .entry_pc = ULONG_MAX
   }};
   if( has_calldests && elf_info->text_cnt>0UL ) {

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -359,7 +359,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
   ulong         text_cnt = vm->text_cnt;
 
   for( ulong i=0UL; i<text_cnt; i++ ) {
-    fd_sbpf_instr_t instr = fd_sbpf_instr( text[i] );
+    fd_sbpf_instr_t instr = fd_sbpf_instr( FD_LOAD( ulong, text+i ) );
 
     uchar validation_code = validation_map[ instr.opcode.raw ];
     switch( validation_code ) {
@@ -376,7 +376,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
       long jmp_dst = (long)i + (long)instr.offset + 1L;
       if( FD_UNLIKELY( (jmp_dst<0) | (jmp_dst>=(long)text_cnt)                          ) ) return FD_VM_ERR_JMP_OUT_OF_BOUNDS;
       //FIXME: this shouldn't be here?
-      if( FD_UNLIKELY( fd_sbpf_instr( text[ jmp_dst ] ).opcode.raw==FD_SBPF_OP_ADDL_IMM ) ) return FD_VM_ERR_JMP_TO_ADDL_IMM;
+      if( FD_UNLIKELY( fd_sbpf_instr( FD_LOAD( ulong, text+jmp_dst ) ).opcode.raw==FD_SBPF_OP_ADDL_IMM ) ) return FD_VM_ERR_JMP_TO_ADDL_IMM;
       break;
     }
 
@@ -391,7 +391,7 @@ fd_vm_validate( fd_vm_t const * vm ) {
       if( FD_UNLIKELY( (i+1UL)>=text_cnt ) ) return FD_VM_ERR_INCOMPLETE_LDQ;
 
       /* https://github.com/solana-labs/rbpf/blob/b503a1867a9cfa13f93b4d99679a17fe219831de/src/verifier.rs#L137-L139 */
-      fd_sbpf_instr_t addl_imm = fd_sbpf_instr( text[ i+1UL ] );
+      fd_sbpf_instr_t addl_imm = fd_sbpf_instr( FD_LOAD( ulong, text+i+1UL ) );
       if( FD_UNLIKELY( addl_imm.opcode.raw!=FD_SBPF_OP_ADDL_IMM ) ) return FD_VM_ERR_LDQ_NO_ADDL_IMM;
 
       /* FIXME: SET A BIT MAP HERE OF ADDL_IMM TO DENOTE * AS FORBIDDEN

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -95,7 +95,7 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
 
   uchar const * rodata;    /* Program read only data, indexed [0,rodata_sz), aligned 8 */
   ulong         rodata_sz; /* Program read only data size in bytes, FIXME: BOUNDS? */
-  ulong const * text;      /* Program sBPF words, indexed [0,text_cnt), aligned 8 */
+  ulong const * text;      /* Program sBPF words, indexed [0,text_cnt), not necessarily aligned 8, read with FD_LOAD */
   ulong         text_cnt;  /* Program sBPF word count, all text words are inside the rodata */
   ulong         text_off;  /* CALLX virtual address offset in bytes (NOT words).
                               SBPF V0-V2: ==(ulong)text - (ulong)rodata (file offset of text within ELF).

--- a/src/flamenco/vm/fd_vm_disasm.c
+++ b/src/flamenco/vm/fd_vm_disasm.c
@@ -245,20 +245,20 @@ fd_vm_disasm_instr( ulong const *              text,
   if( FD_UNLIKELY( (!text) | (!text_cnt) | (!out) | (!out_max) | (!_out_len) ) ) return FD_VM_ERR_INVAL;
   if( FD_UNLIKELY( (*_out_len)>=out_max ) ) return FD_VM_ERR_INVAL;
 
-  fd_sbpf_instr_t i0 = fd_sbpf_instr( text[0] );
+  fd_sbpf_instr_t i0 = fd_sbpf_instr( FD_LOAD( ulong, text ) );
 
   switch( i0.opcode.any.op_class ) {
 
   case FD_SBPF_OPCODE_CLASS_LD: {
     if( FD_UNLIKELY( text_cnt<2UL ) ) return FD_VM_ERR_INVAL;
-    fd_sbpf_instr_t i1 = fd_sbpf_instr( text[1] );
+    fd_sbpf_instr_t i1 = fd_sbpf_instr( FD_LOAD( ulong, text+1 ) );
     /* FIXME: VALIDATE I1 IS PROPER */
     OUT_PRINTF( "lddw r%d, 0x%lx", i0.dst_reg, (ulong)((ulong)i0.imm | (ulong)((ulong)i1.imm << 32UL)) );
     return FD_VM_SUCCESS;
   }
 
   case FD_SBPF_OPCODE_CLASS_ST: { /* FIXME: FIGURE OUT WHAT'S UP HERE */
-    OUT_PRINTF( "FIXME: %016lx (ST)", text[0] );
+    OUT_PRINTF( "FIXME: %016lx (ST)", FD_LOAD( ulong, text ) );
     return FD_VM_SUCCESS;
   }
 
@@ -295,7 +295,7 @@ fd_vm_disasm_program( ulong const *              text,
   ulong label_pc[ 65536 ]; ulong label_cnt = 0UL;
 
   for( ulong i=0UL; i<text_cnt; i++ ) {
-    fd_sbpf_instr_t instr = fd_sbpf_instr( text[i] );
+    fd_sbpf_instr_t instr = fd_sbpf_instr( FD_LOAD( ulong, text+i ) );
     if     ( instr.opcode.raw==FD_SBPF_OP_CALL_IMM ) func_cnt++;
     else if( instr.opcode.raw==FD_SBPF_OP_EXIT     ) func_cnt++;
     else if( instr.opcode.raw==FD_SBPF_OP_CALL_REG ) continue;
@@ -309,7 +309,7 @@ fd_vm_disasm_program( ulong const *              text,
   label_cnt = 0UL;
 
   for( ulong i=0UL; i<text_cnt; i++ ) {
-    fd_sbpf_instr_t instr = fd_sbpf_instr( text[i] );
+    fd_sbpf_instr_t instr = fd_sbpf_instr( FD_LOAD( ulong, text+i ) );
     if     ( instr.opcode.raw==FD_SBPF_OP_CALL_IMM ) func_pc[ func_cnt++ ] = i + instr.imm + 1UL; /* FIXME: what if out of bounds? */
     else if( instr.opcode.raw==FD_SBPF_OP_EXIT     ) func_pc[ func_cnt++ ] = i + instr.imm + 1UL; /* FIXME: what if out of bounds? */
     else if( instr.opcode.raw==FD_SBPF_OP_CALL_REG ) continue;
@@ -340,7 +340,7 @@ fd_vm_disasm_program( ulong const *              text,
        AND NOT JUST FOR DISASSEMBLY ... POTENTIAL CONSENSUS FAILURE
        MECHANISM! */
 
-    fd_sbpf_instr_t instr = fd_sbpf_instr( text[i] );
+    fd_sbpf_instr_t instr = fd_sbpf_instr( FD_LOAD( ulong, text+i ) );
     ulong extra_cnt = fd_ulong_if( instr.opcode.any.op_class==FD_SBPF_OPCODE_CLASS_LD, 1UL, 0UL );
     if( FD_UNLIKELY( (i+extra_cnt)>=text_cnt ) ) return FD_VM_ERR_INVAL; /* Truncated multiword instruction at end of text */
 

--- a/src/flamenco/vm/fd_vm_interp_core.c
+++ b/src/flamenco/vm/fd_vm_interp_core.c
@@ -94,7 +94,7 @@
 
 # define FD_VM_INTERP_INSTR_EXEC                                                                                    \
   if( FD_UNLIKELY( pc>=block_text_limit ) ) goto sigtext_or_sigcost; /* Note: untaken branches don't consume BTB */ \
-  instr   = text[ pc ];                  /* Guaranteed in-bounds */                                                 \
+  instr   = FD_LOAD( ulong, text+pc );   /* Guaranteed in-bounds */                                                 \
   opcode  = fd_vm_instr_opcode( instr ); /* in [0,256) even if malformed */                                         \
   dst     = fd_vm_instr_dst   ( instr ); /* in [0, 16) even if malformed */                                         \
   src     = fd_vm_instr_src   ( instr ); /* in [0, 16) even if malformed */                                         \
@@ -387,7 +387,7 @@ interp_exec:
     ic_correction++;
     /* No need to check pc because it's already checked during validation.
        if( FD_UNLIKELY( pc>=text_cnt ) ) goto sigsplit; // Note: untaken branches don't consume BTB */
-    reg[ dst ] = (ulong)((ulong)imm | ((ulong)fd_vm_instr_imm( text[ pc ] ) << 32));
+    reg[ dst ] = (ulong)((ulong)imm | ((ulong)fd_vm_instr_imm( FD_LOAD( ulong, text+pc ) ) << 32));
   FD_VM_INTERP_INSTR_END;
 
   FD_VM_INTERP_INSTR_BEGIN(0x1c) /* FD_SBPF_OP_SUB_REG */

--- a/src/flamenco/vm/fd_vm_trace.c
+++ b/src/flamenco/vm/fd_vm_trace.c
@@ -123,7 +123,7 @@ fd_vm_trace_event_exe( fd_vm_trace_t * trace,
 
   if( FD_UNLIKELY( (!trace) | (!reg) | (!text) | (!text_cnt) ) ) return FD_VM_ERR_INVAL;
 
-  ulong text0     = text[0];
+  ulong text0     = FD_LOAD( ulong, text );
   int   multiword = (text_cnt>1UL) & (fd_sbpf_instr( text0 ).opcode.any.op_class==FD_SBPF_OPCODE_CLASS_LD);
 
   ulong event_footprint = sizeof(fd_vm_trace_event_exe_t) - fd_ulong_if( !multiword, 8UL, 0UL );
@@ -146,7 +146,7 @@ fd_vm_trace_event_exe( fd_vm_trace_t * trace,
   event->text[0] = text0;
   event->ic_correction = ic_correction;
   event->frame_cnt = frame_cnt;
-  if( FD_UNLIKELY( multiword ) ) event->text[1] = text[1];
+  if( FD_UNLIKELY( multiword ) ) event->text[1] = FD_LOAD( ulong, text+1 );
 
   return FD_VM_SUCCESS;
 }

--- a/src/flamenco/vm/test_vm_base.c
+++ b/src/flamenco/vm/test_vm_base.c
@@ -1,4 +1,5 @@
 #include "fd_vm.h"
+#include "fd_vm_private.h"
 #include "../../ballet/sbpf/fd_sbpf_instr.h"
 #include "../../ballet/sbpf/fd_sbpf_opcodes.h"
 #include "../../ballet/murmur3/fd_murmur3.h"
@@ -113,6 +114,68 @@ FD_STATIC_ASSERT( FD_VM_LOADED_ACCOUNTS_DATA_SIZE_LIMIT          ==64UL*1024UL*1
 FD_STATIC_ASSERT( FD_VM_TRACE_EVENT_TYPE_EXE   ==0, vm_trace );
 FD_STATIC_ASSERT( FD_VM_TRACE_EVENT_TYPE_READ  ==1, vm_trace );
 FD_STATIC_ASSERT( FD_VM_TRACE_EVENT_TYPE_WRITE ==2, vm_trace );
+
+/* test_unaligned_text validates, executes, disassembles, and traces
+   the same program out of an aligned and a misaligned buffer and
+   requires identical results.  The loader can produce a misaligned
+   text (see test_unaligned_text in ballet/sbpf/test_sbpf_loader.c).
+   instr_ctx may be NULL because neither fd_vm_validate nor a program
+   that makes no syscalls uses it. */
+
+static void
+test_unaligned_text( void ) {
+  FD_LOG_NOTICE(( "Testing VM with misaligned text" ));
+
+  ulong prog[4] = {
+    fd_vm_instr( FD_SBPF_OP_MOV64_IMM, 0, 0, 0, 1U          ),
+    fd_vm_instr( FD_SBPF_OP_LDDW,      1, 0, 0, 0xAAAAAAAAU ),
+    fd_vm_instr( FD_SBPF_OP_ADDL_IMM,  0, 0, 0, 0xBBBBBBBBU ),
+    fd_vm_instr( FD_SBPF_OP_EXIT,      0, 0, 0, 0U          )
+  };
+  uchar buf[ sizeof(prog)+1UL ] __attribute__((aligned(8)));
+  ulong const * unaligned = (ulong const *)( buf+1UL );
+  fd_memcpy( buf+1UL, prog, sizeof(prog) );
+  FD_TEST( !fd_ulong_is_aligned( (ulong)unaligned, 8UL ) );
+
+  ulong const * text[2] = { prog, unaligned };
+
+  for( ulong i=0UL; i<2UL; i++ ) {
+    fd_vm_t _vm[1];
+    fd_vm_t * vm = fd_vm_join( fd_vm_new( _vm ) );
+    FD_TEST( vm );
+    FD_TEST( fd_vm_init( vm, NULL, FD_VM_HEAP_DEFAULT, FD_VM_COMPUTE_UNIT_LIMIT,
+                         (uchar const *)text[i], sizeof(prog), text[i], 4UL, 0UL, sizeof(prog),
+                         0UL, NULL, FD_SBPF_V0, NULL, NULL, NULL, NULL, 0U, NULL,
+                         0, 0, 0, 0, 0, 0UL ) );
+    FD_TEST( fd_vm_validate( vm )==FD_VM_SUCCESS );
+    FD_TEST( fd_vm_exec_notrace( vm )==FD_VM_SUCCESS );
+    FD_TEST( vm->reg[0]==1UL );
+    FD_TEST( vm->reg[1]==0xBBBBBBBBAAAAAAAAUL );
+    fd_vm_delete( fd_vm_leave( vm ) );
+  }
+
+  char  out[2][ 256 ];
+  ulong out_len[2] = { 0UL, 0UL };
+  for( ulong i=0UL; i<2UL; i++ ) {
+    out[i][0] = '\0';
+    FD_TEST( fd_vm_disasm_program( text[i], 4UL, NULL, out[i], 256UL, &out_len[i] )==FD_VM_SUCCESS );
+  }
+  FD_TEST( out_len[0]==out_len[1] );
+  FD_TEST( fd_memeq( out[0], out[1], out_len[0] ) );
+
+  uchar tr_mem[2][ 1024 ] __attribute__((aligned(8)));
+  FD_TEST( fd_vm_trace_footprint( 256UL, 64UL )<=sizeof(tr_mem[0]) );
+  ulong reg[ FD_VM_REG_CNT ] = { 0 };
+  fd_vm_trace_t * tr[2];
+  for( ulong i=0UL; i<2UL; i++ ) {
+    tr[i] = fd_vm_trace_join( fd_vm_trace_new( tr_mem[i], 256UL, 64UL ) );
+    FD_TEST( tr[i] );
+    FD_TEST( fd_vm_trace_event_exe( tr[i], 1UL, 1UL, 0UL, reg, text[i]+1UL, 3UL, 0UL, 0UL )==FD_VM_SUCCESS );
+  }
+  FD_TEST( fd_vm_trace_event_sz( tr[0] )==fd_vm_trace_event_sz( tr[1] ) );
+  FD_TEST( fd_memeq( fd_vm_trace_event( tr[0] ), fd_vm_trace_event( tr[1] ), fd_vm_trace_event_sz( tr[0] ) ) );
+  for( ulong i=0UL; i<2UL; i++ ) FD_TEST( fd_vm_trace_delete( fd_vm_trace_leave( tr[i] ) ) );
+}
 
 int
 main( int     argc,
@@ -309,6 +372,8 @@ vm_trace_done:
 
   FD_TEST( !fd_vm_trace_join  ( _trace ) ); /* not a trace */
   FD_TEST( !fd_vm_trace_delete( _trace ) ); /* not a trace */
+
+  test_unaligned_text();
 
   fd_rng_delete( fd_rng_leave( rng ) );
 


### PR DESCRIPTION
Addresses #10341.

On the lenient path a program's text section can land at an odd address, making every instruction read a misaligned load. As far as I can tell Agave accepts and runs such programs, since it reads instructions byte by byte and never checks alignment (https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/ebpf.rs#L675-L684), so rejecting them on our side would diverge. Instead this reads the text words through `FD_LOAD`, which compiles down to the exact same load as before, so the interpreter doesn't pay for it.

One thing I left alone: the text pointer itself is still typed as if it were aligned, which strictly speaking is still UB even with nothing reading through it. Cleaning that up means retyping the field and touching a bunch of signatures, and that felt too big for a first PR here. Happy to do the wider version instead if that's preferred.

The tests guard the parity, not the UB: a program with oddly placed text has to keep loading and validating exactly like an aligned one, so a well-meaning alignment check can't slip in later. The UB itself they can't catch, since the sanitizer report doesn't fail the build and x86 shrugs the load off, so the ubsan job going quiet is the only visible change there.

I ran the loader and VM unit tests under both gcc and clang with ubsan: the misaligned-load report shows up without the fix and is gone with it. The workspace-backed tests wouldn't run in my environment, so those ride on CI.




