### PR TITLE
build: replace bare .SECONDARY with .NOTINTERMEDIATE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ undefine LD
 endif
 # Disable implicit rules
 .SUFFIXES:
-# Re-evaluate the Makefile to apply $(MAKEFLAGS)
-.SECONDARY:
+.NOTINTERMEDIATE:
 .SECONDEXPANSION:
 
 ifndef MACHINE


### PR DESCRIPTION
Bare .SECONDARY made every file an intermediate, so missing outputs were silently never rebuilt; .NOTINTERMEDIATE restores must-build semantics.