### PR TITLE
build: prefer vendored zstd/lz4/s2n-bignum headers over opt/include

### DIFF
--- a/config/extra/with-lz4.mk
+++ b/config/extra/with-lz4.mk
@@ -4,5 +4,5 @@
 # everything.mk and LDFLAGS is simply-expanded.
 FD_HAS_LZ4:=1
 CFLAGS+=-DFD_HAS_LZ4=1
-CPPFLAGS+=-isystem src/third_party/lz4/lib
+CPPFLAGS:=-isystem src/third_party/lz4/lib $(CPPFLAGS)
 LDFLAGS+=$(BASEDIR)/$(BUILDDIR)/lib/libfd_lz4.a

--- a/config/extra/with-s2nbignum.mk
+++ b/config/extra/with-s2nbignum.mk
@@ -1,4 +1,4 @@
 # Vendored in-tree (src/third_party/s2n-bignum)
 FD_HAS_S2NBIGNUM:=1
 CFLAGS+=-DFD_HAS_S2NBIGNUM=1
-CPPFLAGS+=-isystem src/third_party/s2n-bignum/include
+CPPFLAGS:=-isystem src/third_party/s2n-bignum/include $(CPPFLAGS)

--- a/config/extra/with-zstd.mk
+++ b/config/extra/with-zstd.mk
@@ -5,5 +5,5 @@
 # everything.mk and LDFLAGS is simply-expanded.
 FD_HAS_ZSTD:=1
 CFLAGS+=-DFD_HAS_ZSTD=1
-CPPFLAGS+=-isystem src/third_party/zstd/lib
+CPPFLAGS:=-isystem src/third_party/zstd/lib $(CPPFLAGS)
 LDFLAGS+=$(BASEDIR)/$(BUILDDIR)/lib/libfd_zstd.a


### PR DESCRIPTION
-isystem ./opt/include comes first, so a stale pre-vendoring deps bundle shadows the vendored headers; prepend the vendored include dirs instead.