### PR TITLE
build: only bump native config.mk mtime on real feature drift

### DIFF
--- a/config/machine/native_config.sh
+++ b/config/machine/native_config.sh
@@ -61,4 +61,11 @@ printf '\n' | "$@" -march=native -E -dM - | awk '
     print "CPPFLAGS_NATIVE+=-DFD_HAS_DOUBLE=1"
     printf "%s", cppflags
   }
-' > "$OUT"
+' > "$OUT.tmp.$$"
+
+# Touch OUT only on real feature drift
+if cmp -s "$OUT.tmp.$$" "$OUT" 2>/dev/null; then
+  rm -f "$OUT.tmp.$$"
+else
+  mv -f "$OUT.tmp.$$" "$OUT"
+fi


### PR DESCRIPTION
native_config.sh rewrote its output unconditionally every parse; write a PID-keyed tmp and publish via cmp+rename so the mtime moves only on change.