### PR TITLE
build: fingerprint build flavor per OBJDIR

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,10 +71,10 @@ make BUILDDIR=clang-fuzz CC=clang EXTRAS=fuzz
 make BUILDDIR=clang-fuzz-asan CC=clang EXTRAS="fuzz asan"
 
 # Run unit tests
-build/native/gcc/unit-test/<test_name>
+$(make --silent objdir)/unit-test/<test_name>
 
-# Run binaries directly
-build/native/gcc/bin/<bin_name>
+# Run binaries directly (hardlinked from the keyed build dir)
+build/<bin_name>
 ```
 
 ## Development
@@ -102,7 +102,7 @@ build/native/gcc/bin/<bin_name>
 - To add new test vectors:
   1. PR to test-vectors repository with fixtures
   2. Update `contrib/test/test-vectors-fixtures/test-vectors-commit-sha.txt` with commit SHA
-- Run unit tests: `build/native/gcc/unit-test/<test_name>`
+- Run unit tests: `$(make --silent objdir)/unit-test/<test_name>`
 
 ## Documentation
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,6 @@ jobs:
     - uses: ./.github/actions/cpusonline
     - uses: actions/setup-node@v7
     - run: make -j
-    - run: echo OBJDIR=$(make help | grep OBJDIR | awk '{print $4}') >> $GITHUB_ENV
 
     - name: Checkout main for baseline
       uses: actions/checkout@v7
@@ -51,7 +50,9 @@ jobs:
         ref: main
         clean: false
 
+    # OBJDIR is resolved per checkout: the two trees may key it differently
     - run: make -j
+    - run: echo OBJDIR=$(make help | grep OBJDIR | awk '{print $4}') >> $GITHUB_ENV
 
     - name: Run baseline benchmarks
       run: |
@@ -82,6 +83,7 @@ jobs:
         clean: false
 
     - run: make -j
+    - run: echo OBJDIR=$(make help | grep OBJDIR | awk '{print $4}') >> $GITHUB_ENV
 
     - name: Run new benchmarks
       run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
       "type": "lldb-dap",
       "request": "launch",
       "name": "testnet",
-      "program": "${workspaceRoot}/build/native/gcc/bin/firedancer-dev",
+      "program": "${workspaceRoot}/build/firedancer-dev",
       "args": [],
       "env": [],
       "cwd": "${workspaceRoot}",

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ ifndef MACHINE
 MACHINE=native
 endif
 
+override EXTRAS:=$(sort $(EXTRAS))
+
 # Default target
 all:
 

--- a/book/guide/getting-started.md
+++ b/book/guide/getting-started.md
@@ -137,7 +137,8 @@ $ MACHINE=linux_gcc_x86_64 make -j fdctl solana
 ```
 
 The default target is `native`, and compiled binaries will be placed in
-`./build/native/gcc/bin`.
+`./build/native/gcc/<compiler-version>/bin`, with a hardlink to each at
+`./build/<name>`.
 
 ## Updating
 If you checked out Firedancer using Git, run through these steps to
@@ -274,7 +275,7 @@ The initialization steps are described [in detail](/guide/initializing.md)
 later. But plowing ahead at the moment:
 
 ```sh [bash]
-$ sudo ./build/native/gcc/bin/fdctl configure init all --config ~/config.toml
+$ sudo ./build/fdctl configure init all --config ~/config.toml
 ```
 
 You will be told what steps are performed:
@@ -289,7 +290,7 @@ boots, and it needs to be run each time the system is rebooted.
 Finally, we can run Firedancer:
 
 ```sh [bash]
-$ sudo ./build/native/gcc/bin/fdctl run --config ~/config.toml
+$ sudo ./build/fdctl run --config ~/config.toml
 ```
 
 Firedancer logs selected output to `stderr` and a more detailed log to a
@@ -299,7 +300,7 @@ security isolation, so you will see a complete process tree get launched.
 ```sh [bash]
 $ pstree 1741904 -as
 systemd --switched-root --system --deserialize 17
-  └─sudo ./build/native/gcc/bin/fdctl run --config ~/config.toml
+  └─sudo ./build/fdctl run --config ~/config.toml
       └─fdctl run --config ~/config.toml
           └─fdctl run --config ~/config.toml
               ├─fdctl run-agave --config-fd 0

--- a/book/guide/monitoring.md
+++ b/book/guide/monitoring.md
@@ -10,8 +10,8 @@ $ make solana
     Finished release-with-debug [optimized + debuginfo] target(s) in 0.44s
 ```
 
-Similar to `fdctl`, the compiled binary will be placed in
-`./build/native/gcc/bin` by default.
+Similar to `fdctl`, the compiled binary is hardlinked at
+`./build/solana` by default.
 
 ::: tip NOTE
 

--- a/book/snippets/bench/bench1.ansi
+++ b/book/snippets/bench/bench1.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fddev bench
+$ ./build/fddev bench
 [32mNOTICE [0m main configure.c(106): kill ... configuring
 [32mNOTICE [0m main configure.c(102): hugetlbfs ... already valid
 [32mNOTICE [0m main configure.c(102): sysctl ... already valid

--- a/book/snippets/bench/bench2.ansi
+++ b/book/snippets/bench/bench2.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fddev monitor
+$ ./build/fddev monitor
 snapshot for 2024-07-29 16:44:59.066296419 GMT+00
     tile |     pid |      stale | heart |        sig | in backp |           backp cnt |  % hkeep |  % backp |   % wait |  % ovrnp |  % ovrnr |  % filt1 |  % filt2 | % finish
 ---------+---------+------------+-------+------------+----------+---------------------+----------+----------+----------+----------+----------+----------+----------+----------

--- a/book/snippets/bench/bench4.ansi
+++ b/book/snippets/bench/bench4.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fddev bench --config src/app/fdctl/config/bench-zen3-32core.toml
+$ ./build/fddev bench --config src/app/fdctl/config/bench-zen3-32core.toml
 [ ... snip ... ]
 [32mNOTICE [0m bencho:0 fd_bencho.c(137): 191180 txn/s
 [32mNOTICE [0m bencho:0 fd_bencho.c(137): 308027 txn/s

--- a/book/snippets/bench/bench5.ansi
+++ b/book/snippets/bench/bench5.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fddev monitor --config src/app/fdctl/config/bench-zen3-32core.toml
+$ ./build/fddev monitor --config src/app/fdctl/config/bench-zen3-32core.toml
 snapshot for 2024-07-29 16:44:59.066296419 GMT+00
     tile |     pid |      stale | heart |        sig | in backp |           backp cnt |  % hkeep |  % backp |   % wait |  % ovrnp |  % ovrnr |  % filt1 |  % filt2 | % finish
 ---------+---------+------------+-------+------------+----------+---------------------+----------+----------+----------+----------+----------+----------+----------+----------

--- a/book/snippets/bench/bench7.ansi
+++ b/book/snippets/bench/bench7.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fddev bench --config src/app/fdctl/config/bench-zen3-32core.toml
+$ ./build/fddev bench --config src/app/fdctl/config/bench-zen3-32core.toml
 [ ... snip ... ]
 [32mNOTICE [0m bencho:0 fd_bencho.c(137): 272840 txn/s
 [32mNOTICE [0m bencho:0 fd_bencho.c(137): 278380 txn/s

--- a/book/snippets/capabilities.ansi
+++ b/book/snippets/capabilities.ansi
@@ -1,4 +1,4 @@
-$ ./build/native/gcc/bin/fdctl run
+$ ./build/fdctl run
 [93mWARNING[0m run ... process requires capability `CAP_NET_RAW` to call `socket(2)` to bind to a raw socket for use by XDP
 [93mWARNING[0m run ... process requires capability `CAP_SYS_ADMIN` to call `bpf(2)` with the `BPF_OBJ_GET` command to initialize XDP
 [93mWARNING[0m run ... process requires capability `CAP_SYS_ADMIN` to call `unshare(2)` with `CLONE_NEWUSER` to sandbox the process in a user namespace

--- a/config/everything.mk
+++ b/config/everything.mk
@@ -1,12 +1,28 @@
 .PHONY: all info check bin rust include lib unit-test integration-test fuzz-test help clean distclean asm ppp show-deps proof
 .PHONY: run-unit-test run-integration-test run-script-test run-fuzz-test
-.PHONY: seccomp-policies cov-report dist-cov-report frontend frontend-clean
+.PHONY: seccomp-policies cov-report dist-cov-report frontend frontend-clean env objdir
+
+# Key default build dirs on CC version+EXTRAS so flavors never share an
+# OBJDIR; explicit BUILDDIR overrides rely on the flavor stamps alone.
+empty:=
+space:=$(empty) $(empty)
+CC_VERSION:=$(or $(shell $(CC) -dumpfullversion -dumpversion 2>/dev/null | head -1),unknown)
+# name + resolved binary + inline args: same-version toolchains at
+# different installs, or CC='gcc -mX' variants, must not share objects
+CC_ID:=$(notdir $(firstword $(CC))) $(realpath $(shell command -v $(firstword $(CC)) 2>/dev/null)) $(wordlist 2,$(words $(CC)),$(CC))
+LD_ID:=$(notdir $(firstword $(LD))) $(realpath $(shell command -v $(firstword $(LD)) 2>/dev/null)) $(wordlist 2,$(words $(LD)),$(LD))
+CLEANDIR:=$(BASEDIR)/$(BUILDDIR)
+ifeq ($(BUILDDIR1)$(filter-out file,$(origin BUILDDIR)),)
+BUILDDIR:=$(BUILDDIR)/$(CC_VERSION)$(if $(EXTRAS),-$(subst $(space),-,$(sort $(EXTRAS))))
+endif
 
 OBJDIR:=$(BASEDIR)/$(BUILDDIR)
 
 # A failed recipe must not leave a fresh-mtime partial target that later
 # builds accept as up to date
 .DELETE_ON_ERROR:
+
+LDFLAGS+=$(foreach l,$(VENDOR_LINK_LIBS),$(OBJDIR)/lib/lib$(l).a)
 
 # Grab all the Local.mk files in the source tree, save to a variable so that
 # other rules can depend on this list. We will include these files later on.
@@ -32,7 +48,7 @@ endif
 endif
 
 # Auxiliary rules that should not set up dependencies
-AUX_RULES:=clean distclean help run-unit-test run-integration-test cov-report dist-cov-report seccomp-policies frontend frontend-clean env
+AUX_RULES:=clean distclean help run-unit-test run-integration-test cov-report dist-cov-report seccomp-policies frontend frontend-clean env objdir
 
 # Dry rules that should set up dependency targets, but not generate them
 DRY_RULES:=check show-deps proof
@@ -105,11 +121,12 @@ help:
 	# "make run-unit-test" runs all unit-tests for the current platform. NOTE: this will not (re)build the test executables
 	# "make run-integration-test" runs all integration-tests for the current platform. NOTE: this will not (re)build the test executables
 	# "make help" prints this message
-	# "make clean" removes editor temp files and the current platform build
+	# "make clean" removes editor temp files, the current platform build and its build/<name> links
 	# "make distclean" removes editor temp files and all platform builds
 	# "make asm" makes all source files into assembly language files
 	# "make ppp" run all source files through the preprocessor
 	# "make show-deps" shows all the dependencies
+	# "make objdir" prints the build directory for the current configuration
 	# "make cov-report" creates an LCOV coverage report from LLVM profdata. Requires make run-unit-test EXTRAS="llvm-cov"
 	# Fuzzing (requires fuzzing profile):
 	#   "make fuzz-test" makes all fuzz-tests for the current platform
@@ -120,7 +137,8 @@ help:
 info: $(OBJDIR)/info
 
 clean: frontend-clean
-	$(RMDIR) $(OBJDIR) && $(RMDIR) target && $(RMDIR) agave/target && \
+	$(RMDIR) $(CLEANDIR) && { [ ! -d $(BASEDIR) ] || $(FIND) $(BASEDIR)/ -maxdepth 1 -type f -perm -u+x -links 1 -delete; } && \
+$(RMDIR) target && $(RMDIR) agave/target && \
 $(SCRUB)
 
 distclean:
@@ -230,7 +248,7 @@ DEPFILES+=$(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR
 .PHONY: $(1)
 $(1): $(OBJDIR)/$(5)/$(1)
 
-$(OBJDIR)/$(5)/$(1): $(foreach lib,$(filter $(SCHED_HOT_LIBS),$(3)),$(OBJDIR)/lib/lib$(lib).a) $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),$(OBJDIR)/lib/lib$(lib).a)
+$(OBJDIR)/$(5)/$(1): $(foreach lib,$(filter $(SCHED_HOT_LIBS),$(3)),$(OBJDIR)/lib/lib$(lib).a) $(foreach obj,$(2),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o)) $(foreach lib,$(3),$(OBJDIR)/lib/lib$(lib).a) $(OBJDIR)/.ldflags $(OBJDIR)/.ldflags.d/$(5)_$(1)@$(subst /,_,$(subst $(space),_,$(strip $(subst $(OPT)/,,$(subst $(OBJDIR)/,,$(subst $(CURDIR)/,,$(6)))))))
 	@echo -e "LD\t$$(notdir $$@) ($(5))"
 	$(Q)$(MKDIR) $$(dir $$@) && \
 $(if $(filter bin,$(5)),{ echo 'char const fd_bin_build_info[] ='; echo "  \"# date     $$$$(date +'%Y-%m-%d %H:%M:%S %z')\\n\""; [ "$$$$(git rev-parse --show-toplevel 2>/dev/null)" = "$$$$(pwd -P)" ] && git --no-optional-locks status --porcelain=2 2>/dev/null | grep -E '^[12u] ' | head -100 | sed 's/\\/\\\\/g; s/"/\\"/g; s/.*/  "&\\n"/'; echo ';'; } > $$@.buildinfo.c && $$(CC) -c -o $$@.buildinfo.o $$@.buildinfo.c && ) \
@@ -294,8 +312,22 @@ run-fuzz-test: $(1)_unit
 
 endef
 
-make-bin       = $(eval $(call _make-exe,$(1),$(2),$(3),bin,bin,$(4) $(LDFLAGS_EXE)))
-make-bin-rust  = $(eval $(call _make-exe,$(1),$(2),$(3),rust,bin,$(4) $(LDFLAGS_EXE)))
+# build/<name> tracks the last-built flavor: hardlink, copy if impossible
+# $(call publish,src,dst): hardlink dst to src, copy when impossible
+publish = { [ $(1) -ef $(2) ] || cmp -s $(1) $(2) || ln -f $(1) $(2) 2>/dev/null || { cp -f $(1) $(2).tmp && mv -f $(2).tmp $(2); }; }
+
+define _publish-bin
+
+.PHONY: publish-$(1)
+publish-$(1): $(OBJDIR)/bin/$(1)
+	$(Q)$(call publish,$(OBJDIR)/bin/$(1),$(BASEDIR)/$(1))
+$(1): publish-$(1)
+$(2): publish-$(1)
+
+endef
+
+make-bin       = $(eval $(call _make-exe,$(1),$(2),$(3),bin,bin,$(4) $(LDFLAGS_EXE)))$(eval $(call _publish-bin,$(1),bin))
+make-bin-rust  = $(eval $(call _make-exe,$(1),$(2),$(3),rust,bin,$(4) $(LDFLAGS_EXE)))$(eval $(call _publish-bin,$(1),rust))
 make-shared    = $(eval $(call _make-exe,$(1),$(2),$(3),lib,lib,$(4) $(LDFLAGS_SO)))
 make-unit-test = $(eval $(call _make-exe,$(1),$(2),$(3),unit-test,unit-test,$(4) $(LDFLAGS_EXE)))
 run-unit-test  = $(eval $(call _run-unit-test,$(1)))
@@ -332,6 +364,7 @@ echo -e \
 mv -f $@.tmp $@
 
 $(OBJDIR)/obj/util/log/fd_log.o: $(OBJDIR)/info
+$(OBJDIR)/info: $(OBJDIR)/.flags
 
 # Depfiles are written to a tmp and published by $(DEPFIX): the compiler
 # truncates the .d in place near the end of the compile, so a killed/failed
@@ -342,23 +375,23 @@ $(OBJDIR)/obj/util/log/fd_log.o: $(OBJDIR)/info
 DEPFLAGS=-MD -MP -MF $@.dtmp -MT "$(basename $@).o" -MT "$(basename $@).S" -MT "$(basename $@).i" -MT "$(basename $@).d"
 DEPFIX=mv -f $@.dtmp $(basename $@).d
 
-$(OBJDIR)/obj/%.o : src/%.c
+$(OBJDIR)/obj/%.o : src/%.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@ && $(DEPFIX)
 
-$(OBJDIR)/obj/%.o : src/%.S
+$(OBJDIR)/obj/%.o : src/%.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
-$(OBJDIR)/obj/%.S : src/%.c
+$(OBJDIR)/obj/%.S : src/%.c $(OBJDIR)/.flags
 	$(MKDIR) $(dir $@) && \
 $(CC) $(patsubst -g,,$(CPPFLAGS) $(CFLAGS)) $(DEPFLAGS) -S -fverbose-asm $< -o $@.tmp && \
 $(SED) 's,^#,                                                                                               #,g' < $@.tmp > $@ && \
 $(RM) $@.tmp && $(DEPFIX)
 
-$(OBJDIR)/obj/%.i : src/%.c
+$(OBJDIR)/obj/%.i : src/%.c $(OBJDIR)/.flags
 	$(MKDIR) $(dir $@) && \
 $(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -E $< -o $@ && $(DEPFIX)
 
@@ -392,6 +425,39 @@ endef
 
 # Include all of the Local.mk files we found earlier
 $(foreach mk,$(LOCAL_MKS),$(eval $(call _include-mk,$(mk))))
+
+# Flavor stamps: objects depend on $(OBJDIR)/.flags (compiler+flags),
+# links on $(OBJDIR)/.ldflags (linker+global link flags) plus a per-target
+# $(OBJDIR)/.ldflags.d/<target>@<arg 6> stamp (constant path prefixes
+# dropped from the name), so a link-flag change relinks only that target;
+# its previous stamp is dropped, so flipping back relinks too.
+# Written after the fragments (any of them may extend the flags).  Dry
+# runs (-n/-q/-t) must not write; their letters only count in a bare
+# leading short-flag cluster (both 4.3 and 4.4.x encode them there).
+FD_MF1:=$(firstword $(MAKEFLAGS))
+FD_MF1:=$(if $(findstring =,$(FD_MF1))$(filter -%,$(FD_MF1)),,$(FD_MF1))
+FD_DRYRUN:=$(findstring n,$(FD_MF1))$(findstring q,$(FD_MF1))$(findstring t,$(FD_MF1))
+FLAVOR:=$(MACHINE) | $(sort $(EXTRAS)) | $(CC_ID) $(CC_VERSION) | $(CPPFLAGS) | $(CFLAGS)
+LINK_FLAVOR:=$(LD_ID) | $(LDFLAGS) | $(LDFLAGS_EXE) | $(LDFLAGS_SO) | $(LDFLAGS_FUZZ)
+ifeq ($(filter $(DRY_RULES),$(MAKECMDGOALS))$(FD_DRYRUN),)
+$(shell mkdir -p $(OBJDIR))
+$(file >$(OBJDIR)/.flags.tmp,$(strip $(FLAVOR)))
+$(file >$(OBJDIR)/.ldflags.tmp,$(strip $(LINK_FLAVOR)))
+$(shell for f in .flags .ldflags; do cmp -s $(OBJDIR)/$$f.tmp $(OBJDIR)/$$f || mv -f $(OBJDIR)/$$f.tmp $(OBJDIR)/$$f 2>/dev/null; rm -f $(OBJDIR)/$$f.tmp; done)
+endif
+# strip both sides: make 4.3's $(file <) does not reliably drop the
+# trailing newline
+ifneq ($(FD_DRYRUN),)
+ifneq ($(strip $(file <$(OBJDIR)/.flags)),$(strip $(FLAVOR)))
+.PHONY: $(OBJDIR)/.flags
+endif
+ifneq ($(strip $(file <$(OBJDIR)/.ldflags)),$(strip $(LINK_FLAVOR)))
+.PHONY: $(OBJDIR)/.ldflags
+endif
+endif
+$(OBJDIR)/.flags $(OBJDIR)/.ldflags: ;@:
+$(OBJDIR)/.ldflags.d/%:
+	@$(MKDIR) $(dir $@) && $(RM) "$(dir $@)$(firstword $(subst @, ,$(notdir $@)))@"* && $(TOUCH) $@
 
 # Include all the dependencies.  Must be after the make fragments
 # include so that DEPFILES is fully populated (similarly for the
@@ -526,7 +592,7 @@ $(BASEDIR)/cov/cov.lcov: $(shell $(FIND) $(BASEDIR) -name 'cov.lcov' -print)
 cov-report: $(OBJDIR)/cov/html/index.html
 	$(LCOV) --summary $(OBJDIR)/cov/cov.lcov
 
-# `make dist-cov-report OBJDIRS="build/native/gcc build/native/clang ..."`
+# `make dist-cov-report OBJDIRS="build/native/gcc/<ver> build/native/clang/<ver> ..."`
 # produces a coverage report from multiple build profiles
 dist-cov-report: $(BASEDIR)/cov/html/index.html
 	$(LCOV) --summary $(BASEDIR)/cov/cov.lcov
@@ -591,6 +657,9 @@ frontend: frontend-clean
 frontend-clean:
 	rm -rf src/discoh/guih/dist_cmp
 	rm -rf src/disco/gui/dist_cmp
+
+objdir:
+	@echo $(OBJDIR)
 
 env:
 	@echo BUILDDIR=\'$(BUILDDIR)\'

--- a/config/extra/with-blst.mk
+++ b/config/extra/with-blst.mk
@@ -3,9 +3,7 @@
 # links agave_validator (which statically bundles its own blst crate
 # copy) together with fd_ballet, and a trailing archive preserves the
 # agave-copy-wins member selection the opt/ path had.
-# $(BASEDIR)/$(BUILDDIR) spelled out: OBJDIR is not defined until
-# everything.mk and LDFLAGS is simply-expanded.
 FD_HAS_BLST:=1
 CFLAGS+=-DFD_HAS_BLST=1
-BLST_LIBS:=$(BASEDIR)/$(BUILDDIR)/lib/libfd_blst.a
-LDFLAGS+=$(BLST_LIBS)
+BLST_LIBS=$(OBJDIR)/lib/libfd_blst.a
+VENDOR_LINK_LIBS+=fd_blst

--- a/config/extra/with-lz4.mk
+++ b/config/extra/with-lz4.mk
@@ -1,8 +1,6 @@
 # Vendored in-tree (src/third_party/lz4), standalone trailing archive
 # resolving fd_util's LZ4 refs (checkpt/wksp/vinyl).
-# $(BASEDIR)/$(BUILDDIR) spelled out: OBJDIR is not defined until
-# everything.mk and LDFLAGS is simply-expanded.
 FD_HAS_LZ4:=1
 CFLAGS+=-DFD_HAS_LZ4=1
 CPPFLAGS:=-isystem src/third_party/lz4/lib $(CPPFLAGS)
-LDFLAGS+=$(BASEDIR)/$(BUILDDIR)/lib/libfd_lz4.a
+VENDOR_LINK_LIBS+=fd_lz4

--- a/config/extra/with-zstd.mk
+++ b/config/extra/with-zstd.mk
@@ -1,9 +1,7 @@
 # Vendored in-tree (src/third_party/zstd), standalone trailing
 # archive (some targets, e.g. test_libc_zstd, link without fd_ballet
 # and resolve ZSTD_* from LDFLAGS).
-# $(BASEDIR)/$(BUILDDIR) spelled out: OBJDIR is not defined until
-# everything.mk and LDFLAGS is simply-expanded.
 FD_HAS_ZSTD:=1
 CFLAGS+=-DFD_HAS_ZSTD=1
 CPPFLAGS:=-isystem src/third_party/zstd/lib $(CPPFLAGS)
-LDFLAGS+=$(BASEDIR)/$(BUILDDIR)/lib/libfd_zstd.a
+VENDOR_LINK_LIBS+=fd_zstd

--- a/contrib/offline-replay/README.md
+++ b/contrib/offline-replay/README.md
@@ -35,7 +35,6 @@ webhook URLs filled in) exports the environment below and runs
 | `SLACK_DEBUG_WEBHOOK_URL` | debug notifications |
 | `LOG_DIR` (optional) | log directory, default `/data/offline-replay/logs` |
 | `AGAVE_TAG` (optional) | fallback tag if a ledger's `version.txt` is unreadable |
-| `OBJDIR` (optional) | Firedancer build dir, default `build/native/gcc` |
 
 The blockstore helper tools require RocksDB development headers/libs:
 `rocksdb-devel` on dnf systems or `librocksdb-dev` on apt systems.

--- a/contrib/offline-replay/run_offline_replay_backtest.sh
+++ b/contrib/offline-replay/run_offline_replay_backtest.sh
@@ -12,7 +12,7 @@
 # unquoted globs that must expand at use sites, so quoting is deliberately
 # loose in those places.
 
-OBJDIR=${OBJDIR:-build/native/gcc}   # relative to FIREDANCER_REPO
+OBJDIR=
 LOG_DIR=${LOG_DIR:-/data/offline-replay/logs}
 
 # All harness output (builds, downloads, git operations, step markers) is
@@ -314,6 +314,9 @@ build_firedancer() {
     git submodule update --init --recursive --force
     echo "y" | FD_AUTO_INSTALL_PACKAGES=1 ./deps.sh
     EXTRAS=offline-replay make -j
+
+    OBJDIR=$(EXTRAS=offline-replay make --silent --no-print-directory objdir 2>/dev/null || true)
+    : "${OBJDIR:?cannot determine OBJDIR (make objdir failed)}"
 }
 
 # Convert the downloaded rocksdb into a shredcap capture covering the replay
@@ -321,7 +324,7 @@ build_firedancer() {
 # rocksdb directory is kept for agave-ledger-tool and blockstore_minify during
 # minimization. Skipped if the capture already exists. Expects
 # build_firedancer to have run (needs blockstore2shredcap) and cwd =
-# FIREDANCER_REPO (OBJDIR is relative).
+# FIREDANCER_REPO.
 convert_rocksdb_to_shredcap() {
     SHREDCAP_FILE=$LEDGER_DIR/shreds.pcapng.zst
     if [ -e "$SHREDCAP_FILE" ]; then

--- a/contrib/quic/agave_compat/build.rs
+++ b/contrib/quic/agave_compat/build.rs
@@ -9,10 +9,58 @@ fn main() {
         .expect("failed to locate Firedancer root")
         .to_path_buf();
 
-    let mut build_path = firedancer_path.clone();
-    build_path.push("build");
-    build_path.push("native");
-    build_path.push("gcc");
+    // build dir is compiler-keyed: take OBJDIR from the env or ask make;
+    // every input to the key (env, compiler binary, make config) must
+    // re-run this script
+    for v in [
+        "OBJDIR",
+        "MACHINE",
+        "CC",
+        "PATH",
+        "EXTRAS",
+        "BASEDIR",
+        "BUILDDIR",
+        "BUILDDIR1",
+    ] {
+        println!("cargo:rerun-if-env-changed={}", v);
+    }
+    let root = firedancer_path.to_str().unwrap();
+    println!("cargo:rerun-if-changed={}/Makefile", root);
+    println!("cargo:rerun-if-changed={}/config", root);
+    let out = std::process::Command::new("make")
+        .args(["--silent", "--no-print-directory", "-C", root, "env"])
+        .output()
+        .expect("failed to run make env");
+    assert!(
+        out.status.success(),
+        "make env failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mk_env = String::from_utf8(out.stdout).unwrap();
+    let mk_var = |k: &str| {
+        mk_env
+            .lines()
+            .find_map(|l| l.strip_prefix(k).and_then(|v| v.strip_prefix('=')))
+            .map(|v| v.trim_matches('\'').to_string())
+            .expect(k)
+    };
+    if let Ok(out) = std::process::Command::new("sh")
+        .args([
+            "-c",
+            &format!(
+                "command -v {}",
+                mk_var("CC").split_whitespace().next().unwrap_or("cc")
+            ),
+        ])
+        .output()
+    {
+        let cc = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if let Ok(cc) = std::fs::canonicalize(&cc) {
+            println!("cargo:rerun-if-changed={}", cc.display());
+        }
+    }
+    let objdir = env::var("OBJDIR").unwrap_or_else(|_| mk_var("OBJDIR"));
+    let build_path = firedancer_path.join(&objdir);
 
     let mut lib_path = build_path.clone();
     lib_path.push("lib");

--- a/contrib/quic/go_compat/main.go
+++ b/contrib/quic/go_compat/main.go
@@ -1,7 +1,9 @@
 package main
 
-// #cgo CFLAGS: -I../../../build/native/gcc/include
-// #cgo LDFLAGS: -L../../../build/native/gcc/lib
+// Build dir is compiler-keyed; from this directory (cgo needs absolute paths):
+//   O=$(cd ../../.. && pwd)/$(make --silent --no-print-directory -C ../../.. objdir)
+//   CGO_CFLAGS=-I$O/include CGO_LDFLAGS=-L$O/lib go build
+
 // #cgo LDFLAGS: -lfd_quic
 // #cgo LDFLAGS: -lfd_waltz
 // #cgo LDFLAGS: -lfd_tls

--- a/contrib/quic/rust_compat/build.rs
+++ b/contrib/quic/rust_compat/build.rs
@@ -9,10 +9,58 @@ fn main() {
         .expect("failed to locate Firedancer root")
         .to_path_buf();
 
-    let mut build_path = firedancer_path.clone();
-    build_path.push("build");
-    build_path.push("native");
-    build_path.push("gcc");
+    // build dir is compiler-keyed: take OBJDIR from the env or ask make;
+    // every input to the key (env, compiler binary, make config) must
+    // re-run this script
+    for v in [
+        "OBJDIR",
+        "MACHINE",
+        "CC",
+        "PATH",
+        "EXTRAS",
+        "BASEDIR",
+        "BUILDDIR",
+        "BUILDDIR1",
+    ] {
+        println!("cargo:rerun-if-env-changed={}", v);
+    }
+    let root = firedancer_path.to_str().unwrap();
+    println!("cargo:rerun-if-changed={}/Makefile", root);
+    println!("cargo:rerun-if-changed={}/config", root);
+    let out = std::process::Command::new("make")
+        .args(["--silent", "--no-print-directory", "-C", root, "env"])
+        .output()
+        .expect("failed to run make env");
+    assert!(
+        out.status.success(),
+        "make env failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mk_env = String::from_utf8(out.stdout).unwrap();
+    let mk_var = |k: &str| {
+        mk_env
+            .lines()
+            .find_map(|l| l.strip_prefix(k).and_then(|v| v.strip_prefix('=')))
+            .map(|v| v.trim_matches('\'').to_string())
+            .expect(k)
+    };
+    if let Ok(out) = std::process::Command::new("sh")
+        .args([
+            "-c",
+            &format!(
+                "command -v {}",
+                mk_var("CC").split_whitespace().next().unwrap_or("cc")
+            ),
+        ])
+        .output()
+    {
+        let cc = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if let Ok(cc) = std::fs::canonicalize(&cc) {
+            println!("cargo:rerun-if-changed={}", cc.display());
+        }
+    }
+    let objdir = env::var("OBJDIR").unwrap_or_else(|_| mk_var("OBJDIR"));
+    let build_path = firedancer_path.join(&objdir);
 
     let mut lib_path = build_path.clone();
     lib_path.push("lib");

--- a/contrib/test/check_fp_fma.sh
+++ b/contrib/test/check_fp_fma.sh
@@ -15,7 +15,7 @@
 # incompatible objdump, unreadable object) is a hard error, so the
 # guard can never be silently skipped.
 #
-# Expects OBJDIR to be set (e.g. build/native/gcc).  OBJDUMP overrides
+# Expects OBJDIR to be set (see `make objdir`).  OBJDUMP overrides
 # the disassembler.
 
 set -uo pipefail

--- a/contrib/test/run_solcap_tests.sh
+++ b/contrib/test/run_solcap_tests.sh
@@ -4,7 +4,8 @@ set -eou pipefail
 source contrib/test/ledger_common.sh
 
 DUMP=${DUMP:="./dump"}
-OBJDIR=${OBJDIR:-build/native/gcc}
+OBJDIR=${OBJDIR:-$(make --silent --no-print-directory objdir 2>/dev/null || true)}
+: "${OBJDIR:?cannot determine OBJDIR (make objdir failed)}"
 SKIP_INGEST=${SKIP_INGEST:-0}
 
 LEDGER="mainnet-424669000-solcap-v4.2.0-beta.1-vat"

--- a/contrib/test/run_test_vectors.sh
+++ b/contrib/test/run_test_vectors.sh
@@ -9,7 +9,8 @@ DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
 DIR="$( realpath -e -- "$DIR"; )"
 cd "$DIR/../.."
 
-OBJDIR=${OBJDIR:-build/native/gcc}
+OBJDIR=${OBJDIR:-$(make --silent --no-print-directory objdir 2>/dev/null || true)}
+: "${OBJDIR:?cannot determine OBJDIR (make objdir failed)}"
 NUM_PROCESSES=${NUM_PROCESSES:-12}
 PAGE_SZ=gigantic
 PAGE_CNT=$(( 7 * NUM_PROCESSES ))

--- a/contrib/test/rust-float/Makefile
+++ b/contrib/test/rust-float/Makefile
@@ -2,10 +2,11 @@
 #
 #   make -C contrib/test/rust-float
 #
-# Builds the C unit test too, so this is the only step needed.  OBJDIR
-# selects which Firedancer build to use, RUSTC which compiler.
+# Builds the C unit test too, so this is the only step needed.  The usual
+# MACHINE/CC/EXTRAS (or an explicit OBJDIR) select which Firedancer build
+# to use, RUSTC which Rust compiler.
 #
-#   make -C contrib/test/rust-float OBJDIR=build/linux/clang/icelake
+#   MACHINE=linux_clang_icelake make -C contrib/test/rust-float
 #
 # Both programs print raw results on stdout, nan payloads included, so
 # the diff names the exact operation and operands that disagree.  A
@@ -16,10 +17,13 @@
 # which is the form CI runs as a unit test.
 
 FD_ROOT := ../../..
-OBJDIR  ?= build/native/gcc
+# derive the keyed build dir under the same CC/MACHINE/EXTRAS/BUILDDIR the
+# recipe's sub-make will see; MAKEFLAGS dropped (-n/-w corrupt the output)
+FD_VARS := $(foreach v,CC MACHINE EXTRAS BASEDIR BUILDDIR BUILDDIR1,$(if $(filter command% environment,$(origin $(v))),'$(v)=$($(v))'))
+OBJDIR  ?= $(shell MAKEFLAGS= $(MAKE) --silent --no-print-directory -C ../../.. objdir $(FD_VARS) 2>/dev/null)
 RUSTC   ?= rustc
 OUT     := out
-C_BIN   := $(FD_ROOT)/$(OBJDIR)/unit-test/test_rust_float
+C_BIN   := $(if $(filter /%,$(OBJDIR)),,$(FD_ROOT)/)$(OBJDIR)/unit-test/test_rust_float
 
 .PHONY: test diff clean
 test: $(OUT)/rust-float

--- a/doc/build-system.md
+++ b/doc/build-system.md
@@ -63,7 +63,7 @@ Firedancer depends on the GNU C Library (glibc) and the C++ standard library.
 Both are linked dynamically.
 
 ```
-$ ldd build/native/gcc/bin/fdctl
+$ ldd build/fdctl
         linux-vdso.so.1 (0x00007ffce652e000)
         librt.so.1 => /lib64/librt.so.1 (0x00007f0d0398c000)
         libdl.so.2 => /lib64/libdl.so.2 (0x00007f0d03788000)

--- a/doc/organization.txt
+++ b/doc/organization.txt
@@ -5,7 +5,7 @@ Firedancer source tree
   ├── book/            https://docs.firedancer.io/
   │
   ├── build/                   Build artifacts
-  │   └── native/gcc           Build profile
+  │   └── native/gcc/<cc-ver>  Build profile
   │       ├── bin/             Main programs and scripts
   │       ├── cov/             Coverage report
   │       ├── include/         Exported include headers

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -113,7 +113,7 @@ If no fuzzing engine is provided, the fuzz tests are still built with a
 stub engine.  The stub engine cannot find any new inputs, but can still
 regression test against old inputs like so:
 ```
-$ build/native/gcc/fuzz-test/fuzz_bla/fuzz_bla <input1> <input2> ...
+$ $(make --silent objdir)/fuzz-test/fuzz_bla <input1> <input2> ...
 ```
 
 ### Sanitizers

--- a/src/app/fdctl/Local.mk
+++ b/src/app/fdctl/Local.mk
@@ -119,12 +119,12 @@ $(OBJDIR)/lib/libagave_validator.a: cargo-validator
 	$(MKDIR) $(dir $@) && { cmp -s agave/target/$(RUST_PROFILE)/libagave_validator.a $@ || cp agave/target/$(RUST_PROFILE)/libagave_validator.a $@; }
 
 $(OBJDIR)/bin/solana: cargo-solana
-	$(MKDIR) -p $(dir $@) && { cmp -s agave/target/$(RUST_PROFILE)/solana $@ || cp agave/target/$(RUST_PROFILE)/solana $@; }
+	$(MKDIR) -p $(dir $@) && { cmp -s agave/target/$(RUST_PROFILE)/solana $@ || { cp agave/target/$(RUST_PROFILE)/solana $@.tmp && mv -f $@.tmp $@; }; } && $(call publish,$@,$(BASEDIR)/solana)
 
 solana: $(OBJDIR)/bin/solana
 
 $(OBJDIR)/bin/agave-ledger-tool: cargo-ledger-tool
-	$(MKDIR) -p $(dir $@) && { cmp -s agave/dev-bins/target/$(RUST_PROFILE)/agave-ledger-tool $@ || cp agave/dev-bins/target/$(RUST_PROFILE)/agave-ledger-tool $@; }
+	$(MKDIR) -p $(dir $@) && { cmp -s agave/dev-bins/target/$(RUST_PROFILE)/agave-ledger-tool $@ || { cp agave/dev-bins/target/$(RUST_PROFILE)/agave-ledger-tool $@.tmp && mv -f $@.tmp $@; }; } && $(call publish,$@,$(BASEDIR)/agave-ledger-tool)
 
 agave-ledger-tool: $(OBJDIR)/bin/agave-ledger-tool
 

--- a/src/ballet/ed25519/fd_curve25519_tables.c
+++ b/src/ballet/ed25519/fd_curve25519_tables.c
@@ -10,8 +10,8 @@
       $ MACHINE=linux_gcc_noarch64 make -j
 
    3. Run the scripts:
-      $ ./build/linux/gcc/icelake/unit-test/fd_curve25519_tables
-      $ ./build/linux/gcc/noarch64/unit-test/fd_curve25519_tables
+      $ $(MACHINE=linux_gcc_icelake make --silent objdir)/unit-test/fd_curve25519_tables
+      $ $(MACHINE=linux_gcc_noarch64 make --silent objdir)/unit-test/fd_curve25519_tables
 
    4. Commit the changes. */
 

--- a/src/discof/replay/rdisp_format_block_for_test.py
+++ b/src/discof/replay/rdisp_format_block_for_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Example usage:  solana -um block 123456789 --output json-compact | src/discof/replay/rdisp_format_block_for_test.py > /tmp/123456789.bin &&  build/native/gcc/unit-test/test_rdisp --block-file /tmp/123456789.bin
+# Example usage:  solana -um block 123456789 --output json-compact | src/discof/replay/rdisp_format_block_for_test.py > /tmp/123456789.bin &&  $(make --silent objdir)/unit-test/test_rdisp --block-file /tmp/123456789.bin
 import solders
 from solders.transaction import Transaction, VersionedTransaction
 from solders.pubkey import Pubkey

--- a/src/flamenco/runtime/tests/run_conformance_tests.sh
+++ b/src/flamenco/runtime/tests/run_conformance_tests.sh
@@ -118,6 +118,9 @@ export PATH
 PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH
 echo "y"|./deps.sh
 make -j
+FD_OBJDIR=$(make --silent --no-print-directory objdir 2>/dev/null || true)
+: "${FD_OBJDIR:?cannot determine OBJDIR (make objdir failed)}"
+FD_OBJDIR=$(realpath -m "$FD_OBJDIR")   # cwd is FIREDANCER_REPO; absolute either way
 
 # setup solfuzz-agave
 cd $AGAVE_REPO
@@ -137,4 +140,4 @@ if [ -z "${OUTPUT_DIR}" ]; then
 fi
 mkdir -p $OUTPUT_DIR
 
-solana-test-suite run-tests --input-dir $TEST_INPUTS --solana-target ${AGAVE_REPO}/target/debug/libsolfuzz_agave.so --target ${FIREDANCER_REPO}/build/native/gcc/lib/libfd_exec_sol_compat.so --output-dir $OUTPUT_DIR --consensus-mode --failures-only --save-failures
+solana-test-suite run-tests --input-dir $TEST_INPUTS --solana-target ${AGAVE_REPO}/target/debug/libsolfuzz_agave.so --target ${FD_OBJDIR}/lib/libfd_exec_sol_compat.so --output-dir $OUTPUT_DIR --consensus-mode --failures-only --save-failures

--- a/src/flamenco/runtime/tests/run_ledger_backtest.sh
+++ b/src/flamenco/runtime/tests/run_ledger_backtest.sh
@@ -3,7 +3,8 @@
 source contrib/test/ledger_common.sh
 
 POSITION_ARGS=()
-OBJDIR=${OBJDIR:-build/native/gcc}
+OBJDIR=${OBJDIR:-$(make --silent --no-print-directory objdir 2>/dev/null || true)}
+: "${OBJDIR:?cannot determine OBJDIR (make objdir failed)}"
 
 LEDGER=""
 RESTORE_ARCHIVE=""

--- a/src/third_party/blst/Local.mk
+++ b/src/third_party/blst/Local.mk
@@ -11,12 +11,12 @@ ifdef FD_HAS_X86
 BLST_CFLAGS_NOWARN+=-D__BLST_PORTABLE__ -mno-avx
 endif
 
-$(OBJDIR)/obj/third_party/blst/server.o : src/third_party/blst/src/server.c
+$(OBJDIR)/obj/third_party/blst/server.o : src/third_party/blst/src/server.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(BLST_CFLAGS_NOWARN) -c $< -o $@
 
-$(OBJDIR)/obj/third_party/blst/assembly.o : src/third_party/blst/build/assembly.S
+$(OBJDIR)/obj/third_party/blst/assembly.o : src/third_party/blst/build/assembly.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(BLST_CFLAGS_NOWARN) -c $< -o $@

--- a/src/third_party/bzip2/Local.mk
+++ b/src/third_party/bzip2/Local.mk
@@ -3,7 +3,7 @@ $(OBJDIR)/lib/libfd_ballet.a: $(patsubst %,$(OBJDIR)/obj/third_party/bzip2/%.o,$
 
 BZIP2_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS)))
 
-$(OBJDIR)/obj/third_party/bzip2/%.o : src/third_party/bzip2/%.c
+$(OBJDIR)/obj/third_party/bzip2/%.o : src/third_party/bzip2/%.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(BZIP2_CFLAGS_NOWARN) -c $< -o $@

--- a/src/third_party/lz4/Local.mk
+++ b/src/third_party/lz4/Local.mk
@@ -6,7 +6,7 @@ ifdef FD_HAS_LZ4
 # -lfd_util, and LDFLAGS is last in _make-exe.
 LZ4_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS)))
 
-$(OBJDIR)/obj/third_party/lz4/lib/%.o : src/third_party/lz4/lib/%.c
+$(OBJDIR)/obj/third_party/lz4/lib/%.o : src/third_party/lz4/lib/%.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(LZ4_CFLAGS_NOWARN) -c $< -o $@

--- a/src/third_party/picohttpparser/Local.mk
+++ b/src/third_party/picohttpparser/Local.mk
@@ -6,7 +6,7 @@ $(OBJDIR)/lib/libfd_waltz.a: $(OBJDIR)/obj/third_party/picohttpparser/picohttppa
 
 PICOHTTP_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS)))
 
-$(OBJDIR)/obj/third_party/picohttpparser/picohttpparser.o : src/third_party/picohttpparser/picohttpparser.c
+$(OBJDIR)/obj/third_party/picohttpparser/picohttpparser.o : src/third_party/picohttpparser/picohttpparser.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(PICOHTTP_CFLAGS_NOWARN) -c $< -o $@

--- a/src/third_party/zlib/Local.mk
+++ b/src/third_party/zlib/Local.mk
@@ -7,7 +7,7 @@ lib: $(OBJDIR)/lib/libfd_zlib.a
 
 ZLIB_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS))) -DZ_SOLO
 
-$(OBJDIR)/obj/third_party/zlib/%.o : src/third_party/zlib/%.c
+$(OBJDIR)/obj/third_party/zlib/%.o : src/third_party/zlib/%.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(ZLIB_CFLAGS_NOWARN) -c $< -o $@

--- a/src/third_party/zstd/Local.mk
+++ b/src/third_party/zstd/Local.mk
@@ -27,19 +27,19 @@ ZSTD_OBJS:=\
 
 ZSTD_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS))) -DZSTD_TRACE=0 -DDEBUGLEVEL=0 -DZSTD_LEGACY_SUPPORT=0 -DZSTD_ASAN_DONT_POISON_WORKSPACE=1 -DZSTD_MSAN_DONT_POISON_WORKSPACE=1
 
-$(OBJDIR)/obj/third_party/zstd/lib/%.o : src/third_party/zstd/lib/%.c
+$(OBJDIR)/obj/third_party/zstd/lib/%.o : src/third_party/zstd/lib/%.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(ZSTD_CFLAGS_NOWARN) -c $< -o $@
 
 # upstream builds this TU with -fno-tree-vectorize
-$(OBJDIR)/obj/third_party/zstd/lib/decompress/zstd_decompress_block.o : src/third_party/zstd/lib/decompress/zstd_decompress_block.c
+$(OBJDIR)/obj/third_party/zstd/lib/decompress/zstd_decompress_block.o : src/third_party/zstd/lib/decompress/zstd_decompress_block.c $(OBJDIR)/.flags
 	@echo -e "CC\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(ZSTD_CFLAGS_NOWARN) -fno-tree-vectorize -c $< -o $@
 
 # self-gated on __x86_64__/ZSTD_ASM_SUPPORTED; empty object elsewhere
-$(OBJDIR)/obj/third_party/zstd/lib/decompress/huf_decompress_amd64.o : src/third_party/zstd/lib/decompress/huf_decompress_amd64.S
+$(OBJDIR)/obj/third_party/zstd/lib/decompress/huf_decompress_amd64.o : src/third_party/zstd/lib/decompress/huf_decompress_amd64.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
 $(CC) $(ZSTD_CFLAGS_NOWARN) -c $< -o $@


### PR DESCRIPTION
Every object and link now depends on a cmp-guarded $(OBJDIR)/.flags stamp of the effective compiler+flags, so an OBJDIR reused under a different config rebuilds correctly instead of shipping mixed-flag binaries. Default BUILDDIRs gain a <version>[-extras] suffix so flavors stop sharing paths; bins also hardlink to build/<name> for convenience.