### PR TITLE
bundle: defense-in-depth against zero tip receiver

### DIFF
--- a/src/disco/bundle/fd_bundle_crank.c
+++ b/src/disco/bundle/fd_bundle_crank.c
@@ -308,6 +308,12 @@ fd_bundle_crank_generate( fd_bundle_crank_gen_t                       * gen,
     return ULONG_MAX;
   }
 
+  if( FD_UNLIKELY( pidx_map_key_inval( *old_tip_payment_config->tip_receiver ) ||
+                   pidx_map_key_inval( *old_tip_payment_config->block_builder ) ) ) {
+    FD_LOG_WARNING(( "Found null pubkey in tip payment config account.  Refusing to crank bundles." ));
+    return ULONG_MAX;
+  }
+
   int swap3 = !fd_memeq( tip_receiver_owner, gen->crank3->tip_distribution_program, sizeof(fd_acct_addr_t) );
 
   if( FD_LIKELY( fd_memeq( old_tip_payment_config->tip_receiver,  gen->crank3->new_tip_receiver, 32UL ) &&

--- a/src/disco/bundle/test_bundle_crank.c
+++ b/src/disco/bundle/test_bundle_crank.c
@@ -249,6 +249,19 @@ test_crank_cnt( void ) {
   uchar _txn[ FD_TXN_MAX_SZ ];
   fd_txn_t * txn = (fd_txn_t *)_txn;
 
+  fd_acct_addr_t old_tip_receiver  = *tip_payment_config->tip_receiver;
+  fd_acct_addr_t old_block_builder = *tip_payment_config->block_builder;
+
+  memset( tip_payment_config->tip_receiver, 0, sizeof(fd_acct_addr_t) );
+  FD_TEST( ULONG_MAX==crank_generate_and_test( g, tip_payment_config, _feeywn2ffX8DivmRvBJ9i9YZnss7WBouTmujfQcEdeY,
+      _GwHH8ciFhR8vejWCqmg8FWZUCNtubPY2esALvy5tBvji, _4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7, 740UL, 5UL, payload, txn ) );
+  *tip_payment_config->tip_receiver = old_tip_receiver;
+
+  memset( tip_payment_config->block_builder, 0, sizeof(fd_acct_addr_t) );
+  FD_TEST( ULONG_MAX==crank_generate_and_test( g, tip_payment_config, _feeywn2ffX8DivmRvBJ9i9YZnss7WBouTmujfQcEdeY,
+      _GwHH8ciFhR8vejWCqmg8FWZUCNtubPY2esALvy5tBvji, _4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7, 740UL, 5UL, payload, txn ) );
+  *tip_payment_config->block_builder = old_block_builder;
+
   fd_acct_addr_t uncreated[1] = {{{ 0 }}};
   FD_TEST( sizeof(fd_bundle_crank_3_t)==crank_generate_and_test( g, tip_payment_config, _feeywn2ffX8DivmRvBJ9i9YZnss7WBouTmujfQcEdeY,
       _GwHH8ciFhR8vejWCqmg8FWZUCNtubPY2esALvy5tBvji, uncreated, 740UL, 5UL, payload, txn ) );


### PR DESCRIPTION
turn unreachable memory corruption into explicit reject
