### PR TITLE
eqvoc: detect last shred conflicts

### DIFF
--- a/src/choreo/eqvoc/fd_eqvoc.c
+++ b/src/choreo/eqvoc/fd_eqvoc.c
@@ -756,7 +756,10 @@ fd_eqvoc_shred_insert( fd_eqvoc_t *                eqvoc,
       last = fec_insert( eqvoc, slot, UINT_MAX );  /* specially index the last shred in a slot */
       fd_memcpy( &last->sample_shred, shred, fd_shred_sz( shred ) );
     } else if( FD_UNLIKELY( ( is_last_shred( shred               ) && shred->idx < last->sample_shred.idx ) ||
-                            ( is_last_shred( &last->sample_shred ) && shred->idx > last->sample_shred.idx ) ) ) {
+                            ( is_last_shred( &last->sample_shred ) && shred->idx > last->sample_shred.idx ) ||
+                            ( shred->idx==last->sample_shred.idx &&
+                              ( is_last_shred( shred ) || is_last_shred( &last->sample_shred ) ) &&
+                              verify_proof( eqvoc, shred->version, NULL, shred, &last->sample_shred )==FD_EQVOC_SUCCESS ) ) ) {
       construct_proof( shred, &last->sample_shred, chunks_out );
       dup_insert( eqvoc, slot );
       return 1;

--- a/src/choreo/eqvoc/test_eqvoc.c
+++ b/src/choreo/eqvoc/test_eqvoc.c
@@ -79,6 +79,44 @@ test_shred_insert( void ) {
 
   teardown( eqvoc );
 
+  /* Equal-index last-shred conflicts require different payloads. */
+
+  eqvoc = setup();
+  uchar last_bytes[ FD_SHRED_MIN_SZ ]; memcpy( last_bytes, id, FD_SHRED_MIN_SZ );
+  fd_shred_t * last_shred = (fd_shred_t *)fd_type_pun( last_bytes );
+  last_shred->slot        = 97UL;
+  last_shred->idx         = 31U;
+  last_shred->variant     = fd_shred_variant( FD_SHRED_TYPE_MERKLE_DATA_CHAINED, (uchar)(FD_SHRED_MERKLE_LAYER_CNT-1UL) );
+  last_shred->data.flags |= FD_SHRED_DATA_FLAG_SLOT_COMPLETE;
+
+  FD_TEST( fd_eqvoc_shred_insert( eqvoc, 0, last_shred, chunks_out )==0 );
+  FD_TEST( fd_eqvoc_shred_insert( eqvoc, 0, last_shred, chunks_out )==0 ); /* identical retransmission */
+
+  uchar conflict_bytes[ FD_SHRED_MIN_SZ ]; memcpy( conflict_bytes, last_bytes, FD_SHRED_MIN_SZ );
+  fd_shred_t * conflict_shred = (fd_shred_t *)fd_type_pun( conflict_bytes );
+  conflict_bytes[ FD_SHRED_DATA_HEADER_SZ ] ^= 1U;
+  FD_TEST( fd_eqvoc_shred_insert( eqvoc, 0, conflict_shred, chunks_out )==1 );
+
+  teardown( eqvoc );
+
+  /* Also detect when the equal-index last shred arrives second. */
+
+  eqvoc = setup();
+  memcpy( last_bytes, id, FD_SHRED_MIN_SZ );
+  last_shred             = (fd_shred_t *)fd_type_pun( last_bytes );
+  last_shred->slot       = 98UL;
+  last_shred->idx        = 31U;
+  last_shred->variant    = fd_shred_variant( FD_SHRED_TYPE_MERKLE_DATA_CHAINED, (uchar)(FD_SHRED_MERKLE_LAYER_CNT-1UL) );
+  last_shred->data.flags = (uchar)(last_shred->data.flags & ~FD_SHRED_DATA_FLAG_SLOT_COMPLETE);
+  FD_TEST( fd_eqvoc_shred_insert( eqvoc, 0, last_shred, chunks_out )==0 );
+
+  memcpy( conflict_bytes, last_bytes, FD_SHRED_MIN_SZ );
+  conflict_shred              = (fd_shred_t *)fd_type_pun( conflict_bytes );
+  conflict_shred->data.flags |= FD_SHRED_DATA_FLAG_SLOT_COMPLETE;
+  FD_TEST( fd_eqvoc_shred_insert( eqvoc, 0, conflict_shred, chunks_out )==1 );
+
+  teardown( eqvoc );
+
   /* FEC eviction by (slot, fec_set_idx). */
 
   eqvoc = setup();


### PR DESCRIPTION
fixes a gap in eqvoc where it could not detect shred conflicts
when the shred index is the same and the shred is the last in slot.

This gap only exists on the repair path, Turbine uses a different
code path.
