### PR TITLE
net: only enable native_bond for 802.3ad LACP

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1099,6 +1099,9 @@ dynamic_port_range = "8900-9000"
         # devices.  This causes outgoing traffic to be load balanced with
         # an arbitrary/opaque hash policy.  Supports up to 16 slave devices.
         #
+        # Only 802.3ad (LACP) bonds are supported.  In "auto" mode,
+        # native bonding is only enabled for bonds in 802.3ad mode.
+        #
         # Assumes that bond memberships don't change, i.e. running `ip
         # link set dev eth1 master bond0` will crash Firedancer.
         # However, it is fine to bring individual bonded devices down,

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -1279,6 +1279,9 @@ telemetry = true
         # devices.  This causes outgoing traffic to be load balanced with
         # an arbitrary/opaque hash policy.  Supports up to 16 slave devices.
         #
+        # Only 802.3ad (LACP) bonds are supported.  In "auto" mode,
+        # native bonding is only enabled for bonds in 802.3ad mode.
+        #
         # Assumes that bond memberships don't change, i.e. running `ip
         # link set dev eth1 master bond0` will crash Firedancer.
         # However, it is fine to bring individual bonded devices down,

--- a/src/app/shared/fd_config_auto.c
+++ b/src/app/shared/fd_config_auto.c
@@ -24,8 +24,9 @@ struct fd_auto_info {
 
   /* Networking */
   char driver[ NAME_SZ ];
-  int  is_virtual_if;
-  int  is_bonded_if;
+  uint is_virtual_if:1;
+  uint is_bonded_if:1;
+  uint is_lacp_if:1;
   uint bonded_if_slave_count;
   int  is_using_gre;
   int  has_mlx5_rdma_port;
@@ -172,6 +173,7 @@ static int
 xdp_native_bond_check( fd_config_t    const * config,
                        fd_auto_info_t const * info ) {
   if( !info->is_bonded_if ) return 0;
+  if( !info->is_lacp_if ) return 0;
 
   if( 0==info->bonded_if_slave_count || info->bonded_if_slave_count>FD_NET_BOND_SLAVE_MAX ) return 0;
 
@@ -432,8 +434,11 @@ scrape_networking( fd_auto_info_t * info,
   info->is_virtual_if = ( -1==access( path, F_OK ) );
 
   /* Check for bond */
-  info->is_bonded_if = fd_bonding_is_master( if_name );
-  if( info->is_bonded_if ) info->bonded_if_slave_count = (uint)fd_bonding_slave_cnt( if_name );
+  info->is_bonded_if = !!fd_bonding_is_master( if_name );
+  if( info->is_bonded_if ) {
+    info->bonded_if_slave_count = (uint)fd_bonding_slave_cnt( if_name );
+    info->is_lacp_if            = !!fd_bonding_is_lacp( if_name );
+  }
 
   /* Get driver name.  A bond master reports "n/a" so no driver specific
      config is applied. If all slaves share a driver name then reports
@@ -533,7 +538,7 @@ fd_config_auto( fd_config_t * config ) {
   fd_auto_net( config, &info );
 
   fd_cstr_printf( config->auto_config_log, sizeof(config->auto_config_log), NULL,
-      "network auto configure system info: provider=%s xdp_mode=%s poll_mode=%s zero_copy=%d native_bond=%d listen_gre=%d rss_queue_mode=%s (driver=%s kernel=%lu.%lu gre=%d virtual_if=%d bonded_if=%d slaves=%u, net_tile_cnt=%u)",
+      "network auto configure system info: provider=%s xdp_mode=%s poll_mode=%s zero_copy=%d native_bond=%d listen_gre=%d rss_queue_mode=%s (driver=%s kernel=%lu.%lu gre=%d virtual_if=%d bonded_if=%d lacp_if=%d slaves=%u, net_tile_cnt=%u)",
       config->net.provider,
       config->net.xdp.xdp_mode,
       config->net.xdp.poll_mode,
@@ -546,6 +551,7 @@ fd_config_auto( fd_config_t * config ) {
       info.is_using_gre,
       info.is_virtual_if,
       info.is_bonded_if,
+      info.is_lacp_if,
       info.bonded_if_slave_count,
       config->layout.net_tile_count );
 }

--- a/src/app/shared/test_config_auto.c
+++ b/src/app/shared/test_config_auto.c
@@ -123,7 +123,8 @@ main( int     argc,
 
   reset_auto( 4U );
   fd_auto_info_t info3 = { .linux_major=1, .linux_minor=0, .driver="mlx5_core",
-                           .is_virtual_if=1, .is_bonded_if=1, .bonded_if_slave_count=2U };
+                           .is_virtual_if=1, .is_bonded_if=1, .is_lacp_if=1,
+                           .bonded_if_slave_count=2U };
   fd_auto_net( config, &info3 );
   FD_TEST( 0==strcmp( config->net.xdp.xdp_mode,  "skb"     ) );
   FD_TEST( 0==strcmp( config->net.xdp.poll_mode, "softirq" ) );
@@ -144,6 +145,16 @@ main( int     argc,
   FD_TEST( 0==strcmp( config->net.xdp.rss_queue_mode, "auto" ) );
   FD_TEST( config->net.xdp.xdp_zero_copy==1 );
   FD_TEST( config->net.xdp.listen_gre==0 );
+
+  /* A bond that is not in 802.3ad mode (e.g. active-backup) does not
+     enable native bond, and therefore stays in skb mode */
+
+  reset_auto( 4U );
+  fd_auto_info_t info5 = info4;
+  info5.is_lacp_if = 0;
+  fd_auto_net( config, &info5 );
+  FD_TEST( config->net.xdp.native_bond==0 );
+  FD_TEST( 0==strcmp( config->net.xdp.xdp_mode, "skb" ) );
 
   /* Non XDP provider still collapses "auto" fields to defaults */
 

--- a/src/disco/net/fd_linux_bond.c
+++ b/src/disco/net/fd_linux_bond.c
@@ -66,6 +66,34 @@ fd_bonding_slave_iter_ele(
   return iter->tok;
 }
 
+int
+fd_bonding_is_lacp( char const * device ) {
+  char path[ PATH_MAX ];
+  FD_TEST( fd_cstr_printf_check( path, PATH_MAX, NULL, "/sys/class/net/%s/bonding/mode", device ) );
+
+  FILE * fp = fopen( path, "r" );
+  if( FD_UNLIKELY( !fp ) ) {
+    FD_LOG_WARNING(( "failed to detect bonding mode of device `%s`, fopen(%s) failed (%i-%s)",
+                     device, path, errno, fd_io_strerror( errno ) ));
+    return 0;
+  }
+
+  /* The mode node holds the mode name followed by its numeric ID,
+     e.g. "802.3ad 4" */
+  char line[ 64 ];
+  errno = 0;
+  char * res = fgets( line, sizeof(line), fp );
+  int    err = errno;
+  fclose( fp );
+  if( FD_UNLIKELY( !res ) ) {
+    FD_LOG_WARNING(( "failed to detect bonding mode of device `%s`, fgets(%s) failed (%i-%s)",
+                     device, path, err, fd_io_strerror( err ) ));
+    return 0;
+  }
+
+  return 0==strncmp( line, "802.3ad ", 8UL );
+}
+
 uint
 fd_bonding_slave_cnt( char const * device ) {
   fd_bonding_slave_iter_t iter_[1];

--- a/src/disco/net/fd_linux_bond.h
+++ b/src/disco/net/fd_linux_bond.h
@@ -22,6 +22,15 @@ fd_bonding_is_master( char const * device );
 uint
 fd_bonding_slave_cnt( char const * device );
 
+/* fd_bonding_is_lacp returns 1 if the given bond master is in 802.3ad
+   (LACP link aggregation) mode.  Returns 0 if it is in any other mode,
+   or if the bonding mode could not be determined (in which case a
+   warning is logged).  device is assumed to be a bond master (see
+   fd_bonding_is_master). */
+
+int
+fd_bonding_is_lacp( char const * device );
+
 /* fd_bonding_slave_iter provides an API to iterate over the slave
    devices of a network bond. */
 


### PR DESCRIPTION
Fixes a bug where auto mode enables native_bond for unsupported
bonding modes like active-backup which results in a lot of TX
packet loss.

Thank you to Matthias from Staking Facilities for reporting
