### PR TITLE
stem: fix regime accounting on the returnable frag path

### DIFF
--- a/src/disco/stem/fd_stem.c
+++ b/src/disco/stem/fd_stem.c
@@ -749,8 +749,9 @@ STEM_(run1)( ulong                        in_cnt,
     int return_frag = STEM_CALLBACK_RETURNABLE_FRAG( ctx, (ulong)this_in->idx, seq_found, sig, chunk, sz, ctl, tsorig, tspub, &stem );
     if( FD_UNLIKELY( return_frag ) ) {
       metric_regime_ticks[1] += housekeeping_ticks;
+      metric_regime_ticks[4] += prefrag_ticks;
       long next = fd_tickcount();
-      metric_regime_ticks[4] += (ulong)(next - now);
+      metric_regime_ticks[7] += (ulong)(next - now);
       now = next;
       continue;
     }


### PR DESCRIPTION
impact is metrics only