### PR TITLE
net: do not enable zero copy on ice

### DIFF
--- a/src/app/shared/fd_config_auto.c
+++ b/src/app/shared/fd_config_auto.c
@@ -328,10 +328,7 @@ static const fd_auto_provider_t NET_PROVIDERS[] = {
         .name              = "Zero Copy",
         .supported_drivers = {
           { "mlx5_core", 6,  1, 0,  0 },
-          { "i40e",      5, 19, 0,  0 },
-          { "ice",       5, 15, 5, 18 },
-          { "ice",       6,  1, 6,  1 },
-          { "ice",       6,  3, 0,  0 }
+          { "i40e",      5, 19, 0,  0 }
         },
         .is_feat_auto      = is_xdp_zc_auto,
         .check             = xdp_zc_check,


### PR DESCRIPTION
causes remote kernel memory corruption
https://lore.kernel.org/netdev/20260512152658.2818805-1-lorenz@monogon.tech/
