### PR TITLE
arm: no isb on tickcount

### DIFF
--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -1321,7 +1321,6 @@ fd_tickcount( void ) {
   /* consider using 'isb' */
   ulong value;
   __asm__ __volatile__ (
-    "isb\n"
     "mrs %0, cntvct_el0\n"
     "nop"
     : "=r" (value) );


### PR DESCRIPTION
empirically the barrier greatly reduces performance and increases
clock jitter on Neoverse V2
