### PR TITLE
build: emit depfiles for assembly objects

### DIFF
--- a/config/everything.mk
+++ b/config/everything.mk
@@ -180,6 +180,9 @@ add-objs = $(eval $(call _add-objs,$(1),$(2)))
 
 define _add-asms
 
+# separate from DEPFILES: asm objects have no .S/.i/.check-from-.c targets
+ASM_DEPFILES+=$(foreach obj,$(1),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).d))
+
 $(OBJDIR)/lib/lib$(2).a: $(foreach obj,$(1),$(patsubst $(OBJDIR)/src/%,$(OBJDIR)/obj/%,$(OBJDIR)/$(MKPATH)$(obj).o))
 
 endef
@@ -383,7 +386,7 @@ $(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@ && $(DEPFIX)
 $(OBJDIR)/obj/%.o : src/%.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
-$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@ && $(DEPFIX)
 
 $(OBJDIR)/obj/%.S : src/%.c $(OBJDIR)/.flags
 	$(MKDIR) $(dir $@) && \
@@ -464,7 +467,7 @@ $(OBJDIR)/.ldflags.d/%:
 # show-deps target).
 
 show-deps:
-	@for d in $(DEPFILES); do echo $$d; done
+	@for d in $(DEPFILES) $(ASM_DEPFILES); do echo $$d; done
 
 # Define the check target.  Must be after the make fragments include so that
 # DEPFILES is fully populated
@@ -476,6 +479,7 @@ ifeq ($(filter $(AUX_RULES) $(DRY_RULES),$(MAKECMDGOALS)),)
 # The leading dash avoids the old up-front dependency generation pass on clean
 # trees, which kept make busy before it could start compiling objects.
 -include $(DEPFILES)
+-include $(ASM_DEPFILES)
 endif
 
 # Define the asm target.  Must be after the make fragments include so that

--- a/src/third_party/blst/Local.mk
+++ b/src/third_party/blst/Local.mk
@@ -19,7 +19,9 @@ $(CC) $(BLST_CFLAGS_NOWARN) -c $< -o $@
 $(OBJDIR)/obj/third_party/blst/assembly.o : src/third_party/blst/build/assembly.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
-$(CC) $(BLST_CFLAGS_NOWARN) -c $< -o $@
+$(CC) $(BLST_CFLAGS_NOWARN) $(DEPFLAGS) -c $< -o $@ && $(DEPFIX)
+
+ASM_DEPFILES+=$(OBJDIR)/obj/third_party/blst/assembly.d
 
 $(OBJDIR)/lib/libfd_blst.a: $(OBJDIR)/obj/third_party/blst/server.o $(OBJDIR)/obj/third_party/blst/assembly.o
 

--- a/src/third_party/zstd/Local.mk
+++ b/src/third_party/zstd/Local.mk
@@ -42,7 +42,9 @@ $(CC) $(ZSTD_CFLAGS_NOWARN) -fno-tree-vectorize -c $< -o $@
 $(OBJDIR)/obj/third_party/zstd/lib/decompress/huf_decompress_amd64.o : src/third_party/zstd/lib/decompress/huf_decompress_amd64.S $(OBJDIR)/.flags
 	@echo -e "AS\t$(notdir $@)"
 	$(Q)$(MKDIR) $(dir $@) && \
-$(CC) $(ZSTD_CFLAGS_NOWARN) -c $< -o $@
+$(CC) $(ZSTD_CFLAGS_NOWARN) $(DEPFLAGS) -c $< -o $@ && $(DEPFIX)
+
+ASM_DEPFILES+=$(OBJDIR)/obj/third_party/zstd/lib/decompress/huf_decompress_amd64.d
 
 $(OBJDIR)/lib/libfd_zstd.a: $(patsubst %,$(OBJDIR)/obj/third_party/zstd/lib/%.o,$(ZSTD_OBJS)) $(OBJDIR)/obj/third_party/zstd/lib/decompress/huf_decompress_amd64.o
 


### PR DESCRIPTION
The .S rule had no DEPFLAGS, so asm objects (s2n-bignum wrappers, blst assembly.S, zstd amd64) never tracked their includes and stayed stale across header edits. Asm depfiles are kept in ASM_DEPFILES since asm sources have no .S/.i/.check derivations.