### PR TITLE
flamenco: vectorize fd_borrowed_account_is_zeroed

### DIFF
--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -40,6 +40,8 @@ $(call add-objs,fd_compute_budget_details,fd_flamenco)
 
 $(call add-hdrs,fd_borrowed_account.h)
 $(call add-objs,fd_borrowed_account,fd_flamenco)
+$(call make-unit-test,test_borrowed_account,test_borrowed_account,fd_flamenco fd_util)
+$(call run-unit-test,test_borrowed_account)
 
 ifdef FD_HAS_ATOMIC
 ifdef FD_HAS_HOSTED

--- a/src/flamenco/runtime/fd_borrowed_account.h
+++ b/src/flamenco/runtime/fd_borrowed_account.h
@@ -7,6 +7,12 @@
 #include "sysvar/fd_sysvar_rent.h"
 #include "program/fd_program_util.h"
 
+#if FD_HAS_AVX512
+#include "../../util/simd/fd_avx512.h"
+#elif FD_HAS_AVX
+#include "../../util/simd/fd_avx.h"
+#endif
+
 #define MAX_PERMITTED_DATA_LENGTH                 (FD_RUNTIME_ACC_SZ_MAX) /* 10MiB */
 #define MAX_PERMITTED_ACCOUNT_DATA_ALLOCS_PER_TXN (10L<<21)  /* 20MiB */
 
@@ -352,13 +358,43 @@ fd_borrowed_account_can_data_be_resized( fd_borrowed_account_t const * borrowed_
 
 FD_FN_PURE static inline int
 fd_borrowed_account_is_zeroed( fd_borrowed_account_t const * borrowed_acct ) {
-  /* TODO: optimize this */
-  uchar const * data = borrowed_acct->acc->data;
-  for( ulong i=0UL; i<borrowed_acct->acc->data_len; i++ ) {
-    if( data[i] != 0 ) {
-      return 0;
-    }
+  uchar const * data    = borrowed_acct->acc->data;
+  ulong         data_sz = borrowed_acct->acc->data_len;
+
+  /* Peel the loop to avoid unaligned accesses. */
+  while( data_sz && ( (ulong)data & 0x3fUL ) ) {
+    if( FD_UNLIKELY( *data ) ) return 0;
+    data++;
+    data_sz--;
   }
+
+#if FD_HAS_AVX512
+  while( data_sz>=512UL ) {
+    wwv_t x0 = wwv_or( wwv_ldu( data       ), wwv_ldu( data+ 64UL ) );
+    wwv_t x1 = wwv_or( wwv_ldu( data+128UL ), wwv_ldu( data+192UL ) );
+    wwv_t x2 = wwv_or( wwv_ldu( data+256UL ), wwv_ldu( data+320UL ) );
+    wwv_t x3 = wwv_or( wwv_ldu( data+384UL ), wwv_ldu( data+448UL ) );
+    wwv_t x  = wwv_or( wwv_or( x0, x1 ), wwv_or( x2, x3 ) );
+    if( FD_UNLIKELY( _mm512_test_epi64_mask( x, x ) ) ) return 0;
+    data    += 512UL;
+    data_sz -= 512UL;
+  }
+#elif FD_HAS_AVX
+  while( data_sz>=256UL ) {
+    wv_t x0 = wv_or( wv_ldu( data       ), wv_ldu( data+ 32UL ) );
+    wv_t x1 = wv_or( wv_ldu( data+ 64UL ), wv_ldu( data+ 96UL ) );
+    wv_t x2 = wv_or( wv_ldu( data+128UL ), wv_ldu( data+160UL ) );
+    wv_t x3 = wv_or( wv_ldu( data+192UL ), wv_ldu( data+224UL ) );
+    wv_t x  = wv_or( wv_or( x0, x1 ), wv_or( x2, x3 ) );
+    if( FD_UNLIKELY( !_mm256_testz_si256( x, x ) ) ) return 0;
+    data    += 256UL;
+    data_sz -= 256UL;
+  }
+#endif
+
+  for( ulong i=0UL; i<data_sz; i++ )
+    if( FD_UNLIKELY( data[i] ) ) return 0;
+
   return 1;
 }
 

--- a/src/flamenco/runtime/test_borrowed_account.c
+++ b/src/flamenco/runtime/test_borrowed_account.c
@@ -1,0 +1,60 @@
+#include "../../util/fd_util_base.h"
+#include "fd_borrowed_account.h"
+#include <string.h>
+
+/* Helper to invoke fd_borrowed_account_is_zeroed on a (data,data_len) pair. */
+static int
+is_zeroed( uchar const * data, ulong data_len ) {
+  fd_acc_t              acc[1] = {0};
+  fd_borrowed_account_t ba [1] = {0};
+  acc->data     = (uchar *)data;
+  acc->data_len = data_len;
+  ba->acc       = acc;
+  return fd_borrowed_account_is_zeroed( ba );
+}
+
+static uchar scratch[ 8192 ] __attribute__((aligned(4096)));
+static ulong const test_sz[] = { 0UL, 1UL, 63UL, 64UL, 65UL, 255UL, 256UL, 257UL,
+                                 300UL, 511UL, 512UL, 513UL, 700UL, 1023UL, 1024UL,
+                                 1025UL, 1536UL, 2048UL };
+#define TEST_SZ_CNT (sizeof(test_sz)/sizeof(test_sz[0]))
+
+/* Start offsets mimic account data that is not 64-byte aligned. */
+static ulong const test_off[] = { 0UL, 1UL, 8UL, 24UL, 40UL, 63UL };
+#define TEST_OFF_CNT (sizeof(test_off)/sizeof(test_off[0]))
+
+static void
+test_is_zeroed( void ) {
+  FD_LOG_NOTICE(( "Testing fd_borrowed_account_is_zeroed" ));
+
+  /* Test case 1: an empty account (data==NULL, len==0) is zeroed. */
+  FD_TEST( is_zeroed( NULL, 0UL )==1 );
+
+  /* Test case 2: sweep size and start offset. */
+  for( ulong oi=0UL; oi<TEST_OFF_CNT; oi++ ) {
+    for( ulong si=0UL; si<TEST_SZ_CNT; si++ ) {
+      uchar * data = scratch + test_off[ oi ];
+      ulong   sz   = test_sz[ si ];
+
+      memset( data, 0, sz );
+      FD_TEST( is_zeroed( data, sz )==1 );
+
+      for( ulong pos=0UL; pos<sz; pos++ ) {
+        data[ pos ] = 0xff; FD_TEST( is_zeroed( data, sz )==0 );
+        data[ pos ] = 0x00; FD_TEST( is_zeroed( data, sz )==1 );
+      }
+    }
+  }
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  test_is_zeroed();
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}


### PR DESCRIPTION
`fd_borrowed_account_is_zeroed` was using a byte-by-byte scan.

This PR implements AVX512 and AVX2 vectorization for that function.