### PR TITLE
config: disable UBSan signed-integer-overflow

### DIFF
--- a/config/extra/with-ubsan.mk
+++ b/config/extra/with-ubsan.mk
@@ -19,8 +19,8 @@ CPPFLAGS+=-fsanitize=undefined \
           -fsanitize=vla-bound \
           -fsanitize=null \
           -fsanitize=return \
-          -fsanitize=signed-integer-overflow \
           -fsanitize=bounds \
+          -fno-sanitize=signed-integer-overflow \
           -fsanitize=alignment \
           -fsanitize=object-size \
           -fsanitize=float-divide-by-zero \


### PR DESCRIPTION
Firedancer builds with -fwrapv, thus these are false positives.
