### PR TITLE
xdp: fix uninitialized padding in bpf(2) syscalls

### DIFF
--- a/src/waltz/ebpf/fd_linux_bpf.h
+++ b/src/waltz/ebpf/fd_linux_bpf.h
@@ -34,11 +34,11 @@ static inline int
 fd_bpf_map_get_next_key( int          map_fd,
                          void const * key,
                          void       * next_key ) {
-  union bpf_attr attr = {
-    .map_fd   = (uint)map_fd,
-    .key      = (ulong)key,
-    .next_key = (ulong)next_key
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.map_fd   = (uint)map_fd;
+  attr.key      = (ulong)key;
+  attr.next_key = (ulong)next_key;
   return (int)bpf( BPF_MAP_GET_NEXT_KEY, &attr, sizeof(union bpf_attr) );
 }
 
@@ -57,12 +57,12 @@ fd_bpf_map_update_elem( int          map_fd,
                         void const * key,
                         void const * value,
                         ulong        flags ) {
-  union bpf_attr attr = {
-    .map_fd   = (uint)map_fd,
-    .key      = (ulong)key,
-    .value    = (ulong)value,
-    .flags    = flags
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.map_fd = (uint)map_fd;
+  attr.key    = (ulong)key;
+  attr.value  = (ulong)value;
+  attr.flags  = flags;
   return (int)bpf( BPF_MAP_UPDATE_ELEM, &attr, sizeof(union bpf_attr) );
 }
 
@@ -76,10 +76,10 @@ fd_bpf_map_update_elem( int          map_fd,
 static inline int
 fd_bpf_map_delete_elem( int          map_fd,
                         void const * key ) {
-  union bpf_attr attr = {
-    .map_fd   = (uint)map_fd,
-    .key      = (ulong)key
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.map_fd = (uint)map_fd;
+  attr.key    = (ulong)key;
   return (int)bpf( BPF_MAP_DELETE_ELEM, &attr, sizeof(union bpf_attr) );
 }
 
@@ -91,9 +91,9 @@ fd_bpf_map_delete_elem( int          map_fd,
 
 static inline int
 fd_bpf_obj_get( char const * pathname ) {
-  union bpf_attr attr = {
-    .pathname = (ulong)pathname
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.pathname = (ulong)pathname;
   return (int)bpf( BPF_OBJ_GET, &attr, sizeof(union bpf_attr) );
 }
 
@@ -106,10 +106,10 @@ fd_bpf_obj_get( char const * pathname ) {
 static inline int
 fd_bpf_obj_pin( int          bpf_fd,
                 char const * pathname ) {
-  union bpf_attr attr = {
-    .bpf_fd   = (uint)bpf_fd,
-    .pathname = (ulong)pathname
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.bpf_fd   = (uint)bpf_fd;
+  attr.pathname = (ulong)pathname;
   return (int)bpf( BPF_OBJ_PIN, &attr, sizeof(union bpf_attr) );
 }
 

--- a/src/waltz/xdp/fd_xdp1.c
+++ b/src/waltz/xdp/fd_xdp1.c
@@ -266,13 +266,13 @@ fd_xdp_install( uint           if_idx,
 
   /* Create XSK map */
 
-  union bpf_attr attr2 = {
-    .map_type    = BPF_MAP_TYPE_XSKMAP,
-    .key_size    = 4U,
-    .value_size  = 4U,
-    .max_entries = 256U,
-    .map_name    = "fd_xdp_xsks"
-  };
+  union bpf_attr attr2;
+  memset( &attr2, 0, sizeof(union bpf_attr) );
+  attr2.map_type    = BPF_MAP_TYPE_XSKMAP;
+  attr2.key_size    = 4U;
+  attr2.value_size  = 4U;
+  attr2.max_entries = 256U;
+  fd_memcpy( attr2.map_name, "fd_xdp_xsks", sizeof("fd_xdp_xsks") );
   int xsk_map_fd = (int)bpf( BPF_MAP_CREATE, &attr2, sizeof(union bpf_attr) );
   if( FD_UNLIKELY( -1==xsk_map_fd ) ) FD_LOG_ERR(( "Failed to create XSKMAP (%i-%s)", errno, fd_io_strerror( errno ) ));
 
@@ -283,11 +283,8 @@ fd_xdp_install( uint           if_idx,
 
   char ebpf_kern_log[ 32768UL ];
 
-  /* Work around a compiler bug: Clang+ASan fails to zero-initialize the
-     entire struct if we use union assignment syntax.  (It memsets 148
-     bytes instead of 152, leaving 4 trailing bytes uninitialized, which
-     fails in BPF_PROG_LOAD) */
-  union bpf_attr attr = {0};
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
   attr.prog_type = BPF_PROG_TYPE_XDP;
   attr.insn_cnt  = (uint)code_cnt;
   attr.insns     = (ulong)code_buf;

--- a/src/waltz/xdp/test_xdp_ebpf.c
+++ b/src/waltz/xdp/test_xdp_ebpf.c
@@ -54,16 +54,16 @@ load_prog( ulong * code_buf,
            ulong   code_cnt ) {
   static char ebpf_kern_log[ 32768UL ];
   ebpf_kern_log[0] = 0;
-  union bpf_attr attr = {
-    .prog_type = BPF_PROG_TYPE_XDP,
-    .insn_cnt  = (uint)code_cnt,
-    .insns     = (ulong)code_buf,
-    .license   = (ulong)"Apache-2.0",
-    .prog_name = "fd_redirect",
-    .log_level = 6,
-    .log_size  = 32768UL,
-    .log_buf   = (ulong)ebpf_kern_log
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.prog_type = BPF_PROG_TYPE_XDP;
+  attr.insn_cnt  = (uint)code_cnt;
+  attr.insns     = (ulong)code_buf;
+  attr.license   = (ulong)"Apache-2.0";
+  fd_memcpy( attr.prog_name, "fd_redirect", sizeof("fd_redirect") );
+  attr.log_level = 6;
+  attr.log_size  = 32768UL;
+  attr.log_buf   = (ulong)ebpf_kern_log;
   prog_fd = (int)bpf( BPF_PROG_LOAD, &attr, sizeof(union bpf_attr) );
   if( FD_UNLIKELY( prog_fd<0 ) ) {
     if( errno==EPERM ) {
@@ -91,13 +91,11 @@ prog_test( uchar const * pkt,
   int rx_queue = 0;
   FD_TEST( 0==fd_bpf_map_update_elem( xsks_fd, &rx_queue, &xsk_fd, 0UL ) );
 
-  union bpf_attr attr = {
-    .test = {
-      .prog_fd      = (uint)prog_fd,
-      .data_in      = (ulong)pkt,
-      .data_size_in = (uint)pkt_sz
-    }
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.test.prog_fd      = (uint)prog_fd;
+  attr.test.data_in      = (ulong)pkt;
+  attr.test.data_size_in = (uint)pkt_sz;
   FD_XDP_TEST( 0==bpf( BPF_PROG_TEST_RUN, &attr, sizeof(union bpf_attr) ) );
 
   FD_LOG_INFO(( "bpf test %s returned %#x expected %#x", name, attr.test.retval, expected_action));
@@ -340,13 +338,13 @@ int main( int     argc,
 
   /* Create maps */
 
-  union bpf_attr attr = {
-    .map_type    = BPF_MAP_TYPE_XSKMAP,
-    .key_size    = 4U,
-    .value_size  = 4U,
-    .max_entries = 4U,
-    .map_name    = "fd_xdp_xsks"
-  };
+  union bpf_attr attr;
+  memset( &attr, 0, sizeof(union bpf_attr) );
+  attr.map_type    = BPF_MAP_TYPE_XSKMAP;
+  attr.key_size    = 4U;
+  attr.value_size  = 4U;
+  attr.max_entries = 4U;
+  fd_memcpy( attr.map_name, "fd_xdp_xsks", sizeof("fd_xdp_xsks") );
   xsks_fd = (int)bpf( BPF_MAP_CREATE, &attr, sizeof(union bpf_attr) );
   if( FD_UNLIKELY( xsks_fd<0 ) ) {
     if( FD_UNLIKELY( errno==EPERM ) ) {


### PR DESCRIPTION
struct assignment syntax with 'union bpf_attr' leaves ranges
uninitialized that the kernel rejects with EINVAL
