### PR TITLE
alpenglow, runtime: fix alpenclock lamport balance

### DIFF
--- a/src/flamenco/runtime/fd_runtime.c
+++ b/src/flamenco/runtime/fd_runtime.c
@@ -1753,11 +1753,18 @@ apply_footer( fd_bank_t *               bank,
   fd_pubkey_t alpenclock_addr;
   fd_alpenglow_pda( "alpenclock", &alpenclock_addr );
 
-  /* size the alpenclock balance with default rent */
+  /* size the alpenclock balance with exactly the default rent, any
+     excess lamports must be burned */
   uchar data[ 8UL ];
   FD_STORE( ulong, data, producer_time_nanos );
-  fd_accdb_svm_write( bank, accdb, capture_ctx, &alpenclock_addr, &fd_solana_system_program_id,
-                      data, sizeof(data), fd_rent_exempt_minimum_balance( &FD_RENT_DEFAULT_PARAMS, sizeof(data) ), 0 );
+  fd_accdb_svm_update_t update[1];
+  fd_acc_t acc = fd_accdb_svm_open_rw( bank, accdb, update, &alpenclock_addr, 1 );
+  acc.lamports = fd_rent_exempt_minimum_balance( &FD_RENT_DEFAULT_PARAMS, sizeof(data) );
+  fd_memcpy( acc.owner, fd_solana_system_program_id.uc, sizeof(fd_pubkey_t) );
+  acc.executable = 0;
+  acc.data_len   = sizeof(data);
+  fd_memcpy( acc.data, data, sizeof(data) );
+  fd_accdb_svm_close_rw( bank, accdb, capture_ctx, &acc, update );
 
   return fd_alpen_rewards_apply( bank, accdb, capture_ctx, certs, producer_time_nanos );
 }

--- a/src/flamenco/runtime/tests/run_backtest_all.sh
+++ b/src/flamenco/runtime/tests/run_backtest_all.sh
@@ -166,3 +166,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l relax_fee_payer_constraint 
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-legacy-vote-ixs --alpenglow -m 2000000 -e 126
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-deactivated-stake --alpenglow -m 2000000 -e 810
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-leader-credits --alpenglow -m 2000000 -e 3915
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-alpenclock-lamports --alpenglow -m 2000000 -e 280

--- a/src/flamenco/runtime/tests/run_backtest_ci.sh
+++ b/src/flamenco/runtime/tests/run_backtest_ci.sh
@@ -43,3 +43,4 @@ src/flamenco/runtime/tests/run_ledger_backtest.sh -l programdata-poison -m 10000
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-legacy-vote-ixs --alpenglow -m 2000000 -e 126
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-deactivated-stake --alpenglow -m 2000000 -e 810
 src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-leader-credits --alpenglow -m 2000000 -e 3915
+src/flamenco/runtime/tests/run_ledger_backtest.sh -l alpenglow-alpenclock-lamports --alpenglow -m 2000000 -e 280


### PR DESCRIPTION
any excess lamports that may have been sent to the alpenclock account should be burnt