### PR TITLE
replay: tighten block marker length-prefix check

### DIFF
--- a/src/discof/replay/fd_block_marker.c
+++ b/src/discof/replay/fd_block_marker.c
@@ -274,16 +274,17 @@ fd_block_marker_de( fd_block_marker_t * marker,
 
   marker->variant = variant;
 
-  /* payload deserializer may consume less than length */
-  int err;
+  int   err;
+  ulong payload_sz;
   switch( variant ) {
-    case FOOTER:        err = fd_block_footer_de ( &marker->footer,        buf, length, NULL ); break;
-    case HEADER:        err = fd_block_header_de ( &marker->header,        buf, length, NULL ); break;
-    case UPDATE_PARENT: err = fd_update_parent_de( &marker->update_parent, buf, length, NULL ); break;
+    case FOOTER:        err = fd_block_footer_de ( &marker->footer,        buf, length, &payload_sz ); break;
+    case HEADER:        err = fd_block_header_de ( &marker->header,        buf, length, &payload_sz ); break;
+    case UPDATE_PARENT: err = fd_update_parent_de( &marker->update_parent, buf, length, &payload_sz ); break;
     case GENESIS_CERTIFICATE: return FD_BLOCK_MARKER_DE_ERR_UNSUPPORTED;
     default:                  return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
   }
   if( FD_UNLIKELY( err ) ) return err;
+  if( FD_UNLIKELY( payload_sz!=length ) ) return FD_BLOCK_MARKER_DE_ERR_MALFORMED;
   ADVANCE( length );
 
   if( buf_sz ) *buf_sz = buf_max-rem;

--- a/src/discof/replay/test_block_marker.c
+++ b/src/discof/replay/test_block_marker.c
@@ -456,6 +456,25 @@ test_errors( void ) {
   emit_u8( 1 ); emit_rep( 0x66, 32UL ); emit_u64( 0UL ); emit_u8( 0 );
   emit_u8( 2 ); /* block_final_cert tag */
   FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  /* LengthPrefixed is exact: a length prefix larger than the payload's
+     serialized size is malformed even when the bytes are present */
+  emit_reset();
+  emit_preamble( HEADER, (ushort)42 );
+  emit_u8( 1 ); emit_rep( 0, 40UL ); emit_u8( 0xee ); /* one byte of padding */
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  emit_reset();
+  emit_preamble( UPDATE_PARENT, (ushort)42 );
+  emit_u8( 1 ); emit_rep( 0, 40UL ); emit_u8( 0xee );
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
+
+  emit_reset();
+  emit_preamble( FOOTER, (ushort)(1UL+32UL+8UL+1UL+3UL+1UL) );
+  emit_u8( 1 ); emit_rep( 0x66, 32UL ); emit_u64( 0UL ); emit_u8( 0 );
+  emit_u8( 0 ); emit_u8( 0 ); emit_u8( 0 ); /* all certs None */
+  emit_u8( 0xee );                          /* one byte of padding */
+  FD_TEST( fd_block_marker_de( marker, g_buf, g_sz, NULL )==FD_BLOCK_MARKER_DE_ERR_MALFORMED );
 }
 
 /* roundtrip re-encodes the marker occupying g_buf[0,marker_sz) and


### PR DESCRIPTION
Agave's block validity checks were more restrictive than ours
regarding whether a block footer/header's deserialized length
matches the length prefix.

Closes #11308
