### PR TITLE
mlx5: detect if ib_uverbs is missing

### DIFF
--- a/src/app/shared/fd_config_auto.c
+++ b/src/app/shared/fd_config_auto.c
@@ -30,6 +30,7 @@ struct fd_auto_info {
   uint bonded_if_slave_count;
   int  is_using_gre;
   int  has_mlx5_rdma_port;
+  int  has_uverbs;
 };
 typedef struct fd_auto_info fd_auto_info_t;
 
@@ -255,6 +256,7 @@ mlx5_check( fd_config_t    const * config,
             fd_auto_info_t const * info ) {
   if( strcmp( config->net.provider, "auto" ) ) return 0;
   if( !info->has_mlx5_rdma_port ) return 0;
+  if( !info->has_uverbs ) return 0;
   if( !fd_ulong_is_pow2( config->layout.net_tile_count ) ) return 0;
   return 1;
 }
@@ -466,6 +468,7 @@ scrape_networking( fd_auto_info_t * info,
     char rdma_name[ FD_MLX5_RDMA_NAME_MAX ];
     uint rdma_port;
     info->has_mlx5_rdma_port = fd_mlx5_rdma_dev_find( rdma_name, &rdma_port, if_name );
+    info->has_uverbs         = fd_mlx5_uverbs_avail();
   }
 }
 

--- a/src/app/shared/test_config_auto.c
+++ b/src/app/shared/test_config_auto.c
@@ -33,7 +33,8 @@ main( int     argc,
   /* Auto selects mlx5 only for a supported driver, kernel, RDMA port,
      and tile count.  Otherwise it falls back to XDP. */
 
-  fd_auto_info_t info1 = { .linux_major=7, .linux_minor=0, .driver="mlx5_core", .has_mlx5_rdma_port=1 };
+  fd_auto_info_t info1 = { .linux_major=7, .linux_minor=0, .driver="mlx5_core",
+                           .has_mlx5_rdma_port=1, .has_uverbs=1 };
 
   reset_provider_auto( 1U );
   fd_auto_net( config, &info1 );
@@ -57,6 +58,15 @@ main( int     argc,
   fd_auto_info_t info_no_rdma = info1;
   info_no_rdma.has_mlx5_rdma_port = 0;
   fd_auto_net( config, &info_no_rdma );
+  FD_TEST( 0==strcmp( config->net.provider, "xdp" ) );
+
+  /* An RDMA device without the uverbs API (ib_uverbs not loaded) must
+     fall back to XDP -- the mlx5 tile cannot open the device. */
+
+  reset_provider_auto( 1U );
+  fd_auto_info_t info_no_uverbs = info1;
+  info_no_uverbs.has_uverbs = 0;
+  fd_auto_net( config, &info_no_uverbs );
   FD_TEST( 0==strcmp( config->net.provider, "xdp" ) );
 
   /* Explicit providers bypass automatic provider requirements. */

--- a/src/disco/net/mlx5/fd_mlx5.c
+++ b/src/disco/net/mlx5/fd_mlx5.c
@@ -323,6 +323,12 @@ fd_mlx5_rdma_dev_find( char         rdma_name[ FD_MLX5_RDMA_NAME_MAX ],
   return 1;
 }
 
+int
+fd_mlx5_uverbs_avail( void ) {
+  struct stat class_stat;
+  return !stat( "/sys/class/infiniband_verbs", &class_stat ) && S_ISDIR( class_stat.st_mode );
+}
+
 struct fd_mlx5_pd {
   fd_uverbs_ctx_t * ctx;    /* uverbs context */
   uint              handle; /* protection domain handle */

--- a/src/disco/net/mlx5/fd_mlx5.h
+++ b/src/disco/net/mlx5/fd_mlx5.h
@@ -19,6 +19,9 @@ fd_mlx5_rdma_dev_find( char         rdma_name[ FD_MLX5_RDMA_NAME_MAX ],
                        uint *       rdma_port,
                        char const * interface_name );
 
+int
+fd_mlx5_uverbs_avail( void );
+
 FD_PROTOTYPES_END
 
 #endif /* defined(__linux__) */

--- a/src/disco/net/mlx5/fd_mlx5_tile.c
+++ b/src/disco/net/mlx5/fd_mlx5_tile.c
@@ -1292,6 +1292,10 @@ fd_topo_install_mlx5( fd_topo_t *     topo,
   }
 
   fd_mlx5_tile_t * first = ctxs[ 0 ];
+  if( FD_UNLIKELY( !fd_mlx5_uverbs_avail() ) ) {
+    FD_LOG_ERR(( "cannot run mlx5 tile: kernel does not provide uverbs API "
+                 "(ib_uverbs kernel module missing or NIC not Mellanox?)" ));
+  }
   FD_LOG_INFO(( "Opening direct mlx5 device `%s` port %u for %lu tiles",
                 rdma_device_name, rdma_port_num, tile_cnt ));
   if( FD_UNLIKELY( !fd_uverbs_init( &first->uverbs, queues, tile_cnt,


### PR DESCRIPTION
our CI host had a Mellanox NIC but the ib_uverbs module was not
loaded.  This resulted in firedancer(-dev) startup issues because
auto mode picked mlx5, but mlx5 couldn't init.

- net: do not auto-pick mlx5 if /dev/infiniband/uverbs* missing
- mlx5: human-readable error message if uverbs socket missing
