### PR TITLE
gossip: fix 3 byte OOB write

### DIFF
--- a/src/flamenco/gossip/fd_gossip_message.c
+++ b/src/flamenco/gossip/fd_gossip_message.c
@@ -291,6 +291,7 @@ deser_duplicate_shred( fd_gossip_value_t * value,
   READ_U8( value->duplicate_shred->chunk_index, payload, payload_sz );
   CHECK( value->duplicate_shred->chunk_index<value->duplicate_shred->num_chunks );
   READ_U64( value->duplicate_shred->chunk_len, payload, payload_sz );
+  CHECK( value->duplicate_shred->chunk_len<=sizeof(value->duplicate_shred->chunk) );
   READ_BYTES( value->duplicate_shred->chunk, value->duplicate_shred->chunk_len, payload, payload_sz );
   return 1;
 }


### PR DESCRIPTION
benign OOB write into padding

Octane report:

  Out-of-bounds write in deser_duplicate_shred:
  a DUPLICATE_SHRED-typed CRDS value embedded in a PULL_REQUEST
  reaches the parser with a 3-byte-smaller preamble, letting
  unvalidated chunk_len (up to 1058) exceed chunk[1055] and
  overflow the array.
