### PR TITLE
quic: switch to ChaCha8 CSPRNG 

### DIFF
--- a/src/ballet/chacha/fd_chacha_rng.h
+++ b/src/ballet/chacha/fd_chacha_rng.h
@@ -187,6 +187,25 @@ fd_chacha_rng_ulong( fd_chacha_rng_t * rng ) {
   return x;
 }
 
+/* fd_chacha_rng_read32 reads 32 bytes from the RNG stream into buf.
+   buf may be unaligned. */
+
+static inline void
+fd_chacha_rng_read32( fd_chacha_rng_t * rng,
+                      void *            buf ) {
+  rng->buf_off = fd_ulong_align_up( rng->buf_off, 32UL );
+  if( FD_UNLIKELY( fd_chacha_rng_avail( rng )<32UL ) ) {
+    if( rng->algo==FD_CHACHA_RNG_ALGO_CHACHA8 ) {
+      fd_chacha8_rng_private_refill( rng );
+    } else {
+      fd_chacha20_rng_private_refill( rng );
+    }
+  }
+
+  fd_memcpy( buf, rng->buf + (rng->buf_off % FD_CHACHA_RNG_BUFSZ), 32UL );
+  rng->buf_off += 32UL;
+}
+
 /* fd_chacha_rng_ulong_roll returns an uniform IID rand in [0,n)
    analogous to fd_rng_ulong_roll.  Rejection method based using
    fd_chacha_rng_ulong.

--- a/src/ballet/chacha/test_chacha_rng.c
+++ b/src/ballet/chacha/test_chacha_rng.c
@@ -173,6 +173,59 @@ main( int     argc,
     FD_LOG_NOTICE(( "OK: 64-bit counter" ));
   }
 
+  /* Test fd_chacha_rng_read32 */
+
+  {
+    /* Reference stream: the first 8 blocks of ChaCha8 keystream */
+    uchar ref[ 8*FD_CHACHA_BLOCK_SZ ] __attribute__((aligned(64)));
+    for( ulong i=0UL; i<8UL; i++ ) {
+      uint idx_nonce[4] __attribute__((aligned(16))) = { (uint)i, 0U, 0U, 0U };
+      fd_chacha8_block( ref + i*FD_CHACHA_BLOCK_SZ, key, idx_nonce );
+    }
+
+    /* Sequential aligned reads walk the stream and advance the cursor
+       by 32 each, crossing at least one buffer refill */
+
+    FD_TEST( fd_chacha_rng_init( rng, key, FD_CHACHA_RNG_ALGO_CHACHA8 ) );
+    for( ulong i=0UL; i<sizeof(ref)/32UL; i++ ) {
+      uchar out[ 33 ]; /* read into an unaligned address */
+      fd_chacha_rng_read32( rng, out+1 );
+      FD_TEST( !memcmp( out+1, ref + i*32UL, 32UL ) );
+      FD_TEST( rng->buf_off==(i+1UL)*32UL );
+    }
+
+    /* A read32 following an 8 byte read aligns up, discarding the 24
+       bytes in between */
+
+    uchar out32[ 32 ];
+    FD_TEST( fd_chacha_rng_init( rng, key, FD_CHACHA_RNG_ALGO_CHACHA8 ) );
+    FD_TEST( fd_chacha_rng_ulong( rng )==FD_LOAD( ulong, ref ) );
+    FD_TEST( rng->buf_off==8UL );
+    fd_chacha_rng_read32( rng, out32 );
+    FD_TEST( !memcmp( out32, ref+32, 32UL ) );
+    FD_TEST( rng->buf_off==64UL );
+
+    /* An 8 byte read following a read32 continues at the next 8 bytes */
+
+    FD_TEST( fd_chacha_rng_ulong( rng )==FD_LOAD( ulong, ref+64 ) );
+    FD_TEST( rng->buf_off==72UL );
+
+    /* Read right up to the refill boundary, then across it */
+
+    FD_TEST( fd_chacha_rng_init( rng, key, FD_CHACHA_RNG_ALGO_CHACHA8 ) );
+    ulong fill = rng->buf_fill;
+    FD_TEST( fill && fd_ulong_is_aligned( fill, FD_CHACHA_BLOCK_SZ ) );
+    for( ulong off=0UL; off<fill; off+=32UL )
+      fd_chacha_rng_read32( rng, out32 );
+    FD_TEST( rng->buf_off ==fill ); /* buffer drained exactly */
+    FD_TEST( rng->buf_fill==fill );
+    fd_chacha_rng_read32( rng, out32 ); /* forces a refill */
+    FD_TEST( rng->buf_off ==fill+32UL );
+    FD_TEST( rng->buf_fill> fill      );
+
+    FD_LOG_NOTICE(( "OK: fd_chacha_rng_read32" ));
+  }
+
   /* Test leave/delete */
 
   FD_TEST( fd_chacha_rng_leave( NULL )==NULL ); /* invalid mem */

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -318,6 +318,17 @@ fd_quic_stream_init( fd_quic_stream_t * stream ) {
   stream->upd_pkt_number     = 0;
 }
 
+FD_FN_SENSITIVE void
+fd_quic_rng_reseed( fd_quic_state_t * state ) {
+  uchar key[ FD_CHACHA_KEY_SZ ];
+  if( FD_UNLIKELY( !fd_rng_secure( key, sizeof(key) ) ) ) {
+    FD_LOG_CRIT(( "fd_rng_secure failed" ));
+  }
+  fd_chacha_rng_init( state->_rng, key, FD_CHACHA_RNG_ALGO_CHACHA8 );
+  fd_memzero_explicit( key, sizeof(key) );
+  state->rng_reseed_at = state->now + FD_QUIC_RNG_RESEED_INTERVAL;
+}
+
 FD_QUIC_API fd_quic_t *
 fd_quic_join( void * shquic ) {
 
@@ -512,13 +523,12 @@ fd_quic_init( fd_quic_t * quic ) {
     state->stream_pool = fd_quic_stream_pool_new( (void*)stream_pool_laddr, stream_pool_cnt, tx_buf_sz );
   }
 
-  /* generate a secure random number as seed for fd_rng */
-  uint rng_seed = 0;
-  int rng_seed_ok = !!fd_rng_secure( &rng_seed, sizeof(rng_seed) );
-  if( FD_UNLIKELY( !rng_seed_ok ) ) {
-    FD_LOG_ERR(( "fd_rng_secure failed" ));
+  if( FD_UNLIKELY( !fd_chacha_rng_join( fd_chacha_rng_new( state->_rng, FD_CHACHA_RNG_MODE_SHIFT ) ) ) ) {
+    FD_LOG_WARNING(( "fd_chacha_rng_new failed" ));
+    return NULL;
   }
-  fd_rng_new( state->_rng, rng_seed, 0UL );
+  fd_quic_rng_reseed( state );
+  state->rng_reseed_at = 0L;
 
   /* use rng to generate secret bytes for future RETRY token generation */
   int rng1_ok = !!fd_rng_secure( state->retry_secret, FD_QUIC_RETRY_SECRET_SZ );
@@ -1339,7 +1349,9 @@ fd_quic_send_retry( fd_quic_t *               quic,
 
   long  expire_at = state->now + quic->config.retry_ttl;
   uchar retry_pkt[ FD_QUIC_RETRY_LOCAL_SZ ];
-  ulong retry_pkt_sz = fd_quic_retry_create( retry_pkt, pkt, state->_rng, state->retry_secret, state->retry_iv, odcid, scid, new_conn_id, expire_at );
+  ulong nonce0 = fd_quic_rng_ulong( state );
+  ulong nonce1 = fd_quic_rng_ulong( state );
+  ulong retry_pkt_sz = fd_quic_retry_create( retry_pkt, pkt, nonce0, nonce1, state->retry_secret, state->retry_iv, odcid, scid, new_conn_id, expire_at );
 
   quic->metrics.retry_tx_cnt++;
 
@@ -1497,13 +1509,13 @@ fd_quic_handle_v1_initial( fd_quic_t *               quic,
         - No retry token, retry request:  generate new random ID
         - Retry token, accepted:          reuse SCID from retry token */
     if( !quic->config.retry ) {
-      scid = fd_rng_ulong( state->_rng );
+      scid = fd_quic_rng_ulong( state );
     } else { /* retry configured */
 
       /* Need to send retry? Do so before more work */
       if( initial->token_len != sizeof(fd_quic_retry_token_t) ) {
 
-        ulong new_conn_id_u64 = fd_rng_ulong( state->_rng );
+        ulong new_conn_id_u64 = fd_quic_rng_ulong( state );
         if( FD_UNLIKELY( fd_quic_send_retry(
               quic, pkt,
               dcid, peer_scid, new_conn_id_u64 ) ) ) {
@@ -4224,12 +4236,10 @@ fd_quic_connect( fd_quic_t * quic,
     }
   }
 
-  fd_rng_t * rng = state->_rng;
-
   /* create conn ids for us and them
      client creates connection id for the peer, peer immediately replaces it */
-  ulong our_conn_id_u64 = fd_rng_ulong( rng );
-  fd_quic_conn_id_t peer_conn_id;  fd_quic_conn_id_rand( &peer_conn_id, rng );
+  ulong our_conn_id_u64 = fd_quic_rng_ulong( state );
+  fd_quic_conn_id_t peer_conn_id;  fd_quic_conn_id_from_u64( &peer_conn_id, fd_quic_rng_ulong( state ) );
 
   fd_quic_conn_t * conn = fd_quic_conn_create(
       quic,

--- a/src/waltz/quic/fd_quic.c
+++ b/src/waltz/quic/fd_quic.c
@@ -473,6 +473,13 @@ fd_quic_init( fd_quic_t * quic ) {
     return NULL;
   }
 
+  if( FD_UNLIKELY( !fd_chacha_rng_join( fd_chacha_rng_new( state->_rng, FD_CHACHA_RNG_MODE_SHIFT ) ) ) ) {
+    FD_LOG_WARNING(( "fd_chacha_rng_new failed" ));
+    return NULL;
+  }
+  fd_quic_rng_reseed( state );
+  state->rng_reseed_at = 0L;
+
   /* State: Initialize TLS */
 
   fd_quic_tls_cfg_t tls_cfg = {
@@ -489,6 +496,7 @@ fd_quic_init( fd_quic_t * quic ) {
     },
 
     .cert_public_key       = quic->config.identity_public_key,
+    .rng                   = state->_rng,
 
     .alpn                  = config->alpn,
     .alpn_sz               = config->alpn_sz,
@@ -522,13 +530,6 @@ fd_quic_init( fd_quic_t * quic ) {
     ulong stream_pool_laddr = (ulong)quic + layout.stream_pool_off;
     state->stream_pool = fd_quic_stream_pool_new( (void*)stream_pool_laddr, stream_pool_cnt, tx_buf_sz );
   }
-
-  if( FD_UNLIKELY( !fd_chacha_rng_join( fd_chacha_rng_new( state->_rng, FD_CHACHA_RNG_MODE_SHIFT ) ) ) ) {
-    FD_LOG_WARNING(( "fd_chacha_rng_new failed" ));
-    return NULL;
-  }
-  fd_quic_rng_reseed( state );
-  state->rng_reseed_at = 0L;
 
   /* use rng to generate secret bytes for future RETRY token generation */
   int rng1_ok = !!fd_rng_secure( state->retry_secret, FD_QUIC_RETRY_SECRET_SZ );

--- a/src/waltz/quic/fd_quic_conn_id.h
+++ b/src/waltz/quic/fd_quic_conn_id.h
@@ -1,8 +1,7 @@
 #ifndef HEADER_fd_src_waltz_quic_fd_quic_conn_id_h
 #define HEADER_fd_src_waltz_quic_fd_quic_conn_id_h
 
-#include "../../util/fd_util_base.h"
-#include "../../util/rng/fd_rng.h"
+#include "../../util/bits/fd_bits.h"
 #include <string.h>
 
 /* TODO move this into more reasonable place */
@@ -37,25 +36,11 @@ fd_quic_conn_id_new( void const * conn_id,
   return id;
 }
 
-/* fd_quic_conn_id_rand creates a new random 8 byte conn ID.  Returns
-   conn ID.  Cannot fail. */
-
 static inline fd_quic_conn_id_t *
-fd_quic_conn_id_rand( fd_quic_conn_id_t * conn_id,
-                      fd_rng_t *          rng ) {
-
-  /* from rfc9000:
-     Each endpoint selects connection IDs using an implementation-specific (and
-       perhaps deployment-specific) method that will allow packets with that
-       connection ID to be routed back to the endpoint and to be identified by
-       the endpoint upon receipt. */
-  /* this means we can generate a connection id with the property that it can
-     be delivered to the same endpoint by flow control */
-  /* TODO load balancing / flow steering */
-
-  /* padding must be set to zero also */
+fd_quic_conn_id_from_u64( fd_quic_conn_id_t * conn_id,
+                          ulong               v ) {
   *conn_id = (fd_quic_conn_id_t){ .sz = 8u, .conn_id = {0u}, .pad = {0u} };
-  FD_STORE( ulong, conn_id->conn_id, fd_rng_ulong( rng ) );
+  FD_STORE( ulong, conn_id->conn_id, v );
   return conn_id;
 }
 

--- a/src/waltz/quic/fd_quic_private.h
+++ b/src/waltz/quic/fd_quic_private.h
@@ -13,6 +13,7 @@
 #include "fd_quic_svc_q.h"
 #include <math.h>
 
+#include "../../ballet/chacha/fd_chacha_rng.h"
 #include "../../util/log/fd_dtrace.h"
 #include "../../util/net/fd_ip4.h"
 #include "../../util/net/fd_udp.h"
@@ -83,7 +84,8 @@ struct __attribute__((aligned(16UL))) fd_quic_state_private {
 
   fd_quic_stream_pool_t * stream_pool;    /* stream pool, nullable */
   fd_quic_pkt_meta_t    * pkt_meta_pool;
-  fd_rng_t                _rng[1];        /* random number generator */
+  fd_chacha_rng_t         _rng[1];        /* CSPRNG, see fd_quic_rng_ulong */
+  long                    rng_reseed_at;  /* rekey _rng at the first refill due at/after this timestamp */
 
   /* need to be able to access connections by index */
   ulong                   conn_base;      /* address of array of all connections */
@@ -153,6 +155,19 @@ fd_quic_get_state( fd_quic_t * quic ) {
 FD_FN_CONST static inline fd_quic_state_t const *
 fd_quic_get_state_const( fd_quic_t const * quic ) {
   return (fd_quic_state_t const *)( (ulong)quic + FD_QUIC_STATE_OFF );
+}
+
+#define FD_QUIC_RNG_RESEED_INTERVAL ((long)300e9) /* 5 minutes */
+
+FD_FN_SENSITIVE void
+fd_quic_rng_reseed( fd_quic_state_t * state );
+
+static inline ulong
+fd_quic_rng_ulong( fd_quic_state_t * state ) {
+  if( FD_UNLIKELY( state->now >= state->rng_reseed_at ) ) {
+    fd_quic_rng_reseed( state );
+  }
+  return fd_chacha_rng_ulong( state->_rng );
 }
 
 /* fd_quic_conn_service is called periodically to perform pending

--- a/src/waltz/quic/fd_quic_retry.c
+++ b/src/waltz/quic/fd_quic_retry.c
@@ -58,7 +58,8 @@ ulong
 fd_quic_retry_create(
     uchar                     retry[FD_QUIC_RETRY_LOCAL_SZ], /* out */
     fd_quic_pkt_t const *     pkt,
-    fd_rng_t *                rng,
+    ulong                     nonce0,
+    ulong                     nonce1,
     uchar const               retry_secret[ FD_QUIC_RETRY_SECRET_SZ ],
     uchar const               retry_iv[ FD_QUIC_RETRY_IV_SZ ],
     fd_quic_conn_id_t const * orig_dst_conn_id,
@@ -95,7 +96,7 @@ fd_quic_retry_create(
   uint   src_ip4_addr = pkt->ip4->saddr;  /* net order */
   ushort src_udp_port = (ushort)fd_ushort_bswap( (ushort)pkt->udp->net_sport );
 
-  fd_quic_retry_data_new( &retry_token->data, rng );
+  fd_quic_retry_data_new( &retry_token->data, nonce0, nonce1 );
   fd_quic_retry_data_set_ip4( &retry_token->data, src_ip4_addr );
   retry_token->data.udp_port    = (ushort)src_udp_port;
   retry_token->data.expire_comp = (ulong)( expire_at >> FD_QUIC_RETRY_EXPIRE_SHIFT );

--- a/src/waltz/quic/fd_quic_retry.h
+++ b/src/waltz/quic/fd_quic_retry.h
@@ -81,10 +81,10 @@ FD_PROTOTYPES_END
 
    Security Note: This scheme relies on a 128-bit auth key and 96-bit
    unique nonces.  The encryption key is sourced from CSPRNG on startup
-   and stays secret.  Nonces are generated using fd_rng_t (fine if an
-   attacker can guess these nonces).  However, if fd_rng_t generates the
-   same 96-bit nonce twice, the retry token authentication mechanism
-   breaks down entirely (AES-GCM IV reuse). */
+   and stays secret.  Nonces only have to be unique, not unguessable,
+   but if the same 96-bit nonce is ever generated twice the retry token
+   authentication mechanism breaks down entirely (AES-GCM IV reuse).
+   Callers therefore source them from fd_quic_rng_ulong. */
 
 /* fd_quic_retry_data_t encodes data within the QUIC Retry token.
    It contains claims about the client. */
@@ -118,18 +118,17 @@ typedef struct fd_quic_retry_token fd_quic_retry_token_t;
 
 FD_PROTOTYPES_BEGIN
 
-/* fd_quic_retry_data_new initializes fd_quic_retry_data_t with a random
-   nonce.  Uses fd_rng_t because only random (unique) bytes are required
-   but it is not required that they are unguessable. */
+/* fd_quic_retry_data_new initializes fd_quic_retry_data_t with a
+   randomly generated 96-bit nonce. */
 
 static inline fd_quic_retry_data_t *
 fd_quic_retry_data_new( fd_quic_retry_data_t * data,
-                        fd_rng_t *             rng ) {
+                        ulong                  nonce0,    /* rand */
+                        ulong                  nonce1 ) { /* rand */
   memset( data, 0, sizeof(fd_quic_retry_data_t) );
   data->magic = FD_QUIC_RETRY_TOKEN_MAGIC;
-  FD_STORE( uint, data->token_id + 0, fd_rng_uint( rng ) );
-  FD_STORE( uint, data->token_id + 4, fd_rng_uint( rng ) );
-  FD_STORE( uint, data->token_id + 8, fd_rng_uint( rng ) );
+  FD_STORE( ulong, data->token_id + 0, nonce0         );
+  FD_STORE( uint,  data->token_id + 8, (uint)nonce1   );
   return data;
 }
 
@@ -202,13 +201,15 @@ FD_PROTOTYPES_BEGIN
 
    orig_dst_conn_id is the DCID chosen by the client in the Initial that
    triggered a Retry.  retry_src_conn_id is the SCID chosen by the server
-   in the Retry packet. */
+   in the Retry packet.  nonce0 and nonce1 are the two halves of the
+   token's single 96-bit AES-GCM nonce. */
 
 ulong
 fd_quic_retry_create(
     uchar                     retry[FD_QUIC_RETRY_LOCAL_SZ], /* out */
     fd_quic_pkt_t const *     pkt,
-    fd_rng_t *                rng,
+    ulong                     nonce0, /* rand */
+    ulong                     nonce1, /* rand */
     uchar const               retry_secret[ FD_QUIC_RETRY_SECRET_SZ ],
     uchar const               retry_iv[ FD_QUIC_RETRY_IV_SZ ],
     fd_quic_conn_id_t const * orig_dst_conn_id,

--- a/src/waltz/quic/tests/test_quic_conformance.c
+++ b/src/waltz/quic/tests/test_quic_conformance.c
@@ -1026,6 +1026,56 @@ FD_UNIT_TEST( quic_datagram_express_tx ) {
   FD_TEST( conn->pkt_number[2]==pkt_num+1UL );
 }
 
+/* fd_quic_rng_ulong periodically rekeys the CSPRNG.  Verify that it only
+   does so at/after the deadline, and that the deadline advances. */
+
+FD_UNIT_TEST( quic_rng_reseed ) {
+  fd_quic_sandbox_init( sandbox, FD_QUIC_ROLE_SERVER );
+  fd_quic_state_t * state = fd_quic_get_state( sandbox->quic );
+
+  long const t0 = 1000000000L;
+  state->now           = t0;
+  state->rng_reseed_at = t0 + FD_QUIC_RNG_RESEED_INTERVAL;
+
+  uchar key0[ FD_CHACHA_KEY_SZ ];
+  memcpy( key0, state->_rng->key, sizeof(key0) );
+
+  /* No reseed strictly before the deadline */
+
+  for( ulong i=0UL; i<1024UL; i++ ) fd_quic_rng_ulong( state );
+  FD_TEST( state->rng_reseed_at==t0+FD_QUIC_RNG_RESEED_INTERVAL );
+  FD_TEST( !memcmp( state->_rng->key, key0, sizeof(key0) ) );
+
+  state->now = state->rng_reseed_at - 1L;
+  fd_quic_rng_ulong( state );
+  FD_TEST( state->rng_reseed_at==t0+FD_QUIC_RNG_RESEED_INTERVAL );
+  FD_TEST( !memcmp( state->_rng->key, key0, sizeof(key0) ) );
+
+  /* Reseed exactly at the deadline */
+
+  state->now = state->rng_reseed_at;
+  long const t1 = state->now;
+  fd_quic_rng_ulong( state );
+  FD_TEST( state->rng_reseed_at==t1+FD_QUIC_RNG_RESEED_INTERVAL );
+  FD_TEST( memcmp( state->_rng->key, key0, sizeof(key0) )!=0 );
+
+  /* ... and not again until the new deadline */
+
+  memcpy( key0, state->_rng->key, sizeof(key0) );
+  state->now = state->rng_reseed_at - 1L;
+  for( ulong i=0UL; i<1024UL; i++ ) fd_quic_rng_ulong( state );
+  FD_TEST( state->rng_reseed_at==t1+FD_QUIC_RNG_RESEED_INTERVAL );
+  FD_TEST( !memcmp( state->_rng->key, key0, sizeof(key0) ) );
+
+  /* A clock jump well past the deadline reseeds once */
+
+  state->now = state->rng_reseed_at + 3L*FD_QUIC_RNG_RESEED_INTERVAL;
+  long const t2 = state->now;
+  fd_quic_rng_ulong( state );
+  FD_TEST( state->rng_reseed_at==t2+FD_QUIC_RNG_RESEED_INTERVAL );
+  FD_TEST( memcmp( state->_rng->key, key0, sizeof(key0) )!=0 );
+}
+
 int
 main( int     argc,
       char ** argv ) {

--- a/src/waltz/quic/tests/test_quic_retry_unit.c
+++ b/src/waltz/quic/tests/test_quic_retry_unit.c
@@ -102,13 +102,13 @@ bench_retry_create( void ) {
   uchar aes_iv [16] = {2};
   ulong ttl         = (ulong)3e9;
 
-  fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 7315969L+(long)ttl );
+  fd_quic_retry_create( retry, &pkt, fd_rng_ulong( rng ), fd_rng_ulong( rng ), aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 7315969L+(long)ttl );
   FD_LOG_HEXDUMP_INFO(( "Retry Token", retry+0x1f, sizeof(fd_quic_retry_token_t) ));
 
   long dt = -fd_log_wallclock();
   ulong iter = 1000000UL;
   for( ulong j=0UL; j<iter; j++ ) {
-    fd_quic_retry_create( retry, &pkt, rng, aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 1L+(long)ttl );
+    fd_quic_retry_create( retry, &pkt, fd_rng_ulong( rng ), fd_rng_ulong( rng ), aes_key, aes_iv, &orig_dst_conn_id, &peer_src_conn_id, retry_src_conn_id, 1L+(long)ttl );
     FD_COMPILER_UNPREDICTABLE( retry[0] );
   }
   dt += fd_log_wallclock();
@@ -132,9 +132,6 @@ bench_retry_server_verify( void ) {
     0x00, 0x00, 0x00, 0x00, 0x08, 0xc0, 0x2a, 0x34, 0xf1, 0x0d, 0x8d, 0x8c, 0x60, 0x5b, 0xe2, 0x28,
     0x27, 0x5e, 0xd0, 0x18, 0xc7
   };
-
-  fd_rng_t _rng[1];
-  fd_rng_t * rng = fd_rng_join( fd_rng_new( _rng, 0U, 0UL ) );
 
   fd_quic_pkt_t const pkt = {0};
 
@@ -161,8 +158,6 @@ bench_retry_server_verify( void ) {
   double ns   = (double)dt / (double)iter;
   FD_LOG_NOTICE(( "  ~%9.3f Mpps / core", mpps ));
   FD_LOG_NOTICE(( "  ~%9.3f ns / pkt",    ns   ));
-
-  fd_rng_delete( fd_rng_leave( rng ) );
 }
 
 /* bench_retry_client tests packet throughput for client-side retry

--- a/src/waltz/quic/tests/test_quic_tls_hs.c
+++ b/src/waltz/quic/tests/test_quic_tls_hs.c
@@ -78,6 +78,9 @@ main( int     argc,
   fd_tls_test_sign_ctx_t sign_ctx[1];
   fd_tls_test_sign_ctx( sign_ctx, rng );
 
+  static fd_chacha_rng_t chacha[1];
+  fd_tls_test_rand( chacha, rng );
+
   // config parameters
   fd_quic_tls_cfg_t cfg = {
     .secret_cb             = my_secrets,
@@ -87,6 +90,7 @@ main( int     argc,
     .max_concur_handshakes = 16,
     .cert_public_key       = sign_ctx->public_key,
     .signer                = fd_tls_test_sign( &sign_ctx ),
+    .rng                   = chacha,
   };
 
   /* dump transport params */

--- a/src/waltz/quic/tls/fd_quic_tls.c
+++ b/src/waltz/quic/tls/fd_quic_tls.c
@@ -30,16 +30,6 @@ fd_quic_tls_secrets( void const * handshake,
                      void const * send_secret,
                      uint         encryption_level );
 
-/* fd_quic_tls_rand is the RNG provided to fd_tls.  Note: This is
-   a layering violation ... The user should pass the CSPRNG handle to
-   both fd_quic and fd_tls.  Currently, implemented via the getrandom()
-   syscall ... Inefficient! */
-
-void *
-fd_quic_tls_rand( void * ctx,
-                  void * buf,
-                  ulong  bufsz );
-
 /* fd_quic_tls_tp_self is called by fd_tls to retrieve fd_quic's QUIC
    transport parameters. */
 
@@ -63,7 +53,8 @@ fd_quic_tls_init( fd_tls_t *    tls,
                   fd_tls_sign_t signer,
                   uchar const   cert_public_key[ static 32 ],
                   uchar const * alpn,
-                  ulong         alpn_sz );
+                  ulong             alpn_sz,
+                  fd_chacha_rng_t * rng );
 
 fd_quic_tls_t *
 fd_quic_tls_new( fd_quic_tls_t *     self,
@@ -83,13 +74,17 @@ fd_quic_tls_new( fd_quic_tls_t *     self,
     FD_LOG_WARNING(( "Missing callbacks" ));
     return NULL;
   }
+  if( FD_UNLIKELY( !cfg->rng ) ) {
+    FD_LOG_WARNING(( "NULL rng" ));
+    return NULL;
+  }
 
   self->secret_cb             = cfg->secret_cb;
   self->handshake_complete_cb = cfg->handshake_complete_cb;
   self->peer_params_cb        = cfg->peer_params_cb;
 
   /* Initialize fd_tls */
-  fd_quic_tls_init( &self->tls, cfg->signer, cfg->cert_public_key, cfg->alpn, cfg->alpn_sz );
+  fd_quic_tls_init( &self->tls, cfg->signer, cfg->cert_public_key, cfg->alpn, cfg->alpn_sz, cfg->rng );
 
   return self;
 }
@@ -98,18 +93,16 @@ fd_quic_tls_new( fd_quic_tls_t *     self,
    the embedded fd_tls instance. */
 
 static void
-fd_quic_tls_init( fd_tls_t *    tls,
-                  fd_tls_sign_t signer,
-                  uchar const   cert_public_key[ static 32 ],
-                  uchar const * alpn,
-                  ulong         alpn_sz ) {
+fd_quic_tls_init( fd_tls_t *        tls,
+                  fd_tls_sign_t     signer,
+                  uchar const       cert_public_key[ static 32 ],
+                  uchar const *     alpn,
+                  ulong             alpn_sz,
+                  fd_chacha_rng_t * rng ) {
   tls = fd_tls_new( tls );
   *tls = (fd_tls_t) {
     .quic = 1,
-    .rand = {
-      .ctx     = NULL,
-      .rand_fn = fd_quic_tls_rand
-    },
+    .rng  = rng,
     .sign = signer,
     .secrets_fn = fd_quic_tls_secrets,
     .sendmsg_fn = fd_quic_tls_sendmsg,
@@ -393,15 +386,6 @@ void
 fd_quic_tls_clear_hs_data( fd_quic_tls_hs_t * self, uint enc_level ) {
   self->hs_data_pend_idx[enc_level] = FD_QUIC_TLS_HS_DATA_UNUSED;
   self->hs_data_pend_end_idx[enc_level] = FD_QUIC_TLS_HS_DATA_UNUSED;
-}
-
-void *
-fd_quic_tls_rand( void * ctx,
-                  void * buf,
-                  ulong  bufsz ) {
-  (void)ctx;
-  FD_TEST( fd_rng_secure( buf, bufsz ) );
-  return buf;
 }
 
 ulong

--- a/src/waltz/quic/tls/fd_quic_tls.h
+++ b/src/waltz/quic/tls/fd_quic_tls.h
@@ -11,6 +11,15 @@
    This defines an API for QUIC-TLS
 
    General operation:
+     // seed a CSPRNG
+     static fd_chacha_rng_t _rng[1];
+     fd_chacha_rng_t * rng = fd_chacha_rng_join(
+         fd_chacha_rng_new( _rng, FD_CHACHA_RNG_MODE_SHIFT ) );
+     uchar key[ FD_CHACHA_KEY_SZ ];
+     if( FD_UNLIKELY( !fd_rng_secure( key, sizeof(key) ) ) ) abort();
+     fd_chacha_rng_init( rng, key, FD_CHACHA_RNG_ALGO_CHACHA8 );
+     fd_memzero_explicit( key, sizeof(key) );
+
      // set up a quic-tls config object
      fd_quic_tls_cfg_t quic_tls_cfg = {
        .secret_cb             = my_secret_cb,        // callback for communicating secrets
@@ -19,6 +28,8 @@
 
        .max_concur_handshakes = 1234,                // number of handshakes this object can
                                                      // manage concurrently
+
+       .rng                   = rng,                 // required, see above
        };
 
      // create a quic-tls object to manage handshakes:
@@ -88,6 +99,10 @@ struct fd_quic_tls_cfg {
 
   /* Ed25519 public key */
   uchar const * cert_public_key;
+
+  /* rng is a seeded CSPRNG used to generate the TLS random of every
+     handshake.  caller-managed, outlives quic_tls. */
+  fd_chacha_rng_t * rng;
 
   /* alpn: either "solana-tpu" or "alpenglow-v1" */
   uchar const * alpn;

--- a/src/waltz/tls/fd_tls.c
+++ b/src/waltz/tls/fd_tls.c
@@ -528,8 +528,7 @@ fd_tls_server_hs_start( fd_tls_t const *      const server,
   /* Create server random */
 
   uchar server_random[ 32 ];
-  if( FD_UNLIKELY( !fd_tls_rand( &server->rand, server_random, 32UL ) ) )
-    return fd_tls_alert( &handshake->base, FD_TLS_ALERT_HANDSHAKE_FAILURE, FD_TLS_REASON_RAND_FAIL );
+  fd_chacha_rng_read32( server->rng, server_random );
 
   /* Create server hello message */
 
@@ -1167,8 +1166,7 @@ fd_tls_client_hs_start( fd_tls_t const * const      client,
   /* Create client random */
 
   uchar client_random[ 32 ];
-  if( FD_UNLIKELY( !fd_tls_rand( &client->rand, client_random, 32UL ) ) )
-    return fd_tls_alert( &handshake->base, FD_TLS_ALERT_INTERNAL_ERROR, FD_TLS_REASON_RAND_FAIL );
+  fd_chacha_rng_read32( client->rng, client_random );
 
   /* Remember client random for SSLKEYLOGFILE */
   fd_memcpy( handshake->base.client_random, client_random, 32UL );
@@ -1863,8 +1861,6 @@ fd_tls_reason_cstr( uint reason ) {
     return "sendmsg callback failed";
   case FD_TLS_REASON_WRONG_ENC_LVL:
     return "wrong encryption level";
-  case FD_TLS_REASON_RAND_FAIL:
-    return "rand function failed";
   case FD_TLS_REASON_CH_EXPECTED:
     return "expected ClientHello, but got other message type";
   case FD_TLS_REASON_CH_PARSE:

--- a/src/waltz/tls/fd_tls.h
+++ b/src/waltz/tls/fd_tls.h
@@ -2,6 +2,7 @@
 #define HEADER_fd_src_waltz_tls_fd_tls_h
 
 #include "fd_tls_estate.h"
+#include "../../ballet/chacha/fd_chacha_rng.h"
 
 /* fd_tls implements a subset of the TLS v1.3 (RFC 8446) handshake
    protocol.
@@ -119,43 +120,6 @@ typedef void
                               uchar const * quic_tp,
                               ulong         quic_tp_sz );
 
-/* fd_tls_rand_vt_t is an abstraction for retrieving secure pseudorandom
-   values.  When fd_tls needs random values, it calls fd_tls_rand_fn_t.
-
-   ctx is an arbitrary pointer that is provided as a callback argument.
-   buf points to a buffer of bufsz bytes that is to be filled with
-   cryptographically secure randomness.  bufsz is usually 32 bytes.
-   Assume buf is unaligned.  Returns buf on success and NULL on failure.
-
-   Function must not block, but may synchronously pre-calculate a
-   reasonable amount of data ahead of time.  NULL return value implies
-   inability to keep up with demand for random values.  In this case,
-   function should return NULL.  Function should minimize side effects
-   (notably, should not log).
-
-   TODO API considerations:
-   - read() style error codes?
-   - Buffering to reduce amount of virtual function calls? */
-
-typedef void *
-(* fd_tls_rand_fn_t)( void * ctx,
-                      void * buf,
-                      ulong  bufsz );
-
-struct fd_tls_rand_vt {
-  void *           ctx;
-  fd_tls_rand_fn_t rand_fn;
-};
-
-typedef struct fd_tls_rand_vt fd_tls_rand_t;
-
-static inline void *
-fd_tls_rand( fd_tls_rand_t const * rand,
-             void *                buf,
-             ulong                 bufsz ) {
-  return rand->rand_fn( rand->ctx, buf, bufsz );
-}
-
 /* fd_tls_sign_fn_t is called by by fd_tls to request signing of a
    TLS 1.3 certificate verify payload.
 
@@ -229,7 +193,8 @@ extern char const fd_tls13_srv_sign_prefix[ 98 ];
    across multiple TLS handshakes. */
 
 struct fd_tls {
-  fd_tls_rand_t       rand;
+  /* CSPRNG, caller-provided.  caller is responsible for reseeding. */
+  fd_chacha_rng_t *   rng;
   fd_tls_secrets_fn_t secrets_fn;
   fd_tls_sendmsg_fn_t sendmsg_fn;
 
@@ -295,7 +260,6 @@ typedef struct fd_tls fd_tls_t;
 #define FD_TLS_REASON_ILLEGAL_STATE   ( 1)  /* illegal hs state */
 #define FD_TLS_REASON_SENDMSG_FAIL    ( 2)  /* sendmsg callback failed */
 #define FD_TLS_REASON_WRONG_ENC_LVL   ( 3)  /* wrong encryption level */
-#define FD_TLS_REASON_RAND_FAIL       ( 4)  /* rand fn failed */
 
 #define FD_TLS_REASON_X25519_FAIL     ( 9)  /* fd_x25519_exchange failed */
 #define FD_TLS_REASON_NO_X509         (10)  /* no X.509 cert installed */

--- a/src/waltz/tls/fuzz_tls.c
+++ b/src/waltz/tls/fuzz_tls.c
@@ -142,7 +142,8 @@ LLVMFuzzerTestOneInput( uchar const * input,
   uint  enc_lvl   = (uint)(  ( state>>11 )&0x3UL );
 
   fd_tls_t tls[1]; fd_memcpy( tls, tls_tmpl, sizeof(fd_tls_t) );
-  tls->rand = fd_tls_test_rand( rng );
+  fd_chacha_rng_t chacha[1];
+  tls->rng = fd_tls_test_rand( chacha, rng );
   tls->quic = (uchar)(is_quic&1);
   if( !has_alpn ) tls->alpn_sz      = 0UL;
   if( !has_x509 ) tls->cert_x509_sz = 0UL;

--- a/src/waltz/tls/test_tls.c
+++ b/src/waltz/tls/test_tls.c
@@ -165,18 +165,19 @@ prepare_tls_pair( fd_rng_t * rng,
                   fd_tls_t * client,
                   fd_tls_t * server ) {
   static fd_tls_test_sign_ctx_t client_sign_ctx[1], server_sign_ctx[1];
+  static fd_chacha_rng_t client_chacha[1], server_chacha[1];
   fd_tls_test_sign_ctx( client_sign_ctx, rng );
   fd_tls_test_sign_ctx( server_sign_ctx, rng );
 
   *client = (fd_tls_t) {
-    .rand       = fd_tls_test_rand( rng ),
+    .rng        = fd_tls_test_rand( client_chacha, rng ),
     .sign       = fd_tls_test_sign( &client_sign_ctx ),
     .secrets_fn = test_tls_secrets,
     .sendmsg_fn = test_tls_sendmsg,
   };
 
   *server = (fd_tls_t) {
-    .rand       = fd_tls_test_rand( rng ),
+    .rng        = fd_tls_test_rand( server_chacha, rng ),
     .sign       = fd_tls_test_sign( &server_sign_ctx ),
     .secrets_fn = test_tls_secrets,
     .sendmsg_fn = test_tls_sendmsg,

--- a/src/waltz/tls/test_tls_helper.h
+++ b/src/waltz/tls/test_tls_helper.h
@@ -8,29 +8,19 @@
 
 /* Common routines for fd_tls unit tests */
 
-/* fd_tls_test_rand creates an fd_tls provider from an fd_rng_t.
-   This is a deliberately insecure, deterministic RNG intended for tests. */
+/* fd_tls_test_rand formats mem as a ChaCha8 RNG keyed from rng and
+   returns it, for use as fd_tls_t.rng.  Deliberately deterministic:
+   tests and fuzz cases must be reproducible.  mem must outlive every
+   handshake driven by the fd_tls_t it is installed in. */
 
-static void *
-fd_tls_test_rand_read( void * ctx,
-                       void * buf,
-                       ulong  bufsz ) {
-
-  if( FD_UNLIKELY( !ctx ) ) return NULL;
-
-  fd_rng_t * rng  = (fd_rng_t *)ctx;
-  uchar *    buf_ = (uchar *)buf;
-  for( ulong i=0UL; i<bufsz; i++ )
-    buf_[i] = (uchar)fd_rng_uchar( rng );
-  return buf_;
-}
-
-static FD_FN_UNUSED fd_tls_rand_t
-fd_tls_test_rand( fd_rng_t * rng ) {
-  return (fd_tls_rand_t) {
-    .ctx     = rng,
-    .rand_fn = fd_tls_test_rand_read
-  };
+static FD_FN_UNUSED fd_chacha_rng_t *
+fd_tls_test_rand( fd_chacha_rng_t * mem,
+                  fd_rng_t *        rng ) {
+  uchar key[ 32 ];
+  for( ulong i=0UL; i<sizeof(key); i++ ) key[i] = fd_rng_uchar( rng );
+  fd_chacha_rng_t * chacha = fd_chacha_rng_join( fd_chacha_rng_new( mem, FD_CHACHA_RNG_MODE_SHIFT ) );
+  FD_TEST( chacha );
+  return fd_chacha_rng_init( chacha, key, FD_CHACHA_RNG_ALGO_CHACHA8 );
 }
 
 struct fd_tls_test_sign_ctx {

--- a/src/waltz/tls/test_tls_openssl.c
+++ b/src/waltz/tls/test_tls_openssl.c
@@ -318,9 +318,9 @@ _setup_ssl_cert_and_quic( SSL *           ssl,
 
 
 static fd_tls_t
-_fd_tls_t( void* sign_ctx, fd_rng_t* rng ) {
+_fd_tls_t( void * sign_ctx, fd_rng_t* rng, fd_chacha_rng_t * chacha ) {
   return (fd_tls_t) {
-    .rand       =  fd_tls_test_rand( rng ),
+    .rng        =  fd_tls_test_rand( chacha, rng ),
     .secrets_fn = _fdtls_secrets,
     .sendmsg_fn = _fdtls_sendmsg,
 
@@ -354,7 +354,8 @@ test_server( SSL_CTX * ctx ) {
   fd_tls_t * server = fd_tls_join( fd_tls_new( _server ) );
   fd_tls_test_sign_ctx_t server_sign_ctx[1];
   fd_tls_test_sign_ctx( server_sign_ctx, rng );
-  *server = _fd_tls_t( &server_sign_ctx, rng );
+  static fd_chacha_rng_t server_chacha[1];
+  *server = _fd_tls_t( &server_sign_ctx, rng, server_chacha );
 
   fd_tls_estate_srv_t hs[1];
   FD_TEST( fd_tls_estate_srv_new( hs ) );
@@ -441,7 +442,8 @@ test_client( SSL_CTX * ctx ) {
   fd_tls_t * client = fd_tls_join( fd_tls_new( _client ) );
   fd_tls_test_sign_ctx_t client_sign_ctx[1];
   fd_tls_test_sign_ctx( client_sign_ctx, rng );
-  *client = _fd_tls_t( &client_sign_ctx, rng );
+  static fd_chacha_rng_t client_chacha[1];
+  *client = _fd_tls_t( &client_sign_ctx, rng, client_chacha );
 
   fd_tls_estate_cli_t hs[1];
   FD_TEST( fd_tls_estate_cli_new( hs ) );


### PR DESCRIPTION
Switch QUIC PRNG (for CIDs, cookies) and TLS CSPRNG (for challenge-response randoms) to ChaCha8 as used in Solana.

Periodically reseed via getrandom() in fd_quic. 

- **quic: switch to ChaCha8 CSPRNG**
- **tls: switch to ChaCha8 CSPRNG**
