### PR TITLE
mlx5: publish neighbor solicits on the tile's own link

### DIFF
--- a/src/disco/net/mlx5/fd_mlx5_tile.c
+++ b/src/disco/net/mlx5/fd_mlx5_tile.c
@@ -1463,7 +1463,10 @@ unprivileged_init( fd_topo_t const *      topo,
     FD_LOG_ERR(( "fd_neigh4_hmap_join failed" ));
   }
 
-  ulong net_netlnk_id = fd_topo_find_link( topo, "net_netlnk", 0UL );
+  ulong net_netlnk_id = ULONG_MAX;
+  for( ulong i=0UL; i<tile->out_cnt; i++ ) {
+    if( !strcmp( topo->links[ tile->out_link_id[ i ] ].name, "net_netlnk" ) ) net_netlnk_id = tile->out_link_id[ i ];
+  }
   if( FD_LIKELY( net_netlnk_id!=ULONG_MAX ) ) {
     fd_topo_link_t const * net_netlnk = &topo->links[ net_netlnk_id ];
     if( FD_UNLIKELY( !net_netlnk->mcache ) ) FD_LOG_ERR(( "netlink request link not initialized" ));

--- a/src/disco/net/mlx5/test_mlx5_tile.c
+++ b/src/disco/net/mlx5/test_mlx5_tile.c
@@ -544,7 +544,7 @@ main( int     argc,
   FD_TEST( rx_link->mcache );
 
   /* UMEM */
-  ulong const dcache_depth   = rxq_depth+txq_depth+link_depth;
+  ulong const dcache_depth   = rxq_depth+txq_depth+2UL*link_depth;
   ulong const dcache_data_sz = fd_dcache_req_data_sz( FD_NET_MTU, dcache_depth, 1UL, 1 );
   FD_TEST( dcache_data_sz );
   void *  rx_dcache_mem = fd_wksp_alloc_laddr( wksp, fd_dcache_align(), fd_dcache_footprint( dcache_data_sz, 0UL ), WKSP_TAG );
@@ -641,6 +641,7 @@ main( int     argc,
 
   /* Attach links to tile */
   fd_topob_tile_out( topo, "mlx5", 0UL, "net_shred", 0UL );
+  fd_topob_tile_out( topo, "mlx5", 0UL, "net_netlnk", 0UL );
   fd_topob_tile_in( topo, "mlx5", 0UL, "wksp", "shred_net", 0UL, 0, 1 );
 
   /* Initialize tile state (assigns frames) */


### PR DESCRIPTION
Every mlx5 tile looked up net_netlnk:0, so with more than one tile they all published on the first tile's link with independent sequence numbers.  Select the tile's own out by name, as the xdp tile does.