### PR TITLE
disco: add the tile sleep object

### DIFF
--- a/src/app/firedancer-dev/main.h
+++ b/src/app/firedancer-dev/main.h
@@ -12,6 +12,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_dcache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_fseq;
 extern fd_topo_obj_callbacks_t fd_obj_cb_metrics;
 extern fd_topo_obj_callbacks_t fd_obj_cb_adminctl;
+extern fd_topo_obj_callbacks_t fd_obj_cb_sleep;
 extern fd_topo_obj_callbacks_t fd_obj_cb_netdev_tbl;
 extern fd_topo_obj_callbacks_t fd_obj_cb_neigh4_hmap;
 extern fd_topo_obj_callbacks_t fd_obj_cb_keyswitch;
@@ -33,6 +34,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_fseq,
   &fd_obj_cb_metrics,
   &fd_obj_cb_adminctl,
+  &fd_obj_cb_sleep,
   &fd_obj_cb_netdev_tbl,
   &fd_obj_cb_neigh4_hmap,
   &fd_obj_cb_keyswitch,

--- a/src/app/firedancer/main.c
+++ b/src/app/firedancer/main.c
@@ -26,6 +26,7 @@ extern fd_topo_obj_callbacks_t fd_obj_cb_banks;
 extern fd_topo_obj_callbacks_t fd_obj_cb_progcache;
 extern fd_topo_obj_callbacks_t fd_obj_cb_rnonce_ss;
 extern fd_topo_obj_callbacks_t fd_obj_cb_adminctl;
+extern fd_topo_obj_callbacks_t fd_obj_cb_sleep;
 
 fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_mcache,
@@ -47,6 +48,7 @@ fd_topo_obj_callbacks_t * CALLBACKS[] = {
   &fd_obj_cb_progcache,
   &fd_obj_cb_rnonce_ss,
   &fd_obj_cb_adminctl,
+  &fd_obj_cb_sleep,
   NULL,
 };
 

--- a/src/app/shared/fd_config_json.c
+++ b/src/app/shared/fd_config_json.c
@@ -11,7 +11,7 @@
    or knowingly skipped) before the constant is bumped.  String keys of
    the user's own file are separately forced through the classification
    lists below. */
-FD_STATIC_ASSERT( sizeof(fd_config_t)==22970296UL, update_fd_config_to_json_for_the_layout_change );
+FD_STATIC_ASSERT( sizeof(fd_config_t)==22970304UL, update_fd_config_to_json_for_the_layout_change );
 
 #define REDACTED "[redacted]"
 

--- a/src/app/shared/fd_obj_callbacks.c
+++ b/src/app/shared/fd_obj_callbacks.c
@@ -5,10 +5,12 @@
 #include "../../tango/mcache/fd_mcache.h"
 #include "../../tango/dcache/fd_dcache.h"
 #include "../../tango/fseq/fd_fseq.h"
+#include "../../tango/tempo/fd_tempo.h"
 #include "../../waltz/mib/fd_netdev_tbl.h"
 #include "../../waltz/neigh/fd_neigh4_map.h"
 #include "../../disco/keyguard/fd_keyswitch.h"
 #include "../../disco/node_info/fd_node_info.h"
+#include "../../disco/sleep/fd_sleep.h"
 #include "../../discof/poh/fd_poh.h"
 
 #define VAL(name) (__extension__({                                                             \
@@ -307,6 +309,31 @@ fd_topo_obj_callbacks_t fd_obj_cb_tile = {
   .align     = tile_align,
   .loose     = tile_loose,
   .new       = NULL,
+};
+
+static ulong
+sleep_footprint( fd_topo_t const *     topo FD_FN_UNUSED,
+                 fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return fd_sleep_footprint();
+}
+
+static ulong
+sleep_align( fd_topo_t const *     topo FD_FN_UNUSED,
+             fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
+  return fd_sleep_align();
+}
+
+static void
+sleep_new( fd_topo_t const *     topo,
+           fd_topo_obj_t const * obj ) {
+  FD_TEST( fd_sleep_new( fd_topo_obj_laddr( topo, obj->id ), fd_tempo_tick_per_ns( NULL ) ) );
+}
+
+fd_topo_obj_callbacks_t fd_obj_cb_sleep = {
+  .name      = "sleep",
+  .footprint = sleep_footprint,
+  .align     = sleep_align,
+  .new       = sleep_new,
 };
 
 #undef VAL

--- a/src/disco/sleep/Local.mk
+++ b/src/disco/sleep/Local.mk
@@ -1,0 +1,8 @@
+ifdef FD_HAS_HOSTED
+ifdef FD_HAS_LINUX
+$(call add-hdrs,fd_sleep.h)
+$(call add-objs,fd_sleep,fd_disco)
+$(call make-unit-test,test_sleep,test_sleep,fd_disco fd_tango fd_util)
+$(call run-unit-test,test_sleep)
+endif
+endif

--- a/src/disco/sleep/fd_sleep.c
+++ b/src/disco/sleep/fd_sleep.c
@@ -1,0 +1,122 @@
+#define _GNU_SOURCE
+#include "fd_sleep.h"
+#include "../topo/fd_topo.h"
+
+#include <errno.h>
+#include <float.h>
+#include <time.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+FD_FN_CONST ulong fd_sleep_align    ( void ) { return FD_SLEEP_ALIGN;    }
+FD_FN_CONST ulong fd_sleep_footprint( void ) { return sizeof(fd_sleep_t); }
+
+void *
+fd_sleep_new( void * shmem,
+              double tick_per_ns ) {
+  if( FD_UNLIKELY( !shmem ) ) {
+    FD_LOG_WARNING(( "NULL shmem" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !(tick_per_ns>0.0 && tick_per_ns<=DBL_MAX) ) ) {
+    FD_LOG_WARNING(( "bad tick_per_ns" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shmem, fd_sleep_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shmem" ));
+    return NULL;
+  }
+
+  fd_sleep_t * sleep = (fd_sleep_t *)shmem;
+  fd_memset( sleep, 0, fd_sleep_footprint() );
+  for( ulong i=0UL; i<FD_SLEEP_TILE_MAX; i++ ) sleep->tile[ i ].word = 1UL; /* running */
+  sleep->tick_per_ns = tick_per_ns;
+
+  FD_COMPILER_MFENCE();
+  FD_VOLATILE( sleep->magic ) = FD_SLEEP_MAGIC;
+  FD_COMPILER_MFENCE();
+
+  return shmem;
+}
+
+ulong
+fd_sleep_wake_table( fd_sleep_wake_t *      wake,
+                     struct fd_topo const * topo,
+                     ulong                  link_id ) {
+  if( FD_UNLIKELY( topo->sleep_obj_id==ULONG_MAX ) ) return 0UL;
+  ulong mask[ FD_SLEEP_BITS_CNT ] = {0};
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    fd_topo_tile_t const * consumer = &topo->tiles[ i ];
+    for( ulong j=0UL; j<consumer->in_cnt; j++ ) {
+      if( FD_UNLIKELY( consumer->in_link_id[ j ]==link_id && consumer->in_link_poll[ j ] ) ) {
+        mask[ consumer->id>>6 ] |= 1UL<<(consumer->id&63UL);
+      }
+    }
+  }
+
+  ulong cnt = 0UL;
+  for( ulong w=0UL; w<FD_SLEEP_BITS_CNT; w++ ) {
+    if( FD_UNLIKELY( mask[ w ] ) ) wake[ cnt++ ] = (fd_sleep_wake_t){ .w=w, .mask=mask[ w ] };
+  }
+  return cnt;
+}
+
+fd_sleep_t *
+fd_sleep_join( void * shsleep ) {
+  if( FD_UNLIKELY( !shsleep ) ) {
+    FD_LOG_WARNING(( "NULL shsleep" ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !fd_ulong_is_aligned( (ulong)shsleep, fd_sleep_align() ) ) ) {
+    FD_LOG_WARNING(( "misaligned shsleep" ));
+    return NULL;
+  }
+
+  fd_sleep_t * sleep = (fd_sleep_t *)shsleep;
+
+  if( FD_UNLIKELY( sleep->magic!=FD_SLEEP_MAGIC ) ) {
+    FD_LOG_WARNING(( "bad magic" ));
+    return NULL;
+  }
+
+  return sleep;
+}
+
+int
+fd_sleep_park_wait( fd_sleep_t const * sleep,
+                    ulong *            word,
+                    long               deadline_ticks ) {
+  /* Absolute timeout, anchored on a clock read taken before the tick
+     read: preemption anywhere after can only shorten the sleep, never
+     stretch it past deadline_ticks */
+  struct timespec ts;
+  clock_gettime( CLOCK_MONOTONIC, &ts );
+  long remaining = (long)((double)(deadline_ticks-fd_tickcount())/sleep->tick_per_ns);
+  if( FD_UNLIKELY( remaining<=0L ) ) return FD_SLEEP_UNPARK_DEADLINE;
+  long abs_ns = ts.tv_sec*(long)1e9 + ts.tv_nsec + remaining;
+  ts.tv_sec  = abs_ns/(long)1e9;
+  ts.tv_nsec = abs_ns%(long)1e9;
+
+  for(;;) {
+    long res = syscall( SYS_futex, (uint *)word, FUTEX_WAIT_BITSET, 0U, &ts, NULL, FUTEX_BITSET_MATCH_ANY );
+    if( FD_LIKELY( !res ) ) return FD_SLEEP_UNPARK_RING;
+
+    switch( errno ) {
+      case ETIMEDOUT: return FD_SLEEP_UNPARK_DEADLINE;
+      case EAGAIN:    return FD_SLEEP_UNPARK_RING;  /* word already 1 */
+      case EINTR:     continue;                     /* signal: same absolute timeout */
+      default: FD_LOG_ERR(( "futex(FUTEX_WAIT_BITSET) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+    }
+  }
+}
+
+void
+fd_sleep_wake_one( ulong * word ) {
+  FD_VOLATILE( word[0] ) = 1UL;
+  long res = syscall( SYS_futex, (uint *)word, FUTEX_WAKE, 1, NULL, NULL, 0 );
+  if( FD_UNLIKELY( -1L==res ) ) FD_LOG_ERR(( "futex(FUTEX_WAKE) failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+}

--- a/src/disco/sleep/fd_sleep.h
+++ b/src/disco/sleep/fd_sleep.h
@@ -1,0 +1,147 @@
+#ifndef HEADER_fd_src_disco_sleep_fd_sleep_h
+#define HEADER_fd_src_disco_sleep_fd_sleep_h
+
+/* Idle tiles park in futex_wait instead of spinning and are woken
+   when work arrives.  Three roles share one shmem region:
+
+     sleeper   a stem tile with no work: flushes its link state, sets
+               its bit in parked_bits, re-checks its ins once under the
+               RMW fence, then FUTEX_WAIT_BITSETs on its word with an
+               absolute deadline.
+
+     producer  on publish: load parked_bits[w] & a mask precomputed at
+               boot; if nonzero, locked OR into doorbell[w].
+
+     mwaitx    naps in hardware on the doorbell line (umwait/mwaitx),
+               turns rung bits into FUTEX_WAKEs, and runs the verifying
+               sweep (seq_mirror vs seq_snap) that bounds a lost
+               doorbell to one nap.  The only FUTEX_WAKE issuer.
+
+   word 0 = parked, nonzero = running.  The doorbell is a hint: truth
+   is level triggered (seqs, deadline) and re-checked on every wake,
+   so spurious wakes are absorbed and a lost hint costs only bounded
+   latency (the sweep, then the tile's own deadline). */
+
+#include "../../util/fd_util_base.h"
+
+#define FD_SLEEP_ALIGN     (128UL)
+#define FD_SLEEP_MAGIC     (0xf17eda2c3751ee90UL) /* firedancer sleep ver 0 */
+
+#define FD_SLEEP_TILE_MAX  (512UL)
+#define FD_SLEEP_BITS_CNT  (FD_SLEEP_TILE_MAX/64UL)
+#define FD_SLEEP_LINK_MAX  (256UL) /* ==FD_TOPO_MAX_LINKS  */
+#define FD_SLEEP_IN_MAX    (128UL) /* ==FD_TOPO_MAX_TILE_IN_LINKS */
+
+#define FD_SLEEP_LINGER_NS   (0L)        /* park as soon as caught up */
+#define FD_SLEEP_PARK_CAP_NS (20000000L) /* longest park */
+#define FD_SLEEP_PARK_MIN_NS (5000L)     /* shorter than this and the futex round trip costs more than the spin */
+
+struct __attribute__((aligned(FD_SLEEP_ALIGN))) fd_sleep_private {
+  /* Loaded on every publish, written only at park/unpark */
+  ulong parked_bits[ FD_SLEEP_BITS_CNT ];
+  ulong  magic;       /* ==FD_SLEEP_MAGIC, off the parked_bits line */
+  double tick_per_ns; /* fd_tickcount ticks per ns, for futex deadlines */
+  ulong  pad0[ 6 ];
+
+  /* Locked OR on wake edges; the line mwaitx monitors.  Own line. */
+  ulong doorbell[ FD_SLEEP_BITS_CNT ];
+  ulong pad1[ 8 ];
+
+  /* Indexed by tile->id; written by the owner and mwaitx only */
+  struct __attribute__((aligned(64UL))) {
+    ulong word;      /* futex word: 0 parked, 1 running */
+    ulong gen;       /* park count, diagnostics */
+    ulong deadline;  /* abs fd_tickcount of the next timed obligation */
+    ulong pad[ 5 ];
+  } tile[ FD_SLEEP_TILE_MAX ];
+
+  /* Sweep state: producers mirror out seqs at housekeeping, a parking
+     tile snapshots the next seq it expects per polled in.
+     mirror[link]>snap means a frag is pending. */
+  ulong seq_mirror[ FD_SLEEP_LINK_MAX ];
+  ulong seq_snap[ FD_SLEEP_TILE_MAX ][ FD_SLEEP_IN_MAX ];
+};
+
+typedef struct fd_sleep_private fd_sleep_t;
+
+/* Wake table entry: the consumers of one out link as a (bitmap word,
+   mask) pair.  One pair per link in practice. */
+
+struct fd_sleep_wake {
+  ulong w;
+  ulong mask;
+};
+
+typedef struct fd_sleep_wake fd_sleep_wake_t;
+
+struct fd_topo;
+
+FD_PROTOTYPES_BEGIN
+
+FD_FN_CONST ulong fd_sleep_align    ( void );
+FD_FN_CONST ulong fd_sleep_footprint( void );
+
+/* fd_sleep_new formats shmem (fd_sleep_align aligned, fd_sleep_footprint
+   bytes) as a sleep region with every tile running.  tick_per_ns is
+   the fd_tickcount rate used to turn park deadlines into futex
+   timeouts.  Returns shmem on success, NULL on failure (logs
+   details). */
+
+void * fd_sleep_new( void * shmem,
+                     double tick_per_ns );
+
+fd_sleep_t * fd_sleep_join( void * shsleep );
+
+/* fd_sleep_wake_table fills wake (FD_SLEEP_BITS_CNT entries) with the
+   (word,mask) pairs covering every tile that polls link_id, and
+   returns the pair count (0 if none, or in performance mode).  A
+   consumer that never parks never has its bit set, so rings to it are
+   free. */
+
+ulong
+fd_sleep_wake_table( fd_sleep_wake_t *       wake,
+                     struct fd_topo const *  topo,
+                     ulong                   link_id );
+
+/* fd_sleep_ring marks tile_id as having work.  Safe from any thread;
+   ringing a running tile is harmless. */
+
+static inline void
+fd_sleep_ring( fd_sleep_t * sleep,
+               ulong        tile_id ) {
+  __atomic_fetch_or( &sleep->doorbell[ tile_id>>6 ], 1UL<<(tile_id&63UL), __ATOMIC_RELEASE );
+}
+
+/* fd_sleep_wake_check rings the parked consumers of one out link.
+   One load per pair; the locked OR only on a hit. */
+
+static inline void
+fd_sleep_wake_check( fd_sleep_t *      sleep,
+                     fd_sleep_wake_t const * wake,
+                     ulong                   wake_cnt ) {
+  for( ulong k=0UL; k<wake_cnt; k++ ) {
+    ulong rung = FD_VOLATILE_CONST( sleep->parked_bits[ wake[ k ].w ] ) & wake[ k ].mask;
+    if( FD_UNLIKELY( rung ) ) __atomic_fetch_or( &sleep->doorbell[ wake[ k ].w ], rung, __ATOMIC_RELEASE );
+  }
+}
+
+/* Unpark causes, in ParkWake metrics enum order */
+
+#define FD_SLEEP_UNPARK_RING     (0)
+#define FD_SLEEP_UNPARK_DEADLINE (1)
+#define FD_SLEEP_UNPARK_PENDING  (2)
+
+/* fd_sleep_park_wait blocks on word (caller set it to 0) until woken
+   or deadline_ticks (abs fd_tickcount) passes.  Returns the cause.
+   fd_sleep_wake_one sets word to 1 and wakes one waiter; called by
+   the mwaitx tile only. */
+
+int  fd_sleep_park_wait( fd_sleep_t const * sleep,
+                         ulong *            word,
+                         long               deadline_ticks );
+
+void fd_sleep_wake_one( ulong * word );
+
+FD_PROTOTYPES_END
+
+#endif /* HEADER_fd_src_disco_sleep_fd_sleep_h */

--- a/src/disco/sleep/test_sleep.c
+++ b/src/disco/sleep/test_sleep.c
@@ -1,0 +1,123 @@
+#include "fd_sleep.h"
+
+#include "../topo/fd_topo.h"
+#include "../../util/fd_util.h"
+#include "../../tango/tempo/fd_tempo.h"
+
+#include <pthread.h>
+
+static uchar        shmem_mem[ sizeof(fd_sleep_t) ] __attribute__((aligned(FD_SLEEP_ALIGN)));
+static fd_sleep_t * sleep;
+
+#define HAMMER_ITER (100000UL)
+
+static volatile int hammer_done;
+
+/* Plays the mwaitx tile: whenever tile 1 is parked, ring and wake it.
+   Extra wakes are absorbed, as in production. */
+
+static void *
+waker_thread( void * arg ) {
+  (void)arg;
+  while( !hammer_done ) {
+    if( ( FD_VOLATILE_CONST( sleep->parked_bits[ 0 ] ) & 2UL ) &&
+        !FD_VOLATILE_CONST( sleep->tile[ 1 ].word ) ) {
+      fd_sleep_ring( sleep, 1UL );
+      if( __atomic_exchange_n( &sleep->doorbell[ 0 ], 0UL, __ATOMIC_ACQUIRE ) & 2UL )
+        fd_sleep_wake_one( &sleep->tile[ 1 ].word );
+    } else {
+      FD_SPIN_PAUSE();
+    }
+  }
+  return NULL;
+}
+
+int
+main( int     argc,
+      char ** argv ) {
+  fd_boot( &argc, &argv );
+
+  FD_TEST( fd_sleep_align()==FD_SLEEP_ALIGN );
+  FD_TEST( fd_sleep_footprint()==sizeof(shmem_mem) );
+  double tick_per_ns = fd_tempo_tick_per_ns( NULL );
+
+  FD_TEST( !fd_sleep_new( NULL, tick_per_ns ) );
+  FD_TEST( !fd_sleep_new( shmem_mem+8UL, tick_per_ns ) );
+  FD_TEST( !fd_sleep_new( shmem_mem, 0.0 ) );
+  FD_TEST( !fd_sleep_join( shmem_mem ) ); /* no magic yet */
+  FD_TEST( fd_sleep_new( shmem_mem, tick_per_ns )==shmem_mem );
+  sleep = fd_sleep_join( shmem_mem );
+  FD_TEST( sleep );
+  for( ulong i=0UL; i<FD_SLEEP_TILE_MAX; i++ ) FD_TEST( sleep->tile[ i ].word==1UL );
+
+  /* wake_check rings only parked consumers in the mask */
+  fd_sleep_wake_t wake[ 2 ] = { { .w=0UL, .mask=6UL }, { .w=1UL, .mask=1UL } };
+  fd_sleep_wake_check( sleep, wake, 2UL );
+  FD_TEST( !sleep->doorbell[ 0 ] && !sleep->doorbell[ 1 ] );        /* nobody parked   */
+  sleep->parked_bits[ 0 ] = 4UL;
+  sleep->parked_bits[ 1 ] = 1UL;
+  fd_sleep_wake_check( sleep, wake, 2UL );
+  FD_TEST( sleep->doorbell[ 0 ]==4UL && sleep->doorbell[ 1 ]==1UL ); /* parked&mask     */
+  sleep->parked_bits[ 0 ] = 0UL; sleep->doorbell[ 0 ] = 0UL;
+  sleep->parked_bits[ 1 ] = 0UL; sleep->doorbell[ 1 ] = 0UL;
+
+  /* wake_table: polled consumers of one link, as (word,mask) pairs */
+  static fd_topo_t topo[ 1 ];
+  topo->sleep_obj_id = ULONG_MAX;
+  topo->tile_cnt     = 70UL;
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) { topo->tiles[ i ].id = i; topo->tiles[ i ].in_cnt = 0UL; }
+  topo->tiles[  2 ].in_cnt = 2UL; topo->tiles[  2 ].in_link_id[ 0 ] = 7UL; topo->tiles[  2 ].in_link_poll[ 0 ] = 1;
+  /**/                            topo->tiles[  2 ].in_link_id[ 1 ] = 8UL; topo->tiles[  2 ].in_link_poll[ 1 ] = 1;
+  topo->tiles[  5 ].in_cnt = 1UL; topo->tiles[  5 ].in_link_id[ 0 ] = 7UL; topo->tiles[  5 ].in_link_poll[ 0 ] = 0; /* unpolled: no wake */
+  topo->tiles[ 65 ].in_cnt = 1UL; topo->tiles[ 65 ].in_link_id[ 0 ] = 7UL; topo->tiles[ 65 ].in_link_poll[ 0 ] = 1; /* second word */
+  fd_sleep_wake_t table[ FD_SLEEP_BITS_CNT ];
+  FD_TEST( fd_sleep_wake_table( table, topo, 7UL )==0UL ); /* no sleep object: nothing to ring */
+  topo->sleep_obj_id = 0UL;
+  FD_TEST( fd_sleep_wake_table( table, topo, 9UL )==0UL ); /* no consumers */
+  FD_TEST( fd_sleep_wake_table( table, topo, 8UL )==1UL && table[ 0 ].w==0UL && table[ 0 ].mask==(1UL<<2) );
+  FD_TEST( fd_sleep_wake_table( table, topo, 7UL )==2UL );
+  FD_TEST( table[ 0 ].w==0UL && table[ 0 ].mask==(1UL<<2) );
+  FD_TEST( table[ 1 ].w==1UL && table[ 1 ].mask==(1UL<<1) );
+
+  /* deadline: no waker, absolute timeout honored.  Ten 2ms parks in a
+     row: a preemption inside one park can shorten that park, but not
+     eat half of the total. */
+  long t0 = fd_tickcount();
+  for( ulong i=0UL; i<10UL; i++ ) {
+    FD_VOLATILE( sleep->tile[ 0 ].word ) = 0UL;
+    FD_TEST( fd_sleep_park_wait( sleep, &sleep->tile[ 0 ].word, fd_tickcount()+(long)(2e6*tick_per_ns) )==FD_SLEEP_UNPARK_DEADLINE );
+    FD_VOLATILE( sleep->tile[ 0 ].word ) = 1UL;
+  }
+  long waited_ns = (long)((double)(fd_tickcount()-t0)/tick_per_ns);
+  FD_TEST( waited_ns>=10000000L && waited_ns<500000000L );
+
+  /* lapsed deadline returns without sleeping */
+  FD_VOLATILE( sleep->tile[ 0 ].word ) = 0UL;
+  FD_TEST( fd_sleep_park_wait( sleep, &sleep->tile[ 0 ].word, fd_tickcount()-1L )==FD_SLEEP_UNPARK_DEADLINE );
+  FD_VOLATILE( sleep->tile[ 0 ].word ) = 1UL;
+
+  /* word already 1: EAGAIN counts as a ring */
+  FD_VOLATILE( sleep->tile[ 0 ].word ) = 1UL;
+  FD_TEST( fd_sleep_park_wait( sleep, &sleep->tile[ 0 ].word, fd_tickcount()+(long)(1e9*tick_per_ns) )==FD_SLEEP_UNPARK_RING );
+
+  /* lost-wake hammer: a lost wake trips the 1s backstop deadline and
+     fails the cause assertion */
+  pthread_t waker;
+  FD_TEST( !pthread_create( &waker, NULL, waker_thread, NULL ) );
+  long deadline_slack = (long)(1e9*tick_per_ns);
+  for( ulong i=0UL; i<HAMMER_ITER; i++ ) {
+    FD_VOLATILE( sleep->tile[ 1 ].word ) = 0UL;
+    __atomic_fetch_or( &sleep->parked_bits[ 0 ], 2UL, __ATOMIC_SEQ_CST );
+    int cause = fd_sleep_park_wait( sleep, &sleep->tile[ 1 ].word, fd_tickcount()+deadline_slack );
+    FD_TEST( cause==FD_SLEEP_UNPARK_RING );
+    FD_VOLATILE( sleep->tile[ 1 ].word ) = 1UL;
+    __atomic_fetch_and( &sleep->doorbell   [ 0 ], ~2UL, __ATOMIC_SEQ_CST );
+    __atomic_fetch_and( &sleep->parked_bits[ 0 ], ~2UL, __ATOMIC_SEQ_CST );
+  }
+  hammer_done = 1;
+  FD_TEST( !pthread_join( waker, NULL ) );
+
+  FD_LOG_NOTICE(( "pass" ));
+  fd_halt();
+  return 0;
+}

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -827,6 +827,8 @@ struct fd_topo {
   char           app_name[ 256UL ];
   uchar          props[ 32768UL ];
 
+  ulong          sleep_obj_id;
+
   ulong          wksp_cnt;
   ulong          link_cnt;
   ulong          tile_cnt;

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -36,6 +36,8 @@ fd_topob_new( void * mem,
   topo->max_page_size           = FD_SHMEM_GIGANTIC_PAGE_SZ;
   topo->gigantic_page_threshold = 4 * FD_SHMEM_HUGE_PAGE_SZ;
 
+  topo->sleep_obj_id = ULONG_MAX;
+
   topo->agave_affinity_cnt = 0;
   topo->blocklist_cores_cnt = 0;
 


### PR DESCRIPTION
fd_sleep is one shared shmem region holding every tile's park word, the parked and doorbell bitmaps and the sequence mirrors and snapshots a verifying sweep compares.  Producers ring parked consumers with one load and, on a hit, one locked OR; nobody sleeps or wakes on it yet. The topology carries its object id (ULONG_MAX: no object).