### PR TITLE
topo: let tiles float within the layout

### DIFF
--- a/book/api/websocket.md
+++ b/book/api/websocket.md
@@ -1700,7 +1700,7 @@ seconds. The Firedancer allocation breakdown is fixed at startup.
 | online      | `boolean`        | Whether the CPU was online at validator startup |
 | numa_node   | `number`         | NUMA node containing this CPU |
 | sibling_cpu | `number \| null` | Logical CPU ID of the other hyperthread on the same physical core, or `null` when there is no known sibling. This ID indexes the `cpus` array |
-| tile_idxs   | `number[]`       | Indices in `summary.tiles` of tiles configured to run on this CPU. Multiple entries indicate configured CPU sharing, for example between startup and post-start tiles |
+| tile_idxs   | `number[]`       | Indices in `summary.tiles` of tiles pinned to this CPU. Multiple entries indicate configured CPU sharing, for example between startup and post-start tiles. Tiles the kernel schedules across CPUs are not listed |
 
 **`SystemLiveMemory`**
 | Field           | Type                     | Description |

--- a/src/app/shared/commands/configure/cpuset.c
+++ b/src/app/shared/commands/configure/cpuset.c
@@ -11,6 +11,14 @@
    `isolcpus=` boot parameter, and the strongest tool available for
    keeping foreign tasks off tile CPUs.
 
+   The partition type follows the topology.  When every tile is pinned
+   to its own CPU the partition is "isolated".  When some tiles float
+   (the kernel schedules them across a shared set of tile CPUs) it is
+   "root" instead: still exclusive to Firedancer, but the CPUs keep a
+   scheduler domain, which load balancing needs.  An isolated partition
+   has no scheduler domain, so a floating tile would never move off the
+   CPU it started on.
+
    IMPORTANT INTERACTION: once the partition exists, ONLY processes
    inside the cgroup may run on tile CPUs.  The tile launcher
    (execve_tile in run.c) joins the cgroup before setting a fixed
@@ -164,12 +172,13 @@ init( config_t const * config ) {
   if( FD_UNLIKELY( !write_cstr( path, list ) ) )
     FD_LOG_ERR(( "write(%s,\"%s\") failed (%i-%s)", path, list, errno, fd_io_strerror( errno ) ));
 
+  char const * partition = fd_cpu_isolation_partition_type( &config->topo );
   cgroup_path( path, config, "cpuset.cpus.partition" );
-  FD_LOG_NOTICE(( "%sRUN: `echo \"isolated\" > %s`%s", fd_log_style_dim(), path , fd_log_style_normal() ));
-  if( FD_UNLIKELY( !write_cstr( path, "isolated" ) ) )
-    FD_LOG_ERR(( "write(%s,\"isolated\") failed (%i-%s). The kernel may be too old for isolated cpuset "
+  FD_LOG_NOTICE(( "%sRUN: `echo \"%s\" > %s`%s", fd_log_style_dim(), partition, path , fd_log_style_normal() ));
+  if( FD_UNLIKELY( !write_cstr( path, partition ) ) )
+    FD_LOG_ERR(( "write(%s,\"%s\") failed (%i-%s). The kernel may be too old for %s cpuset "
                  "partitions, or a sibling cgroup may have explicitly claimed one of the CPUs `%s`",
-                 path, errno, fd_io_strerror( errno ), list ));
+                 path, partition, errno, fd_io_strerror( errno ), partition, list ));
 }
 
 static int
@@ -214,9 +223,12 @@ check( config_t const * config,
 
   FD_CPUSET_DECL( part_cpus );
   fd_cpu_isolation_partition_cpus( part_cpus, &config->topo );
-  if( FD_UNLIKELY( !fd_cpuset_cnt( part_cpus ) ) ) CONFIGURE_OK();
 
   char cgroup[ PATH_MAX ]; cgroup_path( cgroup, config, NULL );
+  if( FD_UNLIKELY( !fd_cpuset_cnt( part_cpus ) ) ) {
+    if( FD_UNLIKELY( !access( cgroup, F_OK ) ) ) PARTIALLY_CONFIGURED( "`%s` exists but the topology pins no CPUs", cgroup );
+    CONFIGURE_OK();
+  }
   if( FD_UNLIKELY( access( cgroup, F_OK ) ) )
     NOT_CONFIGURED( "`%s` does not exist", cgroup );
 
@@ -242,8 +254,9 @@ check( config_t const * config,
     NOT_CONFIGURED( "`%s` does not exist", path ); /* cgroup removed concurrently */
 
   /* An invalid partition reads as e.g. "isolated invalid (...)". */
-  if( FD_UNLIKELY( strcmp( partition, "isolated" ) ) )
-    PARTIALLY_CONFIGURED( "`%s` is \"%s\", expected \"isolated\"", path, partition );
+  char const * expected = fd_cpu_isolation_partition_type( &config->topo );
+  if( FD_UNLIKELY( strcmp( partition, expected ) ) )
+    PARTIALLY_CONFIGURED( "`%s` is \"%s\", expected \"%s\"", path, partition, expected );
 
   CONFIGURE_OK();
 }

--- a/src/app/shared/commands/configure/fd_cpu_isolation.c
+++ b/src/app/shared/commands/configure/fd_cpu_isolation.c
@@ -100,6 +100,12 @@ fd_cpu_isolation_format_list( char *              buf,
 
 static char const * const smt_sensitive_tiles[] = { "pack", "pohh", "poh", NULL };
 
+char const *
+fd_cpu_isolation_partition_type( fd_topo_t const * topo ) {
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) if( topo->tiles[ i ].floats ) return "root";
+  return "isolated";
+}
+
 fd_cpuset_t *
 fd_cpu_isolation_partition_cpus( fd_cpuset_t       cpuset[ static fd_cpuset_word_cnt ],
                                  fd_topo_t const * topo ) {
@@ -114,6 +120,7 @@ fd_cpu_isolation_partition_cpus( fd_cpuset_t       cpuset[ static fd_cpuset_word
 
     ulong cpu_idx = topo->tiles[ tile_idx ].cpu_idx;
     if( FD_UNLIKELY( cpu_idx>=fd_ulong_min( cpus->cpu_cnt, FD_TILE_MAX ) ) ) continue;
+    if( FD_UNLIKELY( topo->tiles[ tile_idx ].floats ) ) continue; /* not alone on that core anyway */
 
     ulong sibling = cpus->cpu[ cpu_idx ].sibling;
     if( FD_UNLIKELY( sibling==ULONG_MAX || sibling>=FD_TILE_MAX ) ) continue;      /* no sibling */

--- a/src/app/shared/commands/configure/fd_cpu_isolation.h
+++ b/src/app/shared/commands/configure/fd_cpu_isolation.h
@@ -59,6 +59,14 @@ fd_cpu_isolation_format_list( char *              buf,
                               ulong               buf_sz,
                               fd_cpuset_t const * cpuset );
 
+/* fd_cpu_isolation_partition_type returns the cpuset.cpus.partition
+   value for the topology: "isolated" (no scheduler domain, tiles are
+   pinned 1:1) unless some tile floats within the tile CPU set, when
+   the partition must keep a domain to balance them: "root". */
+
+char const *
+fd_cpu_isolation_partition_type( fd_topo_t const * topo );
+
 /* fd_cpu_isolation_partition_cpus fills cpuset with the CPUs that the
    cpuset stage places in the isolated partition: all fixed tile CPUs,
    plus the otherwise-unused hyperthread siblings of the tiles that are

--- a/src/app/shared/commands/configure/hyperthreads.c
+++ b/src/app/shared/commands/configure/hyperthreads.c
@@ -79,6 +79,12 @@ check( config_t const * config,
   ulong pohh_pair  = determine_ht_pair( config, cpus, "pohh",  0UL );
   ulong poh_pair = determine_ht_pair( config, cpus, "poh",  0UL );
 
+  /* A floating tile (efficient scheduler mode) shares its cores with
+     the other floaters, so an idle sibling buys it nothing */
+  if( pack_tile_idx!=ULONG_MAX && config->topo.tiles[ pack_tile_idx ].floats ) pack_pair = ULONG_MAX;
+  if( pohh_tile_idx!=ULONG_MAX && config->topo.tiles[ pohh_tile_idx ].floats ) pohh_pair = ULONG_MAX;
+  if( poh_tile_idx !=ULONG_MAX && config->topo.tiles[ poh_tile_idx  ].floats ) poh_pair  = ULONG_MAX;
+
   int pack_pair_used = determine_cpu_used( config, pack_pair );
   int pohh_pair_used  = determine_cpu_used( config, pohh_pair );
   int poh_pair_used = determine_cpu_used( config, poh_pair );

--- a/src/app/shared/commands/run/run.c
+++ b/src/app/shared/commands/run/run.c
@@ -21,6 +21,7 @@
 #include "../../../../disco/waker/fd_waker.h"
 
 #include "../configure/configure.h"
+#include "../configure/fd_cpu_isolation.h"
 
 #include <dirent.h>
 #include <sched.h>
@@ -247,6 +248,7 @@ leave_isolation_cgroup( struct spawn_cgroup * cg ) {
 static pid_t
 execve_tile( char const *           name,
              fd_topo_tile_t const * tile,
+             fd_cpuset_t const *    float_cpu_set,
              fd_cpuset_t const *    floating_cpu_set,
              int                    floating_priority,
              int                    config_memfd,
@@ -259,7 +261,14 @@ execve_tile( char const *           name,
        kernel first touch happens on the desired thread.  The child
        inherits both. */
     join_isolation_cgroup( name, cg );
-    fd_cpuset_insert( cpu_set, tile->cpu_idx );
+    if( FD_UNLIKELY( tile->floats ) ) {
+      /* the floating CPUs on this tile's NUMA node: memory was placed
+         by cpu_idx */
+      ulong numa_idx = fd_shmem_numa_idx( tile->cpu_idx );
+      for( ulong cpu=0UL; cpu<FD_TILE_MAX; cpu++ )
+        if( fd_cpuset_test( float_cpu_set, cpu ) && fd_shmem_numa_idx( cpu )==numa_idx ) fd_cpuset_insert( cpu_set, cpu );
+    }
+    if( FD_UNLIKELY( !fd_cpuset_cnt( cpu_set ) ) ) fd_cpuset_insert( cpu_set, tile->cpu_idx );
     if( FD_UNLIKELY( -1==setpriority( PRIO_PROCESS, 0, -19 ) ) ) FD_LOG_ERR(( "setpriority() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   } else {
     leave_isolation_cgroup( cg );
@@ -327,6 +336,18 @@ main_pid_namespace( void * _args ) {
   FD_CPUSET_DECL( floating_cpu_set );
   if( FD_UNLIKELY( fd_cpuset_getaffinity( 0, floating_cpu_set ) ) )
     FD_LOG_ERR(( "fd_cpuset_getaffinity failed (%i-%s)", errno, fd_io_strerror( errno ) ));
+
+  /* The CPUs of the floating tiles (efficient mode): floaters share
+     these among themselves and never a pinned tile's CPU */
+  FD_CPUSET_DECL( float_cpu_set );
+  int any_floats = 0;
+  for( ulong i=0UL; i<config->topo.tile_cnt; i++ ) {
+    if( FD_LIKELY( !config->topo.tiles[ i ].floats ) ) continue;
+    fd_cpuset_insert( float_cpu_set, config->topo.tiles[ i ].cpu_idx );
+    any_floats = 1;
+  }
+  for( ulong i=0UL; i<config->topo.tile_cnt; i++ )
+    if( FD_LIKELY( !config->topo.tiles[ i ].floats && config->topo.tiles[ i ].cpu_idx!=ULONG_MAX ) ) fd_cpuset_remove( float_cpu_set, config->topo.tiles[ i ].cpu_idx );
 
   pid_t child_pids[ FD_TOPO_MAX_TILES+1 ];
   ulong actual_pids[ FD_TOPO_MAX_TILES+1 ];
@@ -482,7 +503,9 @@ main_pid_namespace( void * _args ) {
       int pipefd[ 2 ];
       if( FD_UNLIKELY( pipe2( pipefd, O_CLOEXEC ) ) ) FD_LOG_ERR(( "pipe2() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       fds[ child_cnt ] = (struct pollfd){ .fd = pipefd[ 0 ], .events = 0 };
-      child_pids[ child_cnt ] = execve_tile( config->name, tile, floating_cpu_set, save_priority, config_memfd, pipefd[ 1 ], &spawn_cg );
+
+      int floating_priority = ( any_floats && !strcmp( tile->name, "waker" ) ) ? -19 : save_priority;
+      child_pids[ child_cnt ] = execve_tile( config->name, tile, float_cpu_set, floating_cpu_set, floating_priority, config_memfd, pipefd[ 1 ], &spawn_cg );
       child_idxs[ child_cnt ] = i;
       if( FD_UNLIKELY( close( pipefd[ 1 ] ) ) ) FD_LOG_ERR(( "close() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
       strncpy( child_names[ child_cnt ], tile->name, 32 );
@@ -956,6 +979,20 @@ fdctl_check_configure( config_t const * config ) {
     if( FD_UNLIKELY( check.result!=CONFIGURE_OK ) )
       FD_LOG_WARNING(( "Kernel workqueues may steal CPU time from Firedancer tiles: %s. For lower jitter, run "
                        "`%s configure init kworkers`.", check.message, FD_BINARY_NAME ));
+  }
+
+  /* Floating tiles need a scheduler domain to be balanced across their
+     CPUs; isolcpus= removes it, and every floater would stay on the
+     CPU it was forked on. */
+  FD_CPUSET_DECL( isolated );
+  if( FD_LIKELY( fd_cpu_isolation_read_list( "/sys/devices/system/cpu/isolated", isolated ) ) ) {
+    for( ulong i=0UL; i<config->topo.tile_cnt; i++ ) {
+      fd_topo_tile_t const * tile = &config->topo.tiles[ i ];
+      if( FD_UNLIKELY( tile->floats && fd_cpuset_test( isolated, tile->cpu_idx ) ) )
+        FD_LOG_ERR(( "tile %s:%lu floats on CPU %lu, which the isolcpus= boot parameter removed from the kernel scheduler. "
+                     "Floating tiles need their CPUs scheduled: drop them from isolcpus= and isolate them with "
+                     "`%s configure init cpuset` instead.", tile->name, tile->kind_id, tile->cpu_idx, FD_BINARY_NAME ));
+    }
   }
 
   if( FD_LIKELY( fd_cfg_stage_cpuset.enabled( config ) ) ) {

--- a/src/app/shared/fd_config_json.c
+++ b/src/app/shared/fd_config_json.c
@@ -11,7 +11,7 @@
    or knowingly skipped) before the constant is bumped.  String keys of
    the user's own file are separately forced through the classification
    lists below. */
-FD_STATIC_ASSERT( sizeof(fd_config_t)==22970304UL, update_fd_config_to_json_for_the_layout_change );
+FD_STATIC_ASSERT( sizeof(fd_config_t)==22972352UL, update_fd_config_to_json_for_the_layout_change );
 
 #define REDACTED "[redacted]"
 

--- a/src/disco/diag/fd_diag_tile.c
+++ b/src/disco/diag/fd_diag_tile.c
@@ -1349,7 +1349,7 @@ unprivileged_init( fd_topo_t const *      topo,
   for( ulong i=0UL; i<FD_TILE_MAX; i++ ) ctx->cpu_to_tile[ i ] = USHORT_MAX;
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
     ulong cpu_idx = topo->tiles[ i ].cpu_idx;
-    if( cpu_idx>=FD_TILE_MAX ) continue;
+    if( cpu_idx>=FD_TILE_MAX || topo->tiles[ i ].floats ) continue;
     ctx->cpu_to_tile[ cpu_idx ] = (ushort)i;
   }
 

--- a/src/disco/events/fd_boot_report.c
+++ b/src/disco/events/fd_boot_report.c
@@ -1259,9 +1259,9 @@ render_topology_json( fd_boot_report_t * r,
   PRINT( "{\"tiles\":[" );
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
     fd_topo_tile_t const * tile = &topo->tiles[ i ];
-    PRINT( "%s{\"kind\":\"%s\",\"kind_id\":%lu,\"cpu_idx\":%ld,\"in\":[",
+    PRINT( "%s{\"kind\":\"%s\",\"kind_id\":%lu,\"cpu_idx\":%ld,\"floats\":%s,\"in\":[",
            i ? "," : "", tile->name, tile->kind_id,
-           tile->cpu_idx<FD_TILE_MAX ? (long)tile->cpu_idx : -1L );
+           tile->cpu_idx<FD_TILE_MAX ? (long)tile->cpu_idx : -1L, tile->floats ? "true" : "false" );
     for( ulong in=0UL; in<tile->in_cnt; in++ ) PRINT( "%s%lu", in ? "," : "", tile->in_link_id[ in ] );
     PRINT( "],\"out\":[" );
     for( ulong out=0UL; out<tile->out_cnt; out++ ) PRINT( "%s%lu", out ? "," : "", tile->out_link_id[ out ] );

--- a/src/disco/events/test_boot_report.c
+++ b/src/disco/events/test_boot_report.c
@@ -158,6 +158,7 @@ main( int     argc,
   topo->tile_cnt = 2UL;
   strcpy( topo->tiles[ 0 ].name, "net" );
   topo->tiles[ 0 ].cpu_idx = 1UL;
+  topo->tiles[ 0 ].floats  = 1;
   topo->tiles[ 0 ].out_cnt = 1UL;
   topo->tiles[ 0 ].out_link_id[ 0 ] = 0UL;
   strcpy( topo->tiles[ 1 ].name, "shred" );
@@ -179,6 +180,8 @@ main( int     argc,
 
   FD_TEST( report->topology_json_len );
   FD_LOG_NOTICE(( "topology_json %s", report->topology_json ));
+  FD_TEST( strstr( report->topology_json, "\"cpu_idx\":1,\"floats\":true" ) );
+  FD_TEST( strstr( report->topology_json, "\"cpu_idx\":-1,\"floats\":false" ) );
 
   ulong sz = 0UL;
   uchar const * msg = fd_circq_cursor_advance( circq, &sz );

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -1174,7 +1174,7 @@ fd_gui_printf_system_resources( fd_gui_t * gui ) {
               for( ulong j=0UL; j<gui->summary.tile_cnt; j++ ) {
                 ulong topo_tile_idx = gui->summary.tile[ j ];
                 fd_topo_tile_t const * tile = &gui->topo->tiles[ topo_tile_idx ];
-                if( FD_LIKELY( tile->cpu_idx!=i ) ) continue;
+                if( FD_LIKELY( tile->cpu_idx!=i || tile->floats ) ) continue;
                 ulong ordinal = fd_gui_tile_ordinal( gui, topo_tile_idx );
                 if( ordinal!=ULONG_MAX ) jsonp_ulong( gui->http, NULL, ordinal );
               }

--- a/src/disco/topo/fd_topo.c
+++ b/src/disco/topo/fd_topo.c
@@ -580,7 +580,7 @@ fd_topo_print_log( int         stdout,
            i, fd_topo_mem_sz_style( mlock, c_bold, c_dim ), size, c_normal,
            tile->name, tile->kind_id, topo->objs[ tile->tile_obj_id ].wksp_id );
     if( tile->cpu_idx!=ULONG_MAX ) {
-      PRINT( "%4lu", tile->cpu_idx );
+      PRINT( "%s%4lu%s", tile->floats ? c_dim : "", tile->cpu_idx, tile->floats ? c_normal : "" );
     } else {
       PRINT( "%s%4s%s", c_dim, "any", c_normal );
     }
@@ -768,6 +768,7 @@ fd_topo_print_json( fd_topo_t * topo ) {
            tile->kind_id, topo->objs[ tile->tile_obj_id ].wksp_id );
     if( tile->cpu_idx!=ULONG_MAX ) PRINT( "\"cpu_idx\": %lu, ", tile->cpu_idx );
     else                           PRINT( "\"cpu_idx\": null, " );
+    PRINT( "\"floats\": %s, ", tile->floats ? "true" : "false" );
     PRINT( "\"numa_idx\": %lu, \"mlock_bytes\": %lu, \"in_links\": [", tile_numa, fd_topo_mlock_max_tile1( topo, tile ) );
     for( ulong j=0UL; j<tile->in_cnt; j++ ) {
       PRINT( "%s{ \"link_id\": %lu, \"reliable\": %s }", j ? ", " : "", tile->in_link_id[ j ], tile->in_link_reliable[ j ] ? "true" : "false" );

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -139,6 +139,7 @@ struct fd_topo_tile {
   int   allow_shutdown;         /* If the tile is allowed to shutdown gracefully.  If false, when the tile exits it will tear down the entire application. */
 
   ulong cpu_idx;                /* The CPU index to pin the tile on.  A value of ULONG_MAX or more indicates the tile should be floating and not pinned to a core. */
+  int   floats;                 /* Scheduled by the kernel over the CPUs of the floating tiles on its NUMA node, never a pinned tile's CPU, instead of pinned to cpu_idx (efficient mode).  cpu_idx still places memory and isolation, and is the fallback when no such CPU remains. */
 
   ulong waker_client_idx;       /* Client slot in the fixed inherited fd range (inner epoll fd FD_WAKER_INNER_FD( idx )), or ULONG_MAX if not a waker client */
   ulong waker_fseq_obj_id;      /* fseq object holding the tile's waker readiness word or ULONG_MAX */

--- a/src/disco/topo/fd_topo_run.c
+++ b/src/disco/topo/fd_topo_run.c
@@ -253,6 +253,7 @@ run_tile_thread( fd_topo_t *         topo,
                  fd_topo_run_tile_t  tile_run,
                  uint                uid,
                  uint                gid,
+                 fd_cpuset_t const * float_cpu_set,
                  fd_cpuset_t const * floating_cpu_set,
                  int                 floating_priority,
                  fd_topo_run_thread_args_t * args ) {
@@ -270,7 +271,12 @@ run_tile_thread( fd_topo_t *         topo,
   if( FD_LIKELY( tile->cpu_idx<65535UL ) ) {
     /* set the thread affinity before we clone the new process to ensure
        kernel first touch happens on the desired thread. */
-    fd_cpuset_insert( cpu_set, tile->cpu_idx );
+    if( FD_UNLIKELY( tile->floats ) ) {
+      ulong numa_idx = fd_shmem_numa_idx( tile->cpu_idx );
+      for( ulong cpu=0UL; cpu<FD_TILE_MAX; cpu++ )
+        if( fd_cpuset_test( float_cpu_set, cpu ) && fd_shmem_numa_idx( cpu )==numa_idx ) fd_cpuset_insert( cpu_set, cpu );
+    }
+    if( FD_UNLIKELY( !fd_cpuset_cnt( cpu_set ) ) ) fd_cpuset_insert( cpu_set, tile->cpu_idx );
     if( FD_UNLIKELY( -1==setpriority( PRIO_PROCESS, 0, -19 ) ) ) FD_LOG_ERR(( "setpriority() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
   } else {
     fd_memcpy( cpu_set, floating_cpu_set, fd_cpuset_footprint() );
@@ -345,6 +351,18 @@ fd_topo_run_single_process( fd_topo_t *       topo,
   if( FD_UNLIKELY( fd_cpuset_getaffinity( 0, floating_cpu_set ) ) )
     FD_LOG_ERR(( "sched_getaffinity failed (%i-%s)", errno, fd_io_strerror( errno ) ));
 
+  /* The CPUs of the floating tiles (efficient mode): floaters share
+     these among themselves and never a pinned tile's CPU */
+  FD_CPUSET_DECL( float_cpu_set );
+  int any_floats = 0;
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    if( FD_LIKELY( !topo->tiles[ i ].floats ) ) continue;
+    fd_cpuset_insert( float_cpu_set, topo->tiles[ i ].cpu_idx );
+    any_floats = 1;
+  }
+  for( ulong i=0UL; i<topo->tile_cnt; i++ )
+    if( FD_LIKELY( !topo->tiles[ i ].floats && topo->tiles[ i ].cpu_idx!=ULONG_MAX ) ) fd_cpuset_remove( float_cpu_set, topo->tiles[ i ].cpu_idx );
+
   errno = 0;
   int save_priority = getpriority( PRIO_PROCESS, 0 );
   if( FD_UNLIKELY( -1==save_priority && errno ) ) FD_LOG_ERR(( "getpriority() failed (%i-%s)", errno, fd_io_strerror( errno ) ));
@@ -357,7 +375,8 @@ fd_topo_run_single_process( fd_topo_t *       topo,
     if( agave==1 && !tile->is_agave ) continue;
 
     fd_topo_run_tile_t run_tile = tile_run( tile );
-    run_tile_thread( topo, tile, run_tile, uid, gid, floating_cpu_set, save_priority, &args[ i ] );
+    int floating_priority = ( any_floats && !strcmp( tile->name, "waker" ) ) ? -19 : save_priority; /* the waker delivers floaters' fd readiness: never behind them */
+    run_tile_thread( topo, tile, run_tile, uid, gid, float_cpu_set, floating_cpu_set, floating_priority, &args[ i ] );
   }
 
   for( ulong i=0UL; i<topo->tile_cnt; i++ ) {

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -182,6 +182,7 @@ fd_topob_tile( fd_topo_t *    topo,
   tile->event_link_id       = ULONG_MAX;
   tile->uses_obj_cnt        = 0UL;
   tile->is_waker_client     = is_waker_client;
+  tile->floats              = 0;
   tile->waker_client_idx    = ULONG_MAX;
   tile->waker_fseq_obj_id   = ULONG_MAX;
 
@@ -370,6 +371,14 @@ validate( fd_topo_t const * topo ) {
     fd_topo_tile_t const * tile = &topo->tiles[ i ];
     if( FD_UNLIKELY( tile->is_waker_client && tile->waker_client_idx==ULONG_MAX ) )
       FD_LOG_ERR(( "tile %s:%lu is a waker client but fd_topob_waker was not called", tile->name, tile->kind_id ));
+  }
+
+  /* Floating tiles have a CPU: it places their memory and anchors
+     their affinity mask */
+  for( ulong i=0UL; i<topo->tile_cnt; i++ ) {
+    fd_topo_tile_t const * tile = &topo->tiles[ i ];
+    if( FD_UNLIKELY( tile->floats && tile->cpu_idx>=FD_TILE_MAX ) )
+      FD_LOG_ERR(( "tile %s:%lu floats but has no CPU", tile->name, tile->kind_id ));
   }
 
   /* Workspace names are unique */


### PR DESCRIPTION
A tile with floats set keeps its cpu_idx for memory placement and isolation but runs with the affinity of every floating tile's CPU on its NUMA node, never a pinned tile's.  The cpuset stage then creates a root partition (exclusive CPUs with their own scheduler domain) instead of an isolated one, run refuses floaters on isolcpus= CPUs and raises the waker's priority (it delivers their fd readiness), and the SMT and per-CPU diagnostics stop treating a floater's CPU as its own.  No topology sets floats yet.