### PR TITLE
bench: size per-slot structures from runtime limits

### DIFF
--- a/book/guide/tuning.md
+++ b/book/guide/tuning.md
@@ -196,8 +196,8 @@ TPS rate,
   # The Solana protocol consensus limits restrict the benchmark to
   # around 81,000 TPS. We have special options to increase these limits
   # for testing and benchmarking
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 131072
 
 [rpc]
   # Tracking certain transaction history and metadata to serve RPC

--- a/src/app/fdctl/commands/run_agave.c
+++ b/src/app/fdctl/commands/run_agave.c
@@ -215,8 +215,9 @@ agave_boot( config_t const * config ) {
   }
 
   /* Consensus-breaking development-only CU and/or shred limit increase. */
-  _fd_ext_larger_max_cost_per_block     = config->development.bench.larger_max_cost_per_block;
-  _fd_ext_larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
+  /* The Agave patches only know a boolean: any raised limit selects their fixed benchmark limits. */
+  _fd_ext_larger_max_cost_per_block     = !!config->development.bench.max_cost_per_block;
+  _fd_ext_larger_shred_limits_per_block = !!config->development.bench.max_shreds_per_block;
   /* Consensus-breaking bench-only option to disable status cache */
   _fd_ext_disable_status_cache           = config->development.bench.disable_status_cache;
   FD_COMPILER_MFENCE();

--- a/src/app/fdctl/config/bench-icelake-80core.toml
+++ b/src/app/fdctl/config/bench-icelake-80core.toml
@@ -25,8 +25,8 @@ scratch_directory = "/dev/shm/fd1"
   benchg_tile_count = 12
   benchs_tile_count = 2
   affinity = "f1,0-26/2"
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 1048576
   disable_blockstore_from_slot = 1
 
 [rpc]

--- a/src/app/fdctl/config/bench-zen3-32core.toml
+++ b/src/app/fdctl/config/bench-zen3-32core.toml
@@ -22,8 +22,8 @@
   benchg_tile_count = 12
   benchs_tile_count = 2
   affinity = "f1,0-13"
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 1048576
   disable_blockstore_from_slot = 1
 
 [rpc]

--- a/src/app/fdctl/config/bench-zen4-64core.toml
+++ b/src/app/fdctl/config/bench-zen4-64core.toml
@@ -15,8 +15,8 @@ scratch_directory = "/dev/shm/fd1"
 [development.bench]
   benchg_tile_count = 18
   benchs_tile_count = 3
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 1048576
   disable_blockstore_from_slot = 1
   disable_status_cache = true
 

--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1730,32 +1730,33 @@ dynamic_port_range = "8900-9000"
         # automatically.
         affinity = "auto"
 
-        # Solana has a hard-coded maximum CUs per block limit of
-        # 50,000,000+ which works out to around 83,000 transfers a
-        # second, since each consumes about 1500 CUs.  When
-        # benchmarking, this can be the limiting bottleneck of the
-        # system, so this option is provided to raise the limit.  If set
-        # to true, the limit will be lifted to 624,000,000 for a little
-        # over 1 million transfers per second.
+        # Solana has a consensus-agreed maximum number of compute units
+        # per block, on the order of 50,000,000, which works out to
+        # around 83,000 transfers a second since each consumes about
+        # 1,500 CUs.  When benchmarking, this can be the limiting
+        # bottleneck of the system, so this option is provided to raise
+        # the limit.  0 keeps the consensus limits.  Frankendancer's
+        # Agave side raises its limit by a fixed 18x, so the only other
+        # accepted value is 540000000.
         #
         # This option should not be used in production, and would cause
         # consensus violations and a consensus difference between the
         # validator and the rest of the network.
-        larger_max_cost_per_block = false
+        max_cost_per_block = 0
 
-        # Solana has a consensus-agreed-upon limit of 32,768 data and
-        # parity shreds per block.  This limit prevents a malicious (or
-        # mistaken) validator from slowing down the network by producing
-        # a huge block.  When benchmarking, this limit can be the
-        # bottleneck of the whole system, so this option is provided to
-        # raise the limit.  If set to true, the limit will be raised to
-        # 131,072 data and parity shreds per block, for about 1,200,000
-        # small transactions per second.
+        # Solana has a consensus-agreed-upon limit of 32,768 data shreds
+        # (and as many parity shreds) per block.  This limit prevents a
+        # malicious (or mistaken) validator from slowing down the
+        # network by producing a huge block.  When benchmarking, this
+        # limit can be the bottleneck of the whole system, so this
+        # option is provided to raise the limit.  0 keeps the consensus
+        # limit.  Frankendancer's Agave side raises its limit by a fixed
+        # 32x, so the only other accepted value is 1048576.
         #
         # This option should not be used in a production network, since
         # it would cause consensus violations between the validator and
         # the rest of the network.
-        larger_shred_limits_per_block = false
+        max_shreds_per_block = 0
 
         # Frankendancer currently depends on the Agave blockstore
         # component for storing block data to disk.  This component can

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -470,8 +470,9 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
   } else if( FD_UNLIKELY( !strcmp( tile->name, "pack" ) ) ) {
     tile->pack.max_pending_transactions      = config->tiles.pack.max_pending_transactions;
     tile->pack.execle_tile_count             = config->frankendancer.layout.bank_tile_count;
-    tile->pack.larger_max_cost_per_block     = config->development.bench.larger_max_cost_per_block;
-    tile->pack.larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
+    tile->pack.max_cost_per_block            = config->limits.max_cost_per_block;
+    tile->pack.max_shreds_per_block          = config->limits.max_shreds_per_block;
+    tile->pack.bench_max_shreds_per_block    = config->development.bench.max_shreds_per_block;
     tile->pack.use_consumed_cus              = config->tiles.pack.use_consumed_cus;
     tile->pack.schedule_strategy             = config->tiles.pack.schedule_strategy_enum;
     tile->pack.acct_blocklist_cnt            = config->tiles.pack.account_blocklist_cnt;
@@ -522,7 +523,8 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     tile->shred.fec_resolver_depth            = config->tiles.shred.max_pending_shred_sets;
     tile->shred.expected_shred_version        = config->consensus.expected_shred_version;
     tile->shred.shred_listen_port             = config->tiles.shred.shred_listen_port;
-    tile->shred.larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
+    tile->shred.max_shreds_per_block          = config->limits.max_shreds_per_block;
+    tile->shred.bench_max_shreds_per_block    = config->development.bench.max_shreds_per_block;
     for( ulong i=0UL; i<config->tiles.shred.additional_shred_destinations_retransmit_cnt; i++ ) {
       parse_ip_port( "tiles.shred.additional_shred_destinations_retransmit",
                       config->tiles.shred.additional_shred_destinations_retransmit[ i ],

--- a/src/app/firedancer-dev/commands/backtest.c
+++ b/src/app/firedancer-dev/commands/backtest.c
@@ -377,22 +377,22 @@ backtest_topo( config_t * config ) {
   fd_topob_wksp( topo, "store" );
   fd_topo_link_t const * repair_out_link = &topo->links[ fd_topo_find_link( topo, "repair_out", 0UL ) ];
   ulong fec_sets_per_slot = fd_ulong_if( config->firedancer.development.fixed_fec_sets,
-                                         FD_FEC_BLK_MAX, FD_SHRED_BLK_MAX );
+                                         config->limits.max_shreds_per_block/FD_FEC_SHRED_CNT, config->limits.max_shreds_per_block );
   ulong store_fec_max = config->firedancer.runtime.max_live_slots * fec_sets_per_slot + repair_out_link->depth + 1UL;
   ulong store_fec_data_max = fd_ulong_if( config->firedancer.development.fixed_fec_sets, 31840UL, 63985UL );
-  fd_topo_obj_t * store_obj = setup_topo_store( topo, "store", store_fec_max, store_fec_data_max, 0UL, config->tiles.shred.shred_cache_size_mib, 0UL, config->paths.shredb );
+  fd_topo_obj_t * store_obj = setup_topo_store( topo, "store", store_fec_max, store_fec_data_max, 0UL, config->tiles.shred.shred_cache_size_mib, 0UL, config->limits.max_shreds_per_block, config->paths.shredb );
   fd_topob_tile_uses( topo, backt_tile, store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   fd_topob_tile_uses( topo, replay_tile, store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, store_obj->id, "store" ) );
 
   fd_topob_wksp( topo, "banks" );
-  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, 0 );
+  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, config->development.bench.max_cost_per_block );
   fd_topob_tile_uses( topo, replay_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
 
   fd_topob_wksp( topo, "txncache"    );
-  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT, config->development.bench.larger_max_cost_per_block );
+  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, 2UL*config->limits.max_txn_per_slot );
   fd_topob_tile_uses( topo, replay_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   if( FD_LIKELY( !disable_snap_loader ) ) fd_topob_tile_uses( topo, snapin_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   for( ulong i=0UL; i<execrp_tile_cnt; i++ ) {

--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -384,7 +384,7 @@ forktest_topo( config_t * config ) {
   /**/                 fd_topob_tile_uses( topo, replay_tile, progcache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i   ) ], progcache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
 
-  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, config->development.bench.larger_max_cost_per_block );
+  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, config->development.bench.max_cost_per_block );
   /**/                 fd_topob_tile_uses( topo, replay_tile, banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "tower",  0UL ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
   FOR(execrp_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "execrp", i   ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
@@ -400,15 +400,15 @@ forktest_topo( config_t * config ) {
   ulong store_fec_set_cnt = shred_tile_cnt*fec_set_cnt;
 
   ulong fec_sets_per_slot = fd_ulong_if( config->firedancer.development.fixed_fec_sets,
-                                         FD_FEC_BLK_MAX, FD_SHRED_BLK_MAX );
+                                         config->limits.max_shreds_per_block/FD_FEC_SHRED_CNT, config->limits.max_shreds_per_block );
   ulong store_fec_max = config->firedancer.runtime.max_live_slots * fec_sets_per_slot + (shred_depth * shred_tile_cnt) + 1;
   ulong store_fec_data_max = fd_ulong_if( config->firedancer.development.fixed_fec_sets, 31840UL, 63985UL );
-  fd_topo_obj_t * store_obj = setup_topo_store( topo, "store", store_fec_max, store_fec_data_max, 0UL, config->tiles.shred.shred_cache_size_mib, store_fec_set_cnt, config->paths.shredb );
+  fd_topo_obj_t * store_obj = setup_topo_store( topo, "store", store_fec_max, store_fec_data_max, 0UL, config->tiles.shred.shred_cache_size_mib, store_fec_set_cnt, config->limits.max_shreds_per_block, config->paths.shredb );
   FOR(shred_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "shred", i ) ], store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   fd_topob_tile_uses( topo, replay_tile, store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   FD_TEST( fd_pod_insertf_ulong( topo->props, store_obj->id, "store" ) );
 
-  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT, config->development.bench.larger_max_cost_per_block );
+  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, 2UL*config->limits.max_txn_per_slot );
   fd_topob_tile_uses( topo, replay_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   if( FD_LIKELY( snapshots_enabled ) ) {
     fd_topob_tile_uses( topo, snapin_tile, txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );

--- a/src/app/firedancer-dev/commands/rotor.c
+++ b/src/app/firedancer-dev/commands/rotor.c
@@ -18,11 +18,11 @@ extern action_t fd_action_rotor;
    mirror fd_chainer_new. */
 
 static fd_chainer_t
-rotor_chainer_reloc( void * chainer_laddr, ulong ele_max ) {
+rotor_chainer_reloc( void * chainer_laddr, ulong ele_max, ulong max_shreds_per_block ) {
   fd_chainer_t c = *(fd_chainer_t *)chainer_laddr;
 
   ulong blk_max       = ele_max * FD_CHAINER_SLOT_VER_MAX;
-  ulong fec_max       = blk_max * FD_FEC_BLK_MAX;
+  ulong fec_max       = blk_max * ( max_shreds_per_block / FD_FEC_SHRED_CNT );
   ulong fec_chain_cnt = fd_fec_map_chain_cnt_est( fec_max );
   ulong blk_chain_cnt = fd_slotv_map_chain_cnt_est( blk_max );
 
@@ -31,6 +31,7 @@ rotor_chainer_reloc( void * chainer_laddr, ulong ele_max ) {
   c.fec_pool     = fd_fec_pool_join    ( FD_SCRATCH_ALLOC_APPEND( l, fd_fec_pool_align(),     fd_fec_pool_footprint    ( fec_max )        ) );
   c.fec_map      = fd_fec_map_join     ( FD_SCRATCH_ALLOC_APPEND( l, fd_fec_map_align(),      fd_fec_map_footprint     ( fec_chain_cnt )  ) );
   c.slotv_pool   = fd_slotv_pool_join  ( FD_SCRATCH_ALLOC_APPEND( l, fd_slotv_pool_align(),   fd_slotv_pool_footprint  ( blk_max )        ) );
+  c.fec_tbl      =                       FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),           fec_max*sizeof(uint)                        );
   c.slotv_map    = fd_slotv_map_join   ( FD_SCRATCH_ALLOC_APPEND( l, fd_slotv_map_align(),    fd_slotv_map_footprint   ( blk_chain_cnt ) ) );
   c.sched_pool   = fd_sched_pool_join  ( FD_SCRATCH_ALLOC_APPEND( l, fd_sched_pool_align(),   fd_sched_pool_footprint  ( blk_max )        ) );
   c.sched_map    = fd_sched_map_join   ( FD_SCRATCH_ALLOC_APPEND( l, fd_sched_map_align(),    fd_sched_map_footprint   ( blk_chain_cnt )) );
@@ -63,16 +64,17 @@ rotor_cmd_fn( args_t *   args FD_PARAM_UNUSED,
   void *           scratch = fd_topo_obj_laddr( topo, tile->tile_obj_id );
   if( FD_UNLIKELY( !scratch ) ) FD_LOG_ERR(( "Failed to access rotor tile scratch memory" ));
 
-  ulong ele_max = tile->rotor.slot_max;
+  ulong ele_max              = tile->rotor.slot_max;
+  ulong max_shreds_per_block = tile->rotor.max_shreds_per_block;
 
   /* Walk the tile scratch layout (ctx, protocol, chainer) to the chainer
      local address; mirrors the rotor tile's unprivileged_init. */
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   (void)               FD_SCRATCH_ALLOC_APPEND( l, alignof(ctx_t),        sizeof(ctx_t)                    );
   (void)               FD_SCRATCH_ALLOC_APPEND( l, fd_repair_align(),    fd_repair_footprint()            );
-  void * chainer_laddr = FD_SCRATCH_ALLOC_APPEND( l, fd_chainer_align(), fd_chainer_footprint( ele_max ) );
+  void * chainer_laddr = FD_SCRATCH_ALLOC_APPEND( l, fd_chainer_align(), fd_chainer_footprint( ele_max, max_shreds_per_block ) );
 
-  fd_chainer_t c = rotor_chainer_reloc( chainer_laddr, ele_max );
+  fd_chainer_t c = rotor_chainer_reloc( chainer_laddr, ele_max, max_shreds_per_block );
   if( FD_UNLIKELY( c.magic!=FD_CHAINER_MAGIC ) ) FD_LOG_ERR(( "bad chainer magic 0x%lx (tile not initialized?)", c.magic ));
 
   fd_chainer_print( &c );

--- a/src/app/firedancer-dev/commands/snapshot_load.c
+++ b/src/app/firedancer-dev/commands/snapshot_load.c
@@ -81,8 +81,7 @@ snapshot_load_topo( config_t * config ) {
   fd_topob_wksp( topo, "txncache" );
   fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache",
       config->firedancer.runtime.max_live_slots,
-      FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT,
-      config->development.bench.larger_max_cost_per_block );
+      2UL*config->limits.max_txn_per_slot );
   FD_TEST( fd_pod_insertf_ulong( topo->props, txncache_obj->id, "txncache" ) );
 
   fd_topob_wksp( topo, "accdb" );
@@ -102,7 +101,7 @@ snapshot_load_topo( config_t * config ) {
   fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks",
       config->firedancer.runtime.max_live_slots,
       config->firedancer.runtime.max_fork_width,
-      config->development.bench.larger_max_cost_per_block );
+      config->development.bench.max_cost_per_block );
   FD_TEST( fd_pod_insertf_ulong( topo->props, banks_obj->id, "banks" ) );
 
 #define FOR(cnt) for( ulong i=0UL; i<cnt; i++ )

--- a/src/app/firedancer/callbacks.c
+++ b/src/app/firedancer/callbacks.c
@@ -30,9 +30,8 @@ banks_align( fd_topo_t const *     topo FD_FN_UNUSED,
 static void
 banks_new( fd_topo_t const *     topo,
            fd_topo_obj_t const * obj ) {
-  int larger_max_cost_per_block = fd_pod_queryf_int( topo->props, 0, "obj.%lu.larger_max_cost_per_block", obj->id );
   ulong seed = fd_pod_queryf_ulong( topo->props, 0UL, "obj.%lu.seed", obj->id );
-  FD_TEST( fd_banks_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK, FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS, larger_max_cost_per_block, seed ) );
+  FD_TEST( fd_banks_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_fork_width"), FD_RUNTIME_MAX_STAKE_ACCOUNTS, FD_RUNTIME_MAX_STAKE_ACCOUNTS_FALLBACK, FD_RUNTIME_MAX_VAT_VOTE_ACCOUNTS, VAL("bench_max_cost_per_block"), seed ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_banks = {
@@ -151,7 +150,7 @@ store_new( fd_topo_t const *     topo,
   FD_TEST( fd_store_new( fd_topo_obj_laddr( topo, obj->id ),
                          VAL("fec_max"), VAL("fec_data_max"),
                          VAL("shred_storage_gib"), VAL("shred_cache_bytes"),
-                         VAL("fec_set_cnt"),
+                         VAL("fec_set_cnt"), VAL("max_shreds_per_block"),
                          db_path, disk_seed ) );
 }
 
@@ -190,8 +189,7 @@ fd_topo_obj_callbacks_t fd_obj_cb_accdb = {
 static ulong
 txncache_footprint( fd_topo_t const *     topo,
                     fd_topo_obj_t const * obj ) {
-  int larger_max_cost_per_block = fd_pod_queryf_int( topo->props, 0, "obj.%lu.larger_max_cost_per_block", obj->id );
-  return fd_txncache_shmem_footprint( VAL("max_live_slots"), VAL("max_txn_per_slot"), larger_max_cost_per_block );
+  return fd_txncache_shmem_footprint( VAL("max_live_slots"), VAL("max_txn_per_slot") );
 }
 
 static ulong
@@ -203,8 +201,7 @@ txncache_align( fd_topo_t const *     topo FD_FN_UNUSED,
 static void
 txncache_new( fd_topo_t const *     topo,
               fd_topo_obj_t const * obj ) {
-  int larger_max_cost_per_block = fd_pod_queryf_int( topo->props, 0, "obj.%lu.larger_max_cost_per_block", obj->id );
-  FD_TEST( fd_txncache_shmem_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_txn_per_slot"), larger_max_cost_per_block, VAL("seed") ) );
+  FD_TEST( fd_txncache_shmem_new( fd_topo_obj_laddr( topo, obj->id ), VAL("max_live_slots"), VAL("max_txn_per_slot"), VAL("seed") ) );
 }
 
 fd_topo_obj_callbacks_t fd_obj_cb_txncache = {

--- a/src/app/firedancer/config/bench-zen3-32core.toml
+++ b/src/app/firedancer/config/bench-zen3-32core.toml
@@ -22,8 +22,8 @@
 [development.bench]
   benchg_tile_count = 12
   benchs_tile_count = 2
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 131072
 
 [tiles.shred]
   max_pending_shred_sets = 16384

--- a/src/app/firedancer/config/bench-zen4-128core.toml
+++ b/src/app/firedancer/config/bench-zen4-128core.toml
@@ -17,8 +17,8 @@
 [development.bench]
   benchg_tile_count = 20
   benchs_tile_count = 3
-  larger_max_cost_per_block = true
-  larger_shred_limits_per_block = true
+  max_cost_per_block = 540000000
+  max_shreds_per_block = 131072
 
 [tiles.shred]
   max_pending_shred_sets = 16384

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -2069,32 +2069,34 @@ telemetry = true
         # automatically.
         affinity = "auto"
 
-        # Solana has a hard-coded maximum CUs per block limit of
-        # 50,000,000+ which works out to around 83,000 transfers a
-        # second, since each consumes about 1500 CUs.  When
-        # benchmarking, this can be the limiting bottleneck of the
-        # system, so this option is provided to raise the limit.  If set
-        # to true, the limit will be lifted to 624,000,000 for a little
-        # over 1 million transfers per second.
+        # Solana has a consensus-agreed maximum number of compute units
+        # per block, on the order of 50,000,000, which works out to
+        # around 83,000 transfers a second since each consumes about
+        # 1,500 CUs.  When benchmarking, this can be the limiting
+        # bottleneck of the system, so this option is provided to raise
+        # the limit.  0 keeps the consensus limits; any other value is
+        # the raised CUs per block and memory that scales with
+        # transactions per slot is sized up to match.
         #
         # This option should not be used in production, and would cause
         # consensus violations and a consensus difference between the
         # validator and the rest of the network.
-        larger_max_cost_per_block = false
+        max_cost_per_block = 0
 
-        # Solana has a consensus-agreed-upon limit of 32,768 data and
-        # parity shreds per block.  This limit prevents a malicious (or
-        # mistaken) validator from slowing down the network by producing
-        # a huge block.  When benchmarking, this limit can be the
-        # bottleneck of the whole system, so this option is provided to
-        # raise the limit.  If set to true, the limit will be raised to
-        # 131,072 data and parity shreds per block, for about 1,200,000
-        # small transactions per second.
+        # Solana has a consensus-agreed-upon limit of 32,768 data shreds
+        # (and as many parity shreds) per block.  This limit prevents a
+        # malicious (or mistaken) validator from slowing down the
+        # network by producing a huge block.  When benchmarking, this
+        # limit can be the bottleneck of the whole system, so this
+        # option is provided to raise the limit.  0 keeps the consensus
+        # limit; any other value is the raised number of data shreds per
+        # block, which must be a multiple of 32,768, and the block data
+        # byte limit scales with it.
         #
         # This option should not be used in a production network, since
         # it would cause consensus violations between the validator and
         # the rest of the network.
-        larger_shred_limits_per_block = false
+        max_shreds_per_block = 0
 
     # Experimental options for the bundle tile.  These should not be
     # changed on a production validator.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -21,6 +21,7 @@
 #include "../../disco/gui/fd_gui_config_parse.h"
 #include "../../disco/quic/fd_tpu.h"
 #include "../../disco/pack/fd_pack_cost.h"
+#include "../../disco/pack/fd_pack.h"
 #include "../../disco/tiles.h"
 #include "../../disco/topo/fd_topob.h"
 #include "../../disco/topo/fd_cpu_topo.h"
@@ -110,11 +111,11 @@ setup_topo_banks( fd_topo_t *  topo,
                   char const * wksp_name,
                   ulong        max_live_slots,
                   ulong        max_fork_width,
-                  int          larger_max_cost_per_block ) {
+                  ulong        bench_max_cost_per_block ) {
   fd_topo_obj_t * obj = fd_topob_obj( topo, "banks", wksp_name );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_live_slots, "obj.%lu.max_live_slots", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_fork_width, "obj.%lu.max_fork_width", obj->id ) );
-  FD_TEST( fd_pod_insertf_int( topo->props, larger_max_cost_per_block, "obj.%lu.larger_max_cost_per_block", obj->id ) );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, bench_max_cost_per_block, "obj.%lu.bench_max_cost_per_block", obj->id ) );
   ulong seed;
   FD_TEST( fd_rng_secure( &seed, sizeof( ulong ) ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, seed, "obj.%lu.seed", obj->id ) );
@@ -165,6 +166,7 @@ setup_topo_store( fd_topo_t *  topo,
                   ulong        shred_storage_gib,
                   ulong        shred_cache_mib,
                   ulong        fec_set_cnt,
+                  ulong        max_shreds_per_block,
                   char const * db_path ) {
   if( FD_UNLIKELY( !shred_cache_mib ) )
     FD_LOG_ERR(( "tiles.shred.shred_cache_size_mib must be non-zero; the FEC payload cache cannot be disabled" ));
@@ -184,6 +186,7 @@ setup_topo_store( fd_topo_t *  topo,
   FD_TEST( fd_pod_insertf_ulong( topo->props, shred_storage_gib, "obj.%lu.shred_storage_gib", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, shred_cache_bytes, "obj.%lu.shred_cache_bytes", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, fec_set_cnt,       "obj.%lu.fec_set_cnt",       obj->id ) );
+  FD_TEST( fd_pod_insertf_ulong( topo->props, max_shreds_per_block, "obj.%lu.max_shreds_per_block", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, seed,              "obj.%lu.seed",              obj->id ) );
   if( db_path ) {
     FD_TEST( fd_pod_insertf_cstr( topo->props, db_path,          "obj.%lu.disk_path",         obj->id ) );
@@ -195,15 +198,13 @@ fd_topo_obj_t *
 setup_topo_txncache( fd_topo_t *  topo,
                      char const * wksp_name,
                      ulong        max_live_slots,
-                     ulong        max_txn_per_slot,
-                     int          larger_max_cost_per_block ) {
+                     ulong        max_txn_per_slot ) {
   ulong seed;
   FD_TEST( fd_rng_secure( &seed, sizeof( ulong ) ) );
 
   fd_topo_obj_t * obj = fd_topob_obj( topo, "txncache", wksp_name );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_live_slots,   "obj.%lu.max_live_slots",   obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, max_txn_per_slot, "obj.%lu.max_txn_per_slot", obj->id ) );
-  FD_TEST( fd_pod_insertf_int(   topo->props, larger_max_cost_per_block, "obj.%lu.larger_max_cost_per_block", obj->id ) );
   FD_TEST( fd_pod_insertf_ulong( topo->props, seed,             "obj.%lu.seed",             obj->id ) );
 
   return obj;
@@ -1044,12 +1045,13 @@ fd_topo_initialize( config_t * config ) {
 
   if( leader_enabled ) {
     fd_topo_obj_t * ldr_tt_obj = fd_topob_obj( topo, "ldr_tt", poh );
+    FD_TEST( fd_pod_insertf_ulong( topo->props, config->limits.max_txn_per_slot, "obj.%lu.max_txn_per_slot", ldr_tt_obj->id ) );
     fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, poh,      0UL ) ], ldr_tt_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
     fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], ldr_tt_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
     FD_TEST( fd_pod_insertf_ulong( topo->props, ldr_tt_obj->id, "ldr_tt" ) );
   }
 
-  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, config->development.bench.larger_max_cost_per_block );
+  fd_topo_obj_t * banks_obj = setup_topo_banks( topo, "banks", config->firedancer.runtime.max_live_slots, config->firedancer.runtime.max_fork_width, config->development.bench.max_cost_per_block );
   /**/                 fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   if( !alpenglow_enabled ) {
     /**/               fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "tower",  0UL ) ], banks_obj, FD_SHMEM_JOIN_MODE_READ_ONLY  );
@@ -1163,7 +1165,7 @@ fd_topo_initialize( config_t * config ) {
 
   fd_topo_link_t * repair_out_link = &topo->links[ fd_topo_find_link( topo, "repair_out", 0UL ) ];
   ulong fec_sets_per_slot = fd_ulong_if( config->firedancer.development.fixed_fec_sets,
-                                         FD_FEC_BLK_MAX, FD_SHRED_BLK_MAX );
+                                         config->limits.max_shreds_per_block/FD_FEC_SHRED_CNT, config->limits.max_shreds_per_block );
   ulong store_fec_max = config->firedancer.runtime.max_live_slots * fec_sets_per_slot + (shred_depth * shred_tile_cnt) + repair_out_link->depth + 1;
 
   /* 32 shreds * 995 payload bytes = 31840 bytes with fixed_fec_sets = true
@@ -1174,6 +1176,7 @@ fd_topo_initialize( config_t * config ) {
                                                 rserve_enabled ? config->tiles.rserve.shred_storage_limit_gib : 0UL,
                                                 config->tiles.shred.shred_cache_size_mib,
                                                 store_fec_set_cnt,
+                                                config->limits.max_shreds_per_block,
                                                 config->paths.shredb );
   FOR(shred_tile_cnt) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "shred", i ) ], store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], store_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
@@ -1181,7 +1184,7 @@ fd_topo_initialize( config_t * config ) {
   if( rserve_enabled ) fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "rserve", 0UL ) ], store_obj, FD_SHMEM_JOIN_MODE_READ_ONLY );
   FD_TEST( fd_pod_insertf_ulong( topo->props, store_obj->id, "store" ) );
 
-  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT, config->development.bench.larger_max_cost_per_block );
+  fd_topo_obj_t * txncache_obj = setup_topo_txncache( topo, "txncache", config->firedancer.runtime.max_live_slots, 2UL*config->limits.max_txn_per_slot /* sig + message hash */ );
   fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "replay", 0UL ) ], txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
   if( FD_LIKELY( snapshots_enabled ) ) {
     fd_topob_tile_uses( topo, &topo->tiles[ fd_topo_find_tile( topo, "snapin", 0UL ) ], txncache_obj, FD_SHMEM_JOIN_MODE_READ_WRITE );
@@ -1495,6 +1498,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
   } else if( FD_UNLIKELY( !strcmp( tile->name, "snapin" ) ) ) {
 
     tile->snapin.max_live_slots  = config->firedancer.runtime.max_live_slots;
+    tile->snapin.max_txn_per_slot = config->limits.max_txn_per_slot;
     tile->snapin.accdb_obj_id = fd_pod_query_ulong( config->topo.props, "accdb", ULONG_MAX );
     tile->snapin.txncache_obj_id = fd_pod_query_ulong( config->topo.props, "txncache", ULONG_MAX );
     tile->snapin.banks_obj_id = fd_pod_query_ulong( config->topo.props, "banks", ULONG_MAX );
@@ -1505,6 +1509,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "repair" ) ) ) {
     tile->repair.max_pending_shred_sets    = config->tiles.shred.max_pending_shred_sets;
+    tile->repair.max_shreds_per_block      = config->limits.max_shreds_per_block;
     tile->repair.repair_client_listen_port = config->tiles.repair.repair_client_listen_port;
     tile->repair.slot_max                  = config->tiles.repair.slot_max;
     tile->repair.repair_sign_cnt           = config->firedancer.layout.sign_tile_count - 1; /* -1 because this excludes the keyguard client */
@@ -1519,6 +1524,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "rotor" ) ) ) {
     tile->rotor.slot_max = config->tiles.rotor.slot_max;
+    tile->rotor.max_shreds_per_block = config->limits.max_shreds_per_block;
     tile->rotor.repair_client_listen_port = config->tiles.repair.repair_client_listen_port;
 
     for( ulong i=0; i<tile->in_cnt; i++ ) {
@@ -1531,6 +1537,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     fd_cstr_ncpy( tile->rotor.identity_key_path, config->paths.identity_key, sizeof(tile->repair.identity_key_path) );
   } else if( FD_UNLIKELY( !strcmp( tile->name, "rserve" ) ) ) {
     tile->rserve.repair_serve_listen_port = config->tiles.rserve.repair_serve_listen_port;
+    tile->rserve.max_shreds_per_block = config->limits.max_shreds_per_block;
     tile->rserve.ping_cache_entries = 1UL<<16; /* TODO: Configure this from some global metric? */
     fd_cstr_ncpy( tile->rserve.identity_key_path, config->paths.identity_key, sizeof(tile->rserve.identity_key_path) );
 
@@ -1540,7 +1547,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
     tile->replay.fec_max = config->firedancer.runtime.max_live_slots *
                            fd_ulong_if( config->firedancer.development.fixed_fec_sets,
-                                        FD_FEC_BLK_MAX, FD_SHRED_BLK_MAX );
+                                        config->limits.max_shreds_per_block/FD_FEC_SHRED_CNT, config->limits.max_shreds_per_block );
     tile->replay.boot_timestamp_nanos = config->boot_timestamp_nanos;
 
     tile->replay.accdb_obj_id = fd_pod_query_ulong( config->topo.props, "accdb", ULONG_MAX );
@@ -1569,7 +1576,8 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
     fd_cstr_ncpy( tile->replay.genesis_path, config->paths.genesis, sizeof(tile->replay.genesis_path) );
 
-    tile->replay.larger_max_cost_per_block = config->development.bench.larger_max_cost_per_block;
+    tile->replay.max_txn_per_slot     = config->limits.max_txn_per_slot;
+    tile->replay.max_shreds_per_block = config->limits.max_shreds_per_block;
 
     /* not specified by [tiles.replay] */
 
@@ -1618,6 +1626,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "tower" ) ) ) {
     tile->tower.authorized_voter_paths_cnt = config->firedancer.paths.authorized_voter_paths_cnt;
+    tile->tower.max_shreds_per_block = config->limits.max_shreds_per_block;
     for( ulong i=0UL; i<tile->tower.authorized_voter_paths_cnt; i++ ) {
       fd_cstr_ncpy( tile->tower.authorized_voter_paths[ i ], config->firedancer.paths.authorized_voter_paths[ i ], sizeof(tile->tower.authorized_voter_paths[ i ]) );
     }
@@ -1692,8 +1701,9 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
 
     tile->pack.max_pending_transactions      = config->tiles.pack.max_pending_transactions;
     tile->pack.execle_tile_count             = config->firedancer.layout.execle_tile_count;
-    tile->pack.larger_max_cost_per_block     = config->development.bench.larger_max_cost_per_block;
-    tile->pack.larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
+    tile->pack.max_cost_per_block            = config->limits.max_cost_per_block;
+    tile->pack.max_shreds_per_block          = config->limits.max_shreds_per_block;
+    tile->pack.bench_max_shreds_per_block    = config->development.bench.max_shreds_per_block;
     tile->pack.use_consumed_cus              = config->tiles.pack.use_consumed_cus;
     tile->pack.schedule_strategy             = config->tiles.pack.schedule_strategy_enum;
     tile->pack.acct_blocklist_cnt            = config->tiles.pack.account_blocklist_cnt;
@@ -1729,11 +1739,13 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     fd_cstr_ncpy( tile->poh.identity_key_path, config->paths.identity_key, sizeof(tile->poh.identity_key_path) );
 
     tile->poh.execle_cnt = config->firedancer.layout.execle_tile_count;
+    tile->poh.max_txn_per_slot = config->limits.max_txn_per_slot;
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "motor" ) ) ) {
     fd_cstr_ncpy( tile->motor.identity_key_path, config->paths.identity_key, sizeof(tile->motor.identity_key_path) );
 
     tile->motor.execle_cnt = config->firedancer.layout.execle_tile_count;
+    tile->motor.max_txn_per_slot = config->limits.max_txn_per_slot;
 
   } else if( FD_UNLIKELY( !strcmp( tile->name, "shred" ) ) ) {
 
@@ -1743,7 +1755,8 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     tile->shred.fec_resolver_depth            = config->tiles.shred.max_pending_shred_sets;
     tile->shred.expected_shred_version        = config->consensus.expected_shred_version;
     tile->shred.shred_listen_port             = config->tiles.shred.shred_listen_port;
-    tile->shred.larger_shred_limits_per_block = config->development.bench.larger_shred_limits_per_block;
+    tile->shred.max_shreds_per_block          = config->limits.max_shreds_per_block;
+    tile->shred.bench_max_shreds_per_block    = config->development.bench.max_shreds_per_block;
     for( ulong i=0UL; i<config->tiles.shred.additional_shred_destinations_retransmit_cnt; i++ ) {
       parse_ip_port( "tiles.shred.additional_shred_destinations_retransmit",
                       config->tiles.shred.additional_shred_destinations_retransmit[ i ],
@@ -1791,6 +1804,7 @@ fd_topo_configure_tile( fd_topo_tile_t * tile,
     if( FD_UNLIKELY( !fd_cstr_to_ip4_addr( config->tiles.gui.gui_listen_address, &tile->gui.listen_addr ) ) )
       FD_LOG_ERR(( "failed to parse gui listen address `%s`", config->tiles.gui.gui_listen_address ));
     tile->gui.listen_port = config->tiles.gui.gui_listen_port;
+    tile->gui.max_txn_per_slot = config->limits.max_txn_per_slot;
     tile->gui.is_voting = strcmp( config->paths.vote_account, "" );
     tile->gui.is_alpenglow = config->firedancer.development.alpenglow;
     fd_cstr_ncpy( tile->gui.cluster, config->cluster, sizeof(tile->gui.cluster) );

--- a/src/app/firedancer/topology.h
+++ b/src/app/firedancer/topology.h
@@ -18,7 +18,7 @@ setup_topo_banks( fd_topo_t *  topo,
                   char const * wksp_name,
                   ulong        max_live_slots,
                   ulong        max_fork_width,
-                  int          larger_max_cost_per_block );
+                  ulong        bench_max_cost_per_block );
 
 void
 setup_topo_progcache( fd_topo_t *  topo,
@@ -35,6 +35,7 @@ setup_topo_store( fd_topo_t *  topo,
                   ulong        shred_storage_gib,
                   ulong        shred_cache_mib,
                   ulong        fec_set_cnt,
+                  ulong        max_shreds_per_block,
                   char const * db_path );
 
 fd_topo_obj_t *
@@ -59,8 +60,7 @@ fd_topo_obj_t *
 setup_topo_txncache( fd_topo_t *  topo,
                      char const * wksp_name,
                      ulong        max_live_slots,
-                     ulong        max_txn_per_slot,
-                     int          larger_max_cost_per_block );
+                     ulong        max_txn_per_slot );
 
 void
 fd_topo_configure_tile( fd_topo_tile_t * tile,

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -9,6 +9,10 @@
 #include "../../disco/genesis/fd_genesis_cluster.h"
 #include "../../discof/genesis/fd_genesi_tile.h"
 #include "../../disco/net/fd_net_tile.h"
+#include "../../disco/pack/fd_pack_cost.h"
+#include "../../disco/pack/fd_microblock.h"
+#include "../../ballet/shred/fd_shred.h"
+#include "../../ballet/txn/fd_txn.h"
 #include "../../discof/restore/utils/fd_ssarchive.h"
 
 #include <unistd.h>
@@ -398,11 +402,17 @@ fd_config_fill( fd_config_t * config,
   }
   fd_config_validate( config );
 
+  config->limits.max_cost_per_block   = fd_ulong_if( !!config->development.bench.max_cost_per_block,   config->development.bench.max_cost_per_block,   FD_PACK_MAX_COST_PER_BLOCK_UPPER_BOUND );
+  config->limits.max_shreds_per_block = fd_ulong_if( !!config->development.bench.max_shreds_per_block, config->development.bench.max_shreds_per_block, FD_SHRED_BLK_MAX );
+  config->limits.max_txn_per_slot     = fd_ulong_min( config->limits.max_cost_per_block/FD_PACK_MIN_TXN_COST,
+                                                      (config->limits.max_shreds_per_block*FD_SHRED_DATA_PAYLOAD_MAX - 65UL*sizeof(fd_entry_batch_header_t))/FD_TXN_MIN_SERIALIZED_SZ ); /* 64 ticks + one giant microblock */
+  if( FD_LIKELY( !config->development.bench.max_cost_per_block && !config->development.bench.max_shreds_per_block ) ) FD_TEST( config->limits.max_txn_per_slot==FD_MAX_TXN_PER_SLOT );
+
   if( FD_LIKELY( config->is_live_cluster) ) {
     if( FD_UNLIKELY( !config->development.sandbox ) )                            FD_LOG_ERR(( "trying to join a live cluster, but configuration disables the sandbox which is a development only feature" ));
     if( FD_UNLIKELY( config->development.no_clone ) )                            FD_LOG_ERR(( "trying to join a live cluster, but configuration disables multiprocess which is a development only feature" ));
-    if( FD_UNLIKELY( config->development.bench.larger_max_cost_per_block ) )     FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.larger_max_cost_per_block] which is a development only feature" ));
-    if( FD_UNLIKELY( config->development.bench.larger_shred_limits_per_block ) ) FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.larger_shred_limits_per_block] which is a development only feature" ));
+    if( FD_UNLIKELY( config->development.bench.max_cost_per_block ) )            FD_LOG_ERR(( "trying to join a live cluster, but configuration sets [development.bench.max_cost_per_block] which is a development only feature" ));
+    if( FD_UNLIKELY( config->development.bench.max_shreds_per_block ) )          FD_LOG_ERR(( "trying to join a live cluster, but configuration sets [development.bench.max_shreds_per_block] which is a development only feature" ));
     if( FD_UNLIKELY( config->development.bench.disable_blockstore_from_slot ) )  FD_LOG_ERR(( "trying to join a live cluster, but configuration has a non-zero value for [development.bench.disable_blockstore_from_slot] which is a development only feature" ));
     if( FD_UNLIKELY( config->development.bench.disable_status_cache ) )          FD_LOG_ERR(( "trying to join a live cluster, but configuration enables [development.bench.disable_status_cache] which is a development only feature" ));
   }
@@ -570,6 +580,21 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_EMPTY( hugetlbfs.max_page_size );
 
   CFG_HAS_NON_ZERO( net.ingress_buffer_size );
+
+  ulong bench_cost   = config->development.bench.max_cost_per_block;
+  ulong bench_shreds = config->development.bench.max_shreds_per_block;
+  if( FD_UNLIKELY( bench_cost && (bench_cost<FD_PACK_MAX_COST_PER_BLOCK_UPPER_BOUND || bench_cost>=UINT_MAX) ) ) /* fd_pack_limits_t: [0,UINT_MAX) */
+    FD_LOG_ERR(( "invalid [development.bench.max_cost_per_block]: must be 0 or in [%lu,%u)", FD_PACK_MAX_COST_PER_BLOCK_UPPER_BOUND, UINT_MAX ));
+  if( FD_UNLIKELY( bench_shreds && (bench_shreds%FD_SHRED_BLK_MAX || bench_shreds>FD_SHRED_BLK_MAX_RAISED) ) )
+    FD_LOG_ERR(( "invalid [development.bench.max_shreds_per_block]: must be 0 or a multiple of %lu up to %lu", (ulong)FD_SHRED_BLK_MAX, FD_SHRED_BLK_MAX_RAISED ));
+  /* Frankendancer's Agave side only knows the booleans behind these
+     (18x block cost, 32x shreds), so it accepts exactly the values that
+     match what the Firedancer side used to hardcode for them. */
+  if( FD_UNLIKELY( !config->is_firedancer && bench_cost && bench_cost!=18UL*FD_PACK_MAX_COST_PER_BLOCK_LOWER_BOUND ) )
+    FD_LOG_ERR(( "invalid [development.bench.max_cost_per_block]: Frankendancer supports 0 or %lu", 18UL*FD_PACK_MAX_COST_PER_BLOCK_LOWER_BOUND ));
+  if( FD_UNLIKELY( !config->is_firedancer && bench_shreds && bench_shreds!=32UL*FD_SHRED_BLK_MAX ) )
+    FD_LOG_ERR(( "invalid [development.bench.max_shreds_per_block]: Frankendancer supports 0 or %lu", 32UL*FD_SHRED_BLK_MAX ));
+
   if( 0==strcmp( config->net.provider, "xdp" ) ) {
     if( 0!=strcmp( config->net.xdp.xdp_mode, "skb"     ) &&
         0!=strcmp( config->net.xdp.xdp_mode, "drv"     ) &&

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -266,6 +266,19 @@ struct fd_config {
 
   long boot_timestamp_nanos;
 
+  /* Sizing ceilings for every per-slot structure, derived at load: the
+     largest values the consensus limits can take, or the raised
+     [development.bench] limits.  txn/slot is min-cost txns against the
+     cost ceiling and min-size txns against the shred ceiling, the same
+     two bounds as FD_MAX_TXN_PER_SLOT_{CU,SHRED}.  The chain's live
+     limits (cost tracker, shred and replay tiles) are floored by the raw
+     [development.bench] values, which are 0 in production. */
+  struct {
+    ulong max_cost_per_block;
+    ulong max_shreds_per_block;
+    ulong max_txn_per_slot;
+  } limits;
+
   fd_topo_t topo;
 
   char cluster[ 32 ];
@@ -381,8 +394,8 @@ struct fd_config {
       uint  benchg_tile_count;
       uint  benchs_tile_count;
       char  affinity[ AFFINITY_SZ ];
-      int   larger_max_cost_per_block;
-      int   larger_shred_limits_per_block;
+      ulong max_cost_per_block;
+      ulong max_shreds_per_block;
       ulong disable_blockstore_from_slot;
       int   disable_status_cache;
     } bench;

--- a/src/app/shared/fd_config_json.c
+++ b/src/app/shared/fd_config_json.c
@@ -11,7 +11,7 @@
    or knowingly skipped) before the constant is bumped.  String keys of
    the user's own file are separately forced through the classification
    lists below. */
-FD_STATIC_ASSERT( sizeof(fd_config_t)==22972352UL, update_fd_config_to_json_for_the_layout_change );
+FD_STATIC_ASSERT( sizeof(fd_config_t)==22974432UL, update_fd_config_to_json_for_the_layout_change );
 
 #define REDACTED "[redacted]"
 
@@ -488,8 +488,8 @@ fd_config_to_json( fd_config_t const * config,
       jw_ulong( &w, "benchg_tile_count",            config->development.bench.benchg_tile_count );
       jw_ulong( &w, "benchs_tile_count",            config->development.bench.benchs_tile_count );
       jw_str  ( &w, "affinity",                     config->development.bench.affinity );
-      jw_bool ( &w, "larger_max_cost_per_block",    config->development.bench.larger_max_cost_per_block );
-      jw_bool ( &w, "larger_shred_limits_per_block",config->development.bench.larger_shred_limits_per_block );
+      jw_ulong( &w, "max_cost_per_block",           config->development.bench.max_cost_per_block );
+      jw_ulong( &w, "max_shreds_per_block",         config->development.bench.max_shreds_per_block );
       jw_ulong( &w, "disable_blockstore_from_slot", config->development.bench.disable_blockstore_from_slot );
       jw_bool ( &w, "disable_status_cache",         config->development.bench.disable_status_cache );
     jw_obj_close( &w );

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -334,8 +334,8 @@ fd_config_extract_pod( uchar *       pod,
   CFG_POP      ( uint,   development.bench.benchg_tile_count              );
   CFG_POP      ( uint,   development.bench.benchs_tile_count              );
   CFG_POP      ( cstr,   development.bench.affinity                       );
-  CFG_POP      ( bool,   development.bench.larger_max_cost_per_block      );
-  CFG_POP      ( bool,   development.bench.larger_shred_limits_per_block  );
+  CFG_POP      ( ulong,  development.bench.max_cost_per_block             );
+  CFG_POP      ( ulong,  development.bench.max_shreds_per_block           );
   CFG_POP      ( ulong,  development.bench.disable_blockstore_from_slot   );
   CFG_POP      ( bool,   development.bench.disable_status_cache           );
 

--- a/src/app/shared/fd_obj_callbacks.c
+++ b/src/app/shared/fd_obj_callbacks.c
@@ -232,9 +232,9 @@ fd_topo_obj_callbacks_t fd_obj_cb_node_info = {
 };
 
 static ulong
-leader_txn_timing_footprint( fd_topo_t const *     topo FD_FN_UNUSED,
-                             fd_topo_obj_t const * obj  FD_FN_UNUSED ) {
-  return FD_LEADER_TXN_TIMING_TABLE_CNT*sizeof(fd_leader_txn_timing_table_t);
+leader_txn_timing_footprint( fd_topo_t const *     topo,
+                             fd_topo_obj_t const * obj ) {
+  return FD_LEADER_TXN_TIMING_TABLE_CNT*fd_leader_txn_timing_table_footprint( VAL("max_txn_per_slot") );
 }
 
 static ulong

--- a/src/ballet/shred/fd_shred.h
+++ b/src/ballet/shred/fd_shred.h
@@ -158,6 +158,12 @@ FD_STATIC_ASSERT( sizeof(fd_bmtree_node_t) == FD_SHRED_MERKLE_ROOT_SZ, update FD
 
 FD_STATIC_ASSERT( FD_SHRED_BLK_MAX == 32768, check all usages before changing this limit! );
 
+/* Largest [development.bench.max_shreds_per_block] a benchmark cluster
+   may raise the per-block shred limit to: the chainer's fec_set_idx is
+   28 bits.  Sizes what must hold any configurable limit (repair proof
+   depth). */
+#define FD_SHRED_BLK_MAX_RAISED (1UL<<28)
+
 /* 36,536,320 bytes per slot */
 #define FD_SHRED_DATA_PAYLOAD_MAX_PER_SLOT (FD_SHRED_DATA_PAYLOAD_MAX * FD_SHRED_BLK_MAX)
 

--- a/src/disco/gui/fd_gui.c
+++ b/src/disco/gui/fd_gui.c
@@ -23,16 +23,21 @@ fd_gui_align( void ) {
 
 ulong
 fd_gui_footprint( ulong tile_cnt,
-                  ulong max_live_slots ) {
+                  ulong max_live_slots,
+                  ulong max_txn_per_slot ) {
   FD_TEST( tile_cnt && tile_cnt <=FD_DIAG_SYSTEM_TILE_MAX );
   FD_TEST( max_live_slots && max_live_slots<=ULONG_MAX/sizeof(fd_gui_ag_slot_t) );
+  FD_TEST( max_txn_per_slot && max_txn_per_slot<=ULONG_MAX/sizeof(fd_gui_store_txn_start_t) );
 
   ulong l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, fd_gui_align(),            sizeof(fd_gui_t) );
-  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_ag_slot_t), max_live_slots*sizeof(fd_gui_ag_slot_t) );
-  l = FD_LAYOUT_APPEND( l, fd_gui_rate_deque_align(), fd_gui_rate_deque_footprint() ); /* ingress_maxq */
-  l = FD_LAYOUT_APPEND( l, fd_gui_rate_deque_align(), fd_gui_rate_deque_footprint() ); /* egress_maxq  */
-  l = FD_LAYOUT_APPEND( l, fd_gui_hist_align(),       fd_gui_hist_footprint() );
+  l = FD_LAYOUT_APPEND( l, fd_gui_align(),                     sizeof(fd_gui_t) );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_ag_slot_t),         max_live_slots*sizeof(fd_gui_ag_slot_t) );
+  l = FD_LAYOUT_APPEND( l, fd_gui_rate_deque_align(),         fd_gui_rate_deque_footprint() ); /* ingress_maxq */
+  l = FD_LAYOUT_APPEND( l, fd_gui_rate_deque_align(),         fd_gui_rate_deque_footprint() ); /* egress_maxq  */
+  l = FD_LAYOUT_APPEND( l, fd_gui_hist_align(),               fd_gui_hist_footprint() );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_store_txn_start_t), max_txn_per_slot*sizeof(fd_gui_store_txn_start_t) );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_store_txn_end_t),   max_txn_per_slot*sizeof(fd_gui_store_txn_end_t)   );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_gui_slot_txn_join_t),   max_txn_per_slot*sizeof(fd_gui_slot_txn_join_t)   );
   return FD_LAYOUT_FINI( l, fd_gui_align() );
 }
 
@@ -94,6 +99,7 @@ fd_gui_new( void *                   shmem,
             int                      is_full_client,
             int                      is_alpenglow,
             ulong                    max_live_slots,
+            ulong                    max_txn_per_slot,
             int                      snapshots_enabled,
             int                      is_voting,
             int                      schedule_strategy,
@@ -124,11 +130,19 @@ fd_gui_new( void *                   shmem,
   ulong tile_cnt = topo->tile_cnt;
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
-  fd_gui_t * gui              = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),            sizeof(fd_gui_t) );
-  void *     ag_slot_mem      = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_ag_slot_t), max_live_slots*sizeof(fd_gui_ag_slot_t) );
-  void *     ingress_maxq_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_rate_deque_align(), fd_gui_rate_deque_footprint() );
-  void *     egress_maxq_mem  = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_rate_deque_align(), fd_gui_rate_deque_footprint() );
-  void *     hist_mem         = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_hist_align(),       fd_gui_hist_footprint() );
+  fd_gui_t * gui              = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),                    sizeof(fd_gui_t) );
+  void *     ag_slot_mem      = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_ag_slot_t),         max_live_slots*sizeof(fd_gui_ag_slot_t) );
+  void *     ingress_maxq_mem = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_rate_deque_align(),         fd_gui_rate_deque_footprint() );
+  void *     egress_maxq_mem  = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_rate_deque_align(),         fd_gui_rate_deque_footprint() );
+  void *     hist_mem         = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_hist_align(),               fd_gui_hist_footprint() );
+  void *     txn_starts_mem   = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_store_txn_start_t), max_txn_per_slot*sizeof(fd_gui_store_txn_start_t) );
+  void *     txn_ends_mem     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_store_txn_end_t),   max_txn_per_slot*sizeof(fd_gui_store_txn_end_t)   );
+  void *     txn_joined_mem   = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_slot_txn_join_t),   max_txn_per_slot*sizeof(fd_gui_slot_txn_join_t)   );
+
+  gui->slot_txn_scratch.max    = max_txn_per_slot;
+  gui->slot_txn_scratch.starts = txn_starts_mem;
+  gui->slot_txn_scratch.ends   = txn_ends_mem;
+  gui->slot_txn_scratch.joined = txn_joined_mem;
 
   gui->http        = http;
   gui->topo        = topo;

--- a/src/disco/gui/fd_gui.h
+++ b/src/disco/gui/fd_gui.h
@@ -951,9 +951,10 @@ struct fd_gui {
   /* Reusable scratch for reassembling a single slot's transactions at
      query time (fd_gui_printf_slot_transactions_request). */
   struct {
-    fd_gui_store_txn_start_t  starts[ FD_MAX_TXN_PER_SLOT ];
-    fd_gui_store_txn_end_t    ends  [ FD_MAX_TXN_PER_SLOT ];
-    fd_gui_slot_txn_join_t    joined[ FD_MAX_TXN_PER_SLOT ];
+    ulong                      max;
+    fd_gui_store_txn_start_t * starts; /* [max] */
+    fd_gui_store_txn_end_t *   ends;   /* [max] */
+    fd_gui_slot_txn_join_t *   joined; /* [max] */
   } slot_txn_scratch;
 
   struct {
@@ -1023,7 +1024,8 @@ fd_gui_align( void );
 
 ulong
 fd_gui_footprint( ulong tile_cnt,
-                  ulong max_live_slots );
+                  ulong max_live_slots,
+                  ulong max_txn_per_slot );
 
 void *
 fd_gui_new( void *                   shmem,
@@ -1036,6 +1038,7 @@ fd_gui_new( void *                   shmem,
             int                      is_full_client,
             int                      is_alpenglow,
             ulong                    max_live_slots,
+            ulong                    max_txn_per_slot,
             int                      snapshots_enabled,
             int                      is_voting,
             int                      schedule_strategy,

--- a/src/disco/gui/fd_gui_printf.c
+++ b/src/disco/gui/fd_gui_printf.c
@@ -2443,13 +2443,14 @@ fd_gui_printf_slot_transactions_request( fd_gui_t *            gui,
                                lmeta->leader_end_time  !=LONG_MAX &&
                                lmeta->leader_start_time<=lmeta->leader_end_time;
 
-      fd_gui_store_txn_start_t *  starts = gui->slot_txn_scratch.starts;
-      fd_gui_store_txn_end_t *    ends   = gui->slot_txn_scratch.ends;
-      fd_gui_slot_txn_join_t * joined = gui->slot_txn_scratch.joined;
-      ulong                    start_cnt = 0UL;
-      ulong                    end_cnt   = 0UL;
-      ulong                    txn_cnt   = 0UL;
-      int                      have_txns = gui->db && processed_all_microblocks && have_leader_window;
+      fd_gui_store_txn_start_t * starts    = gui->slot_txn_scratch.starts;
+      fd_gui_store_txn_end_t *   ends      = gui->slot_txn_scratch.ends;
+      fd_gui_slot_txn_join_t *   joined    = gui->slot_txn_scratch.joined;
+      ulong                      txn_max   = gui->slot_txn_scratch.max;
+      ulong                      start_cnt = 0UL;
+      ulong                      end_cnt   = 0UL;
+      ulong                      txn_cnt   = 0UL;
+      int                        have_txns = gui->db && processed_all_microblocks && have_leader_window;
 
       if( FD_LIKELY( have_txns ) ) {
         /* Bound both scans to this slot's leader window, widened by a
@@ -2465,7 +2466,7 @@ fd_gui_printf_slot_transactions_request( fd_gui_t *            gui,
           while( fd_gui_hist_range_next( &it ) ) {
             fd_gui_store_txn_start_t const * r = (fd_gui_store_txn_start_t const *)it.rec;
             if( FD_UNLIKELY( r->slot!=_slot || r->bank_seq!=slot->bank_seq ) ) continue;
-            if( FD_UNLIKELY( start_cnt>=FD_MAX_TXN_PER_SLOT ) ) break;
+            if( FD_UNLIKELY( start_cnt>=txn_max ) ) break;
             starts[ start_cnt++ ] = *r;
           }
           fd_gui_hist_range_end( &it );
@@ -2476,7 +2477,7 @@ fd_gui_printf_slot_transactions_request( fd_gui_t *            gui,
           while( fd_gui_hist_range_next( &it ) ) {
             fd_gui_store_txn_end_t const * r = (fd_gui_store_txn_end_t const *)it.rec;
             if( FD_UNLIKELY( r->slot!=_slot || r->bank_seq!=slot->bank_seq ) ) continue;
-            if( FD_UNLIKELY( end_cnt>=FD_MAX_TXN_PER_SLOT ) ) break;
+            if( FD_UNLIKELY( end_cnt>=txn_max ) ) break;
             ends[ end_cnt++ ] = *r;
           }
           fd_gui_hist_range_end( &it );

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -179,7 +179,7 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   l = FD_LAYOUT_APPEND( l, alignof( fd_gui_ctx_t ), sizeof( fd_gui_ctx_t ) );
   l = FD_LAYOUT_APPEND( l, fd_http_server_align(),  http_fp );
   l = FD_LAYOUT_APPEND( l, fd_gui_peers_align(),    fd_gui_peers_footprint( http_param.max_ws_connection_cnt ) );
-  l = FD_LAYOUT_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots ) );
+  l = FD_LAYOUT_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots, tile->gui.max_txn_per_slot ) );
   l = FD_LAYOUT_APPEND( l, fd_gui_store_align(),    fd_gui_store_footprint( tile->gui.db_size_gib<<30, fd_gui_hist_db_cnt(), fd_gui_hist_db_descs( tile->gui.db_size_gib<<30 ) ) );
   l = FD_LAYOUT_APPEND( l, fd_alloc_align(),        fd_alloc_footprint() );
   return FD_LAYOUT_FINI( l, scratch_align() );
@@ -812,7 +812,7 @@ privileged_init( fd_topo_t const *      topo,
   http_param.treap_seed = ctx->seed;
   fd_http_server_t * _gui = FD_SCRATCH_ALLOC_APPEND( l, fd_http_server_align(), fd_http_server_footprint( http_param ) );
                      FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_align(),    fd_gui_peers_footprint( http_param.max_ws_connection_cnt ) );
-                     FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots ) );
+                     FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots, tile->gui.max_txn_per_slot ) );
   void * _db       = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_store_align(),       fd_gui_store_footprint( tile->gui.db_size_gib<<30, fd_gui_hist_db_cnt(), fd_gui_hist_db_descs( tile->gui.db_size_gib<<30 ) ) );
 
   fd_http_server_callbacks_t gui_callbacks = {
@@ -867,7 +867,7 @@ unprivileged_init( fd_topo_t const *      topo,
   fd_gui_ctx_t * ctx = FD_SCRATCH_ALLOC_APPEND( l, alignof( fd_gui_ctx_t ), sizeof( fd_gui_ctx_t )                                    );
                        FD_SCRATCH_ALLOC_APPEND( l, fd_http_server_align(),  fd_http_server_footprint( http_param )                    );
   void * _peers      = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_align(),    fd_gui_peers_footprint( http_param.max_ws_connection_cnt) );
-  void * _gui        = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots ) );
+  void * _gui        = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_align(),          fd_gui_footprint( tile->gui.tile_cnt, tile->gui.max_live_slots, tile->gui.max_txn_per_slot ) );
                        FD_SCRATCH_ALLOC_APPEND( l, fd_gui_store_align(),       fd_gui_store_footprint( tile->gui.db_size_gib<<30, fd_gui_hist_db_cnt(), fd_gui_hist_db_descs( tile->gui.db_size_gib<<30 ) ) );
   void * _alloc      = FD_SCRATCH_ALLOC_APPEND( l, fd_alloc_align(),        fd_alloc_footprint()                                      );
 
@@ -956,7 +956,7 @@ unprivileged_init( fd_topo_t const *      topo,
     accdb_shmem = fd_accdb_shmem_join( accdb_shmem_raw );
     FD_TEST( accdb_shmem );
   }
-  ctx->gui   = fd_gui_join( fd_gui_new( _gui, ctx->gui_server, fd_version_cstr, tile->gui.cluster, ctx->identity_key, ctx->has_vote_key, ctx->vote_key->uc, ctx->is_full_client, tile->gui.is_alpenglow, tile->gui.max_live_slots, ctx->snapshots_enabled, tile->gui.is_voting, tile->gui.schedule_strategy, tile->gui.wfs_bank_hash, tile->gui.expected_shred_version, tile->gui.accounts_database_path, tile->gui.gui_database_path, ctx->db, ctx->topo, accdb_shmem, fd_clock_tile_now( ctx->clock ) ) );
+  ctx->gui   = fd_gui_join( fd_gui_new( _gui, ctx->gui_server, fd_version_cstr, tile->gui.cluster, ctx->identity_key, ctx->has_vote_key, ctx->vote_key->uc, ctx->is_full_client, tile->gui.is_alpenglow, tile->gui.max_live_slots, tile->gui.max_txn_per_slot, ctx->snapshots_enabled, tile->gui.is_voting, tile->gui.schedule_strategy, tile->gui.wfs_bank_hash, tile->gui.expected_shred_version, tile->gui.accounts_database_path, tile->gui.gui_database_path, ctx->db, ctx->topo, accdb_shmem, fd_clock_tile_now( ctx->clock ) ) );
   FD_TEST( ctx->gui );
   FD_TEST( ctx->db );
 

--- a/src/disco/gui/test_gui_hist_evict.c
+++ b/src/disco/gui/test_gui_hist_evict.c
@@ -525,9 +525,9 @@ static void
 store_open( test_store_t * s, ulong map_bytes, int instance ) {
   fd_cstr_printf_check( s->path, sizeof(s->path), NULL, "/tmp/fd_gui_hist_evict_test.%i.%i", (int)getpid(), instance );
 
-  s->gui = aligned_alloc( fd_gui_align(), fd_gui_footprint( 1UL, 1UL ) );
+  s->gui = aligned_alloc( fd_gui_align(), fd_gui_footprint( 1UL, 1UL, 1UL ) );
   FD_TEST( s->gui );
-  memset( s->gui, 0, fd_gui_footprint( 1UL, 1UL ) );
+  memset( s->gui, 0, fd_gui_footprint( 1UL, 1UL, 1UL ) );
 
   s->db_mem = aligned_alloc( fd_gui_store_align(),
                              fd_ulong_align_up( fd_gui_store_footprint( map_bytes, fd_gui_hist_db_cnt(), fd_gui_hist_db_descs( map_bytes ) ), fd_gui_store_align() ) );

--- a/src/disco/pack/fd_pack.h
+++ b/src/disco/pack/fd_pack.h
@@ -25,12 +25,6 @@
    complicated, so we need to use conservative limits. */
 #define FD_PACK_MAX_DATA_PER_BLOCK (FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX)
 
-/* Optionally allow up to 1M shreds per block for benchmarking. */
-#define LARGER_MAX_DATA_PER_BLOCK  (32UL*FD_SHRED_BATCH_BLOCK_DATA_SZ_MAX)
-
-/* Optionally allow a larger limit for benchmarking */
-#define LARGER_MAX_COST_PER_BLOCK (18UL*FD_PACK_MAX_COST_PER_BLOCK_LOWER_BOUND)
-
 /* ---- End consensus-critical constants */
 
 #define FD_TXN_P_FLAGS_IS_SIMPLE_VOTE     ( 1U)

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -159,7 +159,6 @@ typedef struct {
      block to avoid hitting the shred limits.  See where this is set for
      more explanation. */
   ulong slot_max_data;
-  int   larger_shred_limits_per_block;
 
   /* Consensus critical slot cost limits. */
   struct {
@@ -169,6 +168,7 @@ typedef struct {
     ulong slot_max_allocated_data_per_block;
     ulong slot_max_data_shreds;
   } limits;
+  ulong bench_max_shreds_per_block; /* [development.bench], floors the leader's slot_max_data_shreds */
 
   /* If drain_execle is non-zero, then the pack tile must wait until all
      execle are idle before scheduling any more microblocks.  This is
@@ -340,10 +340,10 @@ scratch_align( void ) {
 FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   fd_pack_limits_t limits[1] = {{
-    .max_cost_per_block           = tile->pack.larger_max_cost_per_block ? LARGER_MAX_COST_PER_BLOCK : FD_PACK_MAX_COST_PER_BLOCK_UPPER_BOUND,
+    .max_cost_per_block           = tile->pack.max_cost_per_block,
     .max_vote_cost_per_block      = FD_PACK_MAX_VOTE_COST_PER_BLOCK_UPPER_BOUND,
     .max_write_cost_per_acct      = FD_PACK_MAX_WRITE_COST_PER_ACCT_UPPER_BOUND,
-    .max_data_bytes_per_block     = tile->pack.larger_shred_limits_per_block ? LARGER_MAX_DATA_PER_BLOCK : FD_PACK_MAX_DATA_PER_BLOCK,
+    .max_data_bytes_per_block     = FD_PACK_MAX_DATA_PER_BLOCK*(tile->pack.max_shreds_per_block/FD_SHRED_BLK_MAX),
     .max_txn_per_microblock       = EFFECTIVE_TXN_PER_MICROBLOCK,
     .max_microblocks_per_block    = (ulong)UINT_MAX, /* Limit not known yet */
     .max_allocated_data_per_block = FD_PACK_MAX_ALLOCATED_DATA_PER_BLOCK,
@@ -1156,19 +1156,14 @@ after_frag( fd_pack_ctx_t *     ctx,
     ctx->leader_bank_seq      = ctx->_became_leader->bank_seq;
     ctx->slot_max_microblocks = ctx->_became_leader->max_microblocks_in_slot;
 
-    ulong base_max_data = ctx->larger_shred_limits_per_block ? LARGER_MAX_DATA_PER_BLOCK : FD_PACK_MAX_DATA_PER_BLOCK;
-    if( FD_LIKELY( !ctx->larger_shred_limits_per_block ) ) {
-      /* Cap pack's entry bytes at the worst case: how many entry
-         bytes fit in max_shred_idx given our shredding.  We fill a
-         batch until the next microblock would not fit in two FEC
-         sets, then pad out that batch.  Empty ticks are subtracted
-         below. */
-      ulong shreds            = ctx->_became_leader->limits.slot_max_data_shreds;
-      ulong max_microblock_sz = sizeof(fd_entry_batch_header_t) + EFFECTIVE_TXN_PER_MICROBLOCK*FD_TPU_MTU;
-      ulong shred_safe        = fd_shred_batch_pack_data_max( shreds, max_microblock_sz );
-      FD_TEST( shred_safe );
-      base_max_data = shred_safe;
-    }
+    /* Cap pack's entry bytes at the worst case: how many entry bytes
+       fit in max_shred_idx given our shredding.  We fill a batch until
+       the next microblock would not fit in two FEC sets, then pad out
+       that batch.  Empty ticks are subtracted below. */
+    ulong shreds            = fd_ulong_max( ctx->_became_leader->limits.slot_max_data_shreds, ctx->bench_max_shreds_per_block );
+    ulong max_microblock_sz = sizeof(fd_entry_batch_header_t) + EFFECTIVE_TXN_PER_MICROBLOCK*FD_TPU_MTU;
+    ulong base_max_data     = fd_shred_batch_pack_data_max( shreds, max_microblock_sz );
+    FD_TEST( base_max_data );
     /* Reserve some space in the block for ticks */
     ctx->slot_max_data        = base_max_data
                                       - 48UL*(ctx->_became_leader->ticks_per_slot+ctx->_became_leader->total_skipped_ticks);
@@ -1177,7 +1172,7 @@ after_frag( fd_pack_ctx_t *     ctx,
     ctx->limits.slot_max_vote_cost                = ctx->_became_leader->limits.slot_max_vote_cost;
     ctx->limits.slot_max_write_cost_per_acct      = ctx->_became_leader->limits.slot_max_write_cost_per_acct;
     ctx->limits.slot_max_allocated_data_per_block = ctx->_became_leader->limits.slot_max_allocated_data_per_block;
-    ctx->limits.slot_max_data_shreds              = ctx->_became_leader->limits.slot_max_data_shreds;
+    ctx->limits.slot_max_data_shreds              = shreds;
 
     double tick_per_ns = ctx->clock->epoch->w;
     long end_ticks = now_ticks + (long)((double)fd_long_max( ctx->_became_leader->slot_end_ns - now_ns, 1L )*tick_per_ns);
@@ -1309,10 +1304,10 @@ unprivileged_init( fd_topo_t const *      topo,
   if( FD_UNLIKELY( tile->pack.max_pending_transactions >= USHORT_MAX-10UL ) ) FD_LOG_ERR(( "pack tile supports up to %lu pending transactions", USHORT_MAX-11UL ));
 
   fd_pack_limits_t limits_upper[1] = {{
-    .max_cost_per_block           = tile->pack.larger_max_cost_per_block ? LARGER_MAX_COST_PER_BLOCK : FD_PACK_MAX_COST_PER_BLOCK_UPPER_BOUND,
+    .max_cost_per_block           = tile->pack.max_cost_per_block,
     .max_vote_cost_per_block      = FD_PACK_MAX_VOTE_COST_PER_BLOCK_UPPER_BOUND,
     .max_write_cost_per_acct      = FD_PACK_MAX_WRITE_COST_PER_ACCT_UPPER_BOUND,
-    .max_data_bytes_per_block     = tile->pack.larger_shred_limits_per_block ? LARGER_MAX_DATA_PER_BLOCK : FD_PACK_MAX_DATA_PER_BLOCK,
+    .max_data_bytes_per_block     = FD_PACK_MAX_DATA_PER_BLOCK*(tile->pack.max_shreds_per_block/FD_SHRED_BLK_MAX),
     .max_txn_per_microblock       = EFFECTIVE_TXN_PER_MICROBLOCK,
     .max_microblocks_per_block    = (ulong)UINT_MAX, /* Limit not known yet */
     .max_allocated_data_per_block = FD_PACK_MAX_ALLOCATED_DATA_PER_BLOCK,
@@ -1326,10 +1321,10 @@ unprivileged_init( fd_topo_t const *      topo,
   if( FD_UNLIKELY( !rng ) ) FD_LOG_ERR(( "fd_rng_new failed" ));
 
   fd_pack_limits_t limits_lower[1] = {{
-    .max_cost_per_block           = tile->pack.larger_max_cost_per_block ? LARGER_MAX_COST_PER_BLOCK : FD_PACK_MAX_COST_PER_BLOCK_LOWER_BOUND,
+    .max_cost_per_block           = FD_PACK_MAX_COST_PER_BLOCK_LOWER_BOUND, /* replaced by the chain's at become-leader */
     .max_vote_cost_per_block      = FD_PACK_MAX_VOTE_COST_PER_BLOCK_LOWER_BOUND,
     .max_write_cost_per_acct      = FD_PACK_MAX_WRITE_COST_PER_ACCT_LOWER_BOUND,
-    .max_data_bytes_per_block     = tile->pack.larger_shred_limits_per_block ? LARGER_MAX_DATA_PER_BLOCK : FD_PACK_MAX_DATA_PER_BLOCK,
+    .max_data_bytes_per_block     = FD_PACK_MAX_DATA_PER_BLOCK*(tile->pack.max_shreds_per_block/FD_SHRED_BLK_MAX),
     .max_txn_per_microblock       = EFFECTIVE_TXN_PER_MICROBLOCK,
     .max_microblocks_per_block    = (ulong)UINT_MAX, /* Limit not known yet */
     .max_allocated_data_per_block = FD_PACK_MAX_ALLOCATED_DATA_PER_BLOCK,
@@ -1429,7 +1424,6 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->slot_dynamic_max_microblocks  = 0UL;
   ctx->pending_reduce_mb_bound       = 0;
   ctx->slot_max_data                 = 0UL;
-  ctx->larger_shred_limits_per_block = tile->pack.larger_shred_limits_per_block;
   ctx->drain_execle                  = 0;
   ctx->rng                           = rng;
   fd_clock_tile_init( ctx->clock );
@@ -1441,6 +1435,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->insert_to_extra               = 0;
 #endif
   ctx->use_consumed_cus              = tile->pack.use_consumed_cus;
+  ctx->bench_max_shreds_per_block    = tile->pack.bench_max_shreds_per_block;
   ctx->crank->enabled                = tile->pack.bundle.enabled;
 
   ctx->limits.slot_max_cost                = limits_lower->max_cost_per_block;

--- a/src/disco/shred/fd_shred_tile.c
+++ b/src/disco/shred/fd_shred_tile.c
@@ -288,7 +288,7 @@ typedef struct {
   ulong                          next_max_shred_idx;
   ulong                          current_max_shred_idx_start_slot;
   ulong                          next_max_shred_idx_start_slot;
-  int                            larger_shred_limits_per_block;
+  ulong                          bench_max_shred_idx; /* [development.bench.max_shreds_per_block], floors the chain's limits */
   /* too large to be left in the stack */
   fd_shred_dest_idx_t scratchpad_dests[ FD_SHRED_DEST_MAX_FANOUT*(FD_REEDSOL_DATA_SHREDS_MAX+FD_REEDSOL_PARITY_SHREDS_MAX) ];
 
@@ -574,28 +574,26 @@ during_frag( fd_shred_ctx_t * ctx,
 
     *ctx->epoch_schedule = epoch_msg->epoch_schedule;
 
-    if( FD_LIKELY( !ctx->larger_shred_limits_per_block ) ) {
-      fd_slot_params_t slot_params = fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
-                                                            &epoch_msg->features,
-                                                            &epoch_msg->epoch_schedule,
-                                                            epoch_msg->start_slot );
+    fd_slot_params_t slot_params = fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
+                                                          &epoch_msg->features,
+                                                          &epoch_msg->epoch_schedule,
+                                                          epoch_msg->start_slot );
 
-      ctx->current_max_shred_idx            = slot_params.max_shred_idx;
-      ctx->current_max_shred_idx_start_slot = fd_slot_params_effective_slot( &slot_params,
-                                                                             &epoch_msg->features,
-                                                                             &epoch_msg->epoch_schedule );
-      ctx->next_max_shred_idx_start_slot    = fd_slot_params_next_effective_slot( &slot_params,
-                                                                                  &epoch_msg->features,
-                                                                                  &epoch_msg->epoch_schedule );
-      ctx->prev_max_shred_idx               = fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
-                                                                     &epoch_msg->features,
-                                                                     &epoch_msg->epoch_schedule,
-                                                                     fd_ulong_sat_sub( ctx->current_max_shred_idx_start_slot, 1UL ) ).max_shred_idx;
-      ctx->next_max_shred_idx               = fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
-                                                                     &epoch_msg->features,
-                                                                     &epoch_msg->epoch_schedule,
-                                                                     ctx->next_max_shred_idx_start_slot ).max_shred_idx;
-    }
+    ctx->current_max_shred_idx            = fd_ulong_max( slot_params.max_shred_idx, ctx->bench_max_shred_idx );
+    ctx->current_max_shred_idx_start_slot = fd_slot_params_effective_slot( &slot_params,
+                                                                           &epoch_msg->features,
+                                                                           &epoch_msg->epoch_schedule );
+    ctx->next_max_shred_idx_start_slot    = fd_slot_params_next_effective_slot( &slot_params,
+                                                                                &epoch_msg->features,
+                                                                                &epoch_msg->epoch_schedule );
+    ctx->prev_max_shred_idx               = fd_ulong_max( fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
+                                                                                 &epoch_msg->features,
+                                                                                 &epoch_msg->epoch_schedule,
+                                                                                 fd_ulong_sat_sub( ctx->current_max_shred_idx_start_slot, 1UL ) ).max_shred_idx, ctx->bench_max_shred_idx );
+    ctx->next_max_shred_idx               = fd_ulong_max( fd_slot_params_lookup( &FD_SLOT_PARAMS_400MS,
+                                                                                 &epoch_msg->features,
+                                                                                 &epoch_msg->epoch_schedule,
+                                                                                 ctx->next_max_shred_idx_start_slot ).max_shred_idx, ctx->bench_max_shred_idx );
     ctx->features_activation->enforce_fixed_fec_set = fd_shred_get_feature_activation_slot0(
       epoch_msg->features.enforce_fixed_fec_set, ctx );
 
@@ -646,14 +644,12 @@ during_frag( fd_shred_ctx_t * ctx,
 
       *ctx->features_activation = msg->features_activation;
 
-      if( FD_LIKELY( !ctx->larger_shred_limits_per_block ) ) {
-        fd_shred_slot_limits_t const * lim    = &msg->slot_limits;
-        ctx->prev_max_shred_idx               = lim->prev_max_shred_idx;
-        ctx->current_max_shred_idx            = lim->current_max_shred_idx;
-        ctx->next_max_shred_idx               = lim->next_max_shred_idx;
-        ctx->current_max_shred_idx_start_slot = lim->current_start_slot;
-        ctx->next_max_shred_idx_start_slot    = lim->next_start_slot;
-      }
+      fd_shred_slot_limits_t const * lim    = &msg->slot_limits;
+      ctx->prev_max_shred_idx               = fd_ulong_max( lim->prev_max_shred_idx,    ctx->bench_max_shred_idx );
+      ctx->current_max_shred_idx            = fd_ulong_max( lim->current_max_shred_idx, ctx->bench_max_shred_idx );
+      ctx->next_max_shred_idx               = fd_ulong_max( lim->next_max_shred_idx,    ctx->bench_max_shred_idx );
+      ctx->current_max_shred_idx_start_slot = lim->current_start_slot;
+      ctx->next_max_shred_idx_start_slot    = lim->next_start_slot;
     }
     else { /* (fd_disco_poh_sig_pkt_type( sig )==POH_PKT_TYPE_MICROBLOCK) */
       /* This is a frag from the PoH tile.  We'll copy it to our pending
@@ -1555,8 +1551,8 @@ unprivileged_init( fd_topo_t const *      topo,
                                                             sign_in->dcache,
                                                             sign_out->mtu ) ) );
 
-  ctx->larger_shred_limits_per_block = tile->shred.larger_shred_limits_per_block;
-  ulong shred_limit                  = fd_ulong_if( tile->shred.larger_shred_limits_per_block, 32UL*32UL*1024UL, 32UL*1024UL );
+  ctx->bench_max_shred_idx           = tile->shred.bench_max_shreds_per_block;
+  ulong shred_limit                  = tile->shred.max_shreds_per_block;
   ctx->shred_limit                   = shred_limit;
   fd_fec_set_t * resolver_sets       = fec_sets + fec_exposure + FD_SHRED_BATCH_FEC_SETS_MAX;
   ctx->shredder = NONNULL( fd_shredder_join     ( fd_shredder_new     ( _shredder, fd_shred_signer, ctx->keyguard_client ) ) );

--- a/src/disco/store/fd_store.c
+++ b/src/disco/store/fd_store.c
@@ -334,6 +334,7 @@ fd_store_new( void       * shmem,
               ulong        shred_storage_gib,
               ulong        shred_cache_bytes,
               ulong        fec_set_cnt,
+              ulong        max_shreds_per_block,
               char const * db_path,
               ulong        seed ) {
 
@@ -344,6 +345,7 @@ fd_store_new( void       * shmem,
   if( FD_UNLIKELY( !fec_max ) ) { FD_LOG_WARNING(( "fec_max must be non-zero" )); return NULL; }
   if( FD_UNLIKELY( fec_max>UINT_MAX ) ) { FD_LOG_WARNING(( "fec_max must fit in uint" )); return NULL; }
   if( FD_UNLIKELY( !fec_data_max ) ) { FD_LOG_WARNING(( "fec_data_max must be non-zero" )); return NULL; }
+  if( FD_UNLIKELY( !max_shreds_per_block || max_shreds_per_block>FD_SHREDB_HINT_VALID ) ) { FD_LOG_WARNING(( "bad max_shreds_per_block (%lu)", max_shreds_per_block )); return NULL; }
   if( FD_UNLIKELY( shred_storage_gib>FD_SHREDB_MAX_SIZE_GIB ) ) {
     FD_LOG_ERR(( "shred database size limit is %lu GiB, but the maximum supported size is %lu GiB",
                  shred_storage_gib, FD_SHREDB_MAX_SIZE_GIB ));
@@ -425,6 +427,7 @@ fd_store_new( void       * shmem,
   store->spill_read_data_gaddr = fd_wksp_gaddr_fast( wksp, spill_read_mem );
   store->fec_set_cnt           = fec_set_cnt;
   store->fec_sets_gaddr        = fec_set_cnt ? fd_wksp_gaddr_fast( wksp, fec_sets ) : 0UL;
+  store->max_shreds_per_block  = max_shreds_per_block;
   fd_rwlock_new( &store->cache_lock );
   fd_rwlock_new( &store->spill_read_lock );
   fd_rwlock_new( &store->fec_lock );
@@ -835,11 +838,11 @@ disk_slot_hint_publish( fd_store_t * store,
                         ulong        slot,
                         uint         shred_idx ) {
   atomic_ulong * hint = disk_slot_hint_laddr( store ) + (slot % store->disk_max_slots);
-  ulong desired = fd_shredb_key_pack( slot, shred_idx ) | (1UL<<15);
+  ulong desired = fd_shredb_key_pack( slot, shred_idx ) | FD_SHREDB_HINT_VALID;
   ulong current = atomic_load_explicit( hint, memory_order_acquire );
   for(;;) {
-    if( FD_LIKELY( current & (1UL<<15) ) ) {
-      uint current_idx = (uint)(current & (FD_SHRED_BLK_MAX-1UL));
+    if( FD_LIKELY( current & FD_SHREDB_HINT_VALID ) ) {
+      uint current_idx = fd_shredb_key_shred_idx( current & ~FD_SHREDB_HINT_VALID );
       if( current_idx>=shred_idx ) return;
     }
     if( atomic_compare_exchange_strong_explicit( hint, &current, desired,
@@ -905,7 +908,7 @@ fd_store_disk_insert( fd_store_t       * store,
 
   ulong slot      = shred->slot;
   uint  shred_idx = shred->idx;
-  if( FD_UNLIKELY( (slot>>48) || shred_idx>=FD_SHRED_BLK_MAX ) ) return FD_STORE_DISK_INSERT_ERR;
+  if( FD_UNLIKELY( slot>=FD_SHREDB_KEY_SLOT_MAX || shred_idx>=store->max_shreds_per_block ) ) return FD_STORE_DISK_INSERT_ERR;
   ulong key = fd_shredb_key_pack( slot, shred_idx );
 
   ulong ticket = atomic_fetch_add_explicit( &store->disk_reservation_head, 1UL, memory_order_relaxed ) + 1UL;
@@ -995,7 +998,7 @@ fd_store_disk_query( fd_store_t const * store,
                      uint               shred_idx,
                      uchar              out[ FD_SHRED_MAX_SZ ] ) {
   if( FD_UNLIKELY( !store || disk_fd<0 || !out || !fd_store_has_disk( store ) ||
-                   (slot>>48) || shred_idx>=FD_SHRED_BLK_MAX ) ) return FD_STORE_DISK_QUERY_MISS;
+                   slot>=FD_SHREDB_KEY_SLOT_MAX || shred_idx>=store->max_shreds_per_block ) ) return FD_STORE_DISK_QUERY_MISS;
   ulong key = fd_shredb_key_pack( slot, shred_idx );
   for( ulong retry=0UL; retry<FD_STORE_DISK_READ_RETRY_CNT; retry++ ) {
     fd_shredb_entry_t rd_entry[1];
@@ -1014,14 +1017,15 @@ fd_store_disk_query_highest( fd_store_t const * store,
                              ulong              slot,
                              uint               min_shred_idx,
                              uchar              out[ FD_SHRED_MAX_SZ ] ) {
-  if( FD_UNLIKELY( !store || disk_fd<0 || !out || !fd_store_has_disk( store ) || (slot>>48) ) )
+  if( FD_UNLIKELY( !store || disk_fd<0 || !out || !fd_store_has_disk( store ) || slot>=FD_SHREDB_KEY_SLOT_MAX ) )
     return FD_STORE_DISK_QUERY_MISS;
   for( ulong retry=0UL; retry<FD_STORE_DISK_READ_RETRY_CNT; retry++ ) {
     atomic_ulong const * hint_ptr = disk_slot_hint_laddr( store ) + (slot % store->disk_max_slots);
     ulong hint = atomic_load_explicit( hint_ptr, memory_order_acquire );
-    if( FD_UNLIKELY( !(hint & (1UL<<15)) ) ) return FD_STORE_DISK_QUERY_MISS;
+    if( FD_UNLIKELY( !(hint & FD_SHREDB_HINT_VALID) ) ) return FD_STORE_DISK_QUERY_MISS;
     if( FD_UNLIKELY( fd_shredb_key_slot( hint )!=slot ) ) return FD_STORE_DISK_QUERY_BUSY;
-    uint idx = (uint)(hint & (FD_SHRED_BLK_MAX-1UL));
+    uint idx = fd_shredb_key_shred_idx( hint & ~FD_SHREDB_HINT_VALID );
+    if( FD_UNLIKELY( idx>=store->max_shreds_per_block ) ) return FD_STORE_DISK_QUERY_MISS;
 
     fd_shredb_entry_t rd_entry[1];
     int result = disk_read_key_once( store, disk_fd, fd_shredb_key_pack( slot, idx ), rd_entry );

--- a/src/disco/store/fd_store.h
+++ b/src/disco/store/fd_store.h
@@ -30,19 +30,26 @@ fd_store_payload_slot_sz( ulong fec_data_max ) {
 #define FD_STORE_FEC_DATA_CONSUMED    (4U)
 #define FD_STORE_FEC_DATA_SPILLING    (5U)
 
+/* Shred ring keys are slot<<32 | shred_idx, so slot<2^32 and shred_idx
+   <2^32.  The per-slot hint reuses the key with bit 31 as the valid
+   flag, which further bounds shred_idx<2^31 (see FD_SHREDB_HINT_VALID). */
+
+#define FD_SHREDB_KEY_SLOT_MAX  (1UL<<32)
+#define FD_SHREDB_HINT_VALID    (1UL<<31)
+
 FD_FN_CONST static inline ulong
 fd_shredb_key_pack( ulong slot, uint shred_idx ) {
-  return (slot << 16) | (ulong)(ushort)shred_idx;
+  return (slot << 32) | (ulong)shred_idx;
 }
 
 FD_FN_CONST static inline ulong
 fd_shredb_key_slot( ulong key ) {
-  return fd_ulong_extract( key, 16, 63 );
+  return fd_ulong_extract( key, 32, 63 );
 }
 
 FD_FN_CONST static inline uint
 fd_shredb_key_shred_idx( ulong key ) {
-  return (uint)fd_ulong_extract( key, 0, 15 );
+  return (uint)fd_ulong_extract( key, 0, 31 );
 }
 
 struct fd_shredb_shred_entry {
@@ -177,6 +184,7 @@ struct fd_store {
   ulong        slot_hint_gaddr;
   ulong        disk_max_shreds;
   ulong        disk_max_slots;
+  ulong        max_shreds_per_block; /* bounds shred idxs, <=FD_SHREDB_HINT_VALID */
   atomic_ulong disk_reservation_head;
   atomic_ulong disk_cnt;
   atomic_ulong disk_insert_cnt;
@@ -268,7 +276,8 @@ fd_store_footprint( ulong fec_max,
 /* Formats a footprint-sized, fd_store_align()-aligned region.  fec_max
    bounds live FECs; fec_data_max bounds each payload.  The remaining size
    arguments configure the shred ring, RAM cache, and shred-tile arena.
-   Does not create the backing file. */
+   max_shreds_per_block bounds shred idxs in the shred ring, in
+   [1,FD_SHREDB_HINT_VALID].  Does not create the backing file. */
 
 void *
 fd_store_new( void       * shmem,
@@ -277,6 +286,7 @@ fd_store_new( void       * shmem,
               ulong        shred_storage_gib,
               ulong        shred_cache_bytes,
               ulong        fec_set_cnt,
+              ulong        max_shreds_per_block,
               char const * db_path,
               ulong        seed );
 
@@ -412,7 +422,7 @@ struct fd_store_disk_stats {
 };
 typedef struct fd_store_disk_stats fd_store_disk_stats_t;
 
-/* Persists one (slot,idx) shred, where idx is below FD_SHRED_BLK_MAX.
+/* Persists one (slot,idx) shred, where idx is below max_shreds_per_block.
    The caller guarantees that the shred has not previously been inserted.
    Returns FD_STORE_DISK_INSERT_SUCCESS or FD_STORE_DISK_INSERT_ERR. */
 
@@ -422,8 +432,8 @@ fd_store_disk_insert( fd_store_t       * store,
                       fd_shred_t const * shred );
 
 /* Copies (slot,shred_idx) to out, where shred_idx is below
-   FD_SHRED_BLK_MAX.  Returns its positive byte count, MISS, or retryable
-   BUSY. */
+   max_shreds_per_block.  Returns its positive byte count, MISS, or
+   retryable BUSY. */
 
 int
 fd_store_disk_query( fd_store_t const * store,

--- a/src/disco/store/test_store.c
+++ b/src/disco/store/test_store.c
@@ -45,7 +45,7 @@ void
 test_api( fd_wksp_t * wksp ) {
   ulong  fec_max     = 8;
   void * mem         = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( fec_max, 31840UL, 0UL, 0UL, 0UL ), 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( store );
 
   fd_store_map_t map[1];
@@ -120,7 +120,7 @@ test_db_path( fd_wksp_t * wksp ) {
 
   ulong fp = fd_store_footprint( 2UL, 31840UL, 0UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fp, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 2UL, 31840UL, 0UL, 0UL, 0UL, db_path, 0UL ) );
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 2UL, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, db_path, 0UL ) );
   FD_TEST( store );
   FD_TEST( !strcmp( store->db_path, db_path ) );
   fd_wksp_free_laddr( fd_store_delete( fd_store_leave( store ) ) );
@@ -129,7 +129,7 @@ test_db_path( fd_wksp_t * wksp ) {
   char too_long[ PATH_MAX ];
   fd_memset( too_long, 'x', sizeof(too_long) );
   mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fp, 1UL );
-  FD_TEST( !fd_store_new( mem, 2UL, 31840UL, 0UL, 0UL, 0UL, too_long, 0UL ) );
+  FD_TEST( !fd_store_new( mem, 2UL, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, too_long, 0UL ) );
   fd_wksp_free_laddr( mem );
 }
 
@@ -139,7 +139,7 @@ test_file_open( fd_wksp_t * wksp ) {
 
   ulong footprint = fd_store_footprint( 2UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 2UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 2UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( store );
   store->disk_max_shreds = 16UL;
@@ -187,7 +187,7 @@ void
 test_query_miss( fd_wksp_t * wksp ) {
   ulong  fec_max     = 16;
   void * mem         = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( fec_max, 31840UL, 0UL, 0UL, 0UL ), 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( store );
 
   fd_store_map_t map[1];
@@ -232,7 +232,7 @@ test_fec_data_max( fd_wksp_t * wksp ) {
   FD_TEST( fp_cap < fp_var );
 
   void * mem         = fd_wksp_alloc_laddr( wksp, fd_store_align(), fp_var, 1UL );
-  fd_store_t * st    = fd_store_join( fd_store_new( mem, fec_max, 63985UL, 0UL, 0UL, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * st    = fd_store_join( fd_store_new( mem, fec_max, 63985UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( st );
   FD_TEST( st->fec_data_max == 63985UL );
 
@@ -280,7 +280,7 @@ test_fec_data_max( fd_wksp_t * wksp ) {
   fd_wksp_free_laddr( fd_store_delete( fd_store_leave( st ) ) );
 
   mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fp_fixed, 1UL );
-  st  = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  st  = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( st );
   FD_TEST( st->fec_data_max == 31840UL );
 
@@ -322,7 +322,7 @@ test_fec_sets_arena( fd_wksp_t * wksp ) {
   FD_TEST( fp_with > fp_without );
 
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fp_with, 1UL );
-  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, fec_set_cnt, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, fec_set_cnt, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( st );
   FD_TEST( st->fec_set_cnt==fec_set_cnt );
 
@@ -345,7 +345,7 @@ test_spill( fd_wksp_t * wksp ) {
   ulong cache_bytes  = 2UL * fd_store_payload_slot_sz( fec_data_max );
 
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( fec_max, fec_data_max, 0UL, cache_bytes, 0UL ), 1UL );
-  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 0UL, cache_bytes, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 0UL, cache_bytes, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( st );
   FD_TEST( st->cache_slot_cnt==2UL );
   FD_TEST( st->cache_free_cnt==2UL );
@@ -436,7 +436,7 @@ test_pinned_spill( fd_wksp_t * wksp ) {
   ulong cache_bytes  = 2UL * fd_store_payload_slot_sz( fec_data_max );
 
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( fec_max, fec_data_max, 0UL, cache_bytes, 0UL ), 1UL );
-  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 0UL, cache_bytes, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  fd_store_t * st = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 0UL, cache_bytes, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( st );
   int fd = store_file_open( st, O_RDWR );
   FD_TEST( fd>=0 );
@@ -513,7 +513,7 @@ test_disk_query_highest( fd_wksp_t * wksp ) {
   ulong fec_data_max = 31840UL;
   ulong footprint    = fd_store_footprint( fec_max, fec_data_max, 1UL, 0UL, 0UL );
   void * mem         = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, fec_max, fec_data_max, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 42UL ) );
   FD_TEST( store );
   store->disk_max_shreds = 64UL;
@@ -582,7 +582,7 @@ void
 test_disk_many_wraps( fd_wksp_t * wksp ) {
   ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 42UL ) );
   FD_TEST( store );
   store->disk_max_shreds = 16UL;
@@ -618,7 +618,7 @@ void
 test_disk_concurrent_writes( fd_wksp_t * wksp ) {
   ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 42UL ) );
   FD_TEST( store );
   store->disk_max_shreds = fd_ulong_max( 16UL, 2UL*fd_tile_cnt() );
@@ -661,7 +661,7 @@ void
 test_disk_slot_hint( fd_wksp_t * wksp ) {
   ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 42UL ) );
   FD_TEST( store );
   store->disk_max_shreds = 4UL;
@@ -673,7 +673,7 @@ test_disk_slot_hint( fd_wksp_t * wksp ) {
   ulong const slot_a = 17UL;
   ulong const slot_b = slot_a + stride;
   ulong const slot_c = slot_b + stride;
-  FD_TEST( stride>8UL && !(slot_c>>48) );
+  FD_TEST( stride>8UL && slot_c<FD_SHREDB_KEY_SLOT_MAX );
   FD_TEST( slot_a%stride==slot_b%stride && slot_b%stride==slot_c%stride );
 
   uchar buf[ FD_SHRED_MAX_SZ ];
@@ -725,7 +725,7 @@ void
 test_disk_lazy_highest( fd_wksp_t * wksp ) {
   ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, 42UL ) );
   FD_TEST( store );
   store->disk_max_shreds = 2UL;
@@ -758,7 +758,7 @@ test_disk_collision_eviction( fd_wksp_t * wksp ) {
   ulong const seed = 42UL;
   ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
   void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
-  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL,
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHRED_BLK_MAX,
                                                     TEST_PAYLOAD_PATH, seed ) );
   FD_TEST( store );
   store->disk_max_shreds = 2UL;
@@ -773,7 +773,7 @@ test_disk_collision_eviction( fd_wksp_t * wksp ) {
   ulong key_cnt = 0UL;
   for( ulong upper=1UL; key_cnt<3UL; upper++ ) {
     ulong key = fd_ulong_hash_inverse( (upper<<32) | 0xdeadbeefUL ) ^ seed;
-    if( fd_shredb_key_shred_idx( key )>=FD_SHRED_BLK_MAX ) continue;
+    if( fd_shredb_key_shred_idx( key )>=store->max_shreds_per_block ) continue;
     keys[ key_cnt++ ] = key;
   }
   FD_TEST( keys[ 0 ]!=keys[ 1 ] );
@@ -810,6 +810,58 @@ test_disk_collision_eviction( fd_wksp_t * wksp ) {
   oversized->data.size = USHRT_MAX;
   FD_TEST( fd_store_disk_insert( store, disk_fd, oversized )==FD_STORE_DISK_INSERT_SUCCESS );
   FD_TEST( fd_store_disk_query( store, disk_fd, 9UL, 0U, out )==(int)FD_SHRED_MAX_SZ );
+
+  close( disk_fd );
+  fd_wksp_free_laddr( fd_store_delete( fd_store_leave( store ) ) );
+}
+
+/* max_shreds_per_block is a runtime value: a store sized for 4x
+   FD_SHRED_BLK_MAX round-trips shred idxs above the production bound
+   through the exact index and the per-slot highest hint, and rejects
+   idxs at or beyond its own bound.  Also pins the key encoding. */
+
+void
+test_disk_max_shreds_per_block( fd_wksp_t * wksp ) {
+  ulong const shred_max = 4UL*FD_SHRED_BLK_MAX;
+  FD_TEST( fd_shredb_key_pack( 5UL, (uint)shred_max-1U )==((5UL<<32)|(shred_max-1UL)) );
+  FD_TEST( fd_shredb_key_slot( fd_shredb_key_pack( FD_SHREDB_KEY_SLOT_MAX-1UL, 7U ) )==FD_SHREDB_KEY_SLOT_MAX-1UL );
+  FD_TEST( fd_shredb_key_shred_idx( fd_shredb_key_pack( FD_SHREDB_KEY_SLOT_MAX-1UL, 7U ) )==7U );
+
+  ulong footprint = fd_store_footprint( 8UL, 31840UL, 1UL, 0UL, 0UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), footprint, 1UL );
+  FD_TEST( !fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, 0UL,                     TEST_PAYLOAD_PATH, 42UL ) );
+  FD_TEST( !fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, FD_SHREDB_HINT_VALID+1UL, TEST_PAYLOAD_PATH, 42UL ) );
+  fd_store_t * store = fd_store_join( fd_store_new( mem, 8UL, 31840UL, 1UL, 0UL, 0UL, shred_max,
+                                                    TEST_PAYLOAD_PATH, 42UL ) );
+  FD_TEST( store && store->max_shreds_per_block==shred_max );
+  store->disk_max_shreds = 8UL;
+
+  int disk_fd = store_file_open( store, O_RDWR );
+  FD_TEST( disk_fd>=0 );
+
+  uchar buf[ FD_SHRED_MAX_SZ ];
+  uchar out[ FD_SHRED_MAX_SZ ];
+  ulong const slot = 21UL;
+  uint  const lo   = FD_SHRED_BLK_MAX-1U; /* highest production idx */
+  uint  const hi   = (uint)shred_max-1U;  /* highest bench idx, bit 15 set */
+
+  FD_TEST( fd_store_disk_insert( store, disk_fd, disk_make_shred( buf, slot, lo, 0x10U ) )==FD_STORE_DISK_INSERT_SUCCESS );
+  FD_TEST( fd_store_disk_insert( store, disk_fd, disk_make_shred( buf, slot, hi, 0x20U ) )==FD_STORE_DISK_INSERT_SUCCESS );
+  FD_TEST( fd_store_disk_insert( store, disk_fd, disk_make_shred( buf, slot, (uint)shred_max, 0x30U ) )==FD_STORE_DISK_INSERT_ERR );
+  FD_TEST( fd_store_disk_insert( store, disk_fd, disk_make_shred( buf, FD_SHREDB_KEY_SLOT_MAX, 0U, 0x40U ) )==FD_STORE_DISK_INSERT_ERR );
+
+  FD_TEST( fd_store_disk_query( store, disk_fd, slot, lo, out )>0 && out[ FD_SHRED_DATA_HEADER_SZ ]==0x10U );
+  FD_TEST( fd_store_disk_query( store, disk_fd, slot, hi, out )>0 && out[ FD_SHRED_DATA_HEADER_SZ ]==0x20U );
+  FD_TEST( fd_store_disk_query( store, disk_fd, slot, (uint)shred_max, out )==FD_STORE_DISK_QUERY_MISS );
+  FD_TEST( fd_store_disk_query( store, disk_fd, FD_SHREDB_KEY_SLOT_MAX, 0U, out )==FD_STORE_DISK_QUERY_MISS );
+
+  /* The hint tracks hi, which a 15-bit hint field would have folded. */
+  FD_TEST( fd_store_disk_query_highest( store, disk_fd, slot, 0U, out )>0 );
+  FD_TEST( ((fd_shred_t const *)fd_type_pun_const( out ))->idx==hi );
+  FD_TEST( out[ FD_SHRED_DATA_HEADER_SZ ]==0x20U );
+  FD_TEST( fd_store_disk_insert( store, disk_fd, disk_make_shred( buf, slot, lo+1U, 0x11U ) )==FD_STORE_DISK_INSERT_SUCCESS );
+  FD_TEST( fd_store_disk_query_highest( store, disk_fd, slot, 0U, out )>0 );
+  FD_TEST( ((fd_shred_t const *)fd_type_pun_const( out ))->idx==hi ); /* never lowered */
 
   close( disk_fd );
   fd_wksp_free_laddr( fd_store_delete( fd_store_leave( store ) ) );
@@ -862,7 +914,7 @@ test_concurrent( fd_wksp_t * wksp ) {
   ulong  tile_cnt = fd_tile_cnt();
   ulong  fec_max  = tile_cnt * num_insert + 16UL;
   void * mem      = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( fec_max, 31840UL, 0UL, 0UL, 0UL ), 1UL );
-  g_store         = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, TEST_PAYLOAD_PATH, 0UL ) );
+  g_store         = fd_store_join( fd_store_new( mem, fec_max, 31840UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, TEST_PAYLOAD_PATH, 0UL ) );
   FD_TEST( g_store );
 
   FD_COMPILER_MFENCE();
@@ -937,6 +989,7 @@ main( int argc, char ** argv ) {
   test_disk_concurrent_writes( wksp );
   test_disk_slot_hint( wksp );
   test_disk_lazy_highest( wksp );
+  test_disk_max_shreds_per_block( wksp );
   test_concurrent  ( wksp );
 
   FD_LOG_NOTICE(( "pass" ));

--- a/src/disco/topo/fd_topo.h
+++ b/src/disco/topo/fd_topo.h
@@ -350,8 +350,9 @@ struct fd_topo_tile {
     struct {
       ulong max_pending_transactions;
       ulong execle_tile_count;
-      int   larger_max_cost_per_block;
-      int   larger_shred_limits_per_block;
+      ulong max_cost_per_block;
+      ulong max_shreds_per_block;
+      ulong bench_max_shreds_per_block; /* [development.bench], floors the leader's per-slot shred limit */
       int   use_consumed_cus;
       int   schedule_strategy;
       struct {
@@ -383,11 +384,13 @@ struct fd_topo_tile {
     struct {
       ulong execle_cnt;
       char  identity_key_path[ PATH_MAX ];
+      ulong max_txn_per_slot;
     } poh;
 
     struct {
       ulong execle_cnt;
       char  identity_key_path[ PATH_MAX ];
+      ulong max_txn_per_slot;
     } motor;
 
     struct {
@@ -395,7 +398,8 @@ struct fd_topo_tile {
       ulong             fec_resolver_depth;
       char              identity_key_path[ PATH_MAX ];
       ushort            shred_listen_port;
-      int               larger_shred_limits_per_block;
+      ulong             max_shreds_per_block;
+      ulong             bench_max_shreds_per_block; /* [development.bench], floors the chain's per-slot limit */
       ushort            expected_shred_version;
       ulong             adtl_dests_retransmit_cnt;
       fd_topo_ip_port_t adtl_dests_retransmit[ FD_TOPO_ADTL_DESTS_MAX ];
@@ -445,6 +449,7 @@ struct fd_topo_tile {
       ushort expected_shred_version;
       ulong  cache_size_gib;
       ulong  accdb_obj_id;
+      ulong  max_txn_per_slot;
     } gui;
 
     struct {
@@ -516,7 +521,8 @@ struct fd_topo_tile {
 
       char  genesis_path[ PATH_MAX ];
 
-      int   larger_max_cost_per_block;
+      ulong max_txn_per_slot;     /* config->limits */
+      ulong max_shreds_per_block;
 
       ulong capture_start_slot;
       char  solcap_capture[ PATH_MAX ];
@@ -577,6 +583,7 @@ struct fd_topo_tile {
       char    identity_key_path[ PATH_MAX ];
       ulong   max_pending_shred_sets;
       ulong   slot_max;
+      ulong   max_shreds_per_block;
 
       /* non-config */
 
@@ -588,6 +595,7 @@ struct fd_topo_tile {
       ushort  repair_client_listen_port;
       char    identity_key_path[ PATH_MAX ];
       ulong   slot_max;
+      ulong   max_shreds_per_block;
 
       ulong   repair_sign_depth;
       ulong   repair_sign_cnt;
@@ -597,6 +605,7 @@ struct fd_topo_tile {
       ushort repair_serve_listen_port;
       char   identity_key_path[ PATH_MAX ];
       ulong  ping_cache_entries;
+      ulong  max_shreds_per_block;
     } rserve;
 
     struct {
@@ -639,6 +648,7 @@ struct fd_topo_tile {
       char  identity_key[ PATH_MAX ];
       char  vote_account[ PATH_MAX ];
       char  base_path[PATH_MAX];
+      ulong max_shreds_per_block;
     } tower;
 
     struct {
@@ -714,6 +724,7 @@ struct fd_topo_tile {
       ulong txncache_obj_id;
       ulong banks_obj_id;
       int   alpenglow;
+      ulong max_txn_per_slot;
     } snapin;
 
     struct {

--- a/src/discof/backup/fd_txncache_writer.c
+++ b/src/discof/backup/fd_txncache_writer.c
@@ -10,7 +10,7 @@
 struct fd_txncache_writer_blockcache {
   fd_txncache_blockcache_shmem_t * shmem;
   uint *           heads;
-  ushort *         pages;
+  void *           pages;   /* ushort or uint per tc->shmem->txnpage_idx_sz */
   descends_set_t * descends;
 };
 
@@ -21,7 +21,7 @@ struct fd_txncache_writer_tc {
   fd_txncache_blockcache_shmem_t *      blockcache_shmem_pool;
   fd_txncache_writer_blockcache_t *     blockcache_pool;
   blockhash_map_t *                     blockhash_map;
-  ushort *                              txnpages_free;
+  void *                                txnpages_free;
   fd_txncache_txnpage_t *               txnpages;
 };
 

--- a/src/discof/backup/test_snap_roundtrip.c
+++ b/src/discof/backup/test_snap_roundtrip.c
@@ -71,10 +71,10 @@ typedef struct {
 
 static test_txncache_t
 create_txncache( void ) {
-  ulong shmem_fp = fd_txncache_shmem_footprint( MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT, 0 );
+  ulong shmem_fp = fd_txncache_shmem_footprint( MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT );
   void * shmem_raw = aligned_alloc( fd_txncache_shmem_align(), shmem_fp );
   FD_TEST( shmem_raw );
-  fd_txncache_shmem_t * shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem_raw, MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT, 0, 1UL ) );
+  fd_txncache_shmem_t * shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem_raw, MAX_LIVE_SLOTS, MAX_TXN_PER_SLOT, 1UL ) );
   FD_TEST( shmem );
 
   ulong ljoin_fp = fd_txncache_footprint( MAX_LIVE_SLOTS );

--- a/src/discof/chainer/fd_chainer.c
+++ b/src/discof/chainer/fd_chainer.c
@@ -6,10 +6,10 @@
 #include <stdio.h>
 
 void *
-fd_chainer_new( void * shmem, ulong ele_max, ulong seed ) {
-  ulong footprint = fd_chainer_footprint( ele_max );
+fd_chainer_new( void * shmem, ulong ele_max, ulong max_shreds_per_block, ulong seed ) {
+  ulong footprint = fd_chainer_footprint( ele_max, max_shreds_per_block );
   if( FD_UNLIKELY( !footprint ) ) {
-    FD_LOG_WARNING(("bad footprint: %lu", ele_max));
+    FD_LOG_WARNING(("bad footprint: %lu %lu", ele_max, max_shreds_per_block));
     return NULL;
   }
 
@@ -23,7 +23,8 @@ fd_chainer_new( void * shmem, ulong ele_max, ulong seed ) {
   fd_chainer_t * chainer;
 
   ulong blk_max       = ele_max * FD_CHAINER_SLOT_VER_MAX;
-  ulong fec_max       = blk_max * FD_FEC_BLK_MAX;
+  ulong fec_blk_max   = max_shreds_per_block / FD_FEC_SHRED_CNT;
+  ulong fec_max       = blk_max * fec_blk_max;
   ulong fec_chain_cnt = fd_fec_map_chain_cnt_est( fec_max );
   ulong blk_chain_cnt = fd_slotv_map_chain_cnt_est( blk_max );
 
@@ -32,6 +33,7 @@ fd_chainer_new( void * shmem, ulong ele_max, ulong seed ) {
   void * fec_pool     = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_pool_align(),     fd_fec_pool_footprint    ( fec_max )         );
   void * fec_map      = FD_SCRATCH_ALLOC_APPEND( l, fd_fec_map_align(),      fd_fec_map_footprint     ( fec_chain_cnt   ) );
   void * slotv_pool   = FD_SCRATCH_ALLOC_APPEND( l, fd_slotv_pool_align(),   fd_slotv_pool_footprint  ( blk_max         ) );
+  void * fec_tbl      = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),           fec_max*sizeof(uint)                         );
   void * slotv_map    = FD_SCRATCH_ALLOC_APPEND( l, fd_slotv_map_align(),    fd_slotv_map_footprint   ( blk_chain_cnt   ) );
   void * sched_pool   = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_pool_align(),   fd_sched_pool_footprint  ( blk_max         ) );
   void * sched_map    = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_map_align(),    fd_sched_map_footprint   ( blk_chain_cnt   ) );
@@ -47,6 +49,8 @@ fd_chainer_new( void * shmem, ulong ele_max, ulong seed ) {
   chainer->fec_pool     = fd_fec_pool_join    ( fd_fec_pool_new    ( fec_pool,     fec_max             ) );
   chainer->fec_map      = fd_fec_map_join     ( fd_fec_map_new     ( fec_map,      fec_chain_cnt, seed ) );
   chainer->slotv_pool   = fd_slotv_pool_join  ( fd_slotv_pool_new  ( slotv_pool,   blk_max             ) );
+  chainer->fec_tbl      = fec_tbl;
+  chainer->fec_blk_max  = fec_blk_max;
   chainer->slotv_map    = fd_slotv_map_join   ( fd_slotv_map_new   ( slotv_map,    blk_chain_cnt, seed ) );
   chainer->sched_pool   = fd_sched_pool_join  ( fd_sched_pool_new  ( sched_pool,   blk_max             ) );
   chainer->sched_map    = fd_sched_map_join   ( fd_sched_map_new   ( sched_map,    blk_chain_cnt, seed ) );
@@ -106,7 +110,7 @@ acquire_slotv( fd_chainer_t * chainer, ulong slot ) {
 
   fd_memset( &slotv->block_id,        0, sizeof(fd_hash_t) );
   fd_memset( &slotv->parent_block_id, 0, sizeof(fd_hash_t) );
-  fd_memset( slotv->fec, 0xff, sizeof(slotv->fec) ); /* UINT_MAX pool_idx sentinel */
+  fd_memset( fd_chainer_slotv_fecs( chainer, slotv ), 0xff, chainer->fec_blk_max*sizeof(uint) ); /* UINT_MAX pool_idx sentinel */
 
   fd_slotv_map_ele_insert( slotv_map, slotv, slotv_pool );
   fd_chainer_repair_add( chainer, slotv ); /* new slotv -> has un-requested shreds */
@@ -160,14 +164,15 @@ slotv_iter_ele( fd_chainer_t * chainer, ulong idx ) {
 
 
 /* slotv_fec returns the FEC that slotv owns at fec_set_idx, or NULL if
-   it holds none there. */
+   it holds none there (or fec_set_idx is beyond max_shreds_per_block). */
 
 static fd_chainer_fec_t *
 slotv_fec( fd_chainer_t * chainer, fd_chainer_slotv_t const * slotv, uint fec_set_idx ) {
-  fd_chainer_fec_t * fec_pool = chainer->fec_pool;
-  uint idx = slotv->fec[ fec_set_idx / FD_FEC_SHRED_CNT ];
+  ulong k = fec_set_idx / FD_FEC_SHRED_CNT;
+  if( FD_UNLIKELY( k>=chainer->fec_blk_max ) ) return NULL;
+  uint idx = fd_chainer_slotv_fecs( chainer, slotv )[ k ];
   if( FD_UNLIKELY( idx==UINT_MAX ) ) return NULL;
-  return fd_fec_pool_ele( fec_pool, (ulong)idx );
+  return fd_fec_pool_ele( chainer->fec_pool, (ulong)idx );
 }
 
 int
@@ -183,9 +188,10 @@ ulong
 fd_chainer_slotv_shred_cnt( fd_chainer_t *     chainer,
                             fd_chainer_slotv_t const * slotv ) {
   fd_chainer_fec_t * fec_pool = chainer->fec_pool;
+  uint const *       fecs     = fd_chainer_slotv_fecs( chainer, slotv );
   ulong cnt = 0UL;
-  for( ulong k=0UL; k<FD_FEC_BLK_MAX; k++ ) {
-    uint idx = slotv->fec[ k ];
+  for( ulong k=0UL; k<chainer->fec_blk_max; k++ ) {
+    uint idx = fecs[ k ];
     if( idx==UINT_MAX ) continue;
     cnt += (ulong)fd_uint_popcnt( fd_fec_pool_ele( fec_pool, (ulong)idx )->data_idxs );
   }
@@ -221,13 +227,14 @@ fec_join( fd_chainer_t    * chainer,
           fd_chainer_slotv_t      * slotv,
           fd_hash_t const * mr ) {
   if( FD_UNLIKELY( slot>(ulong)UINT_MAX ) ) FD_LOG_CRIT(( "slot %lu exceeds uint range", slot ));
+  ulong k = fec_set_idx / FD_FEC_SHRED_CNT;
+  FD_TEST( k<chainer->fec_blk_max );
 
   fd_fec_map_t     * fec_map  = chainer->fec_map;
   fd_chainer_fec_t * fec_pool = chainer->fec_pool;
   fd_chainer_fec_t * fec = fd_fec_map_ele_query( fec_map, mr, NULL, fec_pool );
   if( FD_UNLIKELY( !fec ) ) {
     if( FD_UNLIKELY( !fd_fec_pool_free( fec_pool ) ) ) FD_LOG_CRIT(( "fec_pool is full" ));
-    FD_TEST( fec_set_idx < (1U<<28) );
     fec = fd_fec_pool_ele_acquire( fec_pool );
     fec->merkle_root   = *mr;
     fec->slot          = (uint)slot;
@@ -239,7 +246,7 @@ fec_join( fd_chainer_t    * chainer,
     fec->is_leader     = 0;
     fd_fec_map_ele_insert( fec_map, fec, fec_pool );
   }
-  slotv->fec[ fec_set_idx / FD_FEC_SHRED_CNT ] = (uint)fd_fec_pool_idx( fec_pool, fec );
+  fd_chainer_slotv_fecs( chainer, slotv )[ k ] = (uint)fd_fec_pool_idx( fec_pool, fec );
   return fec;
 }
 
@@ -400,8 +407,8 @@ fd_chainer_verify( fd_chainer_t const * chainer ) {
     uint  fec_set_idx = fec->fec_set_idx;
     uint  fec_idx     = (uint)fd_fec_pool_idx( fec_pool, fec );
 
-    if( FD_UNLIKELY( fec_set_idx % FD_FEC_SHRED_CNT ) ) FAIL( "fec_set_idx is not a multiple of FD_FEC_SHRED_CNT" );
-    if( FD_UNLIKELY( fec_set_idx>=FD_SHRED_BLK_MAX   ) ) FAIL( "fec_set_idx out of range" );
+    if( FD_UNLIKELY( fec_set_idx % FD_FEC_SHRED_CNT                            ) ) FAIL( "fec_set_idx is not a multiple of FD_FEC_SHRED_CNT" );
+    if( FD_UNLIKELY( fec_set_idx / FD_FEC_SHRED_CNT >= chainer->fec_blk_max    ) ) FAIL( "fec_set_idx out of range" );
 
     if( FD_UNLIKELY( chainer->root!=ULONG_MAX && slot<chainer->root ) ) FAIL( "fec below the root" );
 
@@ -410,16 +417,16 @@ fd_chainer_verify( fd_chainer_t const * chainer ) {
 
     if( FD_UNLIKELY( !fd_chainer_slot_query( chainer_, slot ) ) ) FAIL( "slot has a fec but no version to anchor the list" );
 
-    /* A FEC is owned by every version whose forward fec[] array points at
-       it, and at least one must -- otherwise it is unreachable garbage
-       that publish would leak. */
+    /* A FEC is owned by every version whose fec_tbl row points at it,
+       and at least one must -- otherwise it is unreachable garbage that
+       publish would leak. */
 
     int owned = 0;
     for( ulong i = fd_slotv_map_idx_query_const( slotv_map, &slot, ULONG_MAX, slotv_pool );
                i != ULONG_MAX;
                i = fd_slotv_map_idx_next_const( i, ULONG_MAX, slotv_pool ) ) {
       fd_chainer_slotv_t const * slotv = fd_slotv_pool_ele_const( slotv_pool, i );
-      if( FD_LIKELY( slotv->fec[ fec_set_idx / FD_FEC_SHRED_CNT ]==fec_idx ) ) owned = 1;
+      if( FD_LIKELY( fd_chainer_slotv_fecs( chainer, slotv )[ fec_set_idx / FD_FEC_SHRED_CNT ]==fec_idx ) ) owned = 1;
     }
     if( FD_UNLIKELY( !owned ) ) FAIL( "fec claimed by no version" );
   }
@@ -473,13 +480,14 @@ fd_chainer_shred_insert( fd_chainer_t    * chainer,
                          fd_hash_t const * mr,
                          ulong             parent_slot,
                          fd_hash_t const * parent_block_id ) {
-  FD_TEST( shred_idx < FD_SHRED_BLK_MAX ); // guaranteed by fec_resolver
   FD_TEST( slot > chainer->root );
-  uint fec_set_idx = shred_idx & ~( (uint)FD_FEC_SHRED_CNT - 1U );
+  uint  fec_set_idx = shred_idx & ~( (uint)FD_FEC_SHRED_CNT - 1U );
+  ulong k           = fec_set_idx / FD_FEC_SHRED_CNT;
+  uint  shred_max   = (uint)( chainer->fec_blk_max*FD_FEC_SHRED_CNT );
+  FD_TEST( k<chainer->fec_blk_max ); /* guaranteed by fec_resolver */
 
   /* Identify the slot versions this shred belongs to. */
 
-  ulong k = fec_set_idx / FD_FEC_SHRED_CNT;
   fd_chainer_slotv_t * turbine = turbine_slotv_query( chainer, slot );
 
   /* If a votor-driven version of the slot already exists (block-id
@@ -517,11 +525,11 @@ fd_chainer_shred_insert( fd_chainer_t    * chainer,
   uint fec_idx = (uint)fd_fec_pool_idx( chainer->fec_pool, fec );
   for( ulong _i=slotv_iter_init( chainer, slot ); _i!=ULONG_MAX; _i=slotv_iter_next( chainer, _i ) ) {
     fd_chainer_slotv_t * slotv = slotv_iter_ele( chainer, _i );
-    if( FD_UNLIKELY( slotv->fec[ k ]!=fec_idx ) ) continue;
+    if( FD_UNLIKELY( fd_chainer_slotv_fecs( chainer, slotv )[ k ]!=fec_idx ) ) continue;
 
     /* update slot-level shred indexing */
     if( FD_UNLIKELY( slot_complete ) ) slotv->complete_idx = shred_idx;
-    while( slotv->buffered_idx + 1 < FD_SHRED_BLK_MAX && fd_chainer_shred_test( chainer, slotv, slotv->buffered_idx + 1U ) ) {
+    while( slotv->buffered_idx + 1 < shred_max && fd_chainer_shred_test( chainer, slotv, slotv->buffered_idx + 1U ) ) {
       slotv->buffered_idx++;
     }
 
@@ -636,7 +644,9 @@ fd_chainer_fec_complete( fd_chainer_t * chainer,
                          int            is_leader,
                          fd_hash_t    * mr ) {
   FD_TEST( slot > chainer->root );
-  uint fec_set_idx = (uint)fec_set_idx_;
+  uint  fec_set_idx = (uint)fec_set_idx_;
+  ulong k           = fec_set_idx / FD_FEC_SHRED_CNT;
+  FD_TEST( k<chainer->fec_blk_max ); /* guaranteed by fec_resolver */
 
   for( uint i = 0; i < FD_FEC_SHRED_CNT; i++ ) {
     fd_chainer_shred_insert( chainer, slot, fec_set_idx_ + i, slot_complete && (i == FD_FEC_SHRED_CNT - 1), mr, AG_UNKNOWN_SLOT, NULL );
@@ -656,8 +666,7 @@ fd_chainer_fec_complete( fd_chainer_t * chainer,
   /* Process the turbine version first.  It is the only version whose
      block_id may finalize here.  An abandoned turbine version is
      skipped entirely. */
-  uint  fec_idx = (uint)fd_fec_pool_idx( chainer->fec_pool, fec );
-  ulong k       = fec_set_idx / FD_FEC_SHRED_CNT;
+  uint fec_idx = (uint)fd_fec_pool_idx( chainer->fec_pool, fec );
 
   fd_chainer_slotv_t * turbine = NULL;
   for( ulong _i=slotv_iter_init( chainer, slot ); _i!=ULONG_MAX; _i=slotv_iter_next( chainer, _i ) ) {
@@ -665,7 +674,7 @@ fd_chainer_fec_complete( fd_chainer_t * chainer,
     if( FD_LIKELY( slotv->turbine && !slotv->abandoned ) ) { turbine = slotv; break; }
   }
 
-  if( FD_LIKELY( turbine && turbine->fec[ k ]==fec_idx ) ) {
+  if( FD_LIKELY( turbine && fd_chainer_slotv_fecs( chainer, turbine )[ k ]==fec_idx ) ) {
     extend_buffered_fec( chainer, turbine );
 
     /* Slot is complete -> we can record the block_id, and we must have
@@ -685,7 +694,7 @@ fd_chainer_fec_complete( fd_chainer_t * chainer,
   for( ulong _i=slotv_iter_init( chainer, slot ); _i!=ULONG_MAX; _i=slotv_iter_next( chainer, _i ) ) {
     fd_chainer_slotv_t * slotv = slotv_iter_ele( chainer, _i );
     if( FD_UNLIKELY( slotv==turbine || slotv->abandoned ) ) continue;
-    if( FD_UNLIKELY( slotv->fec[ k ]!=fec_idx ) ) continue;
+    if( FD_UNLIKELY( fd_chainer_slotv_fecs( chainer, slotv )[ k ]!=fec_idx ) ) continue;
 
     extend_buffered_fec( chainer, slotv );
     chainer_advance( chainer, slotv );
@@ -701,6 +710,8 @@ fd_chainer_fec_evicted( fd_chainer_t * chainer,
                         fd_hash_t    * merkle_root ) {
   fd_chainer_fec_t * fec = fec_query( chainer, merkle_root );
   if( FD_UNLIKELY( !fec ) ) return;
+  ulong k = fec_set_idx / FD_FEC_SHRED_CNT;
+  FD_TEST( k<chainer->fec_blk_max ); /* guaranteed by fec_resolver */
 
   /* We choose not to remove the FEC from the chainer.  If this FEC
      belongs to a turbine slot and we are having trouble completing it
@@ -714,12 +725,11 @@ fd_chainer_fec_evicted( fd_chainer_t * chainer,
 
   fec->data_idxs = 0U;
   uint fec_idx = (uint)fd_fec_pool_idx( chainer->fec_pool, fec );
-  uint k = fec_set_idx / FD_FEC_SHRED_CNT;
 
   /* find slots that have this FEC root */
   for( ulong _i=slotv_iter_init( chainer, slot ); _i!=ULONG_MAX; _i=slotv_iter_next( chainer, _i ) ) {
     fd_chainer_slotv_t * slotv = slotv_iter_ele( chainer, _i );
-    if( FD_UNLIKELY( slotv->fec[ k ]!=fec_idx ) ) continue;
+    if( FD_UNLIKELY( fd_chainer_slotv_fecs( chainer, slotv )[ k ]!=fec_idx ) ) continue;
 
     /* rederive buffered_idx */
     if( FD_UNLIKELY( slotv->buffered_idx!=UINT_MAX && slotv->buffered_idx >= fec_set_idx ) ) {
@@ -742,7 +752,7 @@ fd_chainer_verified_parent_fec_count( fd_chainer_t * chainer,
   fd_chainer_slotv_t * slotv = fd_chainer_slot_version_query( chainer, slot, block_id );
   if( FD_UNLIKELY( !slotv ) ) FD_LOG_CRIT(("slotv not found for slot %lu", slot ));
 
-  FD_TEST( fec_set_cnt > 0 && fec_set_cnt <= FD_FEC_BLK_MAX );
+  FD_TEST( fec_set_cnt > 0 && fec_set_cnt <= chainer->fec_blk_max );
   slotv->complete_idx    = (fec_set_cnt*FD_FEC_SHRED_CNT) - 1;
   slotv->parent_slot     = parent_slot;
   slotv->parent_block_id = *parent_block_id;
@@ -816,8 +826,8 @@ fd_chainer_fec_rekey( fd_chainer_t *    chainer,
     uint existing_idx = (uint)fd_fec_pool_idx( chainer->fec_pool, existing );
     uint k            = fec_set_idx / FD_FEC_SHRED_CNT;
     for( ulong _i=slotv_iter_init( chainer, slot ); _i!=ULONG_MAX; _i=slotv_iter_next( chainer, _i ) ) {
-      fd_chainer_slotv_t * v = slotv_iter_ele( chainer, _i );
-      if( FD_UNLIKELY( v->fec[ k ]==sentinel_idx ) ) v->fec[ k ] = existing_idx;
+      uint * fecs = fd_chainer_slotv_fecs( chainer, slotv_iter_ele( chainer, _i ) );
+      if( FD_UNLIKELY( fecs[ k ]==sentinel_idx ) ) fecs[ k ] = existing_idx;
     }
     fd_fec_map_ele_remove_fast( chainer->fec_map, fec, chainer->fec_pool );
     fd_fec_pool_ele_release   ( chainer->fec_pool, fec );
@@ -907,7 +917,7 @@ fd_chainer_publish( fd_chainer_t *    chainer,
       fd_chainer_orphan_remove( chainer, slotv );
       fd_chainer_repair_remove( chainer, slotv );
 
-      for( uint k = 0; k < FD_FEC_BLK_MAX; k++ ) {
+      for( uint k = 0; k < chainer->fec_blk_max; k++ ) {
         fd_chainer_fec_t * fec = slotv_fec( chainer, slotv, k * FD_FEC_SHRED_CNT );
         /* because FEC pool eles can be shared across slotvs, in
            equivocating slots we can end up double-freeing the same FEC.
@@ -946,7 +956,7 @@ fd_chainer_publish( fd_chainer_t *    chainer,
     ulong                next = slotv_iter_next( chainer, i );
 
     /* free all FECs on slotv */
-    for( uint k = 0; k < FD_FEC_BLK_MAX; k++ ) {
+    for( uint k = 0; k < chainer->fec_blk_max; k++ ) {
       fd_chainer_fec_t * fec = slotv_fec( chainer, s, k * FD_FEC_SHRED_CNT );
       if( FD_UNLIKELY( fec && fd_fec_map_ele_query_const( fec_map, &fec->merkle_root, NULL, fec_pool ) ) ) {
         if( FD_LIKELY( store && fec->complete ) ) fd_store_remove( store, store_map, &fec->merkle_root );
@@ -963,7 +973,7 @@ fd_chainer_publish( fd_chainer_t *    chainer,
       fd_slotv_pool_ele_release( slotv_pool, s );
     } else {
       /* clear the surviving root's FEC list */
-      fd_memset( s->fec, 0xff, sizeof(s->fec) );
+      fd_memset( fd_chainer_slotv_fecs( chainer, s ), 0xff, chainer->fec_blk_max*sizeof(uint) );
     }
     i = next;
   }

--- a/src/discof/chainer/fd_chainer.h
+++ b/src/discof/chainer/fd_chainer.h
@@ -124,8 +124,6 @@ struct fd_chainer_slotv {
                                 a block_id, and stays off the repair worklists.
                                 See the header comment above. */
   fd_hash_t       block_id;
-  uint            fec[FD_FEC_BLK_MAX]; /* fec[k] = fd_fec_pool idx of the FEC this
-                                          version owns. TODO assert pool_idx < UINT_MAX */
   uint            complete_idx;
   uint            buffered_idx;     /* idx of highest buffered shred */
   uint            buffered_fec_idx; /* last shred idx of highest buffered FEC set we have received completion for */
@@ -254,6 +252,9 @@ struct fd_chainer {
 
   fd_chainer_slotv_t * slotv_pool;
   fd_slotv_map_t     * slotv_map;
+  uint               * fec_tbl;     /* fec_tbl[ slotv_idx*fec_blk_max + k ] = fd_fec_pool idx of the FEC
+                                       that slotv owns at FEC set k, UINT_MAX if none */
+  ulong                fec_blk_max; /* max FEC sets per block (max_shreds_per_block/FD_FEC_SHRED_CNT) */
 
   /* Repair scheduling worklists */
   fd_sched_ele_t    * sched_pool;
@@ -275,13 +276,26 @@ fd_chainer_align( void ) {
   return fd_ulong_max( alignof(fd_chainer_t), 128UL );
 }
 
+/* fd_chainer_footprint returns the footprint for ele_max slots, each
+   with up to FD_CHAINER_SLOT_VER_MAX versions of up to
+   max_shreds_per_block data shreds (FD_SHRED_BLK_MAX in production,
+   larger under bench limits).  Returns 0 if max_shreds_per_block is not
+   a positive multiple of FD_FEC_SHRED_CNT, exceeds the 28-bit
+   fec_set_idx, or asks for more FEC elements than the uint pool and map
+   indices can address. */
+
 FD_FN_CONST static inline ulong
-fd_chainer_footprint( ulong ele_max ) {
+fd_chainer_footprint( ulong ele_max,
+                      ulong max_shreds_per_block ) {
+  if( FD_UNLIKELY( !max_shreds_per_block || max_shreds_per_block%FD_FEC_SHRED_CNT || max_shreds_per_block>FD_SHRED_BLK_MAX_RAISED ) ) return 0UL;
   ulong blk_max       = ele_max * FD_CHAINER_SLOT_VER_MAX;
-  ulong fec_max       = blk_max * FD_FEC_BLK_MAX;
+  ulong fec_blk_max   = max_shreds_per_block / FD_FEC_SHRED_CNT;
+  ulong fec_max       = blk_max * fec_blk_max;
+  if( FD_UNLIKELY( !fd_fec_pool_footprint( fec_max ) ) ) return 0UL;
   ulong fec_chain_cnt = fd_fec_map_chain_cnt_est( fec_max );
   ulong blk_chain_cnt = fd_slotv_map_chain_cnt_est( blk_max );
   return FD_LAYOUT_FINI(
+    FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
@@ -298,6 +312,7 @@ fd_chainer_footprint( ulong ele_max ) {
       fd_fec_pool_align(),     fd_fec_pool_footprint    ( fec_max )        ),
       fd_fec_map_align(),      fd_fec_map_footprint     ( fec_chain_cnt )  ),
       fd_slotv_pool_align(),   fd_slotv_pool_footprint  ( blk_max )        ),
+      alignof(uint),           fec_max*sizeof(uint)                        ), /* fec_tbl */
       fd_slotv_map_align(),    fd_slotv_map_footprint   ( blk_chain_cnt  ) ),
       fd_sched_pool_align(),   fd_sched_pool_footprint  ( blk_max        ) ),
       fd_sched_map_align(),    fd_sched_map_footprint   ( blk_chain_cnt  ) ),
@@ -309,7 +324,7 @@ fd_chainer_footprint( ulong ele_max ) {
 }
 
 void *
-fd_chainer_new( void * shmem, ulong ele_max, ulong seed );
+fd_chainer_new( void * shmem, ulong ele_max, ulong max_shreds_per_block, ulong seed );
 
 fd_chainer_t *
 fd_chainer_join( void * chainer );
@@ -338,7 +353,9 @@ fd_chainer_init( fd_chainer_t    * chainer,
 
 /* fd_chainer_shred_insert inserts a shred into the chainer.  If the
    parent_slot is provided, parent_block_id must also be provided.
-   Otherwise caller should pass AG_UNKNOWN_SLOT for parent_slot. */
+   Otherwise caller should pass AG_UNKNOWN_SLOT for parent_slot.
+   Returns the turbine version of slot, or NULL if shred_idx is at or
+   beyond max_shreds_per_block (the shred is dropped). */
 fd_chainer_slotv_t *
 fd_chainer_shred_insert( fd_chainer_t *    chainer,
                          ulong             slot,
@@ -348,7 +365,8 @@ fd_chainer_shred_insert( fd_chainer_t *    chainer,
                          ulong             parent_slot,
                          fd_hash_t const * parent_block_id );
 
-/* 0 if the FEC was accepted, 1 if rejected */
+/* 0 if the FEC was accepted, 1 if rejected (unauthorized equivocating
+   root, or fec_set_idx beyond max_shreds_per_block) */
 int
 fd_chainer_fec_complete( fd_chainer_t * chainer,
                          ulong          slot,
@@ -426,7 +444,8 @@ fd_chainer_fec_query( fd_chainer_t *    chainer,
 /* fd_chainer_shred_test returns 1 if slotv has data shred shred_idx --
    i.e. it owns the FEC at shred_idx's position and that FEC's presence
    bitmap has the shred.  The per-shred bitmap lives on the (shared) FEC,
-   so this indexes slotv->fec[] then tests fd_chainer_fec.data_idxs. */
+   so this indexes slotv's fec_tbl row then tests fd_chainer_fec.data_idxs.
+   Returns 0 for shred_idx at or beyond max_shreds_per_block. */
 
 int
 fd_chainer_shred_test( fd_chainer_t *             chainer,
@@ -466,6 +485,17 @@ fd_chainer_slot_version_query( fd_chainer_t *    chainer,
     if( FD_UNLIKELY( fd_hash_eq( &slotv->block_id, block_id ) ) ) return slotv;
   }
   return NULL;
+}
+
+/* fd_chainer_slotv_fecs returns slotv's row of chainer->fec_tbl:
+   fecs[ k ] is the fd_fec_pool idx of the FEC slotv owns at FEC set k
+   (shred position k*FD_FEC_SHRED_CNT), UINT_MAX if none, for k in
+   [0,chainer->fec_blk_max). */
+
+FD_FN_PURE static inline uint *
+fd_chainer_slotv_fecs( fd_chainer_t const *       chainer,
+                       fd_chainer_slotv_t const * slotv ) {
+  return chainer->fec_tbl + fd_slotv_pool_idx( chainer->slotv_pool, slotv )*chainer->fec_blk_max;
 }
 
 /* fd_chainer_slot_query returns any version of slot, or NULL if the slot

--- a/src/discof/chainer/test_chainer.c
+++ b/src/discof/chainer/test_chainer.c
@@ -10,6 +10,9 @@
 
 #define ELE_MAX (64UL)
 
+/* a [development.bench.max_shreds_per_block] value used by the bench configs */
+#define BENCH_SHRED_MAX (4UL*FD_SHRED_BLK_MAX)
+
 /* mkhash returns a distinct, deterministic, never-zero hash for n. */
 
 static fd_hash_t
@@ -36,6 +39,19 @@ test_fec_pool_layout( void ) {
 
   ulong chain_cnt = fd_fec_map_chain_cnt_est( fec_max );
   FD_TEST( fd_fec_map_footprint( chain_cnt )<=(512UL<<20)+64UL );
+
+  /* bench limits: uint pool idxs (fd_chainer_fec, out_ele) still fit */
+  ulong const bench_fec_max = 30000UL * FD_CHAINER_SLOT_VER_MAX * (BENCH_SHRED_MAX/FD_FEC_SHRED_CNT);
+  FD_TEST( bench_fec_max<(ulong)UINT_MAX     );
+  FD_TEST( bench_fec_max<fd_fec_map_ele_max() );
+
+  /* footprint validates max_shreds_per_block and scales with it */
+  FD_TEST( !fd_chainer_footprint( ELE_MAX, 0UL                     ) );
+  FD_TEST( !fd_chainer_footprint( ELE_MAX, FD_FEC_SHRED_CNT+1UL    ) );
+  FD_TEST( !fd_chainer_footprint( ELE_MAX, (1UL<<28)+FD_FEC_SHRED_CNT ) );
+  FD_TEST( !fd_chainer_footprint( 30000UL, 1UL<<28 ) ); /* 30000*7*2^23 FEC elements do not fit uint indices */
+  FD_TEST(  fd_chainer_footprint( 30000UL, BENCH_SHRED_MAX ) );
+  FD_TEST(  fd_chainer_footprint( ELE_MAX, FD_SHRED_BLK_MAX )<fd_chainer_footprint( ELE_MAX, BENCH_SHRED_MAX ) );
 }
 
 /* slotv_at returns the `ord`-th version of slot in CREATION order (ord 0
@@ -70,13 +86,19 @@ fec_at( fd_chainer_t * chainer, ulong slot, uint fec_set_idx, ulong ord ) {
 }
 
 static fd_chainer_t *
-setup( fd_wksp_t * wksp ) {
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_chainer_align(), fd_chainer_footprint( ELE_MAX ), 1UL );
+setup_sized( fd_wksp_t * wksp, ulong ele_max, ulong max_shreds_per_block ) {
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_chainer_align(), fd_chainer_footprint( ele_max, max_shreds_per_block ), 1UL );
   FD_TEST( mem );
-  fd_chainer_t * chainer = fd_chainer_join( fd_chainer_new( mem, ELE_MAX, 42UL ) );
+  fd_chainer_t * chainer = fd_chainer_join( fd_chainer_new( mem, ele_max, max_shreds_per_block, 42UL ) );
   FD_TEST( chainer );
+  FD_TEST( chainer->fec_blk_max==max_shreds_per_block/FD_FEC_SHRED_CNT );
   FD_TEST( !fd_chainer_verify( chainer ) ); /* an empty chainer is consistent */
   return chainer;
+}
+
+static fd_chainer_t *
+setup( fd_wksp_t * wksp ) {
+  return setup_sized( wksp, ELE_MAX, FD_SHRED_BLK_MAX );
 }
 
 /* teardown does not verify: some subtests deliberately end on a
@@ -1080,6 +1102,114 @@ test_output_order_out_of_order( fd_wksp_t * wksp ) {
   FD_LOG_NOTICE(( "pass: output order out-of-order FEC arrival re-delivers from set 0" ));
 }
 
+/* Per-block shred limit is a runtime value.  The shred tile's resolver
+   bounds every position by the same limit before it reaches the
+   chainer, which asserts it; the last legal position must work. */
+
+static void
+test_shred_limit( fd_wksp_t * wksp ) {
+  fd_chainer_t * chainer = setup( wksp );
+
+  fd_hash_t bid0 = mkhash( 100UL );
+  fd_chainer_init( chainer, 10UL, &bid0 );
+
+  uint const shred_max = (uint)FD_SHRED_BLK_MAX;
+
+  /* the last legal position is accepted */
+  fd_hash_t rL = mkhash( 2UL );
+  FD_TEST( !feed_fec( chainer, 11UL, shred_max-(uint)FD_FEC_SHRED_CNT, 1, &rL, 10UL, &bid0 ) );
+  fd_chainer_slotv_t * v0 = slotv_at( chainer, 11UL, 0UL );
+  FD_TEST( v0 && v0->complete_idx==shred_max-1U );
+  FD_TEST(  fd_chainer_shred_test( chainer, v0, shred_max-1U ) );
+  FD_TEST( !fd_chainer_shred_test( chainer, v0, shred_max    ) ); /* beyond the limit: never present */
+  FD_TEST( !fd_chainer_shred_test( chainer, v0, UINT_MAX     ) );
+  FD_TEST( fd_chainer_slotv_shred_cnt( chainer, v0 )==FD_FEC_SHRED_CNT );
+  FD_TEST( !fd_chainer_fec_query( chainer, 11UL, shred_max, &v0->block_id ) );
+  FD_TEST( !fd_chainer_shred_for_block_id_verify( chainer, 11UL, shred_max, &v0->block_id, &rL ) );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+  FD_TEST( fd_chainer_slotv_shred_cnt( chainer, v0 )==FD_FEC_SHRED_CNT );
+
+  /* a getParentAndFecCount naming exactly the limit connects the version */
+  fd_hash_t bidX = mkhash( 200UL );
+  fd_chainer_notar_fallback( chainer, 11UL, bidX );
+  fd_chainer_slotv_t * v1 = fd_chainer_slot_version_query( chainer, 11UL, &bidX );
+  FD_TEST( v1 && v1->complete_idx==UINT_MAX && v1->parent_slot==AG_UNKNOWN_SLOT );
+  FD_TEST( fd_chainer_verified_parent_fec_count( chainer, 11UL, &bidX, (uint)FD_FEC_BLK_MAX, 10UL, &bid0 )==v1 );
+  FD_TEST( v1->complete_idx==shred_max-1U && v1->connected );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+
+  teardown( chainer );
+  FD_LOG_NOTICE(( "pass: the last legal shred position and FEC count are accepted" ));
+}
+
+/* Under bench limits a block holds 4x the FEC sets: the per-version FEC
+   table is sized at runtime, so positions above FD_FEC_BLK_MAX are
+   owned per version, shared, equivocated and pruned like any other. */
+
+static void
+test_bench_shred_limit( fd_wksp_t * wksp ) {
+  fd_chainer_t * chainer = setup_sized( wksp, 8UL, BENCH_SHRED_MAX );
+  fd_chainer_slotv_t * slotv_pool = chainer->slotv_pool;
+  fd_chainer_fec_t   * fec_pool   = chainer->fec_pool;
+  ulong slotv_free0 = fd_slotv_pool_free( slotv_pool );
+  ulong fec_free0   = fd_fec_pool_free  ( fec_pool   );
+
+  uint const shred_max = (uint)BENCH_SHRED_MAX;
+  uint const last      = shred_max-(uint)FD_FEC_SHRED_CNT; /* fec_set_idx of the last FEC set */
+  FD_TEST( last>=FD_SHRED_BLK_MAX );                        /* beyond the production limit */
+
+  fd_hash_t bid0 = mkhash( 100UL );
+  fd_chainer_init( chainer, 10UL, &bid0 );
+
+  /* turbine version of slot 11: set 0 and the last set */
+  fd_hash_t r0 = mkhash( 1UL );
+  fd_hash_t rA = mkhash( 2UL );
+  FD_TEST( !feed_fec( chainer, 11UL, 0U,   0, &r0, 10UL,            &bid0 ) );
+  FD_TEST( !feed_fec( chainer, 11UL, last, 1, &rA, AG_UNKNOWN_SLOT, NULL  ) );
+  fd_chainer_slotv_t * v0 = slotv_at( chainer, 11UL, 0UL );
+  FD_TEST( v0->complete_idx==shred_max-1U && v0->buffered_idx==31U );
+  FD_TEST( fd_chainer_slotv_shred_cnt( chainer, v0 )==2UL*FD_FEC_SHRED_CNT );
+  for( uint i=last; i<shred_max; i++ ) FD_TEST( fd_chainer_shred_test( chainer, v0, i ) );
+  FD_TEST( !fd_chainer_shred_test( chainer, v0, shred_max ) );
+  FD_TEST( fd_hash_eq( &fec_at( chainer, 11UL, last, 0UL )->merkle_root, &rA ) );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+
+  /* a second version shares set 0 but equivocates on the last set:
+     each version's row holds its own root at the high position */
+  fd_hash_t bidX = mkhash( 200UL );
+  fd_hash_t rB   = mkhash( 3UL );
+  fd_chainer_notar_fallback( chainer, 11UL, bidX );
+  FD_TEST( fd_chainer_verified_parent_fec_count( chainer, 11UL, &bidX, shred_max/(uint)FD_FEC_SHRED_CNT, 10UL, &bid0 ) );
+  fd_hash_t mr;
+  mr = r0; fd_chainer_verified_hash_insert( chainer, 11UL, &bidX, 0U,   &mr );
+  mr = rB; fd_chainer_verified_hash_insert( chainer, 11UL, &bidX, last, &mr );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+  fd_chainer_slotv_t * v1 = slotv_at( chainer, 11UL, 1UL );
+  FD_TEST( v1->complete_idx==shred_max-1U && v1->delivered_idx==31U );
+  FD_TEST( !feed_fec( chainer, 11UL, last, 1, &rB, AG_UNKNOWN_SLOT, NULL ) );
+  FD_TEST( fd_hash_eq( &fec_at( chainer, 11UL, last, 0UL )->merkle_root, &rA ) );
+  FD_TEST( fd_hash_eq( &fec_at( chainer, 11UL, last, 1UL )->merkle_root, &rB ) );
+  FD_TEST( fd_chainer_slotv_fecs( chainer, v0 )[ last/FD_FEC_SHRED_CNT ]!=fd_chainer_slotv_fecs( chainer, v1 )[ last/FD_FEC_SHRED_CNT ] );
+  FD_TEST( fd_chainer_slotv_fecs( chainer, v0 )[ 0 ]==fd_chainer_slotv_fecs( chainer, v1 )[ 0 ] );
+  for( uint i=last; i<shred_max; i++ ) FD_TEST( fd_chainer_shred_test( chainer, v1, i ) );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+
+  /* publish past it: the prune walks the whole runtime-sized row */
+  fd_hash_t r12 = mkhash( 4UL );
+  FD_TEST( !feed_fec( chainer, 12UL, 0U, 1, &r12, 11UL, &bidX ) );
+  FD_TEST( fd_fec_pool_free( fec_pool )==fec_free0-4UL ); /* r0, rA, rB, r12 */
+  out_ele_t * out_queue = chainer->out_queue;
+  while( !out_queue_empty( out_queue ) ) { out_queue_pop_head( out_queue ); }
+  fd_chainer_publish( chainer, 12UL, NULL, NULL );
+  FD_TEST( !fd_chainer_verify( chainer ) );
+  FD_TEST( !fd_chainer_slot_query( chainer, 11UL ) );
+  FD_TEST( fd_slotv_pool_free( slotv_pool )==slotv_free0-1UL );
+  FD_TEST( fd_fec_pool_free  ( fec_pool   )==fec_free0        );
+
+  teardown( chainer );
+  FD_LOG_NOTICE(( "pass: bench shred limit owns/shares/prunes FEC sets above FD_FEC_BLK_MAX" ));
+}
+
 int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
@@ -1104,6 +1234,8 @@ main( int argc, char ** argv ) {
   test_versions_full                     ( wksp );
   test_equivocation_drop                 ( wksp );
   test_verify_detects                    ( wksp );
+  test_shred_limit                       ( wksp );
+  test_bench_shred_limit                 ( wksp );
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/discof/forest/fd_forest.c
+++ b/src/discof/forest/fd_forest.c
@@ -9,7 +9,7 @@ fd_forest_deque( fd_forest_t * forest ) {
 }
 
 void *
-fd_forest_new( void * shmem, ulong ele_max, ulong seed ) {
+fd_forest_new( void * shmem, ulong ele_max, ulong shred_max, ulong seed ) {
   FD_TEST( fd_ulong_is_pow2( ele_max ) );
 
   if( FD_UNLIKELY( !shmem ) ) {
@@ -22,7 +22,12 @@ fd_forest_new( void * shmem, ulong ele_max, ulong seed ) {
     return NULL;
   }
 
-  ulong footprint = fd_forest_footprint( ele_max );
+  if( FD_UNLIKELY( !shred_max || shred_max%FD_FEC_SHRED_CNT || shred_max>UINT_MAX ) ) {
+    FD_LOG_WARNING(( "bad shred_max (%lu)", shred_max ));
+    return NULL;
+  }
+
+  ulong footprint = fd_forest_footprint( ele_max, shred_max );
   if( FD_UNLIKELY( !footprint ) ) {
     FD_LOG_WARNING(( "bad ele_max (%lu)", ele_max ));
     return NULL;
@@ -37,9 +42,15 @@ fd_forest_new( void * shmem, ulong ele_max, ulong seed ) {
   fd_memset( shmem, 0, footprint );
   fd_forest_t * forest;
 
+  ulong idxs_sz   = ele_max*fd_forest_blk_idxs_word_cnt( shred_max )*sizeof(fd_forest_blk_idxs_t);
+  ulong mroots_sz = ele_max*(shred_max/FD_FEC_SHRED_CNT)*sizeof(fd_forest_mr_t);
+
   FD_SCRATCH_ALLOC_INIT( l, shmem );
   forest          = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_align(),          sizeof(fd_forest_t)                     );
   void * pool     = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_pool_align(),     fd_forest_pool_footprint    ( ele_max ) );
+  void * idxs     = FD_SCRATCH_ALLOC_APPEND( l, 128UL,                      idxs_sz                                 );
+  void * code     = FD_SCRATCH_ALLOC_APPEND( l, 128UL,                      idxs_sz                                 );
+  void * mroots   = FD_SCRATCH_ALLOC_APPEND( l, 128UL,                      mroots_sz                               );
   void * ancestry = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_ancestry_align(), fd_forest_ancestry_footprint( ele_max ) );
   void * frontier = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_frontier_align(), fd_forest_frontier_footprint( ele_max ) );
   void * subtrees = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_subtrees_align(), fd_forest_subtrees_footprint( ele_max ) );
@@ -63,6 +74,10 @@ fd_forest_new( void * shmem, ulong ele_max, ulong seed ) {
   forest->root           = ULONG_MAX;
   forest->wksp_gaddr     = fd_wksp_gaddr_fast( wksp, forest );
   forest->pool_gaddr     = fd_wksp_gaddr_fast( wksp, fd_forest_pool_join    ( fd_forest_pool_new    ( pool,     ele_max              ) ) );
+  forest->shred_max      = shred_max;
+  forest->idxs_gaddr     = fd_wksp_gaddr_fast( wksp, idxs   );
+  forest->code_gaddr     = fd_wksp_gaddr_fast( wksp, code   );
+  forest->mroots_gaddr   = fd_wksp_gaddr_fast( wksp, mroots );
   forest->ancestry_gaddr = fd_wksp_gaddr_fast( wksp, fd_forest_ancestry_join( fd_forest_ancestry_new( ancestry, ele_max, seed        ) ) );
   forest->frontier_gaddr = fd_wksp_gaddr_fast( wksp, fd_forest_frontier_join( fd_forest_frontier_new( frontier, ele_max, seed        ) ) );
   forest->subtrees_gaddr = fd_wksp_gaddr_fast( wksp, fd_forest_subtrees_join( fd_forest_subtrees_new( subtrees, ele_max, seed        ) ) );
@@ -214,7 +229,7 @@ fd_forest_init( fd_forest_t * forest, ulong root_slot ) {
   root_ele->complete_idx     = 0;
   root_ele->chain_confirmed  = 1;
 
-  root_ele->merkle_roots[0].mr = (fd_hash_t){ .key = { 0 } };
+  fd_forest_blk_mroots( forest, root_ele )[0].mr = (fd_hash_t){ .key = { 0 } };
 
   forest->root = fd_forest_pool_idx( pool, root_ele );
   fd_forest_frontier_ele_insert( frontier, root_ele, pool ); /* cannot fail */
@@ -1003,16 +1018,17 @@ acquire( fd_forest_t * forest, ulong slot, ulong parent_slot, ulong * evicted ) 
   blk->buffered_idx = UINT_MAX;
   blk->complete_idx = UINT_MAX;
 
-  fd_forest_blk_idxs_null( blk->idxs );
+  ulong idxs_sz = fd_forest_blk_idxs_word_cnt( forest->shred_max )*sizeof(fd_forest_blk_idxs_t);
+  memset( fd_forest_blk_idxs  ( forest, blk ), 0, idxs_sz );
   blk->lowest_verified_fec = UINT_MAX;
-  memset( blk->merkle_roots, 0, sizeof( blk->merkle_roots ) ); /* expensive*/
+  memset( fd_forest_blk_mroots( forest, blk ), 0, (forest->shred_max/FD_FEC_SHRED_CNT)*sizeof(fd_forest_mr_t) ); /* expensive*/
   blk->confirmed_bid = empty_mr;
 
   blk->est_buffered_tick_recv = 0;
 
   /* Metrics tracking */
 
-  fd_forest_blk_idxs_null( blk->code );
+  memset( fd_forest_blk_code( forest, blk ), 0, idxs_sz );
   blk->first_shred_ts = 0;
   blk->last_shred_ts  = 0;
   blk->first_req_ts   = 0;
@@ -1205,8 +1221,8 @@ verified_parent_update( fd_forest_t * forest, fd_forest_blk_t * ele, ulong paren
 }
 
 static inline int
-merkle_recvd( fd_forest_blk_t * ele, uint fec_idx ) {
-  return memcmp( &ele->merkle_roots[fec_idx].mr, &empty_mr, sizeof(fd_hash_t) ) != 0;
+merkle_recvd( fd_forest_mr_t const * mroots, uint fec_idx ) {
+  return memcmp( &mroots[fec_idx].mr, &empty_mr, sizeof(fd_hash_t) ) != 0;
 }
 
 /* returns 1 if the FEC set after the given FEC set has been confirmed */
@@ -1224,19 +1240,19 @@ next_merkle_confirmed( fd_forest_blk_t * ele, uint fec_idx ) {
 /* Returns the chained merkle root that commits to the given FEC set.
    Only meaningful when next_merkle_confirmed() is true; otherwise the
    returned cmr may be uninitialized. For most FEC sets this is
-   merkle_roots[fec_idx+1].cmr.  For the last FEC in the slot (fec_idx
-   == complete_idx/32) it is confirmed_bid.
+   mroots[fec_idx+1].cmr.  For the last FEC in the slot (fec_idx ==
+   complete_idx/32) it is confirmed_bid.
 
    Guard against OOB read: an attacker can send a fec_idx beyond
    complete_idx. The shred gets filtered upstream, so we don't need to
    guard against it here. */
 
 static inline fd_hash_t *
-next_chained_merkle( fd_forest_blk_t * ele, uint fec_idx ) {
+next_chained_merkle( fd_forest_blk_t * ele, fd_forest_mr_t * mroots, uint fec_idx ) {
   if( FD_UNLIKELY( fec_idx == ele->complete_idx / 32UL ) ) {
     return &ele->confirmed_bid;
   }
-  return &ele->merkle_roots[fec_idx + 1].cmr;
+  return &mroots[fec_idx + 1].cmr;
 }
 
 /* data_shred_insert accepts the first complete_idx it sees while
@@ -1257,9 +1273,10 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
                              fd_hash_t   * mr,
                              fd_hash_t   * cmr,
                              long          rx_tick ) {
-  FD_TEST( shred_idx < FD_SHRED_BLK_MAX );
+  FD_TEST( shred_idx < forest->shred_max ); /* guaranteed by fec_resolver */
   fd_forest_blk_t * ele = fd_forest_query( forest, slot );
   FD_CHECK_ERR( !!ele, "ele is not in the forest. data_shred_insert should be preceded by blk_insert" );
+  fd_forest_mr_t * mroots = fd_forest_blk_mroots( forest, ele );
 
   /* Pre-filtering on merkle root.
      If we have knowledge of the confirmed merkle root, we can reject
@@ -1276,10 +1293,10 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
 
   if( FD_UNLIKELY( slot_complete && !fd_hash_eq( &ele->confirmed_bid, &empty_mr ) ) ) {
     if( FD_UNLIKELY( !fd_hash_eq( &ele->confirmed_bid, mr ) ) ) return NULL; /* wrong version */
-    if( FD_UNLIKELY( ele->parent_slot != parent_slot ) ) ele = verified_parent_update( forest, ele, parent_slot );
+    if( FD_UNLIKELY( ele->parent_slot != parent_slot ) ) { ele = verified_parent_update( forest, ele, parent_slot ); mroots = fd_forest_blk_mroots( forest, ele ); }
     ele->lowest_verified_fec = fec_idx; /* last FEC verified */
-    ele->merkle_roots[fec_idx].mr  = *mr;
-    ele->merkle_roots[fec_idx].cmr = *cmr;
+    mroots[fec_idx].mr  = *mr;
+    mroots[fec_idx].cmr = *cmr;
   }
 
   /* We can automatically reject if the shred index is greater than the
@@ -1298,7 +1315,7 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
      status, we can immediately verify or reject. */
 
   if( FD_UNLIKELY( next_merkle_confirmed( ele, fec_idx ) ) ) { /* if the cmr pointing to this FEC has been confirmed, then... */
-    if( FD_UNLIKELY( !fd_hash_eq( next_chained_merkle( ele, fec_idx ), mr ) ) ) {
+    if( FD_UNLIKELY( !fd_hash_eq( next_chained_merkle( ele, mroots, fec_idx ), mr ) ) ) {
       /* merkle root doesn't match the verified CMR  */
       return NULL; /* do not accept this shred. */
     } else {
@@ -1308,30 +1325,30 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
          had a different parent slot.  We need to update the parent
          slot to the correct one. */
 
-      if( FD_UNLIKELY( ele->parent_slot != parent_slot ) ) ele = verified_parent_update( forest, ele, parent_slot );
-      ele->merkle_roots[fec_idx].mr = *mr;
-      ele->merkle_roots[fec_idx].cmr = *cmr;
+      if( FD_UNLIKELY( ele->parent_slot != parent_slot ) ) { ele = verified_parent_update( forest, ele, parent_slot ); mroots = fd_forest_blk_mroots( forest, ele ); }
+      mroots[fec_idx].mr  = *mr;
+      mroots[fec_idx].cmr = *cmr;
 
     }
   } else { /* No verification / knowledge of canonical merkle root */
-    if( FD_UNLIKELY( !merkle_recvd( ele, fec_idx ) ) ) {
+    if( FD_UNLIKELY( !merkle_recvd( mroots, fec_idx ) ) ) {
 
       /* On first mr received for FEC set 0, adopt the shred's parent.
          Otherwise later confirmation would chain verify into the wrong
          ancestor. */
 
-      if( FD_UNLIKELY( ele->parent_slot != parent_slot && fec_idx == 0 ) ) ele = verified_parent_update( forest, ele, parent_slot );
+      if( FD_UNLIKELY( ele->parent_slot != parent_slot && fec_idx == 0 ) ) { ele = verified_parent_update( forest, ele, parent_slot ); mroots = fd_forest_blk_mroots( forest, ele ); }
 
-      ele->merkle_roots[fec_idx].mr  = *mr;
-      ele->merkle_roots[fec_idx].cmr = *cmr;
+      mroots[fec_idx].mr  = *mr;
+      mroots[fec_idx].cmr = *cmr;
     } else {
       /* verify that the received merkle root is consistent with the current merkle root.
          No need to check the cmr, because matching mr implies matching cmr. */
-      fd_hash_t * current_mr = &ele->merkle_roots[fec_idx].mr;
+      fd_hash_t * current_mr = &mroots[fec_idx].mr;
       if( FD_UNLIKELY( !fd_hash_eq( current_mr, mr ) ) ) {
         FD_BASE58_ENCODE_32_BYTES( current_mr->key, current_mr_b58 ); FD_BASE58_ENCODE_32_BYTES( mr->key, mr_b58 );
         FD_LOG_INFO(( "[%s] multiple versions detected for slot %lu fec set %u, invalidating. current_mr %s, received_mr %s", __func__, slot, fec_set_idx, current_mr_b58, mr_b58 ));
-        ele->merkle_roots[fec_idx].mr = invalid_mr; /* invalidate the merkle root */
+        mroots[fec_idx].mr = invalid_mr; /* invalidate the merkle root */
       }
     }
   }
@@ -1346,15 +1363,16 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
   }
   ele->complete_idx = fd_uint_if( slot_complete, shred_idx, ele->complete_idx );
 
-  if( !fd_forest_blk_idxs_test( ele->idxs, shred_idx ) ) { /* newly seen shred */
+  fd_forest_blk_idxs_t * idxs = fd_forest_blk_idxs( forest, ele );
+  if( !fd_forest_blk_idxs_test( idxs, shred_idx ) ) { /* newly seen shred */
     ele->turbine_cnt   += (src==SHRED_SRC_TURBINE);
     ele->repair_cnt    += (src==SHRED_SRC_REPAIR);
     ele->recovered_cnt += (src==SHRED_SRC_RECOVERED);
   }
   if( FD_UNLIKELY( !ele->first_shred_ts || rx_tick<ele->first_shred_ts ) ) ele->first_shred_ts = rx_tick;
 
-  fd_forest_blk_idxs_insert( ele->idxs, shred_idx );
-  while( ele->buffered_idx + 1 < FD_SHRED_BLK_MAX && fd_forest_blk_idxs_test( ele->idxs, ele->buffered_idx + 1U ) ) {
+  fd_forest_blk_idxs_insert( idxs, shred_idx );
+  while( ele->buffered_idx + 1 < forest->shred_max && fd_forest_blk_idxs_test( idxs, ele->buffered_idx + 1U ) ) {
     ele->buffered_idx++;
     ele->est_buffered_tick_recv = fd_int_max(ref_tick, ele->est_buffered_tick_recv);
     /* If the buffered_idx increases, this means the
@@ -1374,10 +1392,11 @@ fd_forest_data_shred_insert( fd_forest_t * forest,
 
 fd_forest_blk_t *
 fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint last_shred_idx, uint fec_set_idx, int slot_complete, int ref_tick, fd_hash_t * mr, fd_hash_t * cmr, long rx_tick ) {
-  FD_TEST( last_shred_idx < FD_SHRED_BLK_MAX );
+  FD_TEST( last_shred_idx < forest->shred_max ); /* guaranteed by fec_resolver */
 
   fd_forest_blk_t * ele = fd_forest_query( forest, slot );
   FD_CHECK_ERR( !!ele, "ele is not in the forest. fec_insert should be preceded by blk_insert" );
+  fd_forest_mr_t * mroots = fd_forest_blk_mroots( forest, ele );
 
   uint fec_idx = fec_set_idx / 32UL; /* index into merkle root array */
 
@@ -1388,11 +1407,11 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
   }
 
   /* reject if the fec is confirmed and the merkle root doesn't match */
-  if( FD_UNLIKELY( next_merkle_confirmed( ele, fec_idx ) && !fd_hash_eq( next_chained_merkle( ele, fec_idx ), mr ) ) ) return NULL;
+  if( FD_UNLIKELY( next_merkle_confirmed( ele, fec_idx ) && !fd_hash_eq( next_chained_merkle( ele, mroots, fec_idx ), mr ) ) ) return NULL;
 
-  if( FD_UNLIKELY( merkle_recvd( ele, fec_idx ) && !fd_hash_eq( &ele->merkle_roots[fec_idx].mr, mr ) ) ) {
+  if( FD_UNLIKELY( merkle_recvd( mroots, fec_idx ) && !fd_hash_eq( &mroots[fec_idx].mr, mr ) ) ) {
     /* overwrite the merkle root with the new one */
-    FD_BASE58_ENCODE_32_BYTES( ele->merkle_roots[fec_idx].mr.key, mr_b58 );
+    FD_BASE58_ENCODE_32_BYTES( mroots[fec_idx].mr.key, mr_b58 );
     FD_BASE58_ENCODE_32_BYTES( mr->key, mr_recv_b58 );
     FD_LOG_WARNING(( "[%s] received a version of slot %lu fec_set_idx %u that isn't recorded. current_mr %s, received_mr %s", __func__, slot, fec_set_idx, mr_b58, mr_recv_b58 ));
 
@@ -1403,7 +1422,8 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
        slot. */
 
     if( FD_UNLIKELY( fec_idx == 0 && ele->parent_slot != parent_slot ) ) {
-      ele = verified_parent_update( forest, ele, parent_slot );
+      ele    = verified_parent_update( forest, ele, parent_slot );
+      mroots = fd_forest_blk_mroots( forest, ele );
     }
     /* there are two cases:
         (1) the first and common case is that we've received a mix of
@@ -1422,8 +1442,8 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
         we need to ask shred to re-deliver the FEC set. Since we
         don't know at this time if B or A is correct, we optimize for
         case 1, and overwrite the merkle root with the new one. */
-    ele->merkle_roots[fec_idx].mr  = *mr;
-    ele->merkle_roots[fec_idx].cmr = *cmr;
+    mroots[fec_idx].mr  = *mr;
+    mroots[fec_idx].cmr = *cmr;
   }
 
   if( FD_UNLIKELY( slot_complete && ele->child != ULONG_MAX ) ) {
@@ -1431,7 +1451,7 @@ fd_forest_fec_insert( fd_forest_t * forest, ulong slot, ulong parent_slot, uint 
     fd_forest_blk_t * child = fd_forest_pool_ele( fd_forest_pool( forest ), ele->child );
     while( FD_UNLIKELY( child ) ) {
       if( FD_UNLIKELY( child->chain_confirmed ) ) {
-        ele->confirmed_bid = child->merkle_roots[0].cmr;
+        ele->confirmed_bid = fd_forest_blk_mroots( forest, child )[0].cmr;
         break;
       }
       child = fd_forest_pool_ele( fd_forest_pool( forest ), child->sibling );
@@ -1456,14 +1476,15 @@ fd_forest_code_shred_insert( fd_forest_t * forest, ulong slot, uint shred_idx, l
   }
   if( FD_UNLIKELY( !ele->first_shred_ts || rx_tick<ele->first_shred_ts ) ) ele->first_shred_ts = rx_tick;
 
-  if( FD_UNLIKELY( shred_idx >= fd_forest_blk_idxs_max( ele->code ) ) ) {
+  if( FD_UNLIKELY( shred_idx >= forest->shred_max ) ) {
     ele->turbine_cnt += 1;
     return ele;
   }
 
-  if( FD_LIKELY( !fd_forest_blk_idxs_test( ele->code, shred_idx ) ) ) { /* newly seen shred */
+  fd_forest_blk_idxs_t * code = fd_forest_blk_code( forest, ele );
+  if( FD_LIKELY( !fd_forest_blk_idxs_test( code, shred_idx ) ) ) { /* newly seen shred */
     ele->turbine_cnt += 1;
-    fd_forest_blk_idxs_insert( ele->code, shred_idx );
+    fd_forest_blk_idxs_insert( code, shred_idx );
   }
   return ele;
 }
@@ -1476,12 +1497,13 @@ fd_forest_fec_chain_verify( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash
   fd_hash_t const * expected_mr = bid;
 
   while( FD_UNLIKELY( !ele->chain_confirmed ) ) {
-    if( FD_UNLIKELY(  fd_hash_eq( &ele->merkle_roots[fec_idx].mr, &empty_mr   ) ) ) return NULL; /* can't verify the chain further */
-    if( FD_UNLIKELY( !fd_hash_eq( expected_mr, &ele->merkle_roots[fec_idx].mr ) ) ) return ele;
+    fd_forest_mr_t * mroots = fd_forest_blk_mroots( forest, ele );
+    if( FD_UNLIKELY(  fd_hash_eq( &mroots[fec_idx].mr, &empty_mr   ) ) ) return NULL; /* can't verify the chain further */
+    if( FD_UNLIKELY( !fd_hash_eq( expected_mr, &mroots[fec_idx].mr ) ) ) return ele;
 
     /* This FEC merkle is correct, and the chained merkle is correct. */
     ele->lowest_verified_fec = fec_idx;
-    expected_mr = &ele->merkle_roots[fec_idx].cmr;
+    expected_mr = &mroots[fec_idx].cmr;
 
     if( FD_UNLIKELY( fec_idx==0 ) ) {
       /* hop to the parent slot, but first we've made it through this
@@ -1506,11 +1528,13 @@ fd_forest_fec_chain_verify( fd_forest_t * forest, fd_forest_blk_t * ele, fd_hash
 void
 fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint max_shred_idx ) {
   if( FD_UNLIKELY( slot <= fd_forest_root_slot( forest ) ) ) return;
+  FD_TEST( (ulong)fec_set_idx+max_shred_idx<forest->shred_max );
   fd_forest_blk_t * ele = fd_forest_query( forest, slot );
   if( FD_UNLIKELY( !ele ) ) return;
 
+  fd_forest_blk_idxs_t * idxs = fd_forest_blk_idxs( forest, ele );
   for( uint i=fec_set_idx; i<=fec_set_idx+max_shred_idx; i++ ) {
-    fd_forest_blk_idxs_remove( ele->idxs, i );
+    fd_forest_blk_idxs_remove( idxs, i );
   }
 
   /* clear complete_idx if we've cleared the last FEC in the slot */
@@ -1538,7 +1562,7 @@ fd_forest_fec_clear( fd_forest_t * forest, ulong slot, uint fec_set_idx, uint ma
   ele->last_shred_ts = 0;
 
   uint fec_idx = fec_set_idx / 32UL;
-  memset( &ele->merkle_roots[fec_idx].mr, 0, sizeof(fd_hash_t) );
+  memset( &fd_forest_blk_mroots( forest, ele )[fec_idx].mr, 0, sizeof(fd_hash_t) );
 
   /* Add this slot back to requests map */
   fd_forest_blk_t      * pool     = fd_forest_pool( forest );
@@ -1847,7 +1871,7 @@ fd_forest_iter_next( fd_forest_iter_t * iter, fd_forest_t * forest ) {
 
     if( ele->complete_idx != UINT_MAX &&
         next_shred_idx <= ele->complete_idx &&
-        !fd_forest_blk_idxs_test( ele->idxs, next_shred_idx ) ) {
+        !fd_forest_blk_idxs_test( fd_forest_blk_idxs( forest, ele ), next_shred_idx ) ) {
       iter->shred_idx = next_shred_idx;
       break;
     }

--- a/src/discof/forest/fd_forest.h
+++ b/src/discof/forest/fd_forest.h
@@ -32,7 +32,7 @@
 
 /* Merkle root tracking.
    For each FEC set in the slot, we record the merkle root of the first
-   shred we receive in `.merkle_roots[ fec_set_idx / 32 ]`. Then for any
+   shred we receive in `mroots[ fec_set_idx / 32 ]`. Then for any
    shred in the same FEC inserted later, the merkle root of the new
    shred is compared to the merkle root we have stored.
 
@@ -131,9 +131,34 @@
 
 #define FD_FOREST_MAGIC (0xf17eda2ce7b1c0UL) /* firedancer forest version 0 */
 
-#define SET_NAME fd_forest_blk_idxs
-#define SET_MAX  FD_SHRED_BLK_MAX
-#include "../../util/tmpl/fd_set.c"
+/* Per-block shred idx bitsets are raw ulong words, word_cnt per block,
+   living in side arrays indexed by pool idx so the per-block shred
+   bound (shred_max) is a runtime value.  idx must be < shred_max. */
+
+typedef ulong fd_forest_blk_idxs_t;
+
+FD_FN_CONST static inline ulong fd_forest_blk_idxs_word_cnt( ulong shred_max ) { return (shred_max+63UL)>>6; }
+FD_FN_PURE  static inline int   fd_forest_blk_idxs_test    ( fd_forest_blk_idxs_t const * set, ulong idx ) { return fd_ulong_extract_bit( set[ idx>>6 ], (int)(idx&63UL) ); }
+static inline void fd_forest_blk_idxs_insert( fd_forest_blk_idxs_t * set, ulong idx ) { set[ idx>>6 ] = fd_ulong_set_bit  ( set[ idx>>6 ], (int)(idx&63UL) ); }
+static inline void fd_forest_blk_idxs_remove( fd_forest_blk_idxs_t * set, ulong idx ) { set[ idx>>6 ] = fd_ulong_clear_bit( set[ idx>>6 ], (int)(idx&63UL) ); }
+
+FD_FN_PURE static inline ulong
+fd_forest_blk_idxs_cnt( fd_forest_blk_idxs_t const * set, ulong word_cnt ) {
+  ulong cnt = 0UL;
+  for( ulong i=0UL; i<word_cnt; i++ ) cnt += (ulong)fd_ulong_popcnt( set[ i ] );
+  return cnt;
+}
+
+/* Per-FEC merkle roots, shred_max/FD_FEC_SHRED_CNT per block, also in
+   a side array indexed by pool idx.  mr is initialized to null hash,
+   written to when a shred is received, invalidated to invalid_mr when
+   multiple versions of the merkle root are detected. */
+
+struct fd_forest_mr {
+  fd_hash_t mr;
+  fd_hash_t cmr;
+};
+typedef struct fd_forest_mr fd_forest_mr_t;
 
 /* fd_forest_blk_t implements a left-child, right-sibling n-ary
    tree. Each ele maintains the `pool` index of its left-most child
@@ -159,14 +184,10 @@ struct __attribute__((aligned(128UL))) fd_forest_blk {
   uint buffered_idx; /* highest contiguous buffered shred idx */
   uint complete_idx; /* shred_idx with SLOT_COMPLETE_FLAG ie. last shred idx in the slot */
 
-  fd_forest_blk_idxs_t idxs[fd_forest_blk_idxs_word_cnt]; /* received data shred idxs */
-  struct {
-    fd_hash_t mr;
-    fd_hash_t cmr;
-  } merkle_roots[ FD_FEC_BLK_MAX ]; /* received merkle roots. mr is initialized to null hash, written to when a shred is
-                                       received. invalidated to invalid_mr on multiple versions of the merkle root are detected. */
+  /* received data shred idxs, received merkle roots and code shred idxs
+     are runtime-sized side arrays, see fd_forest_blk_{idxs,mroots,code} */
 
-  fd_hash_t confirmed_bid;  /* confirmed block id - can't be wrapped in the above struct because we can create sentinel blocks
+  fd_hash_t confirmed_bid;  /* confirmed block id - can't be wrapped in the merkle roots struct because we can create sentinel blocks
                                on confirmation, and don't know the index of the last fec set until we repair the slot.
                                hash_null if unknown.  Otherwise populated by the child slot's CMR on confirmation,
                                or by a confirmation msg from tower.  Has no bearing on if the full slot is correct or not. */
@@ -184,7 +205,6 @@ struct __attribute__((aligned(128UL))) fd_forest_blk {
 
   /* Metrics */
 
-  fd_forest_blk_idxs_t code[fd_forest_blk_idxs_word_cnt]; /* code shred idxs */
   long first_shred_ts;     /* tick of first shred rcved in slot != complete_idx */
   long last_shred_ts;      /* tick at which the slot became fully buffered (buffered_idx==complete_idx) */
   long first_req_ts;       /* tick of first request sent in slot != complete_idx */
@@ -345,6 +365,12 @@ typedef struct fd_forest_ref fd_forest_ref_t;
    |-------------------|
    | pool              |
    |-------------------|
+   | idxs (per blk)    |
+   |-------------------|
+   | code (per blk)    |
+   |-------------------|
+   | mroots (per blk)  |
+   |-------------------|
    | ancestry          |
    |-------------------|
    | frontier          |
@@ -384,6 +410,10 @@ struct __attribute__((aligned(128UL))) fd_forest {
   ulong root;           /* pool idx of the root */
   ulong wksp_gaddr;     /* wksp gaddr of fd_forest in the backing wksp, non-zero gaddr */
   ulong pool_gaddr;     /* wksp gaddr of fd_pool */
+  ulong shred_max;      /* max data shreds per block, bounds shred idxs and fec_set_idxs */
+  ulong idxs_gaddr;     /* wksp gaddr of per-blk data shred idx bitsets, fd_forest_blk_idxs_word_cnt( shred_max ) words each */
+  ulong code_gaddr;     /* wksp gaddr of per-blk code shred idx bitsets */
+  ulong mroots_gaddr;   /* wksp gaddr of per-blk fd_forest_mr_t arrays, shred_max/FD_FEC_SHRED_CNT each */
   ulong ancestry_gaddr; /* wksp_gaddr of fd_forest_ancestry */
   ulong frontier_gaddr; /* leaves that needs repair */
   ulong subtrees_gaddr; /* head of orphaned trees */
@@ -420,7 +450,7 @@ FD_PROTOTYPES_BEGIN
 
 /* fd_forest_{align,footprint} return the required alignment and
    footprint of a memory region suitable for use as forest with up to
-   ele_max eles and vote_max votes. */
+   ele_max eles of up to shred_max data shreds each. */
 
 FD_FN_CONST static inline ulong
 fd_forest_align( void ) {
@@ -428,8 +458,13 @@ fd_forest_align( void ) {
 }
 
 FD_FN_CONST static inline ulong
-fd_forest_footprint( ulong ele_max ) {
+fd_forest_footprint( ulong ele_max, ulong shred_max ) {
+  ulong idxs_sz   = ele_max*fd_forest_blk_idxs_word_cnt( shred_max )*sizeof(fd_forest_blk_idxs_t);
+  ulong mroots_sz = ele_max*(shred_max/FD_FEC_SHRED_CNT)*sizeof(fd_forest_mr_t);
   return FD_LAYOUT_FINI(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
+    FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
     FD_LAYOUT_APPEND(
@@ -450,6 +485,9 @@ fd_forest_footprint( ulong ele_max ) {
     FD_LAYOUT_INIT,
       alignof(fd_forest_t),       sizeof(fd_forest_t)                     ),
       fd_forest_pool_align(),     fd_forest_pool_footprint    ( ele_max ) ),
+      128UL,                      idxs_sz                                 ),
+      128UL,                      idxs_sz                                 ),
+      128UL,                      mroots_sz                               ),
       fd_forest_ancestry_align(), fd_forest_ancestry_footprint( ele_max ) ),
       fd_forest_frontier_align(), fd_forest_frontier_footprint( ele_max ) ),
       fd_forest_subtrees_align(), fd_forest_subtrees_footprint( ele_max ) ),
@@ -471,10 +509,11 @@ fd_forest_footprint( ulong ele_max ) {
 
 /* fd_forest_new formats an unused memory region for use as a
    forest.  mem is a non-NULL pointer to this region in the local
-   address space with the required footprint and alignment. */
+   address space with the required footprint and alignment.  ele_max
+   is a power of 2, shred_max a positive multiple of FD_FEC_SHRED_CNT. */
 
 void *
-fd_forest_new( void * shmem, ulong ele_max, ulong seed );
+fd_forest_new( void * shmem, ulong ele_max, ulong shred_max, ulong seed );
 
 /* fd_forest_join joins the caller to the forest.  forest
    points to the first byte of the memory region backing the forest
@@ -535,6 +574,29 @@ fd_forest_pool( fd_forest_t * forest ) {
 FD_FN_PURE static inline fd_forest_blk_t const *
 fd_forest_pool_const( fd_forest_t const * forest ) {
   return fd_wksp_laddr_fast( fd_forest_wksp( forest ), forest->pool_gaddr );
+}
+
+/* fd_forest_blk_{idxs,code} return blk's data / code shred idx bitset
+   (fd_forest_blk_idxs_word_cnt( forest->shred_max ) words) and
+   fd_forest_blk_mroots blk's merkle roots (forest->shred_max /
+   FD_FEC_SHRED_CNT entries).  blk must be a pool element of forest. */
+
+FD_FN_PURE static inline fd_forest_blk_idxs_t *
+fd_forest_blk_idxs( fd_forest_t const * forest, fd_forest_blk_t const * blk ) {
+  fd_forest_blk_idxs_t * idxs = fd_wksp_laddr_fast( fd_forest_wksp( forest ), forest->idxs_gaddr );
+  return idxs + fd_forest_pool_idx( fd_forest_pool_const( forest ), blk )*fd_forest_blk_idxs_word_cnt( forest->shred_max );
+}
+
+FD_FN_PURE static inline fd_forest_blk_idxs_t *
+fd_forest_blk_code( fd_forest_t const * forest, fd_forest_blk_t const * blk ) {
+  fd_forest_blk_idxs_t * code = fd_wksp_laddr_fast( fd_forest_wksp( forest ), forest->code_gaddr );
+  return code + fd_forest_pool_idx( fd_forest_pool_const( forest ), blk )*fd_forest_blk_idxs_word_cnt( forest->shred_max );
+}
+
+FD_FN_PURE static inline fd_forest_mr_t *
+fd_forest_blk_mroots( fd_forest_t const * forest, fd_forest_blk_t const * blk ) {
+  fd_forest_mr_t * mroots = fd_wksp_laddr_fast( fd_forest_wksp( forest ), forest->mroots_gaddr );
+  return mroots + fd_forest_pool_idx( fd_forest_pool_const( forest ), blk )*(forest->shred_max/FD_FEC_SHRED_CNT);
 }
 
 /* fd_forest_{ancestry, ancestry_const} returns a pointer in the caller's

--- a/src/discof/forest/test_forest.c
+++ b/src/discof/forest/test_forest.c
@@ -87,9 +87,9 @@ test_publish( fd_wksp_t * wksp ) {
 
   for( ulong i = 0; i < sizeof(publish_test_cases) / sizeof(ulong); i++ ) {
     ulong ele_max = 8UL;
-    void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+    void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
     FD_TEST( mem );
-    fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+    fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
     FD_TEST( forest );
     fd_forest_publish( setup_preorder( forest ), publish_test_cases[i] );
@@ -106,9 +106,9 @@ test_publish_incremental( fd_wksp_t * wksp ){
      two incremental snapshots */
 
   ulong ele_max = 32UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_ancestry_t * ancestry = fd_forest_ancestry( forest );
   fd_forest_frontier_t * frontier = fd_forest_frontier( forest );
   //fd_forest_orphaned_t * orphaned = fd_forest_orphaned( forest );
@@ -257,9 +257,9 @@ ulong * consumed_arr( fd_wksp_t * wksp, fd_forest_t * forest ) {
 
 void test_out_of_order( fd_wksp_t * wksp ) {
   ulong ele_max = 8UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 6, 5, 0, 0, 0, 0 );
@@ -354,9 +354,9 @@ void
 test_forks( fd_wksp_t * wksp ){
 
   ulong ele_max = 32UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   // these slots all have 2 shreds, 0,1
   fd_forest_init( forest, 0 );
@@ -427,9 +427,9 @@ test_forks( fd_wksp_t * wksp ){
 void
 test_print_tree( fd_wksp_t *wksp ){
   ulong ele_max = 512UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 1568376 );
   fd_forest_blk_data_shred_insert( forest, 1568377, 1568376, 0, 0, 1, 1 );
@@ -462,9 +462,9 @@ test_large_print_tree( fd_wksp_t * wksp ){
                                                                                                                        └── [330091004, 330091007] ── [330091010, 330091048]
                                                                         └── [330090852, 330090855]*/
   ulong ele_max = 512UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 330090532 );
 
@@ -513,9 +513,9 @@ test_linear_forest_iterator( fd_wksp_t * wksp ) {
   /* Repar forest iterator for a linear chain (expected behavior for
      start up) */
   ulong ele_max = 512UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   /*
      0 - 1(-/1) - 2(-/2) - 3(0/?) - 4(-/?) - 5(-/5)
@@ -551,9 +551,9 @@ test_branched_forest_iterator( fd_wksp_t * wksp ) {
   /* Repair forest iterator for a branched chain (expected behavior for
      regular turbine) */
   ulong ele_max = 512UL;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
    /*
          slot 0
@@ -633,9 +633,9 @@ void
 test_frontier( fd_wksp_t * wksp ) {
   /* bug where we added ele to frontier but didn't remove from ancestry */
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 1, 0, 0, 0, 1, 1 );
@@ -675,9 +675,9 @@ test_invalid_frontier_insert( fd_wksp_t * wksp ) {
      *never get called*, because 108  ALREADY EXISTED.
   */
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 100, 0, 0, 0, 1, 1 );
@@ -717,9 +717,9 @@ test_invalid_frontier_insert( fd_wksp_t * wksp ) {
 void
 test_fec_clear( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
 
@@ -765,9 +765,9 @@ test_fec_clear( fd_wksp_t * wksp ) {
 void
 test_iter_publish( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 1, 0, 0, 0, 0, 0 );
@@ -871,9 +871,9 @@ test_iter_publish( fd_wksp_t * wksp ) {
 void
 test_iter_subtree( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   fd_forest_init( forest, 0 );
   fd_forest_blk_fec_insert       ( forest, 1, 0, 0, 0, 1    );
@@ -904,9 +904,9 @@ test_iter_subtree( fd_wksp_t * wksp ) {
 void
 test_orphan_requests( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   fd_forest_iter_next( &forest->iter, forest );
@@ -929,9 +929,9 @@ test_orphan_requests( fd_wksp_t * wksp ) {
 void
 test_slot_clear( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
 
   /*
        2
@@ -1039,9 +1039,9 @@ print_orphan_requests( fd_forest_t * forest ) {
 void
 test_verify_orphans( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
     /*
        2
       | \
@@ -1095,9 +1095,9 @@ test_verify_orphans( fd_wksp_t * wksp ) {
 void
 test_eviction_simple( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr = (fd_hash_t){ .key = { 1 } };
@@ -1159,9 +1159,9 @@ test_eviction_simple( fd_wksp_t * wksp ) {
 void
 test_eviction_confirmations( fd_wksp_t * wksp ) {
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   /* create forks 10 - 11 - 12 - 13 - 17 (confirmed)
@@ -1233,9 +1233,9 @@ test_eviction_confirmed_orphan_gca( fd_wksp_t * wksp ) {
      - gca(slot 4, slot 5) = slot 4 = latest_confirmed_leaf → evict confirmed_orphan */
 
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr = (fd_hash_t){ .key = { 1 } };
@@ -1313,9 +1313,9 @@ test_eviction_confirmed_bid_orphan( fd_wksp_t * wksp ) {
      Orphan 20: confirmed_bid is set (should survive) */
 
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_forest_blk_fec_insert( forest, 1, 0, 31, 0, 1 );
@@ -1348,9 +1348,9 @@ test_eviction_confirmed_bid_orphan( fd_wksp_t * wksp ) {
 void
 test_eviction_deep( fd_wksp_t * wksp ) {
   ulong ele_max = 512;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 1 );
 
   /* Scenario for DoS attack:
@@ -1414,9 +1414,9 @@ test_eviction_deep( fd_wksp_t * wksp ) {
 void
 test_sentinel_blocks( fd_wksp_t * wksp ) {
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   fd_forest_subtrees_t * subtrees = fd_forest_subtrees( forest );
@@ -1441,9 +1441,9 @@ test_parent_update( fd_wksp_t * wksp ) {
         _ ` */
 
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_1   = (fd_hash_t){ .ul = { 1 } };
@@ -1535,9 +1535,9 @@ void
 test_eqvoc_blk_wrong_parent( fd_wksp_t * wksp ) {
   /* initial block 3 version has slot 1 as parent. It also has multiple siblings 5 -> 4 -> 3, correct version has slot 2 as parent. */
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
   fd_forest_blk_data_shred_insert( forest, 1, 0, 31, 0, 0, 1 );
   fd_forest_blk_data_shred_insert( forest, 2, 1, 31, 0, 0, 1 );
@@ -1581,9 +1581,9 @@ test_buffered_idx_gt_complete_idx( fd_wksp_t * wksp ) {
        - iter_next (thinks slot is done, skips remaining shreds) */
 
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   /* Complete slot 1 so consumed frontier can advance */
@@ -1636,9 +1636,9 @@ test_verified_parent_update_stale_sibling( fd_wksp_t * wksp ) {
      with no sibling self-loops. */
 
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_1   = (fd_hash_t){ .ul = { 1 } };
@@ -1738,9 +1738,9 @@ test_eqvoc_different_slot_size( fd_wksp_t * wksp ) {
      This causes CORRECT shreds to be REJECTED. */
 
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_0 = (fd_hash_t){ .key = { 0 } };
@@ -1799,7 +1799,7 @@ test_eqvoc_different_slot_size( fd_wksp_t * wksp ) {
   ele = fd_forest_data_shred_insert( forest, 3, 2, 0, 0, 0, 0, SHRED_SRC_REPAIR, &mr_3_0c, &mr_2c, fd_tickcount() );
   FD_TEST( ele );
   FD_TEST( ele->parent_slot == 2 ); /* parent_slot changes on shred in fec 0 */
-  FD_TEST( fd_hash_eq( &ele->merkle_roots[0].mr, &mr_3_0c ) );
+  FD_TEST( fd_hash_eq( &fd_forest_blk_mroots( forest, ele )[0].mr, &mr_3_0c ) );
 
   /* shred in the last FEC set doesn't do anything because we still don't know complete_idx */
   FD_TEST( fd_forest_data_shred_insert( forest, 3, 2, 94, 64, 0, 0, SHRED_SRC_REPAIR, &mr_3_2c, &mr_3_1c, fd_tickcount() ) );
@@ -1820,9 +1820,9 @@ test_fec_complete_no_poison_verified( fd_wksp_t * wksp ) {
      already been chain-verified.  The merkle root metadata doesn't get
      overwritten. */
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_0   = (fd_hash_t){ .key = { 0 } };
@@ -1858,8 +1858,8 @@ test_fec_complete_no_poison_verified( fd_wksp_t * wksp ) {
   FD_TEST( ele->chain_confirmed );
   FD_TEST( ele->lowest_verified_fec == 0 );
 
-  fd_hash_t saved_mr  = ele->merkle_roots[1].mr;
-  fd_hash_t saved_cmr = ele->merkle_roots[1].cmr;
+  fd_hash_t saved_mr  = fd_forest_blk_mroots( forest, ele )[1].mr;
+  fd_hash_t saved_cmr = fd_forest_blk_mroots( forest, ele )[1].cmr;
   FD_TEST( fd_hash_eq( &saved_mr, &mr_3_1 ) );
 
   /* Now a conflicting FEC_COMPLETE arrives for FEC 1 (fec_set_idx=32)
@@ -1868,8 +1868,8 @@ test_fec_complete_no_poison_verified( fd_wksp_t * wksp ) {
   fd_forest_fec_insert( forest, 3, 2, 63, 32, 1, 0, &mr_3_1_bad, &cmr_bad, fd_tickcount() );
 
   /* The verified merkle root must NOT have been overwritten */
-  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].mr,  &saved_mr  ) );
-  FD_TEST( fd_hash_eq( &ele->merkle_roots[1].cmr, &saved_cmr ) );
+  FD_TEST( fd_hash_eq( &fd_forest_blk_mroots( forest, ele )[1].mr,  &saved_mr  ) );
+  FD_TEST( fd_hash_eq( &fd_forest_blk_mroots( forest, ele )[1].cmr, &saved_cmr ) );
 
   /* The block should still be chain-confirmed */
   FD_TEST( ele->chain_confirmed );
@@ -1903,9 +1903,9 @@ static void
 test_buffered_idx_oob( fd_wksp_t * wksp ) {
 
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL /* seed */ ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL /* seed */ ) );
   fd_forest_init( forest, 0 );
 
   ulong slot        = 2;
@@ -1957,7 +1957,7 @@ test_buffered_idx_oob( fd_wksp_t * wksp ) {
 
   /* buffered_idx should still be FD_SHRED_BLK_MAX - 1 */
   FD_TEST( blk->buffered_idx == FD_SHRED_BLK_MAX - 1 );
-  FD_TEST( blk->merkle_roots[0].mr.ul[0] == ULONG_MAX );
+  FD_TEST( fd_forest_blk_mroots( forest, blk )[0].mr.ul[0] == ULONG_MAX );
 
   /* no longer blocks consumed-frontier advancement and FEC chain verification. */
   FD_TEST( blk->buffered_idx == blk->complete_idx );
@@ -1970,9 +1970,9 @@ test_fec_insert_reject_oob_after_verify( fd_wksp_t * wksp ) {
      sends a FEC set with the maximum possible fec_set_idx (well beyond
      complete_idx).  The FEC is rejected because fec_set_idx > complete_idx. */
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_0   = (fd_hash_t){ .key = { 0 } };
@@ -2036,9 +2036,9 @@ test_fec_insert_dup_confirm_larger_complete_idx( fd_wksp_t * wksp ) {
   */
 
   ulong ele_max = 16;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 42UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 42UL ) );
   fd_forest_init( forest, 0 );
 
   fd_hash_t mr_0    = (fd_hash_t){ .key = { 0 } };
@@ -2114,9 +2114,9 @@ test_sentinel_parent_update_orphreqs_leak( fd_wksp_t * wksp ) {
    other list - which only surfaces much later (e.g. during a publish) as
    a request-list entry pointing at a freed / reused pool slot. */
   ulong ele_max = 8;
-  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max ), 1UL );
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX ), 1UL );
   FD_TEST( mem );
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_forest_init( forest, 0 );
 
   fd_forest_blk_t      * pool     = fd_forest_pool( forest );
@@ -2153,6 +2153,59 @@ test_sentinel_parent_update_orphreqs_leak( fd_wksp_t * wksp ) {
   fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( forest ) ) );
 }
 
+/* shred_max is a runtime value: a forest sized for 4x FD_SHRED_BLK_MAX
+   accepts a block that fills every extra FEC set, and rejects shred
+   idxs / fec_set_idxs at or beyond shred_max instead of aborting.  Also
+   checks the production footprint equals the pre-side-array layout
+   (blk 256 B + idxs 4 KiB + code 4 KiB + mroots 64 KiB = 73984 B/blk). */
+
+static void
+test_shred_max_runtime( fd_wksp_t * wksp ) {
+  ulong ele_max   = 4UL;
+  ulong shred_max = 4UL*FD_SHRED_BLK_MAX;
+  ulong fec_cnt   = shred_max/FD_FEC_SHRED_CNT;
+
+  ulong fp_prod = fd_forest_footprint( ele_max, FD_SHRED_BLK_MAX );
+  ulong fp_big  = fd_forest_footprint( ele_max, shred_max );
+  FD_TEST( sizeof(fd_forest_blk_t)==256UL );
+  FD_TEST( fp_big-fp_prod==ele_max*3UL*(4096UL+4096UL+65536UL) );
+
+  void * mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fp_big, 1UL );
+  FD_TEST( mem );
+  FD_TEST( !fd_forest_new( mem, ele_max, FD_SHRED_BLK_MAX+1UL, 0UL ) ); /* not a FEC multiple */
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( mem, ele_max, shred_max, 0UL ) );
+  FD_TEST( forest && forest->shred_max==shred_max );
+  fd_forest_init( forest, 0 );
+
+  fd_forest_blk_insert( forest, 1, 0, NULL );
+  fd_forest_blk_insert( forest, 2, 1, NULL );
+  fd_forest_blk_t * blk1 = fd_forest_query( forest, 1 );
+  fd_forest_blk_t * blk2 = fd_forest_query( forest, 2 );
+  FD_TEST( fd_forest_blk_idxs  ( forest, blk2 )-fd_forest_blk_idxs  ( forest, blk1 )==(long)(shred_max/64UL) );
+  FD_TEST( fd_forest_blk_mroots( forest, blk2 )-fd_forest_blk_mroots( forest, blk1 )==(long)fec_cnt );
+
+  /* A code shred past the limit only counts toward turbine_cnt. */
+  fd_hash_t mr = { .ul = { 1 } }; fd_hash_t cmr = { .ul = { 0 } };
+  FD_TEST( fd_forest_code_shred_insert( forest, 1, (uint)shred_max, 0L )==blk1 && blk1->turbine_cnt==1U );
+  FD_TEST( !fd_forest_blk_idxs_cnt( fd_forest_blk_code( forest, blk1 ), shred_max/64UL ) );
+
+  /* Fill every FEC set of slot 1 beyond the production bound. */
+  for( uint fec=0; fec<fec_cnt; fec++ ) {
+    uint fec_set_idx = fec*FD_FEC_SHRED_CNT;
+    mr.ul[0] = fec+1UL; cmr.ul[0] = fec;
+    FD_TEST( fd_forest_fec_insert( forest, 1, 0, fec_set_idx+FD_FEC_SHRED_CNT-1U, fec_set_idx, fec==fec_cnt-1U, 0, &mr, &cmr, 0L ) );
+  }
+  blk1 = fd_forest_query( forest, 1 );
+  FD_TEST( blk1->complete_idx==shred_max-1UL );
+  FD_TEST( blk1->buffered_idx==shred_max-1UL );
+  FD_TEST( fd_forest_blk_idxs_cnt( fd_forest_blk_idxs( forest, blk1 ), shred_max/64UL )==shred_max );
+  FD_TEST( fd_forest_blk_mroots( forest, blk1 )[ fec_cnt-1UL ].mr.ul[0]==fec_cnt );
+  FD_TEST( fd_forest_blk_mroots( forest, blk2 )[ 0 ].mr.ul[0]==0UL ); /* neighbor untouched */
+  FD_TEST( !fd_forest_verify( forest ) );
+
+  fd_wksp_free_laddr( fd_forest_delete( fd_forest_leave( forest ) ) );
+}
+
 int
 main( int argc, char ** argv ) {
   fd_boot( &argc, &argv );
@@ -2164,6 +2217,7 @@ main( int argc, char ** argv ) {
   FD_TEST( wksp );
 
   test_buffered_idx_oob( wksp );
+  test_shred_max_runtime( wksp );
   test_invalid_frontier_insert( wksp );
   test_publish( wksp );
   test_publish_incremental( wksp );

--- a/src/discof/motor/fd_motor_tile.c
+++ b/src/discof/motor/fd_motor_tile.c
@@ -455,7 +455,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ulong ldr_tt_obj_id = fd_pod_query_ulong( topo->props, "ldr_tt", ULONG_MAX );
   if( FD_LIKELY( ldr_tt_obj_id!=ULONG_MAX ) ) timing_tables = fd_topo_obj_laddr( topo, ldr_tt_obj_id );
 
-  FD_TEST( fd_poh_join( fd_poh_new( ctx->poh ), ctx->shred_out, ctx->replay_out, timing_tables ) );
+  FD_TEST( fd_poh_join( fd_poh_new( ctx->poh ), ctx->shred_out, ctx->replay_out, timing_tables, tile->motor.max_txn_per_slot ) );
 
   fd_clock_tile_init( ctx->poh->clock );
 

--- a/src/discof/poh/fd_poh.c
+++ b/src/discof/poh/fd_poh.c
@@ -94,7 +94,8 @@ fd_poh_t *
 fd_poh_join( void *                         shpoh,
              fd_poh_out_t *                 shred_out,
              fd_poh_out_t *                 replay_out,
-             fd_leader_txn_timing_table_t * timing_tables ) {
+             fd_leader_txn_timing_table_t * timing_tables,
+             ulong                          timing_table_max ) {
   if( FD_UNLIKELY( !shpoh ) ) {
     FD_LOG_WARNING(( "NULL shpoh" ));
     return NULL;
@@ -117,6 +118,7 @@ fd_poh_join( void *                         shpoh,
 
   poh->timing_tables    = timing_tables;
   poh->timing_table_idx = 0UL;
+  poh->timing_table_max = timing_table_max;
 
   return poh;
 }
@@ -268,7 +270,7 @@ fd_poh_begin_leader( fd_poh_t * poh,
 
   if( FD_LIKELY( poh->timing_tables ) ) {
     poh->timing_table_idx ^= 1UL;
-    fd_leader_txn_timing_table_t * table = &poh->timing_tables[ poh->timing_table_idx ];
+    fd_leader_txn_timing_table_t * table = fd_leader_txn_timing_table( poh->timing_tables, poh->timing_table_idx, poh->timing_table_max );
     table->slot = slot;
     table->cnt  = 0UL;
   }
@@ -779,11 +781,11 @@ fd_poh1_mixin( fd_poh_t *                         poh,
   if( FD_UNLIKELY( !executed_txn_cnt ) ) return;
 
   if( FD_LIKELY( poh->timing_tables ) ) {
-    fd_leader_txn_timing_table_t * table = &poh->timing_tables[ poh->timing_table_idx ];
+    fd_leader_txn_timing_table_t * table = fd_leader_txn_timing_table( poh->timing_tables, poh->timing_table_idx, poh->timing_table_max );
     long poh_mixed_ticks = fd_tickcount();
     for( ulong i=0UL; i<txn_cnt; i++ ) {
       if( FD_UNLIKELY( !(txns[ i ].flags & FD_TXN_P_FLAGS_EXECUTE_SUCCESS) ) ) continue;
-      if( FD_UNLIKELY( table->cnt>=FD_MAX_TXN_PER_SLOT ) ) break;
+      if( FD_UNLIKELY( table->cnt>=poh->timing_table_max ) ) break;
 
       fd_leader_txn_timing_rec_t * rec = &table->rec[ table->cnt++ ];
       *rec = *timing;

--- a/src/discof/poh/fd_poh.h
+++ b/src/discof/poh/fd_poh.h
@@ -365,15 +365,39 @@ typedef struct fd_leader_txn_timing_rec fd_leader_txn_timing_rec_t;
 
 FD_STATIC_ASSERT( sizeof(fd_leader_txn_timing_rec_t)==32UL, leader_txn_timing_rec );
 
+/* The ldr_tt object holds FD_LEADER_TXN_TIMING_TABLE_CNT tables back to
+   back, each with room for config->limits.max_txn_per_slot records, so
+   the table stride is a runtime value: index them with
+   fd_leader_txn_timing_table(). */
+
 struct fd_leader_txn_timing_table {
   ulong slot;
   ulong cnt;
-  fd_leader_txn_timing_rec_t rec[ FD_MAX_TXN_PER_SLOT ];
+  fd_leader_txn_timing_rec_t rec[]; /* max_txn_per_slot */
 };
 
 typedef struct fd_leader_txn_timing_table fd_leader_txn_timing_table_t;
 
 #define FD_LEADER_TXN_TIMING_TABLE_CNT (2UL)
+
+FD_FN_CONST static inline ulong
+fd_leader_txn_timing_table_footprint( ulong max_txn_per_slot ) {
+  return sizeof(fd_leader_txn_timing_table_t)+max_txn_per_slot*sizeof(fd_leader_txn_timing_rec_t);
+}
+
+FD_FN_CONST static inline fd_leader_txn_timing_table_t const *
+fd_leader_txn_timing_table_const( fd_leader_txn_timing_table_t const * tables,
+                                  ulong                                idx,
+                                  ulong                                max_txn_per_slot ) {
+  return (fd_leader_txn_timing_table_t const *)( (uchar const *)tables + idx*fd_leader_txn_timing_table_footprint( max_txn_per_slot ) );
+}
+
+FD_FN_CONST static inline fd_leader_txn_timing_table_t *
+fd_leader_txn_timing_table( fd_leader_txn_timing_table_t * tables,
+                            ulong                          idx,
+                            ulong                          max_txn_per_slot ) {
+  return (fd_leader_txn_timing_table_t *)fd_leader_txn_timing_table_const( tables, idx, max_txn_per_slot );
+}
 
 struct fd_poh_leader_slot_ended {
   int   completed;
@@ -497,9 +521,10 @@ struct __attribute__((aligned(FD_POH_ALIGN))) fd_poh_private {
   long  pack_end_ns;
 
   /* Shared per-transaction timing tables or NULL when the topology does
-     not provide them. */
+     not provide them; timing_table_max records per table. */
   fd_leader_txn_timing_table_t * timing_tables;
   ulong                          timing_table_idx;
+  ulong                          timing_table_max;
 
   ulong magic;
 };
@@ -521,7 +546,8 @@ fd_poh_t *
 fd_poh_join( void *                         shpoh,
              fd_poh_out_t *                 shred_out,
              fd_poh_out_t *                 replay_out,
-             fd_leader_txn_timing_table_t * timing_tables );
+             fd_leader_txn_timing_table_t * timing_tables,
+             ulong                          timing_table_max ); /* records per table, config->limits.max_txn_per_slot */
 
 void
 fd_poh_reset( fd_poh_t *          poh,

--- a/src/discof/poh/fd_poh_tile.c
+++ b/src/discof/poh/fd_poh_tile.c
@@ -313,7 +313,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ulong ldr_tt_obj_id = fd_pod_query_ulong( topo->props, "ldr_tt", ULONG_MAX );
   if( FD_LIKELY( ldr_tt_obj_id!=ULONG_MAX ) ) timing_tables = fd_topo_obj_laddr( topo, ldr_tt_obj_id );
 
-  FD_TEST( fd_poh_join( fd_poh_new( ctx->poh ), ctx->shred_out, ctx->replay_out, timing_tables ) );
+  FD_TEST( fd_poh_join( fd_poh_new( ctx->poh ), ctx->shred_out, ctx->replay_out, timing_tables, tile->poh.max_txn_per_slot ) );
 
   fd_clock_tile_init( ctx->poh->clock );
 

--- a/src/discof/reasm/fuzz_reasm.c
+++ b/src/discof/reasm/fuzz_reasm.c
@@ -493,7 +493,7 @@ LLVMFuzzerTestOneInput( uchar const * data,
 
   fd_reasm_t * reasm = fd_reasm_join( fd_reasm_new( fuzz_reasm_mem, FUZZ_FEC_MAX, fuzz_bounded( &cur, 1024UL ) ) );
   FD_TEST( reasm );
-  fuzz_store = fd_store_join( fd_store_new( fuzz_store_mem, FUZZ_STORE_FEC_MAX, 1UL, 0UL, 1UL, 0UL,
+  fuzz_store = fd_store_join( fd_store_new( fuzz_store_mem, FUZZ_STORE_FEC_MAX, 1UL, 0UL, 1UL, 0UL, FD_SHRED_BLK_MAX,
                                             "/tmp/fuzz_reasm.store", fuzz_bounded( &cur, 1024UL ) ) );
   FD_TEST( fuzz_store );
   FD_TEST( fd_store_map_ljoin( fuzz_store, fuzz_store_map ) );

--- a/src/discof/reasm/test_reasm.c
+++ b/src/discof/reasm/test_reasm.c
@@ -62,7 +62,7 @@ test_store_release( fd_wksp_t * wksp ) {
   void * store_mem = fd_wksp_alloc_laddr( wksp, fd_store_align(),
       fd_store_footprint( reasm_max, 64UL, 0UL, payload_slot_sz, 0UL ), 1UL );
   fd_store_t * store = fd_store_join( fd_store_new( store_mem, reasm_max, 64UL, 0UL,
-      payload_slot_sz, 0UL, TEST_STORE_PATH, 43UL ) );
+      payload_slot_sz, 0UL, FD_SHRED_BLK_MAX, TEST_STORE_PATH, 43UL ) );
   FD_TEST( store );
   FD_TEST( !fd_store_file_init( store ) );
   int fd = fd_store_file_open( store, O_RDWR );

--- a/src/discof/repair/fd_repair.c
+++ b/src/discof/repair/fd_repair.c
@@ -201,7 +201,8 @@ ag_repair_shred_block_id( fd_repair_t *       repair,
 int
 ag_repair_response_de( ag_repair_response_t * response,
                        uchar const *          buf,
-                       ulong                  buf_sz ) {
+                       ulong                  buf_sz,
+                       ulong                  fec_set_max ) {
   uchar const * cur = buf;
   ulong         rem = buf_sz;
 
@@ -219,7 +220,7 @@ ag_repair_response_de( ag_repair_response_t * response,
       if( FD_UNLIKELY( rem < sizeof(uint) ) ) return -1;
       res->fec_set_count = fd_uint_load_4_fast( cur );
       cur += sizeof(uint); rem -= sizeof(uint);
-      if( FD_UNLIKELY( res->fec_set_count>FD_FEC_BLK_MAX ) ) return -1;
+      if( FD_UNLIKELY( res->fec_set_count>fec_set_max ) ) return -1;
 
       if( FD_UNLIKELY( rem < sizeof(ulong) ) ) return -1;
       res->parent_slot = fd_ulong_load_8_fast( cur );

--- a/src/discof/repair/fd_repair.h
+++ b/src/discof/repair/fd_repair.h
@@ -212,7 +212,7 @@ typedef struct fd_repair_ping fd_repair_ping_t;
 /* alpenglow blockid repair response types */
 
 typedef uchar ag_proof_node_t[FD_SHRED_MERKLE_NODE_SZ];
-#define AG_MAX_FEC_PROOF_NODE_CNT  (1U + (63 - __builtin_clzl( (ulong)FD_FEC_BLK_MAX))) /* 11 = 1 node for parent block_id + 10 for log2(1024) max fec sets */
+#define AG_MAX_FEC_PROOF_NODE_CNT  (1U + (63 - __builtin_clzl( FD_SHRED_BLK_MAX_RAISED/FD_FEC_SHRED_CNT ))) /* 24 = 1 node for parent block_id + 23 for log2 of the most FEC sets any configuration allows */
 
 struct ag_parent_fec_count_res {
   uint      fec_set_count;
@@ -367,13 +367,15 @@ ag_repair_shred_block_id( fd_repair_t * repair, fd_pubkey_t const * to, ulong ts
    Proofs are a concatenation of 20-byte merkle nodes (proof_sz must be
    a multiple of FD_SHRED_MERKLE_NODE_SZ).  Ping responses (tag 2) are
    not handled here; they are the same sz as legacy repair pings and
-   should be routed to the ping path.  Returns 0 on success and -1 if
-   the response is malformed.
+   should be routed to the ping path.  fec_set_max bounds the FEC sets
+   a block may hold (max_shreds_per_block/FD_FEC_SHRED_CNT).  Returns 0
+   on success and -1 if the response is malformed.
    Does NOT verify the merkle proofs. */
 int
 ag_repair_response_de( ag_repair_response_t * response,
                        uchar const *          buf,
-                       ulong                  buf_sz );
+                       ulong                  buf_sz,
+                       ulong                  fec_set_max );
 
 /* ag_repair_parent_fec_count_verify / ag_repair_fec_set_root_verify
    verifies a deserialized Alpenglow repair metadata response against

--- a/src/discof/repair/fd_repair_tile.c
+++ b/src/discof/repair/fd_repair_tile.c
@@ -435,7 +435,7 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof(ctx_t),            sizeof(ctx_t)                                                      );
   l = FD_LAYOUT_APPEND( l, fd_repair_align(),         fd_repair_footprint     ()                                         );
-  l = FD_LAYOUT_APPEND( l, fd_forest_align(),         fd_forest_footprint     ( tile->repair.slot_max )                  );
+  l = FD_LAYOUT_APPEND( l, fd_forest_align(),         fd_forest_footprint     ( tile->repair.slot_max, tile->repair.max_shreds_per_block ) );
   l = FD_LAYOUT_APPEND( l, fd_policy_align(),         fd_policy_footprint     ( FD_REPAIR_PEER_MAX )                     );
   l = FD_LAYOUT_APPEND( l, fd_reqlim_align(),         fd_reqlim_footprint     ( FD_REQLIM_CACHE_MAX )                     );
   l = FD_LAYOUT_APPEND( l, fd_inflights_align(),      fd_inflights_footprint  ()                                         );
@@ -839,11 +839,12 @@ check_confirmed( ctx_t           * ctx,
        early exit above. */
     FD_TEST( bad_fec_idx != UINT_MAX );
 
-    fd_hash_t const * expected = (bad_fec_idx == bad_blk->complete_idx - (FD_FEC_SHRED_CNT - 1)) ? &bad_blk->confirmed_bid : &bad_blk->merkle_roots[(bad_fec_idx / 32) + 1].cmr;
+    fd_forest_mr_t const * bad_mroots = fd_forest_blk_mroots( ctx->forest, bad_blk );
+    fd_hash_t const * expected = (bad_fec_idx == bad_blk->complete_idx - (FD_FEC_SHRED_CNT - 1)) ? &bad_blk->confirmed_bid : &bad_mroots[(bad_fec_idx / 32) + 1].cmr;
 
-    FD_BASE58_ENCODE_32_BYTES( confirmed_bid->uc,                             confirmed_bid_b58 );
-    FD_BASE58_ENCODE_32_BYTES( expected->uc,                                  expected_mr );
-    FD_BASE58_ENCODE_32_BYTES( bad_blk->merkle_roots[bad_fec_idx / 32].mr.uc, recorded_mr );
+    FD_BASE58_ENCODE_32_BYTES( confirmed_bid->uc,                  confirmed_bid_b58 );
+    FD_BASE58_ENCODE_32_BYTES( expected->uc,                       expected_mr );
+    FD_BASE58_ENCODE_32_BYTES( bad_mroots[bad_fec_idx / 32].mr.uc, recorded_mr );
 
     FD_LOG_WARNING(( "[%s] slot %lu block_id %s confirmation detected incorrect FECs. bad FEC is slot %lu fec set %u. expected mr (%s) != recorded mr (%s)",
                        __func__,
@@ -905,7 +906,7 @@ after_fec( ctx_t      * ctx,
     /* Note: this log does not imply that the slot is fully executable.
        It's possible that we have a slot that doesn't chain verify,
        which could be un-executable. */
-    FD_BASE58_ENCODE_32_BYTES( ele->merkle_roots[ele->complete_idx / 32].mr.uc, block_id );
+    FD_BASE58_ENCODE_32_BYTES( fd_forest_blk_mroots( ctx->forest, ele )[ele->complete_idx / 32].mr.uc, block_id );
     FD_BASE58_ENCODE_32_BYTES( mr->uc, fec_mr );
     FD_LOG_INFO(( "[%s] slot is complete %lu. num_data_shreds: %u, num_repaired: %u, num_turbine: %u, num_recovered: %u, duration: %.2f ms. last recvd fec: %u, mr %s. current block_id: %s",
                     __func__,
@@ -1140,8 +1141,9 @@ after_frag( ctx_t *             ctx,
           m->blk_turbine_cnt         = blk->turbine_cnt;
           m->blk_repair_cnt          = blk->repair_cnt;
           m->blk_recovered_cnt       = blk->recovered_cnt;
-          m->blk_data_cnt            = (uint)fd_forest_blk_idxs_cnt( blk->idxs );
-          m->blk_parity_cnt          = (uint)fd_forest_blk_idxs_cnt( blk->code );
+          ulong word_cnt             = fd_forest_blk_idxs_word_cnt( ctx->forest->shred_max );
+          m->blk_data_cnt            = (uint)fd_forest_blk_idxs_cnt( fd_forest_blk_idxs( ctx->forest, blk ), word_cnt );
+          m->blk_parity_cnt          = (uint)fd_forest_blk_idxs_cnt( fd_forest_blk_code( ctx->forest, blk ), word_cnt );
           m->blk_lowest_verified_fec = blk->lowest_verified_fec;
           m->blk_chain_confirmed     = blk->chain_confirmed;
           m->blk_slot_complete       = (uchar)( blk->complete_idx!=UINT_MAX );
@@ -1271,7 +1273,7 @@ after_credit( ctx_t *             ctx,
     fd_inflights_request_pop( ctx->inflights, &nonce, &slot, &block_id, &shred_idx );
 
     fd_forest_blk_t * blk = fd_forest_query( ctx->forest, slot );
-    if( FD_UNLIKELY( blk && shred_idx <= blk->complete_idx && !fd_forest_blk_idxs_test( blk->idxs, shred_idx ) ) ) {
+    if( FD_UNLIKELY( blk && shred_idx <= blk->complete_idx && !fd_forest_blk_idxs_test( fd_forest_blk_idxs( ctx->forest, blk ), shred_idx ) ) ) {
       fd_pubkey_t const * peer = fd_policy_peer_select( ctx->policy );
 
       if( FD_UNLIKELY( !peer || fd_reqlim_next( ctx->dedup, fd_reqlim_key( FD_REPAIR_KIND_SHRED, slot, (uint)shred_idx ), now ) ) ) {
@@ -1408,7 +1410,7 @@ unprivileged_init( fd_topo_t const *      topo,
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   ctx_t * ctx       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ctx_t),            sizeof(ctx_t)                                                 );
   ctx->protocol     = FD_SCRATCH_ALLOC_APPEND( l, fd_repair_align(),         fd_repair_footprint()                                         );
-  ctx->forest       = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_align(),         fd_forest_footprint( tile->repair.slot_max )                  );
+  ctx->forest       = FD_SCRATCH_ALLOC_APPEND( l, fd_forest_align(),         fd_forest_footprint( tile->repair.slot_max, tile->repair.max_shreds_per_block ) );
   ctx->policy       = FD_SCRATCH_ALLOC_APPEND( l, fd_policy_align(),         fd_policy_footprint( FD_REPAIR_PEER_MAX )                     );
   ctx->dedup        = FD_SCRATCH_ALLOC_APPEND( l, fd_reqlim_align(),          fd_reqlim_footprint( FD_REQLIM_CACHE_MAX )                      );
   ctx->inflights    = FD_SCRATCH_ALLOC_APPEND( l, fd_inflights_align(),      fd_inflights_footprint()                                      );
@@ -1420,7 +1422,7 @@ unprivileged_init( fd_topo_t const *      topo,
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
 
   ctx->protocol     = fd_repair_join        ( fd_repair_new        ( ctx->protocol,  &ctx->identity_public_key                                                      ) );
-  ctx->forest       = fd_forest_join        ( fd_forest_new        ( ctx->forest,    tile->repair.slot_max, ctx->repair_seed                                        ) );
+  ctx->forest       = fd_forest_join        ( fd_forest_new        ( ctx->forest,    tile->repair.slot_max, tile->repair.max_shreds_per_block, ctx->repair_seed       ) );
   ctx->policy       = fd_policy_join        ( fd_policy_new        ( ctx->policy,    FD_REPAIR_PEER_MAX, ctx->repair_seed, ctx->repair_nonce_ss ) );
   ctx->dedup        = fd_reqlim_join        ( fd_reqlim_new        ( ctx->dedup,     FD_REQLIM_CACHE_MAX, ctx->repair_seed                      ) );
   ctx->inflights    = fd_inflights_join     ( fd_inflights_new     ( ctx->inflights, ctx->repair_seed+1234UL                                                       ) );

--- a/src/discof/repair/fd_rserve_tile.c
+++ b/src/discof/repair/fd_rserve_tile.c
@@ -78,6 +78,7 @@ typedef struct ctx {
   fd_rserve_t * rserve;
   fd_store_t  * store;
   int           disk_fd;
+  ulong         max_shreds_per_block;
 
   /* Used for verifying incoming requests, and signing outgoing responses. */
   fd_sha512_t sha512[1];
@@ -332,7 +333,7 @@ handle_net_request( ctx_t             * ctx,
         ulong slot = msg->slot;
         ulong shred_idx = msg->shred_idx;
 
-        if( FD_UNLIKELY( shred_idx>=FD_SHRED_BLK_MAX ) ) {
+        if( FD_UNLIKELY( shred_idx>=ctx->max_shreds_per_block ) ) {
           ctx->metrics->fail_invalid_shred_idx++;
           return;
         }
@@ -583,6 +584,7 @@ unprivileged_init( fd_topo_t      const * topo,
     FD_LOG_ERR(( "rserve could not open the store disk file" ));
   }
 
+  ctx->max_shreds_per_block = tile->rserve.max_shreds_per_block;
   ctx->rserve    = fd_rserve_join   ( fd_rserve_new( ctx->rserve, ping_cache_entries, ctx->seed, ctx->rserve_secret ) );
   ctx->keyswitch = fd_keyswitch_join( fd_topo_obj_laddr( topo, tile->id_keyswitch_obj_id ) );
   FD_TEST( ctx->keyswitch );

--- a/src/discof/repair/test_policy.c
+++ b/src/discof/repair/test_policy.c
@@ -288,13 +288,13 @@ new_policy( fd_wksp_t * wksp ) {
 static void
 test_orphan_due_prq( fd_wksp_t * wksp ) {
   ulong const slot_max = 16UL;
-  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * dedup_mem  = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( slot_max ), 1UL );
   void * repair_mem = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(),           1UL );
   FD_TEST( forest_mem && dedup_mem && repair_mem );
 
   fd_pubkey_t identity = {0};
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_reqlim_t * dedup  = fd_reqlim_join( fd_reqlim_new( dedup_mem, slot_max, 0UL ) );
   fd_repair_t * repair = fd_repair_join( fd_repair_new( repair_mem, &identity ) );
   fd_policy_t * policy = new_policy( wksp );
@@ -359,13 +359,13 @@ next_msg( fd_policy_t * policy, fd_reqlim_t * dedup, fd_forest_t * forest, fd_re
 static void
 test_shred_skip_memo( fd_wksp_t * wksp ) {
   ulong const slot_max = 16UL;
-  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * dedup_mem  = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( slot_max ), 1UL );
   void * repair_mem = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(),           1UL );
   FD_TEST( forest_mem && dedup_mem && repair_mem );
 
   fd_pubkey_t identity = {0};
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_reqlim_t * dedup  = fd_reqlim_join( fd_reqlim_new( dedup_mem, slot_max, 0UL ) );
   fd_repair_t * repair = fd_repair_join( fd_repair_new( repair_mem, &identity ) );
   fd_policy_t * policy = new_policy( wksp );
@@ -443,13 +443,13 @@ test_shred_skip_memo( fd_wksp_t * wksp ) {
 static void
 test_orphan_dedup_reschedule( fd_wksp_t * wksp ) {
   ulong const slot_max = 16UL;
-  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * dedup_mem  = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( slot_max ), 1UL );
   void * repair_mem = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(),           1UL );
   FD_TEST( forest_mem && dedup_mem && repair_mem );
 
   fd_pubkey_t identity = {0};
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_reqlim_t * dedup  = fd_reqlim_join( fd_reqlim_new( dedup_mem, slot_max, 0UL ) );
   fd_repair_t * repair = fd_repair_join( fd_repair_new( repair_mem, &identity ) );
   fd_policy_t * policy = new_policy( wksp );
@@ -485,13 +485,13 @@ test_orphan_dedup_reschedule( fd_wksp_t * wksp ) {
 static void
 test_orphan_reclaim_and_rehead( fd_wksp_t * wksp ) {
   ulong const slot_max = 4UL;
-  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * dedup_mem  = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( 64UL ),     1UL );
   void * repair_mem = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(),           1UL );
   FD_TEST( forest_mem && dedup_mem && repair_mem );
 
   fd_pubkey_t identity = {0};
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_reqlim_t * dedup  = fd_reqlim_join( fd_reqlim_new( dedup_mem, 64UL, 0UL ) );
   fd_repair_t * repair = fd_repair_join( fd_repair_new( repair_mem, &identity ) );
   fd_policy_t * policy = new_policy( wksp );
@@ -547,13 +547,13 @@ test_orphan_reclaim_and_rehead( fd_wksp_t * wksp ) {
 static void
 test_orphan_rehead_revival( fd_wksp_t * wksp ) {
   ulong const slot_max = 4UL;
-  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * dedup_mem  = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( 64UL ),     1UL );
   void * repair_mem = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(),           1UL );
   FD_TEST( forest_mem && dedup_mem && repair_mem );
 
   fd_pubkey_t identity = {0};
-  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, 0UL ) );
+  fd_forest_t * forest = fd_forest_join( fd_forest_new( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   fd_reqlim_t * dedup  = fd_reqlim_join( fd_reqlim_new( dedup_mem, 64UL, 0UL ) );
   fd_repair_t * repair = fd_repair_join( fd_repair_new( repair_mem, &identity ) );
   fd_policy_t * policy = new_policy( wksp );

--- a/src/discof/repair/test_repair_tile.c
+++ b/src/discof/repair/test_repair_tile.c
@@ -27,7 +27,7 @@ setup_ctx( ctx_t * ctx, fd_wksp_t * wksp, ulong slot_max ) {
 
   FD_TEST( fd_rng_secure( ctx->repair_nonce_ss, sizeof(fd_rnonce_ss_t) ) );
 
-  void * forest_mem     = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max ), 1UL );
+  void * forest_mem     = fd_wksp_alloc_laddr( wksp, fd_forest_align(), fd_forest_footprint( slot_max, FD_SHRED_BLK_MAX ), 1UL );
   void * policy_mem     = fd_wksp_alloc_laddr( wksp, fd_policy_align(), fd_policy_footprint( peer_max ), 1UL );
   void * dedup_mem      = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(), fd_reqlim_footprint( dedup_max ), 1UL );
   void * inflights_mem  = fd_wksp_alloc_laddr( wksp, fd_inflights_align(), fd_inflights_footprint(), 1UL );
@@ -36,7 +36,7 @@ setup_ctx( ctx_t * ctx, fd_wksp_t * wksp, ulong slot_max ) {
   void * repair_mem     = fd_wksp_alloc_laddr( wksp, fd_repair_align(), fd_repair_footprint(), 1UL );
   void * metrics_mem    = fd_wksp_alloc_laddr( wksp, fd_repair_metrics_align(), fd_repair_metrics_footprint(), 1UL );
 
-  ctx->forest       = fd_forest_join        ( fd_forest_new        ( forest_mem, slot_max, 0UL ) );
+  ctx->forest       = fd_forest_join        ( fd_forest_new        ( forest_mem, slot_max, FD_SHRED_BLK_MAX, 0UL ) );
   ctx->policy       = fd_policy_join        ( fd_policy_new        ( policy_mem, peer_max, 0UL, ctx->repair_nonce_ss ) );
   ctx->dedup        = fd_reqlim_join        ( fd_reqlim_new         ( dedup_mem, dedup_max, 0UL ) );
   ctx->inflights    = fd_inflights_join     ( fd_inflights_new     ( inflights_mem, 0UL ) );
@@ -842,8 +842,8 @@ test_parent_edge_mismatch_with_verified_fec0( fd_wksp_t * wksp ) {
    FD_TEST( slot10->parent_slot == 9 );
    FD_TEST( slot10->buffered_idx == slot10->complete_idx );
    FD_TEST( slot10->complete_idx == FD_FEC_SHRED_CNT - 1U );
-   FD_TEST( fd_hash_eq( &slot10->merkle_roots[0].mr,  &mr_10 ) );
-   FD_TEST( fd_hash_eq( &slot10->merkle_roots[0].cmr, &mr_9  ) );
+   FD_TEST( fd_hash_eq( &fd_forest_blk_mroots( ctx->forest, slot10 )[0].mr,  &mr_10 ) );
+   FD_TEST( fd_hash_eq( &fd_forest_blk_mroots( ctx->forest, slot10 )[0].cmr, &mr_9  ) );
 
    /* Slot 10 gets duplicate confirmed which triggers check_confirmed.
       The parent edge mismatch is detected and slot 8 is returned as the bad block.

--- a/src/discof/replay/fd_replay_tile.c
+++ b/src/discof/replay/fd_replay_tile.c
@@ -151,13 +151,15 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
     l = FD_LAYOUT_APPEND( l, fd_reasm_align(),                    fd_reasm_footprint( tile->replay.fec_max ) );
   }
   l = FD_LAYOUT_APPEND( l, alignof(fd_reception_stats_t),       sizeof(fd_reception_stats_t)*tile->replay.max_live_slots );
-  l = FD_LAYOUT_APPEND( l, fd_sched_align(),                    fd_sched_footprint( tile->replay.sched_depth, tile->replay.max_live_slots ) );
+  l = FD_LAYOUT_APPEND( l, fd_sched_align(),                    fd_sched_footprint( tile->replay.sched_depth, tile->replay.max_live_slots, tile->replay.max_shreds_per_block, tile->replay.max_txn_per_slot ) );
   l = FD_LAYOUT_APPEND( l, fd_vote_tracker_align(),             fd_vote_tracker_footprint() );
   l = FD_LAYOUT_APPEND( l, fd_capture_ctx_align(),              fd_capture_ctx_footprint() );
   l = FD_LAYOUT_APPEND( l, alignof(fd_dump_proto_ctx_t),        sizeof(fd_dump_proto_ctx_t) );
   l = FD_LAYOUT_APPEND( l, alignof(fd_event_block_completed_t), sizeof(fd_event_block_completed_t) );
   l = FD_LAYOUT_APPEND( l, fd_timing_slot_pool_align(),         fd_timing_slot_pool_footprint( FD_REPLAY_TXN_TIMING_SLOTS ) );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_replay_txn_timing_t),     FD_REPLAY_TXN_TIMING_SLOTS*tile->replay.max_txn_per_slot*sizeof(fd_replay_txn_timing_t) );
   l = FD_LAYOUT_APPEND( l, alignof(ulong),                      tile->replay.max_live_slots*sizeof(ulong) );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_reasm_fec_t *),           (tile->replay.max_shreds_per_block/FD_FEC_SHRED_CNT)*sizeof(fd_reasm_fec_t *) );
 
   if( FD_UNLIKELY( tile->replay.dump_block_to_pb ) ) {
     l = FD_LAYOUT_APPEND( l, fd_block_dump_context_align(), fd_block_dump_context_footprint() );
@@ -627,7 +629,7 @@ block_completed_event_fill_leader_txn_timing( fd_replay_tile_t *           ctx,
                                               fd_bank_t *                  bank ) {
   ulong tidx = ctx->leader_stats.timing_table_idx;
   if( FD_UNLIKELY( !ctx->leader_txn_timing || tidx>=FD_LEADER_TXN_TIMING_TABLE_CNT ) ) return;
-  fd_leader_txn_timing_table_t const * table = &ctx->leader_txn_timing[ tidx ];
+  fd_leader_txn_timing_table_t const * table = fd_leader_txn_timing_table_const( ctx->leader_txn_timing, tidx, ctx->max_txn_per_slot );
   if( FD_UNLIKELY( table->slot!=bank->f.slot ) ) return;
 
   ulong cnt = fd_ulong_min( table->cnt, FD_EVENT_BLOCK_COMPLETED_TXN_TIMING_MAX );
@@ -692,9 +694,10 @@ report_block_completed( fd_replay_tile_t *                 ctx,
     ulong tslot = ctx->timing_slot_of_bank[ bank->idx ];
     if( FD_LIKELY( tslot!=fd_timing_slot_pool_idx_null( ctx->timing_slot_pool ) ) ) {
       fd_replay_txn_timing_slot_t const * slot = fd_timing_slot_pool_ele( ctx->timing_slot_pool, tslot );
+      fd_replay_txn_timing_t const *      rec  = ctx->timing_rec + tslot*ctx->max_txn_per_slot;
       ulong cnt = fd_ulong_min( slot->cnt, FD_EVENT_BLOCK_COMPLETED_TXN_TIMING_MAX );
       for( ulong i=0UL; i<cnt; i++ ) {
-        fd_replay_txn_timing_t const * t = &slot->rec[ i ];
+        fd_replay_txn_timing_t const * t = &rec[ i ];
         ev->txn_timing[ i ] = (fd_event_block_completed_txn_timing_t){
           .received_time             = (ulong)t->received_ns, /* already wallclock */
           .parsed_time               = t->parsed_ticks        ==LONG_MAX ? 0UL : (ulong)fd_clock_epoch_y( ctx->clock->epoch, t->parsed_ticks         ),
@@ -948,11 +951,11 @@ publish_txn_executed( fd_replay_tile_t *  ctx,
                       ulong               txn_idx ) {
   fd_sched_txn_info_t * txn_info = fd_sched_get_txn_info( ctx->sched, txn_idx );
 
-  FD_TEST( txn_info->index_in_slot<FD_MAX_TXN_PER_SLOT );
+  FD_TEST( txn_info->index_in_slot<ctx->max_txn_per_slot );
   ulong tslot = ctx->timing_slot_of_bank[ bank_idx ];
   if( FD_LIKELY( tslot!=fd_timing_slot_pool_idx_null( ctx->timing_slot_pool ) ) ) {
     fd_replay_txn_timing_slot_t * slot = fd_timing_slot_pool_ele( ctx->timing_slot_pool, tslot );
-    fd_replay_txn_timing_t * t = &slot->rec[ txn_info->index_in_slot ];
+    fd_replay_txn_timing_t * t = ctx->timing_rec + tslot*ctx->max_txn_per_slot + txn_info->index_in_slot;
     t->received_ns          = txn_info->received_ns;
     t->parsed_ticks         = txn_info->tick_parsed;
     t->sigverify_disp_ticks = txn_info->tick_sigverify_disp;
@@ -1435,7 +1438,7 @@ try_become_leader_ag( fd_replay_tile_t *        ctx,
 
   fd_cost_tracker_t const * cost_tracker = fd_bank_cost_tracker_query( bank );
 
-  msg->limits.slot_max_cost                     = ctx->larger_max_cost_per_block ? LARGER_MAX_COST_PER_BLOCK : cost_tracker->block_cost_limit;
+  msg->limits.slot_max_cost                     = cost_tracker->block_cost_limit;
   msg->limits.slot_max_vote_cost                = FD_PACK_MAX_VOTE_COST_PER_BLOCK_UPPER_BOUND;
   msg->limits.slot_max_write_cost_per_acct      = cost_tracker->account_cost_limit;
   msg->limits.slot_max_allocated_data_per_block = cost_tracker->data_size_limit;
@@ -1829,7 +1832,7 @@ try_become_leader( fd_replay_tile_t *  ctx,
 
   fd_cost_tracker_t const * cost_tracker = fd_bank_cost_tracker_query( bank );
 
-  msg->limits.slot_max_cost                     = ctx->larger_max_cost_per_block ? LARGER_MAX_COST_PER_BLOCK : cost_tracker->block_cost_limit;
+  msg->limits.slot_max_cost                     = cost_tracker->block_cost_limit;
   msg->limits.slot_max_vote_cost                = FD_PACK_MAX_VOTE_COST_PER_BLOCK_UPPER_BOUND;
   msg->limits.slot_max_write_cost_per_acct      = cost_tracker->account_cost_limit;
   msg->limits.slot_max_allocated_data_per_block = cost_tracker->data_size_limit;
@@ -2836,9 +2839,10 @@ backfill_fec_sets( fd_replay_tile_t *  ctx,
   fd_reasm_fec_t * parent = fd_reasm_parent( ctx->reasm, reasm_fec );
   FD_TEST( !!parent );
 
-  fd_reasm_fec_t * path[ FD_FEC_BLK_MAX ];
-  ulong            path_cnt = 0UL;
-  ulong            path_slot = reasm_fec->slot;
+  fd_reasm_fec_t ** path     = ctx->backfill_path;
+  ulong             path_max = ctx->max_shreds_per_block/FD_FEC_SHRED_CNT;
+  ulong             path_cnt = 0UL;
+  ulong             path_slot = reasm_fec->slot;
 
   /* Walk backward from the candidate FEC until we find one with an
      associated bank that we consider 'valid'.  A FEC is considered
@@ -2861,7 +2865,7 @@ backfill_fec_sets( fd_replay_tile_t *  ctx,
       path_slot = curr->slot;
     }
 
-    FD_TEST( path_cnt<FD_FEC_BLK_MAX );
+    FD_TEST( path_cnt<path_max );
     path[ path_cnt++ ] = curr;
 
     curr = fd_reasm_parent( ctx->reasm, curr );
@@ -4527,13 +4531,15 @@ unprivileged_init( fd_topo_t const *      topo,
     reasm_mem               = FD_SCRATCH_ALLOC_APPEND( l, fd_reasm_align(),            fd_reasm_footprint( tile->replay.fec_max ) );
   }
   void * recp_stats_mem     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_reception_stats_t), sizeof(fd_reception_stats_t)*tile->replay.max_live_slots );
-  void * sched_mem          = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),            fd_sched_footprint( tile->replay.sched_depth, tile->replay.max_live_slots ) );
+  void * sched_mem          = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),            fd_sched_footprint( tile->replay.sched_depth, tile->replay.max_live_slots, tile->replay.max_shreds_per_block, tile->replay.max_txn_per_slot ) );
   void * vote_tracker_mem   = FD_SCRATCH_ALLOC_APPEND( l, fd_vote_tracker_align(),     fd_vote_tracker_footprint() );
   void * _capture_ctx       = FD_SCRATCH_ALLOC_APPEND( l, fd_capture_ctx_align(),      fd_capture_ctx_footprint() );
   void * dump_proto_ctx_mem = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_dump_proto_ctx_t), sizeof(fd_dump_proto_ctx_t) );
   void * block_completed_ev = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_event_block_completed_t), sizeof(fd_event_block_completed_t) );
   void * timing_pool_mem    = FD_SCRATCH_ALLOC_APPEND( l, fd_timing_slot_pool_align(),  fd_timing_slot_pool_footprint( FD_REPLAY_TXN_TIMING_SLOTS ) );
+  void * timing_rec_mem     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_replay_txn_timing_t), FD_REPLAY_TXN_TIMING_SLOTS*tile->replay.max_txn_per_slot*sizeof(fd_replay_txn_timing_t) );
   void * timing_of_bank_mem = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),               tile->replay.max_live_slots*sizeof(ulong) );
+  void * backfill_path_mem  = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_reasm_fec_t *),    (tile->replay.max_shreds_per_block/FD_FEC_SHRED_CNT)*sizeof(fd_reasm_fec_t *) );
   void * block_dump_ctx     = NULL;
   if( FD_UNLIKELY( tile->replay.dump_block_to_pb ) ) {
     block_dump_ctx = FD_SCRATCH_ALLOC_APPEND( l, fd_block_dump_context_align(), fd_block_dump_context_footprint() );
@@ -4634,8 +4640,10 @@ unprivileged_init( fd_topo_t const *      topo,
 
   ctx->timing_slot_pool = fd_timing_slot_pool_join( fd_timing_slot_pool_new( timing_pool_mem, FD_REPLAY_TXN_TIMING_SLOTS ) );
   FD_TEST( ctx->timing_slot_pool );
+  ctx->timing_rec          = timing_rec_mem;
   ctx->timing_slot_of_bank = timing_of_bank_mem;
   for( ulong i=0UL; i<tile->replay.max_live_slots; i++ ) ctx->timing_slot_of_bank[ i ] = fd_timing_slot_pool_idx_null( ctx->timing_slot_pool );
+  ctx->backfill_path = backfill_path_mem;
 
   ctx->dump_proto_ctx = NULL;
   if( FD_UNLIKELY( strcmp( "", tile->replay.dump_proto_dir ) ) ) {
@@ -4658,7 +4666,8 @@ unprivileged_init( fd_topo_t const *      topo,
 
   fd_clock_tile_init( ctx->clock );
 
-  ctx->larger_max_cost_per_block = tile->replay.larger_max_cost_per_block;
+  ctx->max_txn_per_slot     = tile->replay.max_txn_per_slot;
+  ctx->max_shreds_per_block = tile->replay.max_shreds_per_block;
 
   FD_TEST( fd_rng_new( ctx->rng, ctx->rng_seed, 0UL ) );
 
@@ -4675,7 +4684,7 @@ unprivileged_init( fd_topo_t const *      topo,
 
   ctx->leader_stats.slot = ULONG_MAX;
   ctx->alpenglow         = tile->replay.alpenglow;
-  ctx->sched = fd_sched_join( fd_sched_new( sched_mem, ctx->rng, tile->replay.sched_depth, tile->replay.max_live_slots, fd_topo_tile_name_cnt( topo, "execrp" ), ctx->alpenglow ) );
+  ctx->sched = fd_sched_join( fd_sched_new( sched_mem, ctx->rng, tile->replay.sched_depth, tile->replay.max_live_slots, ctx->max_shreds_per_block, ctx->max_txn_per_slot, fd_topo_tile_name_cnt( topo, "execrp" ), ctx->alpenglow ) );
   FD_TEST( ctx->sched );
   FD_TEST( ctx->alpenglow || ctx->reasm );
 

--- a/src/discof/replay/fd_replay_tile_private.h
+++ b/src/discof/replay/fd_replay_tile_private.h
@@ -96,7 +96,6 @@ struct fd_replay_txn_timing_slot {
   } pool;
 
   ulong cnt;
-  fd_replay_txn_timing_t rec[ FD_MAX_TXN_PER_SLOT ];
 };
 
 typedef struct fd_replay_txn_timing_slot fd_replay_txn_timing_slot_t;
@@ -405,9 +404,13 @@ struct fd_replay_tile {
      so a small pool of full-depth slots is leased to banks as they start
      replaying.  A block that cannot get a slot (more than
      FD_REPLAY_TXN_TIMING_SLOTS blocks replaying at once) captures
-     nothing. */
+     nothing.  Slot depth is max_txn_per_slot, so the records sit in a
+     side array sized at footprint time. */
   fd_replay_txn_timing_slot_t * timing_slot_pool;    /* fd_pool, FD_REPLAY_TXN_TIMING_SLOTS elements */
+  fd_replay_txn_timing_t *      timing_rec;          /* [FD_REPLAY_TXN_TIMING_SLOTS*max_txn_per_slot], slot i at i*max_txn_per_slot */
   ulong *                       timing_slot_of_bank; /* [max_live_slots] bank_idx -> pool idx or idx_null */
+
+  fd_reasm_fec_t **             backfill_path;       /* [max_shreds_per_block/FD_FEC_SHRED_CNT] scratch for backfill_fec_sets */
 
   /* Whether the runtime has been booted either from snapshot loading
      or from genesis. */
@@ -418,7 +421,8 @@ struct fd_replay_tile {
 
   fd_multi_epoch_leaders_t * mleaders;
 
-  int larger_max_cost_per_block;
+  ulong max_txn_per_slot;
+  ulong max_shreds_per_block;
 
   /* When we transition to becoming leader, we can only unbecome leader
      if we have received a block id from the FEC reassembler, and a

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -5,7 +5,7 @@
 #include "fd_block_marker.h"
 #include "fd_execrp.h" /* for poh hash value */
 #include "../../ballet/sha256/fd_sha256.h"
-#include "../../disco/fd_disco_base.h" /* for FD_MAX_TXN_PER_SLOT */
+#include "../../disco/fd_disco_base.h" /* for FD_MAX_TXN_PER_SLOT_SHRED */
 #include "../../disco/fd_txn_p.h"
 #include "../../disco/metrics/fd_metrics.h" /* for fd_metrics_convert_seconds_to_ticks and etc. */
 #include "../../disco/pack/fd_chkdup.h"
@@ -210,7 +210,6 @@ struct fd_sched_block {
                                                              was ruled invalid (set-once via record_dead_reason), NONE otherwise. */
   uchar               fec_buf[ FD_SCHED_MAX_FEC_BUF_SZ ]; /* The previous FEC set could have some residual data that only becomes
                                                              parseable after the next FEC set is ingested. */
-  ushort              shred_sz[ FD_SHRED_BLK_MAX ];       /* Payload size of each ingested data shred. */
 
   /* Alpenglow block footer, deserialized out of the marker batch at
      parse time.  footer_present is set if the block carries a footer
@@ -223,7 +222,7 @@ typedef struct fd_sched_block fd_sched_block_t;
 
 FD_STATIC_ASSERT( sizeof(fd_sched_mblk_t)==120UL, fd_sched_mblk );
 FD_STATIC_ASSERT( sizeof(fd_sched_txn_info_t)==192UL, fd_sched_txn_info );
-FD_STATIC_ASSERT( sizeof(fd_sched_block_t)==141632UL, fd_sched_block );
+FD_STATIC_ASSERT( sizeof(fd_sched_block_t)==76096UL, fd_sched_block );
 FD_STATIC_ASSERT( sizeof(fd_hash_t)==sizeof(((fd_microblock_hdr_t *)0)->hash), unexpected poh hash size );
 
 
@@ -282,6 +281,9 @@ struct fd_sched {
   fd_acct_addr_t        aluts[ 256 ]; /* Resolve ALUT accounts into this buffer for more parallelism. */
   char                  print_buf[ FD_SCHED_MAX_PRINT_BUF_SZ ];
   ulong                 print_buf_sz;
+  ushort *              shred_sz;             /* Payload size of each ingested data shred, max_shreds_per_block per block pool idx. */
+  ulong                 max_shreds_per_block; /* Immutable. */
+  ulong                 max_txn_per_slot;     /* Immutable. */
   fd_chkdup_t           chkdup[ 1 ];
   fd_sched_metrics_t    metrics[ 1 ];
   int                   is_alpenglow; /* set if alpenglow is enabled. */
@@ -352,7 +354,8 @@ static void
 dispatch_sigverify( fd_sched_t * sched, fd_sched_block_t * block, ulong bank_idx, int exec_tile_idx, fd_sched_task_t * out );
 
 static uint
-shred_split( fd_sched_block_t * block,
+shred_split( fd_sched_t *       sched,
+             fd_sched_block_t * block,
              uint               query );
 
 static int
@@ -675,12 +678,14 @@ handle_bad_block( fd_sched_t * sched, fd_sched_block_t * block, int dead_reason 
    Transaction offsets are visited in nondecreasing order, so each
    shred length is scanned at most once per block. */
 static uint
-shred_split( fd_sched_block_t * block,
+shred_split( fd_sched_t *       sched,
+             fd_sched_block_t * block,
              uint               query ) {
   FD_TEST( block->shred_scan_idx<=block->shred_cnt );
   FD_TEST( block->shred_scan_off<=query );
+  ushort const * shred_sz = sched->shred_sz + block_to_idx( sched, block )*sched->max_shreds_per_block;
   while( block->shred_scan_idx<block->shred_cnt ) {
-    uint next_off = block->shred_scan_off + (uint)block->shred_sz[ block->shred_scan_idx ];
+    uint next_off = block->shred_scan_off + (uint)shred_sz[ block->shred_scan_idx ];
     if( next_off>=query ) break;
     block->shred_scan_off = next_off;
     block->shred_scan_idx++;
@@ -700,16 +705,21 @@ fd_sched_align( void ) {
 
 ulong
 fd_sched_footprint( ulong depth,
-                    ulong block_cnt_max ) {
+                    ulong block_cnt_max,
+                    ulong max_shreds_per_block,
+                    ulong max_txn_per_slot ) {
   if( FD_UNLIKELY( depth<FD_SCHED_MIN_DEPTH || depth>FD_SCHED_MAX_DEPTH ) ) return 0UL; /* bad depth */
   if( FD_UNLIKELY( !block_cnt_max ) ) return 0UL; /* bad block_cnt_max */
   if( FD_UNLIKELY( depth>UINT_MAX-1UL ) ) return 0UL; /* mblk_pool use uint as pointers */
+  if( FD_UNLIKELY( !max_shreds_per_block || max_shreds_per_block>UINT_MAX ) ) return 0UL; /* shred_cnt is uint */
+  if( FD_UNLIKELY( !max_txn_per_slot     || max_txn_per_slot    >UINT_MAX ) ) return 0UL; /* txn_parsed_cnt is uint */
 
   ulong l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                         );
-  l = FD_LAYOUT_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max ) ); /* dispatcher */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)     ); /* block pool */
-  l = FD_LAYOUT_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )           );
+  l = FD_LAYOUT_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                                 );
+  l = FD_LAYOUT_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max )         ); /* dispatcher */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)             ); /* block pool */
+  l = FD_LAYOUT_APPEND( l, alignof(ushort),              block_cnt_max*max_shreds_per_block*sizeof(ushort)  ); /* shred_sz */
+  l = FD_LAYOUT_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )                   );
   l = FD_LAYOUT_APPEND( l, alignof(fd_txn_p_t),          depth*sizeof(fd_txn_p_t)                   ); /* txn_pool */
   l = FD_LAYOUT_APPEND( l, alignof(fd_sched_txn_info_t), depth*sizeof(fd_sched_txn_info_t)          ); /* txn_info_pool */
   l = FD_LAYOUT_APPEND( l, alignof(fd_sched_mblk_t),     depth*sizeof(fd_sched_mblk_t)              ); /* mblk_pool */
@@ -721,6 +731,8 @@ fd_sched_new( void *     mem,
               fd_rng_t * rng,
               ulong      depth,
               ulong      block_cnt_max,
+              ulong      max_shreds_per_block,
+              ulong      max_txn_per_slot,
               ulong      exec_cnt,
               int        is_alpenglow ) {
 
@@ -754,19 +766,30 @@ fd_sched_new( void *     mem,
     return NULL;
   }
 
+  if( FD_UNLIKELY( !max_shreds_per_block || max_shreds_per_block>UINT_MAX ) ) {
+    FD_LOG_WARNING(( "bad max_shreds_per_block (%lu)", max_shreds_per_block ));
+    return NULL;
+  }
+
+  if( FD_UNLIKELY( !max_txn_per_slot || max_txn_per_slot>UINT_MAX ) ) {
+    FD_LOG_WARNING(( "bad max_txn_per_slot (%lu)", max_txn_per_slot ));
+    return NULL;
+  }
+
   if( FD_UNLIKELY( !exec_cnt || exec_cnt>FD_SCHED_MAX_EXEC_TILE_CNT ) ) {
     FD_LOG_WARNING(( "bad exec_cnt (%lu)", exec_cnt ));
     return NULL;
   }
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
-  fd_sched_t *          sched          = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                         );
-  void *                _rdisp         = FD_SCRATCH_ALLOC_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max ) );
-  void *                _bpool         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)     );
-  void *                _ref_q         = FD_SCRATCH_ALLOC_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )           );
-  fd_txn_p_t *          _txn_pool      = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txn_p_t),          depth*sizeof(fd_txn_p_t)                   );
-  fd_sched_txn_info_t * _txn_info_pool = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_txn_info_t), depth*sizeof(fd_sched_txn_info_t)          );
-  fd_sched_mblk_t *     _mblk_pool     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_mblk_t),     depth*sizeof(fd_sched_mblk_t)              );
+  fd_sched_t *          sched          = FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                                );
+  void *                _rdisp         = FD_SCRATCH_ALLOC_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max )        );
+  void *                _bpool         = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)            );
+  /*                                   */ FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),              block_cnt_max*max_shreds_per_block*sizeof(ushort) );
+  void *                _ref_q         = FD_SCRATCH_ALLOC_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )                  );
+  fd_txn_p_t *          _txn_pool      = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txn_p_t),          depth*sizeof(fd_txn_p_t)                          );
+  fd_sched_txn_info_t * _txn_info_pool = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_txn_info_t), depth*sizeof(fd_sched_txn_info_t)                 );
+  fd_sched_mblk_t *     _mblk_pool     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_mblk_t),     depth*sizeof(fd_sched_mblk_t)                     );
   FD_SCRATCH_ALLOC_FINI( l, fd_sched_align() );
 
   sched->txn_pool      = _txn_pool;
@@ -794,6 +817,8 @@ fd_sched_new( void *     mem,
   sched->canary                 = FD_SCHED_MAGIC;
   sched->depth                  = depth;
   sched->block_cnt_max          = block_cnt_max;
+  sched->max_shreds_per_block   = max_shreds_per_block;
+  sched->max_txn_per_slot       = max_txn_per_slot;
   sched->exec_cnt               = exec_cnt;
   sched->poh_simd_max           = fd_sha256_simd_lane_max(); FD_CHECK_ERR( sched->poh_simd_max<=FD_SCHED_POH_PARA, "overly wide PoH SHA batch" );
   sched->poh_simd_min           = fd_sha256_simd_lane_min();
@@ -838,22 +863,25 @@ fd_sched_join( void * mem ) {
 
   fd_sched_t * sched         = (fd_sched_t *)mem;
   FD_TEST( sched->canary==FD_SCHED_MAGIC );
-  ulong        depth         = sched->depth;
-  ulong        block_cnt_max = sched->block_cnt_max;
+  ulong        depth                = sched->depth;
+  ulong        block_cnt_max        = sched->block_cnt_max;
+  ulong        max_shreds_per_block = sched->max_shreds_per_block;
 
   FD_SCRATCH_ALLOC_INIT( l, mem );
-  /*                     */ FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                         );
-  void *           _rdisp = FD_SCRATCH_ALLOC_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max ) );
-  void *           _bpool = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)     );
-  void *           _ref_q = FD_SCRATCH_ALLOC_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )           );
-  /*                     */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txn_p_t),          depth*sizeof(fd_txn_p_t)                   );
-  /*                     */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_txn_info_t), depth*sizeof(fd_sched_txn_info_t)          );
-  /*                     */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_mblk_t),     depth*sizeof(fd_sched_mblk_t)              );
+  /*                        */ FD_SCRATCH_ALLOC_APPEND( l, fd_sched_align(),             sizeof(fd_sched_t)                                );
+  void *           _rdisp    = FD_SCRATCH_ALLOC_APPEND( l, fd_rdisp_align(),             fd_rdisp_footprint( depth, block_cnt_max )        );
+  void *           _bpool    = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_block_t),    block_cnt_max*sizeof(fd_sched_block_t)            );
+  void *           _shred_sz = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),              block_cnt_max*max_shreds_per_block*sizeof(ushort) );
+  void *           _ref_q    = FD_SCRATCH_ALLOC_APPEND( l, ref_q_align(),                ref_q_footprint( block_cnt_max )                  );
+  /*                        */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txn_p_t),          depth*sizeof(fd_txn_p_t)                          );
+  /*                        */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_txn_info_t), depth*sizeof(fd_sched_txn_info_t)                 );
+  /*                        */ FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sched_mblk_t),     depth*sizeof(fd_sched_mblk_t)                     );
   FD_SCRATCH_ALLOC_FINI( l, fd_sched_align() );
 
   sched->rdisp      = fd_rdisp_join( _rdisp );
   sched->ref_q      = ref_q_join( _ref_q );
   sched->block_pool = _bpool;
+  sched->shred_sz   = _shred_sz;
 
   for( ulong i=0; i<block_cnt_max; i++ ) {
     mblk_slist_join( sched->block_pool[ i ].mblks_unhashed );
@@ -1124,9 +1152,10 @@ fd_sched_fec_ingest( fd_sched_t *     sched,
   block->fec_eob = fec->is_last_in_batch;
   block->fec_eos = fec->is_last_in_block;
 
+  ushort * shred_sz = sched->shred_sz + fec->bank_idx*sched->max_shreds_per_block;
   uint prev_shred_off = 0U;
   for( ulong i=0; i<fec->shred_cnt; i++ ) {
-    FD_TEST( block->shred_cnt<FD_SHRED_BLK_MAX );
+    FD_TEST( block->shred_cnt<sched->max_shreds_per_block );
     uint shred_off;
     if( FD_LIKELY( i<32UL ) ) {
       shred_off = fec->fec->shred_offs[ i ];
@@ -1141,7 +1170,7 @@ fd_sched_fec_ingest( fd_sched_t *     sched,
       shred_off = (uint)fec->fec->data_sz;
     }
     FD_TEST( shred_off>=prev_shred_off && shred_off-prev_shred_off<=USHORT_MAX );
-    block->shred_sz[ block->shred_cnt++ ] = (ushort)(shred_off-prev_shred_off);
+    shred_sz[ block->shred_cnt++ ] = (ushort)(shred_off-prev_shred_off);
     prev_shred_off = shred_off;
   }
 
@@ -2311,7 +2340,7 @@ fd_sched_parse( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_ctx_
       fd_microblock_hdr_t * hdr = (fd_microblock_hdr_t *)fd_type_pun( block->fec_buf+block->fec_buf_soff );
       block->fec_buf_soff      += (uint)sizeof(fd_microblock_hdr_t);
 
-      if( FD_UNLIKELY( hdr->txn_cnt>fd_ulong_sat_sub( FD_MAX_TXN_PER_SLOT, block->txn_parsed_cnt ) ) ) {
+      if( FD_UNLIKELY( hdr->txn_cnt>fd_ulong_sat_sub( sched->max_txn_per_slot, block->txn_parsed_cnt ) ) ) {
         FD_LOG_INFO(( "bad block: TOO_MANY_TXNS, microblock header declared too many transactions, slot %lu, parent slot %lu, txn_parsed_cnt %u, hdr->txn_cnt %lu", block->slot, block->parent_slot, block->txn_parsed_cnt, hdr->txn_cnt ));
         return FD_SCHED_DEAD_REASON_TOO_MANY_TXNS;
       }
@@ -2598,9 +2627,9 @@ fd_sched_parse_txn( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_
   /* Can't parse out a full transaction yet, EAGAIN. */
   if( FD_UNLIKELY( !pay_sz || !txn_sz ) ) return -1;
 
-  if( FD_UNLIKELY( block->txn_parsed_cnt>=FD_MAX_TXN_PER_SLOT ) ) {
+  if( FD_UNLIKELY( block->txn_parsed_cnt>=sched->max_txn_per_slot ) ) {
     /* Transaction count is enforced as invariant
-       txn_parsed_cnt+txns_rem<=FD_MAX_TXN_PER_SLOT
+       txn_parsed_cnt+txns_rem<=max_txn_per_slot
        when we read the declared count in a microblock header.  So we
        shouldn't get here. */
     sched->print_buf_sz = 0UL;
@@ -2714,9 +2743,9 @@ fd_sched_parse_txn( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_
   fd_txn_p_t * txn_p = sched->txn_pool + txn_idx;
   txn_p->payload_sz  = pay_sz;
 
-  txn_p->start_shred_idx = (ushort)shred_split( block, block->fec_buf_boff+block->fec_buf_soff );
+  txn_p->start_shred_idx = (ushort)fd_uint_min( shred_split( sched, block, block->fec_buf_boff+block->fec_buf_soff ), USHORT_MAX ); /* monitoring-only ushorts; saturate under bench shred counts */
   txn_p->start_shred_idx = fd_ushort_if( txn_p->start_shred_idx>0U, (ushort)(txn_p->start_shred_idx-1U), txn_p->start_shred_idx );
-  txn_p->end_shred_idx = (ushort)shred_split( block, block->fec_buf_boff+block->fec_buf_soff+(uint)pay_sz );
+  txn_p->end_shred_idx = (ushort)fd_uint_min( shred_split( sched, block, block->fec_buf_boff+block->fec_buf_soff+(uint)pay_sz ), USHORT_MAX );
 
   fd_memcpy( txn_p->payload, payload, pay_sz );
   fd_memcpy( TXN(txn_p),     txn,     txn_sz );

--- a/src/discof/replay/fd_sched.h
+++ b/src/discof/replay/fd_sched.h
@@ -252,14 +252,20 @@ FD_PROTOTYPES_BEGIN
    depth controls the reorder buffer transaction count (~1 million
    recommended for live replay, ~10k recommended for async replay).
    block_cnt_max is the maximum number of blocks that will be tracked by
-   the scheduler. */
+   the scheduler.  max_shreds_per_block bounds the data shreds a block
+   may hold (the shred tile enforces the same limit upstream, sched
+   asserts it); a block declaring more than max_txn_per_slot
+   transactions is ruled invalid.  FD_SHRED_BLK_MAX and
+   FD_MAX_TXN_PER_SLOT in production. */
 
 ulong
 fd_sched_align( void );
 
 ulong
-fd_sched_footprint( ulong depth,           /* in [FD_SCHED_MIN_DEPTH,FD_SCHED_MAX_DEPTH] */
-                    ulong block_cnt_max ); /* >= 1 */
+fd_sched_footprint( ulong depth,                /* in [FD_SCHED_MIN_DEPTH,FD_SCHED_MAX_DEPTH] */
+                    ulong block_cnt_max,        /* >= 1 */
+                    ulong max_shreds_per_block, /* in [1,UINT_MAX] */
+                    ulong max_txn_per_slot );   /* in [1,UINT_MAX] */
 
 /* fd_sched_new creates a sched object backed by the given memory region
    (conforming to align() and footprint()).  Returns NULL if any
@@ -270,6 +276,8 @@ fd_sched_new( void *     mem,
               fd_rng_t * rng,
               ulong      depth,
               ulong      block_cnt_max,
+              ulong      max_shreds_per_block,
+              ulong      max_txn_per_slot,
               ulong      exec_cnt,
               int        is_alpenglow );
 

--- a/src/discof/replay/fuzz_sched_rdisp.c
+++ b/src/discof/replay/fuzz_sched_rdisp.c
@@ -765,7 +765,7 @@ build_case( case_t * tc, uchar const * data, ulong data_sz ) {
 
   fd_rng_t rng[1];
   fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  tc->sched = fd_sched_join( fd_sched_new( tc->mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
+  tc->sched = fd_sched_join( fd_sched_new( tc->mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
 
   /* Seed the scheduler with bank 0 as a completed snapshot root.  The
      notify/advance pair is a no-op for the current root, but using the
@@ -1363,7 +1363,7 @@ LLVMFuzzerInitialize( int  *   argc,
   fd_log_level_core_set( 3 );
   atexit( fd_halt );
 
-  FD_TEST( fd_sched_footprint( TEST_SCHED_DEPTH, TEST_SCHED_BLOCK_CNT_MAX )<=sizeof(g_sched_mem) );
+  FD_TEST( fd_sched_footprint( TEST_SCHED_DEPTH, TEST_SCHED_BLOCK_CNT_MAX, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )<=sizeof(g_sched_mem) );
   FD_TEST( fd_sched_align()==TEST_SCHED_MEM_ALIGN );
 
   return 0;

--- a/src/discof/replay/test_replay_tile.c
+++ b/src/discof/replay/test_replay_tile.c
@@ -321,11 +321,17 @@ static void
 setup_timing( fd_replay_tile_t * ctx,
               fd_wksp_t *        wksp ) {
   fd_clock_tile_init( ctx->clock );
+  ctx->max_txn_per_slot     = FD_MAX_TXN_PER_SLOT;
+  ctx->max_shreds_per_block = FD_SHRED_BLK_MAX;
   void * mem = fd_wksp_alloc_laddr( wksp, fd_timing_slot_pool_align(), fd_timing_slot_pool_footprint( FD_REPLAY_TXN_TIMING_SLOTS ), 1UL );
   ctx->timing_slot_pool = fd_timing_slot_pool_join( fd_timing_slot_pool_new( mem, FD_REPLAY_TXN_TIMING_SLOTS ) );
   FD_TEST( ctx->timing_slot_pool );
+  ctx->timing_rec = fd_wksp_alloc_laddr( wksp, alignof(fd_replay_txn_timing_t), FD_REPLAY_TXN_TIMING_SLOTS*ctx->max_txn_per_slot*sizeof(fd_replay_txn_timing_t), 1UL );
+  FD_TEST( ctx->timing_rec );
   ctx->timing_slot_of_bank = test_timing_of_bank;
   for( ulong i=0UL; i<TEST_BANKS_MAX; i++ ) ctx->timing_slot_of_bank[ i ] = fd_timing_slot_pool_idx_null( ctx->timing_slot_pool );
+  ctx->backfill_path = fd_wksp_alloc_laddr( wksp, alignof(fd_reasm_fec_t *), (ctx->max_shreds_per_block/FD_FEC_SHRED_CNT)*sizeof(fd_reasm_fec_t *), 1UL );
+  FD_TEST( ctx->backfill_path );
 }
 
 static void
@@ -964,7 +970,7 @@ test_consensus_root_notification_handoff( fd_wksp_t * wksp ) {
 
   void * store_mem = fd_wksp_alloc_laddr( wksp, fd_store_align(), fd_store_footprint( 2UL, 1UL, 0UL, 0UL, 0UL ), 1UL );
   FD_TEST( store_mem );
-  ctx->store = fd_store_join( fd_store_new( store_mem, 2UL, 1UL, 0UL, 0UL, 0UL, "/tmp/test_replay_tile_fec_payload.db", 0UL ) );
+  ctx->store = fd_store_join( fd_store_new( store_mem, 2UL, 1UL, 0UL, 0UL, 0UL, FD_SHRED_BLK_MAX, "/tmp/test_replay_tile_fec_payload.db", 0UL ) );
   FD_TEST( ctx->store );
   FD_TEST( fd_store_map_ljoin( ctx->store, ctx->map_join ) );
   ctx->store_disk_fd = -1;

--- a/src/discof/replay/test_sched.c
+++ b/src/discof/replay/test_sched.c
@@ -14,8 +14,14 @@
 static void
 test_sched_footprint( void ) {
   /* Retain the per-block saving from compact shred lengths under the
-     default scheduler sizing. */
-  FD_TEST( fd_sched_footprint( 65536UL, 2048UL )==1122073984UL );
+     default scheduler sizing.  Production limits must reproduce the
+     footprint from before the limits became runtime values. */
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1122073984UL );
+  /* Only the shred length array scales with the shred limit. */
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, 4UL*FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1122073984UL+2048UL*3UL*FD_SHRED_BLK_MAX*sizeof(ushort) );
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, 5UL*FD_MAX_TXN_PER_SLOT )==1122073984UL );
+  FD_TEST( !fd_sched_footprint( 65536UL, 2048UL, 0UL, FD_MAX_TXN_PER_SLOT ) );
+  FD_TEST( !fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, 0UL ) );
 }
 
 static void
@@ -94,12 +100,12 @@ build_shred_test_txn( uchar * payload ) {
 
 static void
 run_interleaved_fec_residual_case( void ) {
-  ulong footprint = fd_sched_footprint( FD_SCHED_MIN_DEPTH, 4UL );
+  ulong footprint = fd_sched_footprint( FD_SCHED_MIN_DEPTH, 4UL, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT );
   void * mem = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
 
   fd_rng_t rng[ 1 ]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, FD_SCHED_MIN_DEPTH, 4UL, TEST_EXEC_CNT, 0 ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, FD_SCHED_MIN_DEPTH, 4UL, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
   fd_sched_set_bypass_poh_verify( sched, 1 );
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -256,12 +262,12 @@ run_bad_tick_case( fd_hash_t const * start_poh,
      one spare slot. */
   ulong depth         = fd_ulong_max( FD_SCHED_MIN_DEPTH, 512UL );
   ulong block_cnt_max = 4UL;
-  ulong footprint     = fd_sched_footprint( depth, block_cnt_max );
+  ulong footprint     = fd_sched_footprint( depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT );
   void * mem          = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
 
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
 
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -359,12 +365,12 @@ run_poh_spread_case( ulong tick_cnt,
                      ulong hashes_per_tick ) {
   ulong depth         = fd_ulong_max( FD_SCHED_MIN_DEPTH, 512UL );
   ulong block_cnt_max = 4UL;
-  ulong footprint     = fd_sched_footprint( depth, block_cnt_max );
+  ulong footprint     = fd_sched_footprint( depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT );
   void * mem          = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
 
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
 
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -499,12 +505,12 @@ run_lane_policy_case( void ) {
   /* This test only needs the root and a handful of synthetic branches. */
   ulong depth         = fd_ulong_max( FD_SCHED_MIN_DEPTH, 512UL );
   ulong block_cnt_max = 8UL;
-  ulong footprint     = fd_sched_footprint( depth, block_cnt_max );
+  ulong footprint     = fd_sched_footprint( depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT );
   void * mem          = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
 
   fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
 
   fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
@@ -627,10 +633,10 @@ add_live_block( fd_sched_t * sched,
 static fd_sched_t *
 new_sched( fd_rng_t * rng, void ** mem_out, ulong block_cnt_max ) {
   ulong depth     = fd_ulong_max( FD_SCHED_MIN_DEPTH, 512UL );
-  ulong footprint = fd_sched_footprint( depth, block_cnt_max );
+  ulong footprint = fd_sched_footprint( depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT );
   void * mem      = aligned_alloc( fd_sched_align(), footprint );
   FD_TEST( mem );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, TEST_EXEC_CNT, 0 ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
   FD_TEST( sched );
   *mem_out = mem;
   return sched;
@@ -780,6 +786,93 @@ run_late_ancestor_discard_case( void ) {
   fd_sched_delete( fd_sched_leave( sched ) ); free( mem );
 }
 
+/* The per-block shred and transaction limits are runtime values.  A
+   block declaring more transactions than the limit is ruled invalid,
+   and shred lengths past the first FEC land in the block's own slice of
+   the shred length array. */
+static void
+run_runtime_limit_case( void ) {
+  fd_rng_t rng[1]; fd_rng_join( fd_rng_new( rng, 0U, 0UL ) );
+  ulong depth         = fd_ulong_max( FD_SCHED_MIN_DEPTH, 512UL );
+  ulong block_cnt_max = 4UL;
+
+  /* Shred limit: a 3 shred block under a limit of 3 fits across two FEC
+     sets, and a sibling block gets its own shred slice. */
+  {
+    ulong footprint = fd_sched_footprint( depth, block_cnt_max, 3UL, FD_MAX_TXN_PER_SLOT );
+    void * mem = aligned_alloc( fd_sched_align(), footprint );
+    FD_TEST( mem );
+    fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, 3UL, FD_MAX_TXN_PER_SLOT, TEST_EXEC_CNT, 0 ) );
+    FD_TEST( sched );
+    fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
+
+    fd_store_fec_t store_fec[ 1 ] __attribute__((aligned(alignof(fd_store_fec_t))));
+    fd_memset( store_fec, 0, sizeof(fd_store_fec_t) );
+    fd_sched_fec_t fec[ 1 ] = {{
+      .bank_idx          = 2UL,
+      .parent_bank_idx   = 1UL,
+      .slot              = TEST_ROOT_SLOT+1UL,
+      .parent_slot       = TEST_ROOT_SLOT,
+      .fec               = store_fec,
+      .shred_cnt         = 2U,
+      .is_first_in_block = 1U
+    }};
+    FD_TEST( fd_sched_fec_ingest( sched, fec ) );
+    FD_TEST( fd_sched_get_shred_cnt( sched, 2UL )==2U );
+
+    fec->is_first_in_block = 0U;
+    fec->shred_cnt         = 1U;
+    FD_TEST( fd_sched_fec_ingest( sched, fec ) );
+    FD_TEST( fd_sched_get_shred_cnt( sched, 2UL )==3U );
+
+    fec->bank_idx          = 3UL;
+    fec->shred_cnt         = 3U;
+    fec->is_first_in_block = 1U;
+    FD_TEST( fd_sched_fec_ingest( sched, fec ) );
+    FD_TEST( fd_sched_get_shred_cnt( sched, 3UL )==3U );
+
+    while( fd_sched_pruned_block_next( sched )!=ULONG_MAX ) {}
+    fd_sched_delete( fd_sched_leave( sched ) ); free( mem );
+  }
+
+  /* Transaction limit: a microblock header declaring more transactions
+     than the limit allows rules the block invalid at ingest. */
+  {
+    ulong footprint = fd_sched_footprint( depth, block_cnt_max, FD_SHRED_BLK_MAX, 1UL );
+    void * mem = aligned_alloc( fd_sched_align(), footprint );
+    FD_TEST( mem );
+    fd_sched_t * sched = fd_sched_join( fd_sched_new( mem, rng, depth, block_cnt_max, FD_SHRED_BLK_MAX, 1UL, TEST_EXEC_CNT, 0 ) );
+    FD_TEST( sched );
+    fd_sched_block_add_done( sched, 1UL, ULONG_MAX, TEST_ROOT_SLOT );
+
+    uchar encoded[ sizeof(ulong)+sizeof(fd_microblock_hdr_t) ] = {0};
+    FD_STORE( ulong, encoded, 1UL );
+    fd_microblock_hdr_t hdr = { .hash_cnt = 1UL, .txn_cnt = 2UL };
+    fd_memcpy( encoded+sizeof(ulong), &hdr, sizeof(hdr) );
+
+    fd_store_fec_t store_fec[ 1 ] __attribute__((aligned(alignof(fd_store_fec_t))));
+    fd_memset( store_fec, 0, sizeof(fd_store_fec_t) );
+    store_fec->data_sz         = sizeof(encoded);
+    store_fec->shred_offs[ 0 ] = (uint)sizeof(encoded);
+    fd_sched_fec_t fec[ 1 ] = {{
+      .bank_idx          = 2UL,
+      .parent_bank_idx   = 1UL,
+      .slot              = TEST_ROOT_SLOT+1UL,
+      .parent_slot       = TEST_ROOT_SLOT,
+      .fec               = store_fec,
+      .data              = encoded,
+      .shred_cnt         = 1U,
+      .is_first_in_block = 1U
+    }};
+    FD_TEST( fd_sched_fec_can_ingest( sched, fec ) );
+    FD_TEST( !fd_sched_fec_ingest( sched, fec ) );
+    FD_TEST( fd_sched_get_dead_reason( sched, 2UL )==FD_SCHED_DEAD_REASON_TOO_MANY_TXNS );
+
+    while( fd_sched_pruned_block_next( sched )!=ULONG_MAX ) {}
+    fd_sched_delete( fd_sched_leave( sched ) ); free( mem );
+  }
+}
+
 int
 main( int     argc,
       char ** argv ) {
@@ -793,6 +886,7 @@ main( int     argc,
   run_abandon_flavor_case();
   run_root_notify_flavor_case();
   run_late_ancestor_discard_case();
+  run_runtime_limit_case();
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/discof/restore/fd_snapin_tile.c
+++ b/src/discof/restore/fd_snapin_tile.c
@@ -66,8 +66,9 @@ typedef struct fd_blockhash_entry fd_blockhash_entry_t;
    Ranges are bump allocated; the ranges of evicted deltas are
    reclaimed by compacting the pool when it runs full, so a status
    cache with up to 300 deltas in any order loads as long as the 151
-   retained ones fit. */
-#define FD_SNAPIN_TXNCACHE_MAX_ENTRIES (FD_TXNCACHE_MAX_SLOT_DELTAS*FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT)
+   retained ones fit.  The pool holds FD_TXNCACHE_MAX_SLOT_DELTAS slots
+   of txncache_max_entries_per_slot entries (2x the transactions per
+   slot, config->limits.max_txn_per_slot). */
 
 FD_STATIC_ASSERT( FD_TXNCACHE_MAX_SLOT_DELTAS<=FD_SLOT_DELTA_MAX_ENTRIES, txncache_staging_slot_cnt );
 
@@ -78,12 +79,9 @@ FD_STATIC_ASSERT( FD_TXNCACHE_MAX_SLOT_DELTAS<=FD_SLOT_DELTA_MAX_ENTRIES, txncac
    (once with message hash and once with signature), both times under
    the same blockhash and slot.  Groups can reference any blockhash,
    including durable nonces that are not in the recent blockhash queue.
-   So an honest slot has at most FD_MAX_TXN_PER_SLOT groups.  Snapshots
-   exceeding this are rejected as malformed. */
-#define FD_SNAPIN_MAX_GROUPS_PER_SLOT (FD_MAX_TXN_PER_SLOT)
-#define FD_SNAPIN_MAX_STAGED_GROUPS   (FD_TXNCACHE_MAX_SLOT_DELTAS*FD_SNAPIN_MAX_GROUPS_PER_SLOT)
-
-FD_STATIC_ASSERT( FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT==2UL*FD_SNAPIN_MAX_GROUPS_PER_SLOT, txncache_staging_groups_per_slot );
+   So an honest slot has at most txncache_max_groups_per_slot groups
+   (config->limits.max_txn_per_slot).  Snapshots exceeding this are
+   rejected as malformed. */
 
 struct blockhash_group {
   uchar blockhash[ 32UL ];
@@ -98,7 +96,8 @@ FD_STATIC_ASSERT( sizeof(blockhash_group_t)==40UL, blockhash_group );
 /* After filtering with the recent blockhash queue, there is at most one
    group per retained (slot, recent blockhash) pair.  Filtering can only
    happen after we receive the manifest, hence we still need
-   FD_SNAPIN_MAX_STAGED_GROUPS to buffer up worst case slot deltas. */
+   FD_TXNCACHE_MAX_SLOT_DELTAS*txncache_max_groups_per_slot worst case
+   slot deltas buffered. */
 #define FD_SNAPIN_MAX_RECENT_GROUPS (FD_TXNCACHE_MAX_SLOT_DELTAS*FD_TXNCACHE_MAX_SLOT_DELTAS)
 
 struct recent_blockhash_group {
@@ -209,6 +208,9 @@ struct fd_snapin_tile {
   ulong                   txncache_entries_len;
   ulong                   txncache_current_slot_idx;
   ulong                   txncache_current_slot_group_cnt;
+  ulong                   txncache_max_groups_per_slot;  /* config->limits.max_txn_per_slot */
+  ulong                   txncache_max_entries_per_slot; /* 2x, signature and message hash entries */
+  ulong                   txncache_entries_max;          /* FD_TXNCACHE_MAX_SLOT_DELTAS slots of entries */
 
   fd_accdb_fork_id_t accdb_root_fork_id;
   fd_accdb_fork_id_t accdb_incr_fork_id; /* child fork for incremental writes (purge on failure) */
@@ -309,7 +311,7 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   l = FD_LAYOUT_APPEND( l, fd_ssmanifest_parser_align(),      fd_ssmanifest_parser_footprint()                             );
   l = FD_LAYOUT_APPEND( l, fd_slot_delta_parser_align(),      fd_slot_delta_parser_footprint()                             );
   l = FD_LAYOUT_APPEND( l, alignof(recent_blockhash_group_t), sizeof(recent_blockhash_group_t)*FD_SNAPIN_MAX_RECENT_GROUPS );
-  l = FD_LAYOUT_APPEND( l, alignof(fd_sstxncache_hash_t),     sizeof(fd_sstxncache_hash_t)*FD_SNAPIN_TXNCACHE_MAX_ENTRIES  );
+  l = FD_LAYOUT_APPEND( l, alignof(fd_sstxncache_hash_t),     sizeof(fd_sstxncache_hash_t)*FD_TXNCACHE_MAX_SLOT_DELTAS*2UL*tile->snapin.max_txn_per_slot );
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
@@ -540,20 +542,22 @@ transition_malformed( fd_snapin_tile_t *  ctx,
 
 static blockhash_group_t *
 txncache_staging_groups_join( void * scratch,
-                              ulong  scratch_sz ) {
+                              ulong  scratch_sz,
+                              ulong  groups_max ) {
   ulong start = fd_ulong_align_up( (ulong)scratch, alignof(blockhash_group_t) );
   ulong pad   = start-(ulong)scratch;
   if( FD_UNLIKELY( pad>scratch_sz ) ) return NULL;
-  if( FD_UNLIKELY( scratch_sz-pad<FD_SNAPIN_MAX_STAGED_GROUPS*sizeof(blockhash_group_t) ) ) return NULL;
+  if( FD_UNLIKELY( scratch_sz-pad<groups_max*sizeof(blockhash_group_t) ) ) return NULL;
   return (blockhash_group_t *)start;
 }
 
 static blockhash_group_t *
 txncache_staging_scratch( fd_snapin_tile_t * ctx ) {
   ulong  scratch_sz;
-  void * scratch = fd_txncache_snapin_scratch( ctx->txncache, &scratch_sz );
-  blockhash_group_t * groups = txncache_staging_groups_join( scratch, scratch_sz );
-  if( FD_UNLIKELY( !groups ) ) FD_LOG_ERR(( "txncache scratch (%lu bytes) too small to stage %lu blockhash groups (%lu bytes)", scratch_sz, FD_SNAPIN_MAX_STAGED_GROUPS, FD_SNAPIN_MAX_STAGED_GROUPS*sizeof(blockhash_group_t) ));
+  void * scratch    = fd_txncache_snapin_scratch( ctx->txncache, &scratch_sz );
+  ulong  groups_max = FD_TXNCACHE_MAX_SLOT_DELTAS*ctx->txncache_max_groups_per_slot;
+  blockhash_group_t * groups = txncache_staging_groups_join( scratch, scratch_sz, groups_max );
+  if( FD_UNLIKELY( !groups ) ) FD_LOG_ERR(( "txncache scratch (%lu bytes) too small to stage %lu blockhash groups (%lu bytes)", scratch_sz, groups_max, groups_max*sizeof(blockhash_group_t) ));
   return groups;
 }
 
@@ -596,7 +600,7 @@ static int
 txncache_staging_group_begin( fd_snapin_tile_t * ctx,
                               uchar const *      blockhash,
                               ulong              txnhash_offset ) {
-  if( FD_UNLIKELY( ctx->txncache_current_slot_group_cnt>=FD_SNAPIN_MAX_GROUPS_PER_SLOT ) ) return -1;
+  if( FD_UNLIKELY( ctx->txncache_current_slot_group_cnt>=ctx->txncache_max_groups_per_slot ) ) return -1;
   ctx->txncache_current_slot_group_cnt++;
   ctx->blockhash_groups_cnt++;
 
@@ -605,8 +609,8 @@ txncache_staging_group_begin( fd_snapin_tile_t * ctx,
 
   FD_TEST( slot_idx<ctx->txncache_slots_len );
   txncache_staging_slot_t * staging_slot = &ctx->txncache_slots[ slot_idx ];
-  FD_TEST( staging_slot->group_cnt<FD_SNAPIN_MAX_GROUPS_PER_SLOT );
-  blockhash_group_t * group = &ctx->blockhash_groups[ slot_idx*FD_SNAPIN_MAX_GROUPS_PER_SLOT+staging_slot->group_cnt ];
+  FD_TEST( staging_slot->group_cnt<ctx->txncache_max_groups_per_slot );
+  blockhash_group_t * group = &ctx->blockhash_groups[ slot_idx*ctx->txncache_max_groups_per_slot+staging_slot->group_cnt ];
   memcpy( group->blockhash, blockhash, 32UL );
   group->txnhash_offset     = (uint)txnhash_offset;
   group->txncache_entry_cnt = 0U;
@@ -647,9 +651,9 @@ txncache_staging_entry_add( fd_snapin_tile_t * ctx,
   ulong slot_idx = ctx->txncache_current_slot_idx;
   if( FD_UNLIKELY( slot_idx==ULONG_MAX ) ) return 0; /* evicted delta, entry discarded */
 
-  if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) {
+  if( FD_UNLIKELY( ctx->txncache_entries_len>=ctx->txncache_entries_max ) ) {
     txncache_staging_compact( ctx );
-    if( FD_UNLIKELY( ctx->txncache_entries_len>=FD_SNAPIN_TXNCACHE_MAX_ENTRIES ) ) return -1;
+    if( FD_UNLIKELY( ctx->txncache_entries_len>=ctx->txncache_entries_max ) ) return -1;
   }
 
   FD_TEST( slot_idx<ctx->txncache_slots_len );
@@ -657,7 +661,7 @@ txncache_staging_entry_add( fd_snapin_tile_t * ctx,
   FD_TEST( staging_slot->slot==slot );
   FD_TEST( staging_slot->group_cnt );
   FD_TEST( staging_slot->entry_base+staging_slot->entry_cnt==ctx->txncache_entries_len );
-  blockhash_group_t * group = &ctx->blockhash_groups[ slot_idx*FD_SNAPIN_MAX_GROUPS_PER_SLOT+staging_slot->group_cnt-1UL ];
+  blockhash_group_t * group = &ctx->blockhash_groups[ slot_idx*ctx->txncache_max_groups_per_slot+staging_slot->group_cnt-1UL ];
   memcpy( ctx->txncache_entries[ ctx->txncache_entries_len ].txnhash, txnhash, sizeof(fd_sstxncache_hash_t) );
   ctx->txncache_entries_len++;
   staging_slot->entry_cnt++;
@@ -672,7 +676,7 @@ filter_staged_groups( fd_snapin_tile_t *           ctx,
   ctx->recent_groups_len = 0UL;
   for( ulong slot_idx=0UL; slot_idx<ctx->txncache_slots_len; slot_idx++ ) {
     txncache_staging_slot_t const * staging_slot = &ctx->txncache_slots[ slot_idx ];
-    blockhash_group_t const *       groups       = &ctx->blockhash_groups[ slot_idx*FD_SNAPIN_MAX_GROUPS_PER_SLOT ];
+    blockhash_group_t const *       groups       = &ctx->blockhash_groups[ slot_idx*ctx->txncache_max_groups_per_slot ];
     ulong                           entry_idx    = staging_slot->entry_base;
 
     for( ulong i=0UL; i<staging_slot->group_cnt; i++ ) {
@@ -1338,13 +1342,13 @@ handle_data_frag( fd_snapin_tile_t *  ctx,
             txncache_staging_slot_begin( ctx, sd_result->slot );
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_GROUP ) ) {
             if( FD_UNLIKELY( txncache_staging_group_begin( ctx, sd_result->group.blockhash, sd_result->group.txnhash_offset ) ) ) {
-              FD_LOG_WARNING(( "blockhash groups overflow for slot %lu, max is %lu", sd_result->group.slot, FD_SNAPIN_MAX_GROUPS_PER_SLOT ));
+              FD_LOG_WARNING(( "blockhash groups overflow for slot %lu, max is %lu", sd_result->group.slot, ctx->txncache_max_groups_per_slot ));
               transition_malformed( ctx, stem );
               return 0;
             }
           } else if( FD_LIKELY( res==FD_SLOT_DELTA_PARSER_ADVANCE_ENTRY ) ) {
             if( FD_UNLIKELY( txncache_staging_entry_add( ctx, sd_result->entry->slot, sd_result->entry->txnhash ) ) ) {
-              FD_LOG_WARNING(( "txncache entries overflow at slot %lu, max is %lu in total", sd_result->entry->slot, FD_SNAPIN_TXNCACHE_MAX_ENTRIES ));
+              FD_LOG_WARNING(( "txncache entries overflow at slot %lu, max is %lu in total", sd_result->entry->slot, ctx->txncache_entries_max ));
               transition_malformed( ctx, stem );
               return 0;
             }
@@ -1876,13 +1880,16 @@ unprivileged_init( fd_topo_t const *      topo,
   void * _manifest_parser = FD_SCRATCH_ALLOC_APPEND( l, fd_ssmanifest_parser_align(),      fd_ssmanifest_parser_footprint()                             );
   void * _sd_parser       = FD_SCRATCH_ALLOC_APPEND( l, fd_slot_delta_parser_align(),      fd_slot_delta_parser_footprint()                             );
   ctx->recent_groups      = FD_SCRATCH_ALLOC_APPEND( l, alignof(recent_blockhash_group_t), sizeof(recent_blockhash_group_t)*FD_SNAPIN_MAX_RECENT_GROUPS );
-  ctx->txncache_entries   = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sstxncache_hash_t),     sizeof(fd_sstxncache_hash_t)*FD_SNAPIN_TXNCACHE_MAX_ENTRIES  );
+  ctx->txncache_entries   = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_sstxncache_hash_t),     sizeof(fd_sstxncache_hash_t)*FD_TXNCACHE_MAX_SLOT_DELTAS*2UL*tile->snapin.max_txn_per_slot );
 
   ctx->full            = 1;
   ctx->init_completed  = 0;
   ctx->state           = FD_SNAPSHOT_STATE_IDLE;
   ctx->lane_cnt        = tile->in_cnt;
   ctx->expected_frame  = 0UL;
+  ctx->txncache_max_groups_per_slot  = tile->snapin.max_txn_per_slot;
+  ctx->txncache_max_entries_per_slot = 2UL*tile->snapin.max_txn_per_slot;
+  ctx->txncache_entries_max          = FD_TXNCACHE_MAX_SLOT_DELTAS*ctx->txncache_max_entries_per_slot;
   clear_control_barrier( ctx );
 
   void * _accdb_shmem = fd_topo_obj_laddr( topo, tile->snapin.accdb_obj_id );

--- a/src/discof/restore/test_snapin_tile.c
+++ b/src/discof/restore/test_snapin_tile.c
@@ -76,6 +76,13 @@ test_stem_publish( fd_stem_context_t * stem,
 
 #include <stdlib.h>
 
+/* Production per-slot limits (tile->snapin.max_txn_per_slot and its
+   derived staging bounds). */
+#define TEST_MAX_GROUPS_PER_SLOT  (FD_MAX_TXN_PER_SLOT)
+#define TEST_MAX_ENTRIES_PER_SLOT (2UL*FD_MAX_TXN_PER_SLOT)
+#define TEST_MAX_STAGED_GROUPS    (FD_TXNCACHE_MAX_SLOT_DELTAS*TEST_MAX_GROUPS_PER_SLOT)
+#define TEST_MAX_ENTRIES          (FD_TXNCACHE_MAX_SLOT_DELTAS*TEST_MAX_ENTRIES_PER_SLOT)
+
 int
 mock_accdb_snapshot_write_batch( fd_accdb_t *        accdb,
                                  fd_accdb_fork_id_t  fork_id,
@@ -165,7 +172,7 @@ void *
 mock_txncache_snapin_scratch( fd_txncache_t * txncache,
                               ulong *         out_sz ) {
   if( FD_UNLIKELY( !txncache ) ) {
-    *out_sz = FD_SNAPIN_MAX_STAGED_GROUPS*sizeof(blockhash_group_t);
+    *out_sz = TEST_MAX_STAGED_GROUPS*sizeof(blockhash_group_t);
     return (void *)4096UL;
   }
   return fd_txncache_snapin_scratch( txncache, out_sz );
@@ -236,6 +243,9 @@ sync_ctx_init( fd_snapin_tile_t * ctx,
   ctx->lane_cnt        = lane_cnt;
   ctx->pending_control = ULONG_MAX;
   ctx->ct_out.idx      = 0UL;
+  ctx->txncache_max_groups_per_slot  = TEST_MAX_GROUPS_PER_SLOT;
+  ctx->txncache_max_entries_per_slot = TEST_MAX_ENTRIES_PER_SLOT;
+  ctx->txncache_entries_max          = TEST_MAX_ENTRIES;
 }
 
 static void
@@ -886,7 +896,7 @@ test_txncache_staging_entry_size( void ) {
 static void
 test_txncache_staging_group_record_size( void ) {
   FD_TEST( sizeof(blockhash_group_t)==40UL );
-  FD_TEST( 2UL*FD_SNAPIN_MAX_GROUPS_PER_SLOT==FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT );
+  FD_TEST( TEST_MAX_ENTRIES_PER_SLOT==FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT );
   FD_TEST( FD_SNAPIN_MAX_RECENT_GROUPS==FD_TXNCACHE_MAX_SLOT_DELTAS*FD_TXNCACHE_MAX_SLOT_DELTAS );
 }
 
@@ -894,7 +904,7 @@ static void
 test_txncache_staging_side_arrays_alloc( fd_snapin_tile_t * ctx,
                                          fd_wksp_t *        wksp ) {
   ctx->recent_groups    = fd_wksp_alloc_laddr( wksp, alignof(recent_blockhash_group_t), FD_SNAPIN_MAX_RECENT_GROUPS*sizeof(recent_blockhash_group_t), 1UL );
-  ctx->txncache_entries = fd_wksp_alloc_laddr( wksp, alignof(fd_sstxncache_hash_t),     FD_SNAPIN_TXNCACHE_MAX_ENTRIES*sizeof(fd_sstxncache_hash_t), 1UL  );
+  ctx->txncache_entries = fd_wksp_alloc_laddr( wksp, alignof(fd_sstxncache_hash_t),     TEST_MAX_ENTRIES*sizeof(fd_sstxncache_hash_t), 1UL  );
   FD_TEST( ctx->recent_groups );
   FD_TEST( ctx->txncache_entries );
 }
@@ -904,8 +914,11 @@ test_txncache_staging_ctx_init( fd_snapin_tile_t * ctx,
                                 fd_wksp_t *        wksp ) {
   fd_memset( ctx, 0, sizeof(*ctx) );
   ctx->seed = 1UL;
+  ctx->txncache_max_groups_per_slot  = TEST_MAX_GROUPS_PER_SLOT;
+  ctx->txncache_max_entries_per_slot = TEST_MAX_ENTRIES_PER_SLOT;
+  ctx->txncache_entries_max          = TEST_MAX_ENTRIES;
   txncache_staging_reset( ctx );
-  ctx->blockhash_groups = fd_wksp_alloc_laddr( wksp, alignof(blockhash_group_t), FD_SNAPIN_MAX_STAGED_GROUPS*sizeof(blockhash_group_t), 1UL );
+  ctx->blockhash_groups = fd_wksp_alloc_laddr( wksp, alignof(blockhash_group_t), TEST_MAX_STAGED_GROUPS*sizeof(blockhash_group_t), 1UL );
   FD_TEST( ctx->blockhash_groups );
   test_txncache_staging_side_arrays_alloc( ctx, wksp );
 }
@@ -914,9 +927,9 @@ test_txncache_staging_ctx_init( fd_snapin_tile_t * ctx,
 static fd_txncache_t *
 new_txncache( fd_wksp_t * wksp,
               ulong       max_txn_per_slot ) {
-  void * shmem = fd_wksp_alloc_laddr( wksp, fd_txncache_shmem_align(), fd_txncache_shmem_footprint( 1UL, max_txn_per_slot, 0 ), 1UL );
+  void * shmem = fd_wksp_alloc_laddr( wksp, fd_txncache_shmem_align(), fd_txncache_shmem_footprint( 1UL, max_txn_per_slot ), 1UL );
   FD_TEST( shmem );
-  fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem, 1UL, max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * txncache_shmem = fd_txncache_shmem_join( fd_txncache_shmem_new( shmem, 1UL, max_txn_per_slot, 0UL ) );
   FD_TEST( txncache_shmem );
 
   void * local = fd_wksp_alloc_laddr( wksp, fd_txncache_align(), fd_txncache_footprint( 1UL ), 1UL );
@@ -934,17 +947,17 @@ test_txncache_staging_groups_fit_txncache_scratch( fd_wksp_t * wksp ) {
   void * scratch = fd_txncache_snapin_scratch( txncache, &scratch_sz );
   FD_TEST( scratch );
 
-  blockhash_group_t * groups = txncache_staging_groups_join( scratch, scratch_sz );
+  blockhash_group_t * groups = txncache_staging_groups_join( scratch, scratch_sz, TEST_MAX_STAGED_GROUPS );
   FD_TEST( groups );
   FD_TEST( fd_ulong_is_aligned( (ulong)groups, alignof(blockhash_group_t) ) );
   FD_TEST( (uchar *)groups>=(uchar *)scratch );
-  FD_TEST( (uchar *)(groups+FD_SNAPIN_MAX_STAGED_GROUPS)<=(uchar *)scratch+scratch_sz );
+  FD_TEST( (uchar *)(groups+TEST_MAX_STAGED_GROUPS)<=(uchar *)scratch+scratch_sz );
 
-  ulong ring_sz = FD_SNAPIN_MAX_STAGED_GROUPS*sizeof(blockhash_group_t);
-  FD_TEST(  txncache_staging_groups_join( (void *)64UL, ring_sz     ) );
-  FD_TEST( !txncache_staging_groups_join( (void *)64UL, ring_sz-1UL ) );
-  FD_TEST( !txncache_staging_groups_join( (void *)66UL, ring_sz     ) );
-  FD_TEST(  txncache_staging_groups_join( (void *)66UL, ring_sz+2UL ) );
+  ulong ring_sz = TEST_MAX_STAGED_GROUPS*sizeof(blockhash_group_t);
+  FD_TEST(  txncache_staging_groups_join( (void *)64UL, ring_sz,     TEST_MAX_STAGED_GROUPS ) );
+  FD_TEST( !txncache_staging_groups_join( (void *)64UL, ring_sz-1UL, TEST_MAX_STAGED_GROUPS ) );
+  FD_TEST( !txncache_staging_groups_join( (void *)66UL, ring_sz,     TEST_MAX_STAGED_GROUPS ) );
+  FD_TEST(  txncache_staging_groups_join( (void *)66UL, ring_sz+2UL, TEST_MAX_STAGED_GROUPS ) );
 }
 
 static void
@@ -990,7 +1003,7 @@ test_txncache_staging_evicted_slot_drops_groups( fd_wksp_t * wksp ) {
   FD_TEST( ctx->txncache_slots[ oldest_idx ].group_cnt==1UL );
   FD_TEST( ctx->txncache_slots[ oldest_idx ].entry_cnt==2UL );
 
-  blockhash_group_t const * group = &ctx->blockhash_groups[ oldest_idx*FD_SNAPIN_MAX_GROUPS_PER_SLOT ];
+  blockhash_group_t const * group = &ctx->blockhash_groups[ oldest_idx*TEST_MAX_GROUPS_PER_SLOT ];
   FD_TEST( !memcmp( group->blockhash, blockhash_x, 32UL ) );
   FD_TEST( group->txnhash_offset==3UL );
   FD_TEST( group->txncache_entry_cnt==2UL );
@@ -1026,18 +1039,18 @@ test_txncache_staging_rejects_group_overflow( fd_wksp_t * wksp ) {
 
   uchar blockhash[ 32UL ] = {0};
   FD_TEST( txncache_staging_slot_begin( ctx, 1000UL )==0UL );
-  for( ulong i=0UL; i<FD_SNAPIN_MAX_GROUPS_PER_SLOT; i++ ) {
+  for( ulong i=0UL; i<TEST_MAX_GROUPS_PER_SLOT; i++ ) {
     FD_STORE( ulong, blockhash, i );
     FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
   }
-  FD_TEST( ctx->txncache_slots[ 0 ].group_cnt==FD_SNAPIN_MAX_GROUPS_PER_SLOT );
+  FD_TEST( ctx->txncache_slots[ 0 ].group_cnt==TEST_MAX_GROUPS_PER_SLOT );
   FD_TEST( txncache_staging_group_begin( ctx, blockhash, 0UL )==-1 );
 
   /* Bound ignored slots too, so malformed input cannot bypass the
      per-slot work limit. */
   for( ulong i=1UL; i<FD_TXNCACHE_MAX_SLOT_DELTAS; i++ ) FD_TEST( txncache_staging_slot_begin( ctx, 1000UL+i )!=ULONG_MAX );
   FD_TEST( txncache_staging_slot_begin( ctx, 999UL )==ULONG_MAX );
-  for( ulong i=0UL; i<FD_SNAPIN_MAX_GROUPS_PER_SLOT; i++ ) FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
+  for( ulong i=0UL; i<TEST_MAX_GROUPS_PER_SLOT; i++ ) FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
   FD_TEST( txncache_staging_group_begin( ctx, blockhash, 0UL )==-1 );
 }
 
@@ -1053,9 +1066,9 @@ test_txncache_staging_rejects_entry_overflow( fd_wksp_t * wksp ) {
   static uchar const txnhash[ 20UL ]   = { 0x33 };
   FD_TEST( txncache_staging_slot_begin( ctx, 1000UL )==0UL );
   FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
-  for( ulong i=0UL; i<FD_SNAPIN_TXNCACHE_MAX_ENTRIES; i++ ) FD_TEST( !txncache_staging_entry_add( ctx, 1000UL, txnhash ) );
-  FD_TEST( ctx->txncache_slots[ 0 ].entry_cnt==FD_SNAPIN_TXNCACHE_MAX_ENTRIES );
-  FD_TEST( ctx->blockhash_groups[ 0 ].txncache_entry_cnt==FD_SNAPIN_TXNCACHE_MAX_ENTRIES );
+  for( ulong i=0UL; i<ctx->txncache_entries_max; i++ ) FD_TEST( !txncache_staging_entry_add( ctx, 1000UL, txnhash ) );
+  FD_TEST( ctx->txncache_slots[ 0 ].entry_cnt==ctx->txncache_entries_max );
+  FD_TEST( ctx->blockhash_groups[ 0 ].txncache_entry_cnt==ctx->txncache_entries_max );
   FD_TEST( txncache_staging_entry_add( ctx, 1000UL, txnhash )==-1 );
 }
 
@@ -1070,7 +1083,7 @@ test_txncache_staging_reclaims_evicted_entries( fd_wksp_t * wksp ) {
   static uchar const blockhash[ 32UL ] = { 0x11 };
   uchar txnhash[ 20UL ] = { 0x33 };
 
-  ulong const big_cnt = FD_SNAPIN_TXNCACHE_MAX_ENTRIES-200UL;
+  ulong const big_cnt = TEST_MAX_ENTRIES-200UL;
   FD_TEST( txncache_staging_slot_begin( ctx, 1000UL )==0UL );
   FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
   for( ulong i=0UL; i<big_cnt; i++ ) FD_TEST( !txncache_staging_entry_add( ctx, 1000UL, txnhash ) );
@@ -1220,8 +1233,55 @@ test_txncache_staging_rejects_recent_group_overflow( fd_wksp_t * wksp ) {
 static void
 test_txncache_staging_fits_one_gigantic_page( void ) {
   fd_topo_tile_t tile = {0};
-  tile.snapin.max_live_slots = 2048UL;
-  FD_TEST( scratch_footprint( &tile )<(1UL<<30) );
+  tile.snapin.max_live_slots   = 2048UL;
+  tile.snapin.max_txn_per_slot = FD_MAX_TXN_PER_SLOT;
+  ulong footprint = scratch_footprint( &tile );
+  FD_TEST( footprint<(1UL<<30) );
+
+  /* The staged entries scale with the per-slot limit (up to the 512
+     byte scratch alignment). */
+  tile.snapin.max_txn_per_slot = 2UL*FD_MAX_TXN_PER_SLOT;
+  ulong delta = scratch_footprint( &tile )-footprint;
+  FD_TEST( delta>=TEST_MAX_ENTRIES*sizeof(fd_sstxncache_hash_t) && delta<TEST_MAX_ENTRIES*sizeof(fd_sstxncache_hash_t)+scratch_align() );
+}
+
+/* Group and entry bounds are runtime limits, so a raised
+   max_txn_per_slot admits proportionally more before rejection. */
+static void
+test_txncache_staging_runtime_limits( fd_wksp_t * wksp ) {
+  fd_snapin_tile_t ctx[ 1 ];
+  test_txncache_staging_ctx_init( ctx, wksp );
+  ctx->txncache_max_groups_per_slot  = 3UL;
+  ctx->txncache_max_entries_per_slot = 6UL;
+  ctx->txncache_entries_max          = FD_TXNCACHE_MAX_SLOT_DELTAS*6UL;
+
+  uchar blockhash[ 32UL ] = {0};
+  static uchar const txnhash[ 20UL ] = { 0x33 };
+  FD_TEST( txncache_staging_slot_begin( ctx, 1000UL )==0UL );
+  for( ulong i=0UL; i<3UL; i++ ) {
+    FD_STORE( ulong, blockhash, i );
+    FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
+    FD_TEST( !txncache_staging_entry_add( ctx, 1000UL, txnhash ) );
+    FD_TEST( !txncache_staging_entry_add( ctx, 1000UL, txnhash ) );
+  }
+  FD_TEST( txncache_staging_group_begin( ctx, blockhash, 0UL )==-1 );
+
+  /* Slot 1's groups start at the runtime stride, not the production one. */
+  FD_TEST( txncache_staging_slot_begin( ctx, 1001UL )==1UL );
+  FD_STORE( ulong, blockhash, 7UL );
+  FD_TEST( !txncache_staging_group_begin( ctx, blockhash, 0UL ) );
+  FD_TEST( !txncache_staging_entry_add( ctx, 1001UL, txnhash ) );
+  FD_TEST( !memcmp( ctx->blockhash_groups[ 3UL ].blockhash, blockhash, 32UL ) );
+  FD_TEST( ctx->txncache_entries[ 6UL ].txnhash[ 0 ]==0x33 );
+
+  uchar __attribute__((aligned(alignof(blockhash_map_t)))) _map[ blockhash_map_footprint( 1024UL ) ];
+  fd_blockhash_entry_t pool[ 1UL ];
+  uchar const * recent[ 1UL ] = { blockhash };
+  blockhash_map_t * map = test_txncache_staging_recent_set( _map, pool, ctx->seed, recent, 1UL );
+  FD_TEST( !filter_staged_groups( ctx, map, pool ) );
+  FD_TEST( ctx->recent_groups_len==1UL );
+  FD_TEST( ctx->recent_groups[ 0 ].txncache_entry_idx==6UL );
+  FD_TEST( ctx->recent_groups[ 0 ].txncache_entry_cnt==1UL );
 }
 
 static int
@@ -1429,6 +1489,7 @@ main( int     argc,
   fd_wksp_reset( wksp, 1UL ); test_txncache_staging_filters_recent_groups( wksp );
   fd_wksp_reset( wksp, 1UL ); test_txncache_staging_rejects_recent_group_overflow( wksp );
   test_txncache_staging_fits_one_gigantic_page();
+  fd_wksp_reset( wksp, 1UL ); test_txncache_staging_runtime_limits( wksp );
   fd_wksp_reset( wksp, 1UL ); test_txncache_staging_rejects_conflicting_group_offsets( wksp );
   fd_wksp_reset( wksp, 1UL ); test_txncache_staging_ignores_evicted_group_offsets( wksp );
   fd_wksp_reset( wksp, 1UL ); test_txncache_staging_populate_inserts_recent_only( wksp );

--- a/src/discof/restore/utils/test_ssload.c
+++ b/src/discof/restore/utils/test_ssload.c
@@ -586,7 +586,7 @@ test_recover_preserves_snapin_stake_delegations( fd_wksp_t * wksp, fd_snapshot_m
 
   fd_banks_t * banks = fd_banks_join( fd_banks_new( banks_mem, max_banks, max_forks,
                                                     max_stake, max_fallback_stake, max_vote,
-                                                    0 /* larger_max_cost_per_block */, seed ) );
+                                                    0UL /* max_cost_per_block */, seed ) );
   FD_TEST( banks );
 
   fd_bank_t * bank = fd_banks_init_bank( banks );

--- a/src/discof/rotor/fd_rotor_tile.c
+++ b/src/discof/rotor/fd_rotor_tile.c
@@ -145,8 +145,7 @@ typedef struct sign_pending sign_pending_t;
 
 #define QUEUE_NAME       ag_req_queue
 #define QUEUE_T          fd_repair_msg_t
-#define QUEUE_MAX        (FD_FEC_BLK_MAX)
-#include "../../util/tmpl/fd_queue.c"
+#include "../../util/tmpl/fd_queue_dynamic.c"
 
 struct ctx {
   long tsdebug; /* timestamp for debug printing */
@@ -213,7 +212,7 @@ struct ctx {
   uint             pending_key_next;
   sign_req_t     * signs_map;    /* contains any request currently in the repair->sign or sign->repair dcache */
   sign_pending_t * pong_queue;   /* contains any pong or initial warmup request waiting to be dispatched to repair->sign. Size is 2*FD_REPAIR_PEER_MAX */
-  fd_repair_msg_t * ag_req_queue; /* contains any alpenglow request waiting to be dispatched to sign->repair. Sized to FD_FEC_BLK_MAX */
+  fd_repair_msg_t * ag_req_queue; /* contains any alpenglow request waiting to be dispatched to sign->repair. Sized to one block's FEC sets (max_shreds_per_block/FD_FEC_SHRED_CNT) */
 
   ushort net_id;
 
@@ -284,19 +283,20 @@ FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   ulong total_sign_depth = tile->rotor.repair_sign_depth * tile->rotor.repair_sign_cnt;
   int   lg_sign_depth    = fd_ulong_find_msb( fd_ulong_pow2_up(total_sign_depth) ) + 1;
+  ulong fec_blk_max      = tile->rotor.max_shreds_per_block / FD_FEC_SHRED_CNT;
 
   ulong l = FD_LAYOUT_INIT;
   l = FD_LAYOUT_APPEND( l, alignof(ctx_t),            sizeof(ctx_t)                                                      );
   l = FD_LAYOUT_APPEND( l, fd_repair_align(),         fd_repair_footprint     ()                                         );
-  l = FD_LAYOUT_APPEND( l, fd_chainer_align(),        fd_chainer_footprint    ( tile->rotor.slot_max )                  );
+  l = FD_LAYOUT_APPEND( l, fd_chainer_align(),        fd_chainer_footprint    ( tile->rotor.slot_max, tile->rotor.max_shreds_per_block ) );
   l = FD_LAYOUT_APPEND( l, fd_policy_align(),         fd_policy_footprint     ( FD_REPAIR_PEER_MAX )                     );
   l = FD_LAYOUT_APPEND( l, fd_reqlim_align(),         fd_reqlim_footprint     ( FD_REQLIM_CACHE_MAX )                    );
   l = FD_LAYOUT_APPEND( l, fd_inflights_align(),      fd_inflights_footprint  ()                                         );
   l = FD_LAYOUT_APPEND( l, fd_signs_map_align(),      fd_signs_map_footprint  ( lg_sign_depth )                          );
   l = FD_LAYOUT_APPEND( l, fd_signs_queue_align(),    fd_signs_queue_footprint()                                         );
-  l = FD_LAYOUT_APPEND( l, ag_req_queue_align(),      ag_req_queue_footprint()                                           );
+  l = FD_LAYOUT_APPEND( l, ag_req_queue_align(),      ag_req_queue_footprint  ( fec_blk_max )                            );
   l = FD_LAYOUT_APPEND( l, fd_repair_metrics_align(), fd_repair_metrics_footprint()                                      );
-  l = FD_LAYOUT_APPEND( l, out_queue_align(),         out_queue_footprint( (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * FD_FEC_BLK_MAX ) );
+  l = FD_LAYOUT_APPEND( l, out_queue_align(),         out_queue_footprint( (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * fec_blk_max ) );
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
@@ -889,7 +889,7 @@ after_frag( ctx_t *             ctx,
         after_ping( ctx, data, data_sz, ip4, udp );
       } else { /* alpen repair response */
         ag_repair_response_t response[1];
-        if( FD_UNLIKELY( ag_repair_response_de( response, data, data_sz ) ) ) return; /* malformed */
+        if( FD_UNLIKELY( ag_repair_response_de( response, data, data_sz, ctx->chainer->fec_blk_max ) ) ) return; /* malformed */
         after_alpen_meta_repair( ctx, response );
       }
       break;
@@ -1165,7 +1165,7 @@ ag_policy_block_id_next( ctx_t * ctx, out_ctx_t * sign_out, long now, int * char
     /* make individual shred request */
 
     uint idx = e->highest_requested+1;
-    while( FD_UNLIKELY( idx<FD_SHRED_BLK_MAX && fd_chainer_shred_test( chainer, e, idx ) ) ) idx++;
+    while( FD_UNLIKELY( idx<chainer->fec_blk_max*FD_FEC_SHRED_CNT && fd_chainer_shred_test( chainer, e, idx ) ) ) idx++;
 
     if( FD_UNLIKELY( idx > e->complete_idx ) ) {
       e->highest_requested = idx;
@@ -1370,7 +1370,7 @@ ag_policy_next( ctx_t * ctx, out_ctx_t * sign_out, long now, int * charge_busy )
     /* make individual shred request */
 
     uint idx = e->highest_requested+1;
-    while( FD_UNLIKELY( idx<FD_SHRED_BLK_MAX && fd_chainer_shred_test( chainer, e, idx ) ) ) idx++;
+    while( FD_UNLIKELY( idx<chainer->fec_blk_max*FD_FEC_SHRED_CNT && fd_chainer_shred_test( chainer, e, idx ) ) ) idx++;
 
     if( FD_UNLIKELY( idx > e->complete_idx ) ) {
       e->highest_requested = idx;
@@ -1490,9 +1490,10 @@ full_fec_path_queue( ctx_t *              ctx,
       kmax = slotv->buffered_fec_idx / (uint)FD_FEC_SHRED_CNT;         /* ancestor: all buffered FECs */
     }
 
+    uint const * fecs = fd_chainer_slotv_fecs( chainer, slotv );
     for( int k=(int)kmax; k>=0; k-- ) {
       if( FD_UNLIKELY( out_queue_full( ctx->deliver_queue ) ) ) FD_LOG_ERR(( "deliver_from_root queue full" ));
-      out_queue_push_head( ctx->deliver_queue, (out_ele_t){ .slotv_idx = slotv_idx, .fec_idx = slotv->fec[ k ] } );
+      out_queue_push_head( ctx->deliver_queue, (out_ele_t){ .slotv_idx = slotv_idx, .fec_idx = fecs[ k ] } );
     }
   }
 }
@@ -1711,25 +1712,26 @@ unprivileged_init( fd_topo_t const *      topo,
 
   ulong total_sign_depth = tile->rotor.repair_sign_depth * tile->rotor.repair_sign_cnt;
   int   lg_sign_depth    = fd_ulong_find_msb( fd_ulong_pow2_up(total_sign_depth) ) + 1;
+  ulong fec_blk_max      = tile->rotor.max_shreds_per_block / FD_FEC_SHRED_CNT;
 
   FD_SCRATCH_ALLOC_INIT( l, scratch );
   ctx_t * ctx        = FD_SCRATCH_ALLOC_APPEND( l, alignof(ctx_t),            sizeof(ctx_t)                                                 );
   ctx->protocol      = FD_SCRATCH_ALLOC_APPEND( l, fd_repair_align(),         fd_repair_footprint()                                         );
-  ctx->chainer       = FD_SCRATCH_ALLOC_APPEND( l, fd_chainer_align(),        fd_chainer_footprint( tile->rotor.slot_max )                 );
+  ctx->chainer       = FD_SCRATCH_ALLOC_APPEND( l, fd_chainer_align(),        fd_chainer_footprint( tile->rotor.slot_max, tile->rotor.max_shreds_per_block ) );
   ctx->policy        = FD_SCRATCH_ALLOC_APPEND( l, fd_policy_align(),         fd_policy_footprint( FD_REPAIR_PEER_MAX )                     );
   ctx->dedup         = FD_SCRATCH_ALLOC_APPEND( l, fd_reqlim_align(),         fd_reqlim_footprint( FD_REQLIM_CACHE_MAX )                    );
   ctx->inflights     = FD_SCRATCH_ALLOC_APPEND( l, fd_inflights_align(),      fd_inflights_footprint()                                      );
   ctx->signs_map     = FD_SCRATCH_ALLOC_APPEND( l, fd_signs_map_align(),      fd_signs_map_footprint( lg_sign_depth )                       );
   ctx->pong_queue    = FD_SCRATCH_ALLOC_APPEND( l, fd_signs_queue_align(),    fd_signs_queue_footprint()                                    );
-  ctx->ag_req_queue  = FD_SCRATCH_ALLOC_APPEND( l, ag_req_queue_align(),      ag_req_queue_footprint()                                        );
+  ctx->ag_req_queue  = FD_SCRATCH_ALLOC_APPEND( l, ag_req_queue_align(),      ag_req_queue_footprint( fec_blk_max )                         );
   ctx->slot_metrics  = FD_SCRATCH_ALLOC_APPEND( l, fd_repair_metrics_align(), fd_repair_metrics_footprint()                                 );
-  ctx->deliver_queue = FD_SCRATCH_ALLOC_APPEND( l, out_queue_align(),         out_queue_footprint( (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * FD_FEC_BLK_MAX ) );
+  ctx->deliver_queue = FD_SCRATCH_ALLOC_APPEND( l, out_queue_align(),         out_queue_footprint( (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * fec_blk_max ) );
   ulong scratch_top  = FD_SCRATCH_ALLOC_FINI( l, scratch_align() );
   if( FD_UNLIKELY( scratch_top > (ulong)scratch + scratch_footprint( tile ) ) )
     FD_LOG_ERR(( "scratch overflow %lu %lu %lu", scratch_top - (ulong)scratch - scratch_footprint( tile ), scratch_top, (ulong)scratch + scratch_footprint( tile ) ));
 
-  ctx->chainer       = fd_chainer_join       ( fd_chainer_new       ( ctx->chainer,   tile->rotor.slot_max, ctx->repair_seed                                        ) );
-  ctx->deliver_queue = out_queue_join        ( out_queue_new        ( ctx->deliver_queue, (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * FD_FEC_BLK_MAX     ) );
+  ctx->chainer       = fd_chainer_join       ( fd_chainer_new       ( ctx->chainer,   tile->rotor.slot_max, tile->rotor.max_shreds_per_block, ctx->repair_seed      ) );
+  ctx->deliver_queue = out_queue_join        ( out_queue_new        ( ctx->deliver_queue, (ulong)tile->rotor.slot_max * FD_CHAINER_SLOT_VER_MAX * fec_blk_max        ) );
 
   ctx->protocol      = fd_repair_join        ( fd_repair_new        ( ctx->protocol,  &ctx->identity_public_key                                                      ) );
   ctx->policy        = fd_policy_join        ( fd_policy_new        ( ctx->policy,    FD_REPAIR_PEER_MAX, ctx->repair_seed, ctx->repair_nonce_ss ) );
@@ -1737,7 +1739,7 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->inflights     = fd_inflights_join     ( fd_inflights_new     ( ctx->inflights, ctx->repair_seed+1234UL                                                       ) );
   ctx->signs_map     = fd_signs_map_join     ( fd_signs_map_new     ( ctx->signs_map, lg_sign_depth, 0UL                                                            ) );
   ctx->pong_queue    = fd_signs_queue_join   ( fd_signs_queue_new   ( ctx->pong_queue                                                                               ) );
-  ctx->ag_req_queue  = ag_req_queue_join     ( ag_req_queue_new     ( ctx->ag_req_queue                                                                             ) );
+  ctx->ag_req_queue  = ag_req_queue_join     ( ag_req_queue_new     ( ctx->ag_req_queue, fec_blk_max                                                                ) );
   ctx->slot_metrics  = fd_repair_metrics_join( fd_repair_metrics_new( ctx->slot_metrics                                                                             ) );
 
   ctx->keyswitch = fd_keyswitch_join( fd_topo_obj_laddr( topo, tile->id_keyswitch_obj_id ) );

--- a/src/discof/rotor/test_rotor_tile.c
+++ b/src/discof/rotor/test_rotor_tile.c
@@ -591,25 +591,25 @@ setup_ctx( ctx_t * ctx, fd_wksp_t * wksp ) {
   FD_TEST( fd_rng_secure( &ctx->repair_seed, sizeof(ulong) ) );
   FD_TEST( fd_rng_secure( ctx->repair_nonce_ss, sizeof(fd_rnonce_ss_t) ) );
 
-  void * chainer_mem    = fd_wksp_alloc_laddr( wksp, fd_chainer_align(),        fd_chainer_footprint( TEST_SLOT_MAX ),   1UL );
+  void * chainer_mem    = fd_wksp_alloc_laddr( wksp, fd_chainer_align(),        fd_chainer_footprint( TEST_SLOT_MAX, FD_SHRED_BLK_MAX ), 1UL );
   void * policy_mem     = fd_wksp_alloc_laddr( wksp, fd_policy_align(),         fd_policy_footprint( TEST_PEER_MAX ),    1UL );
   void * dedup_mem      = fd_wksp_alloc_laddr( wksp, fd_reqlim_align(),         fd_reqlim_footprint( TEST_DEDUP_MAX ),   1UL );
   void * inflights_mem  = fd_wksp_alloc_laddr( wksp, fd_inflights_align(),      fd_inflights_footprint(),                1UL );
   void * signs_map_mem  = fd_wksp_alloc_laddr( wksp, fd_signs_map_align(),      fd_signs_map_footprint( lg_sign_depth ), 1UL );
   void * pong_queue_mem = fd_wksp_alloc_laddr( wksp, fd_signs_queue_align(),    fd_signs_queue_footprint(),              1UL );
-  void * ag_req_mem     = fd_wksp_alloc_laddr( wksp, ag_req_queue_align(),      ag_req_queue_footprint(),                1UL );
+  void * ag_req_mem     = fd_wksp_alloc_laddr( wksp, ag_req_queue_align(),      ag_req_queue_footprint( FD_FEC_BLK_MAX ), 1UL );
   void * repair_mem     = fd_wksp_alloc_laddr( wksp, fd_repair_align(),         fd_repair_footprint(),                   1UL );
   void * metrics_mem    = fd_wksp_alloc_laddr( wksp, fd_repair_metrics_align(), fd_repair_metrics_footprint(),           1UL );
   void * deliver_q_mem  = fd_wksp_alloc_laddr( wksp, out_queue_align(),         out_queue_footprint( (ulong)TEST_SLOT_MAX * FD_CHAINER_SLOT_VER_MAX * FD_FEC_BLK_MAX ), 1UL );
   FD_TEST( chainer_mem && policy_mem && dedup_mem && inflights_mem && signs_map_mem && pong_queue_mem && ag_req_mem && repair_mem && metrics_mem && deliver_q_mem );
 
-  ctx->chainer       = fd_chainer_join       ( fd_chainer_new       ( chainer_mem,    TEST_SLOT_MAX, ctx->repair_seed                       ) );
+  ctx->chainer       = fd_chainer_join       ( fd_chainer_new       ( chainer_mem,    TEST_SLOT_MAX, FD_SHRED_BLK_MAX, ctx->repair_seed     ) );
   ctx->policy        = fd_policy_join        ( fd_policy_new        ( policy_mem,     TEST_PEER_MAX, ctx->repair_seed, ctx->repair_nonce_ss ) );
   ctx->dedup         = fd_reqlim_join        ( fd_reqlim_new        ( dedup_mem,      TEST_DEDUP_MAX, ctx->repair_seed                      ) );
   ctx->inflights     = fd_inflights_join     ( fd_inflights_new     ( inflights_mem,  ctx->repair_seed+1234UL                               ) );
   ctx->signs_map     = fd_signs_map_join     ( fd_signs_map_new     ( signs_map_mem,  lg_sign_depth, 0UL                                    ) );
   ctx->pong_queue    = fd_signs_queue_join   ( fd_signs_queue_new   ( pong_queue_mem                                                        ) );
-  ctx->ag_req_queue  = ag_req_queue_join     ( ag_req_queue_new     ( ag_req_mem                                                            ) );
+  ctx->ag_req_queue  = ag_req_queue_join     ( ag_req_queue_new     ( ag_req_mem,     FD_FEC_BLK_MAX                                        ) );
   ctx->protocol      = fd_repair_join        ( fd_repair_new        ( repair_mem,     &ctx->identity_public_key                             ) );
   ctx->slot_metrics  = fd_repair_metrics_join( fd_repair_metrics_new( metrics_mem                                                           ) );
   ctx->deliver_queue = out_queue_join        ( out_queue_new        ( deliver_q_mem, (ulong)TEST_SLOT_MAX * FD_CHAINER_SLOT_VER_MAX * FD_FEC_BLK_MAX ) );
@@ -1370,7 +1370,7 @@ test_fec_rekey_merge( fd_wksp_t * wksp ) {
   pump( ctx );
   fd_chainer_slotv_t * vA = fd_chainer_slot_query( ctx->chainer, slot );
   FD_TEST( vA && fd_hash_eq( &vA->block_id, &blkA->block_id ) );
-  uint aFec0 = vA->fec[ 0 ]; /* A's complete full-root FEC 0 */
+  uint aFec0 = fd_chainer_slotv_fecs( ctx->chainer, vA )[ 0 ]; /* A's complete full-root FEC 0 */
   FD_TEST( aFec0!=UINT_MAX );
 
   /* Version B shares FEC set 0 with A (identical full root), diverges at
@@ -1400,8 +1400,8 @@ test_fec_rekey_merge( fd_wksp_t * wksp ) {
      A's full-root FEC, so B gets its own distinct sentinel rather than
      sharing A's entry. */
   respond_fec_root( ctx, blkB, 0U, root0->nonce, 0 );
-  FD_TEST( vB->fec[ 0 ]!=UINT_MAX );
-  FD_TEST( vB->fec[ 0 ]!=aFec0 ); /* distinct 20-byte-prefix sentinel */
+  FD_TEST( fd_chainer_slotv_fecs( ctx->chainer, vB )[ 0 ]!=UINT_MAX );
+  FD_TEST( fd_chainer_slotv_fecs( ctx->chainer, vB )[ 0 ]!=aFec0 ); /* distinct 20-byte-prefix sentinel */
 
   /* B requests set-0 shreds (its sentinel is incomplete). */
   pump( ctx );
@@ -1416,8 +1416,8 @@ test_fec_rekey_merge( fd_wksp_t * wksp ) {
   serve_shred_request( ctx, blkB, s0, &blkB->fec_root[ 0 ] );
   pump( ctx );
 
-  FD_TEST( vB->fec[ 0 ]==aFec0 );                          /* merged onto A's FEC */
-  FD_TEST( vA->fec[ 0 ]==aFec0 );                          /* A still owns it */
+  FD_TEST( fd_chainer_slotv_fecs( ctx->chainer, vB )[ 0 ]==aFec0 );                          /* merged onto A's FEC */
+  FD_TEST( fd_chainer_slotv_fecs( ctx->chainer, vA )[ 0 ]==aFec0 );                          /* A still owns it */
   FD_TEST( slot_version_cnt( ctx->chainer, slot )==2UL );  /* no stray version */
   FD_TEST( !fd_chainer_verify( ctx->chainer ) );
   FD_TEST( rep_cnt>rmark );                                /* FEC 0 re-delivered under B */

--- a/src/discof/tower/fd_tower_tile.c
+++ b/src/discof/tower/fd_tower_tile.c
@@ -1594,7 +1594,7 @@ FD_FN_PURE static inline ulong
 scratch_footprint( fd_topo_tile_t const * tile ) {
   ulong slot_max    = fd_ulong_pow2_up( tile->tower.max_live_slots );
   ulong blk_max     = slot_max * EQVOC_MAX;
-  ulong fec_max     = slot_max * FD_SHRED_BLK_MAX / FD_FEC_SHRED_CNT;
+  ulong fec_max     = slot_max * tile->tower.max_shreds_per_block / FD_FEC_SHRED_CNT;
   ulong pub_max     = slot_max * FD_TOWER_SLOT_CONFIRMED_LEVEL_CNT;
 
   ulong l = FD_LAYOUT_INIT;
@@ -1629,7 +1629,7 @@ init_choreo( void                 * scratch,
              fd_topo_tile_t const * tile ) {
   ulong slot_max    = fd_ulong_pow2_up( tile->tower.max_live_slots );
   ulong blk_max     = slot_max * EQVOC_MAX;
-  ulong fec_max     = slot_max * FD_SHRED_BLK_MAX / FD_FEC_SHRED_CNT;
+  ulong fec_max     = slot_max * tile->tower.max_shreds_per_block / FD_FEC_SHRED_CNT;
   ulong pub_max     = slot_max * FD_TOWER_SLOT_CONFIRMED_LEVEL_CNT;
 
   void * _accdb_shmem = fd_topo_obj_laddr( topo, tile->tower.accdb_obj_id );

--- a/src/discof/tower/test_tower_tile.c
+++ b/src/discof/tower/test_tower_tile.c
@@ -497,7 +497,8 @@ test_fixture_replay( fd_wksp_t * wksp ) {
 
   static fd_topo_tile_t tile[1];
   memset( tile, 0, sizeof(*tile) );
-  tile->tower.max_live_slots = MOCK_SLOT_MAX;
+  tile->tower.max_live_slots       = MOCK_SLOT_MAX;
+  tile->tower.max_shreds_per_block = FD_SHRED_BLK_MAX;
 
   static fd_topo_t topo[1];
   mock_topo_with_accdb( wksp, topo, tile );
@@ -622,7 +623,8 @@ static fd_tower_tile_t *
 eqvoc_setup( fd_wksp_t * wksp ) {
   static fd_topo_tile_t tile[1];
   memset( tile, 0, sizeof(*tile) );
-  tile->tower.max_live_slots = MOCK_SLOT_MAX;
+  tile->tower.max_live_slots       = MOCK_SLOT_MAX;
+  tile->tower.max_shreds_per_block = FD_SHRED_BLK_MAX;
 
   static fd_topo_t topo[1];
   memset( topo, 0, sizeof(*topo) );

--- a/src/flamenco/runtime/fd_bank.c
+++ b/src/flamenco/runtime/fd_bank.c
@@ -307,7 +307,7 @@ fd_banks_new( void * shmem,
               ulong  max_stake_accounts,
               ulong  max_fallback_stake_accounts,
               ulong  max_vote_accounts,
-              int    larger_max_cost_per_block,
+              ulong  bench_max_cost_per_block,
               ulong  seed ) {
   if( FD_UNLIKELY( !shmem ) ) {
     FD_LOG_WARNING(( "NULL shmem" ));
@@ -411,7 +411,7 @@ fd_banks_new( void * shmem,
 
   for( ulong i=0UL; i<max_fork_width; i++ ) {
     fd_bank_cost_tracker_t * cost_tracker = fd_bank_cost_tracker_pool_ele( cost_tracker_pool, i );
-    if( FD_UNLIKELY( !fd_cost_tracker_join( fd_cost_tracker_new( cost_tracker->data, larger_max_cost_per_block, seed ) ) ) ) {
+    if( FD_UNLIKELY( !fd_cost_tracker_join( fd_cost_tracker_new( cost_tracker->data, bench_max_cost_per_block, seed ) ) ) ) {
       FD_LOG_WARNING(( "Failed to create cost tracker" ));
       return NULL;
     }

--- a/src/flamenco/runtime/fd_bank.h
+++ b/src/flamenco/runtime/fd_bank.h
@@ -576,7 +576,7 @@ fd_banks_new( void * mem,
               ulong  max_stake_accounts,
               ulong  max_fallback_stake_accounts,
               ulong  max_vote_accounts,
-              int    larger_max_cost_per_block,
+              ulong  bench_max_cost_per_block, /* [development.bench], floors the block cost limit */
               ulong  seed );
 
 /* fd_banks_join() joins an fd_banks_t struct.  It takes in a valid

--- a/src/flamenco/runtime/fd_cost_tracker.c
+++ b/src/flamenco/runtime/fd_cost_tracker.c
@@ -58,7 +58,7 @@ fd_cost_tracker_footprint( void ) {
 
 void *
 fd_cost_tracker_new( void * shmem,
-                     int    larger_max_cost_per_block,
+                     ulong  bench_max_cost_per_block,
                      ulong  seed ) {
   if( FD_UNLIKELY( !shmem ) ) {
     FD_LOG_WARNING(( "NULL shmem" ));
@@ -82,7 +82,7 @@ fd_cost_tracker_new( void * shmem,
 
   cost_tracker->pool_offset = (ulong)_accounts-(ulong)cost_tracker;
 
-  cost_tracker->cost_tracker->larger_max_cost_per_block = larger_max_cost_per_block;
+  cost_tracker->cost_tracker->bench_max_cost_per_block = bench_max_cost_per_block;
 
   fd_rwlock_new( &cost_tracker->lock );
 
@@ -134,7 +134,7 @@ fd_cost_tracker_init( fd_cost_tracker_t *      cost_tracker,
     cost_tracker->account_cost_limit = fd_ulong_sat_mul( cost_tracker->account_cost_limit, 100UL ) / 60UL;
   }
 
-  if( FD_UNLIKELY( cost_tracker->larger_max_cost_per_block ) ) cost_tracker->block_cost_limit = LARGER_MAX_COST_PER_BLOCK;
+  cost_tracker->block_cost_limit = fd_ulong_max( cost_tracker->block_cost_limit, cost_tracker->bench_max_cost_per_block );
 
   cost_tracker->block_cost                   = 0UL;
   cost_tracker->allocated_accounts_data_size = 0UL;

--- a/src/flamenco/runtime/fd_cost_tracker.h
+++ b/src/flamenco/runtime/fd_cost_tracker.h
@@ -57,7 +57,7 @@ struct __attribute__((aligned(FD_COST_TRACKER_ALIGN))) fd_cost_tracker {
   ulong account_cost_limit;
   ulong data_size_limit;
 
-  int larger_max_cost_per_block;
+  ulong bench_max_cost_per_block; /* [development.bench], floors block_cost_limit */
 };
 
 typedef struct fd_cost_tracker fd_cost_tracker_t;
@@ -108,7 +108,7 @@ fd_cost_tracker_footprint( void );
 
 void *
 fd_cost_tracker_new( void * shmem,
-                     int    larger_max_cost_per_block,
+                     ulong  bench_max_cost_per_block,
                      ulong  seed );
 
 fd_cost_tracker_t *

--- a/src/flamenco/runtime/fd_txncache.c
+++ b/src/flamenco/runtime/fd_txncache.c
@@ -8,7 +8,8 @@ struct blockcache {
   uint * heads;          /* The hash table for the blockhash.  Each entry is a pointer to the head of a linked list of
                             transactions that reference this blockhash.  As we add transactions to the bucket, the head
                             pointer is updated to the new item, and the new item is pointed to the previous head. */
-  ushort * pages;        /* A list of the txnpages containing the transactions for this blockcache. */
+  void * pages;          /* A list of the txnpages containing the transactions for this blockcache, elements of
+                            shmem->txnpage_idx_sz bytes (see fd_txncache_txnpage_idx_ld). */
 
   descends_set_t * descends; /* Each fork can descend from other forks in the txncache, and this bit vector contains one
                                 value for each fork in the txncache.  If this fork descends from some other fork F, then
@@ -24,14 +25,15 @@ struct fd_txncache_private {
   blockcache_t * blockcache_pool;
   blockhash_map_t * blockhash_map;
 
-  ushort * txnpages_free;           /* The index in the txnpages array that is free, for each of the free pages. */
+  void * txnpages_free;             /* The index in the txnpages array that is free, for each of the free pages.
+                                       Elements are shmem->txnpage_idx_sz bytes, as are scratch_pages below. */
 
   fd_txncache_txnpage_t * txnpages; /* The actual storage for the transactions.  The blockcache points to these
                                        pages when storing transactions.  Transaction are grouped into pages of
                                        size 16384 to make certain allocation and deallocation operations faster
                                        (just the pages are acquired/released, rather than each txn). */
 
-  ushort * scratch_pages;
+  void * scratch_pages;
   uint * scratch_heads;
   fd_txncache_txnpage_t * scratch_txnpage;
 };
@@ -72,8 +74,9 @@ fd_txncache_new( void *                ljoin,
   /* Page counts come from the shmem header rather than being
      re-derived, so the layout walk below cannot desync from the one in
      fd_txncache_shmem_new. */
-  ushort _max_txnpages               = shmem->max_txnpages;
-  ushort _max_txnpages_per_blockhash = shmem->txnpages_per_blockhash_max;
+  ulong _max_txnpages               = shmem->max_txnpages;
+  ulong _max_txnpages_per_blockhash = shmem->txnpages_per_blockhash_max;
+  ulong _txnpage_idx_sz             = shmem->txnpage_idx_sz;
 
   ulong _descends_footprint = descends_set_footprint( max_active_slots );
   if( FD_UNLIKELY( !_descends_footprint ) ) {
@@ -82,17 +85,17 @@ fd_txncache_new( void *                ljoin,
   }
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
-  fd_txncache_shmem_t * tc    = FD_SCRATCH_ALLOC_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,         sizeof(fd_txncache_shmem_t)                                 );
-  void * _blockhash_map       = FD_SCRATCH_ALLOC_APPEND( l, blockhash_map_align(),           blockhash_map_footprint( blockhash_map_chains )             );
-  void * _blockcache_pool     = FD_SCRATCH_ALLOC_APPEND( l, blockcache_pool_align(),         blockcache_pool_footprint( max_active_slots )               );
-  void * _blockcache_pages    = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 max_active_slots*_max_txnpages_per_blockhash*sizeof(ushort) );
-  void * _blockcache_heads    = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   max_active_slots*bucket_cnt*sizeof(uint)                    );
-  void * _blockcache_descends = FD_SCRATCH_ALLOC_APPEND( l, descends_set_align(),            max_active_slots*_descends_footprint                        );
-  void * _txnpages_free       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 _max_txnpages*sizeof(ushort)                                );
-  void * _txnpages            = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  _max_txnpages*sizeof(fd_txncache_txnpage_t)                 );
-  void * _scratch_pages       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 _max_txnpages_per_blockhash*sizeof(ushort)                  );
-  void * _scratch_heads       = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   bucket_cnt*sizeof(uint)                                     );
-  void * _scratch_txnpage     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  sizeof(fd_txncache_txnpage_t)                               );
+  fd_txncache_shmem_t * tc    = FD_SCRATCH_ALLOC_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,         sizeof(fd_txncache_shmem_t)                                   );
+  void * _blockhash_map       = FD_SCRATCH_ALLOC_APPEND( l, blockhash_map_align(),           blockhash_map_footprint( blockhash_map_chains )               );
+  void * _blockcache_pool     = FD_SCRATCH_ALLOC_APPEND( l, blockcache_pool_align(),         blockcache_pool_footprint( max_active_slots )                 );
+  void * _blockcache_pages    = FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 max_active_slots*_max_txnpages_per_blockhash*_txnpage_idx_sz );
+  void * _blockcache_heads    = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   max_active_slots*bucket_cnt*sizeof(uint)                      );
+  void * _blockcache_descends = FD_SCRATCH_ALLOC_APPEND( l, descends_set_align(),            max_active_slots*_descends_footprint                          );
+  void * _txnpages_free       = FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 _max_txnpages*_txnpage_idx_sz                                 );
+  void * _txnpages            = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  _max_txnpages*sizeof(fd_txncache_txnpage_t)                   );
+  void * _scratch_pages       = FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 _max_txnpages_per_blockhash*_txnpage_idx_sz                   );
+  void * _scratch_heads       = FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   bucket_cnt*sizeof(uint)                                       );
+  void * _scratch_txnpage     = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  sizeof(fd_txncache_txnpage_t)                                 );
 
   FD_SCRATCH_ALLOC_INIT( l2, ljoin );
   fd_txncache_t * ltc           = FD_SCRATCH_ALLOC_APPEND( l2, FD_TXNCACHE_ALIGN,     sizeof(fd_txncache_t)                 );
@@ -104,7 +107,7 @@ fd_txncache_new( void *                ljoin,
   ltc->blockcache_shmem_pool = blockcache_pool_join( _blockcache_pool );
 
   for( ulong i=0UL; i<shmem->active_slots_max; i++ ) {
-    ltc->blockcache_pool[ i ].pages    = (ushort *)_blockcache_pages + i*_max_txnpages_per_blockhash;
+    ltc->blockcache_pool[ i ].pages    = (uchar *)_blockcache_pages + i*_max_txnpages_per_blockhash*_txnpage_idx_sz;
     ltc->blockcache_pool[ i ].heads    = (uint *)_blockcache_heads + i*bucket_cnt;
     ltc->blockcache_pool[ i ].descends = descends_set_join( (uchar *)_blockcache_descends + i*_descends_footprint );
     ltc->blockcache_pool[ i ].shmem    = ltc->blockcache_shmem_pool + i;
@@ -116,7 +119,7 @@ fd_txncache_new( void *                ljoin,
   ltc->blockhash_map = blockhash_map_join( _blockhash_map );
   FD_TEST( ltc->blockhash_map );
 
-  ltc->txnpages_free = (ushort *)_txnpages_free;
+  ltc->txnpages_free = _txnpages_free;
   ltc->txnpages      = (fd_txncache_txnpage_t *)_txnpages;
 
   ltc->scratch_pages   = _scratch_pages;
@@ -151,7 +154,7 @@ fd_txncache_reset( fd_txncache_t * tc ) {
   root_slist_remove_all( tc->shmem->root_ll, tc->blockcache_shmem_pool );
 
   tc->shmem->txnpages_free_cnt = tc->shmem->max_txnpages;
-  for( ushort i=0; i<tc->shmem->max_txnpages; i++ ) tc->txnpages_free[ i ] = i;
+  for( ulong i=0UL; i<tc->shmem->max_txnpages; i++ ) fd_txncache_txnpage_idx_st( tc->shmem->txnpage_idx_sz, tc->txnpages_free, i, i );
 
   blockcache_pool_reset( tc->blockcache_shmem_pool );
   blockhash_map_reset( tc->blockhash_map );
@@ -176,45 +179,49 @@ fd_txncache_bucket( fd_txncache_t const * tc,
 static fd_txncache_txnpage_t *
 fd_txncache_ensure_txnpage( fd_txncache_t * tc,
                             blockcache_t *  blockcache ) {
-  ushort page_cnt = blockcache->shmem->pages_cnt;
+  ulong page_cnt = blockcache->shmem->pages_cnt;
   if( FD_UNLIKELY( page_cnt>tc->shmem->txnpages_per_blockhash_max ) ) return NULL;
 
+  ulong idx_sz = tc->shmem->txnpage_idx_sz;
   if( FD_LIKELY( page_cnt ) ) {
-    ushort txnpage_idx = blockcache->pages[ page_cnt-1 ];
+    ulong txnpage_idx = fd_txncache_txnpage_idx_ld( idx_sz, blockcache->pages, page_cnt-1UL );
     ushort txnpage_free = tc->txnpages[ txnpage_idx ].free;
     if( FD_LIKELY( txnpage_free ) ) return &tc->txnpages[ txnpage_idx ];
   }
 
   if( FD_UNLIKELY( page_cnt==tc->shmem->txnpages_per_blockhash_max ) ) return NULL;
-  if( FD_LIKELY( FD_ATOMIC_CAS( &blockcache->pages[ page_cnt ], (ushort)USHORT_MAX, (ushort)(USHORT_MAX-1UL) )==(ushort)USHORT_MAX ) ) {
+  ulong idx_null = idx_sz==sizeof(uint) ? UINT_MAX : USHORT_MAX;
+  int claimed = idx_sz==sizeof(uint) ? FD_ATOMIC_CAS( (uint   *)blockcache->pages+page_cnt, UINT_MAX,           UINT_MAX-1U             )==UINT_MAX
+                                     : FD_ATOMIC_CAS( (ushort *)blockcache->pages+page_cnt, (ushort)USHORT_MAX, (ushort)(USHORT_MAX-1U) )==(ushort)USHORT_MAX;
+  if( FD_LIKELY( claimed ) ) {
     ulong txnpages_free_cnt = tc->shmem->txnpages_free_cnt;
     for(;;) {
       if( FD_UNLIKELY( !txnpages_free_cnt ) ) {
-        blockcache->pages[ page_cnt ] = (ushort)USHORT_MAX;
+        fd_txncache_txnpage_idx_st( idx_sz, blockcache->pages, page_cnt, idx_null );
         FD_COMPILER_MFENCE();
         return NULL;
       }
-      ulong old_txnpages_free_cnt = FD_ATOMIC_CAS( &tc->shmem->txnpages_free_cnt, (ushort)txnpages_free_cnt, (ushort)(txnpages_free_cnt-1UL) );
+      ulong old_txnpages_free_cnt = FD_ATOMIC_CAS( &tc->shmem->txnpages_free_cnt, txnpages_free_cnt, txnpages_free_cnt-1UL );
       if( FD_LIKELY( old_txnpages_free_cnt==txnpages_free_cnt ) ) break;
       txnpages_free_cnt = old_txnpages_free_cnt;
       FD_SPIN_PAUSE();
     }
 
-    ushort txnpage_idx = tc->txnpages_free[ txnpages_free_cnt-1UL ];
+    ulong txnpage_idx = fd_txncache_txnpage_idx_ld( idx_sz, tc->txnpages_free, txnpages_free_cnt-1UL );
     fd_txncache_txnpage_t * txnpage = &tc->txnpages[ txnpage_idx ];
     txnpage->free = FD_TXNCACHE_TXNS_PER_PAGE;
     FD_COMPILER_MFENCE();
-    blockcache->pages[ page_cnt ] = txnpage_idx;
+    fd_txncache_txnpage_idx_st( idx_sz, blockcache->pages, page_cnt, txnpage_idx );
     FD_COMPILER_MFENCE();
-    blockcache->shmem->pages_cnt = (ushort)(page_cnt+1);
+    blockcache->shmem->pages_cnt = page_cnt+1UL;
     return txnpage;
   } else {
-    ushort txnpage_idx = blockcache->pages[ page_cnt ];
-    while( FD_UNLIKELY( txnpage_idx==(ushort)(USHORT_MAX-1UL) ) ) {
-      txnpage_idx = blockcache->pages[ page_cnt ];
+    ulong txnpage_idx = fd_txncache_txnpage_idx_ld( idx_sz, blockcache->pages, page_cnt );
+    while( FD_UNLIKELY( txnpage_idx==idx_null-1UL ) ) {
+      txnpage_idx = fd_txncache_txnpage_idx_ld( idx_sz, blockcache->pages, page_cnt );
       FD_SPIN_PAUSE();
     }
-    if( FD_UNLIKELY( txnpage_idx==(ushort)USHORT_MAX ) ) return NULL;
+    if( FD_UNLIKELY( txnpage_idx==idx_null ) ) return NULL;
     return &tc->txnpages[ txnpage_idx ];
   }
 }
@@ -293,8 +300,8 @@ fd_txncache_attach_child( fd_txncache_t *       tc,
   fork->shmem->txnhash_offset = 0UL;
   fork->shmem->frozen = 0;
   memset( fork->heads, 0xFF, tc->shmem->bucket_cnt*sizeof(uint) );
-  fork->shmem->pages_cnt = 0;
-  memset( fork->pages, 0xFF, tc->shmem->txnpages_per_blockhash_max*sizeof(fork->pages[ 0 ]) );
+  fork->shmem->pages_cnt = 0UL;
+  memset( fork->pages, 0xFF, tc->shmem->txnpages_per_blockhash_max*tc->shmem->txnpage_idx_sz );
 
   fd_rwlock_unwrite( tc->shmem->lock );
   return fork_id;
@@ -341,8 +348,9 @@ static inline void
 remove_blockcache( fd_txncache_t * tc,
                    blockcache_t *  blockcache ) {
   FD_TEST( blockcache->shmem->frozen>=0 );
-  memcpy( tc->txnpages_free+tc->shmem->txnpages_free_cnt, blockcache->pages, blockcache->shmem->pages_cnt*sizeof(tc->txnpages_free[ 0 ]) );
-  tc->shmem->txnpages_free_cnt = (ushort)(tc->shmem->txnpages_free_cnt+blockcache->shmem->pages_cnt);
+  ulong idx_sz = tc->shmem->txnpage_idx_sz;
+  memcpy( (uchar *)tc->txnpages_free+tc->shmem->txnpages_free_cnt*idx_sz, blockcache->pages, blockcache->shmem->pages_cnt*idx_sz );
+  tc->shmem->txnpages_free_cnt += blockcache->shmem->pages_cnt;
 
   ulong idx = blockcache_pool_idx( tc->blockcache_shmem_pool, blockcache->shmem );
   for( ulong i=0UL; i<tc->shmem->active_slots_max; i++ ) descends_set_remove( tc->blockcache_pool[ i ].descends, idx );
@@ -460,13 +468,14 @@ static void
 purge_stale_on_blockcache( fd_txncache_t * tc,
                            blockcache_t *  blockcache ) {
   FD_TEST( blockcache->shmem->frozen>=0 );
+  ulong idx_sz = tc->shmem->txnpage_idx_sz;
   memset( tc->scratch_heads, 0xFF, tc->shmem->bucket_cnt*sizeof(tc->scratch_heads[ 0 ]) );
-  memset( tc->scratch_pages, 0xFF, tc->shmem->txnpages_per_blockhash_max*sizeof(tc->scratch_pages[ 0 ]) );
-  ushort scratch_pages_cnt = 0;
-  ushort scratch_txnpage_idx = USHORT_MAX;
+  memset( tc->scratch_pages, 0xFF, tc->shmem->txnpages_per_blockhash_max*idx_sz );
+  ulong scratch_pages_cnt = 0UL;
+  ulong scratch_txnpage_idx = ULONG_MAX;
   tc->scratch_txnpage->free = 0;
   for( ulong i=0UL; i<blockcache->shmem->pages_cnt; i++ ) {
-    ushort curr_txnpage_idx = blockcache->pages[ blockcache->shmem->pages_cnt-i-1UL ];
+    ulong curr_txnpage_idx = fd_txncache_txnpage_idx_ld( idx_sz, blockcache->pages, blockcache->shmem->pages_cnt-i-1UL );
     ulong curr_txn_cnt = FD_TXNCACHE_TXNS_PER_PAGE-tc->txnpages[ curr_txnpage_idx ].free;
     for( ulong j=0UL; j<curr_txn_cnt; j++ ) {
       fd_txncache_single_txn_t * curr_txn = tc->txnpages[ curr_txnpage_idx ].txns[ curr_txn_cnt-j-1UL ];
@@ -475,13 +484,13 @@ purge_stale_on_blockcache( fd_txncache_t * tc,
         /* Valid transaction.  Keep. */
         if( FD_UNLIKELY( !tc->scratch_txnpage->free ) ) {
           FD_TEST( scratch_txnpage_idx!=curr_txnpage_idx );
-          if( FD_LIKELY( scratch_txnpage_idx!=USHORT_MAX ) ) {
+          if( FD_LIKELY( scratch_txnpage_idx!=ULONG_MAX ) ) {
             fd_txncache_txnpage_t * txnpage = &tc->txnpages[ scratch_txnpage_idx ];
             memcpy( txnpage, tc->scratch_txnpage, sizeof(*txnpage) );
           }
           scratch_txnpage_idx = curr_txnpage_idx;
           tc->scratch_txnpage->free = FD_TXNCACHE_TXNS_PER_PAGE;
-          tc->scratch_pages[ scratch_pages_cnt ] = scratch_txnpage_idx;
+          fd_txncache_txnpage_idx_st( idx_sz, tc->scratch_pages, scratch_pages_cnt, scratch_txnpage_idx );
           scratch_pages_cnt++;
         }
         ulong txn_idx = FD_TXNCACHE_TXNS_PER_PAGE-tc->scratch_txnpage->free;
@@ -500,16 +509,16 @@ purge_stale_on_blockcache( fd_txncache_t * tc,
     }
     if( FD_UNLIKELY( curr_txnpage_idx!=scratch_txnpage_idx ) ) {
       /* The txnpage is not being used for compaction, free it up. */
-      tc->txnpages_free[ tc->shmem->txnpages_free_cnt ] = curr_txnpage_idx;
+      fd_txncache_txnpage_idx_st( idx_sz, tc->txnpages_free, tc->shmem->txnpages_free_cnt, curr_txnpage_idx );
       tc->shmem->txnpages_free_cnt++;
     }
   }
-  if( FD_LIKELY( scratch_txnpage_idx!=USHORT_MAX ) ) {
+  if( FD_LIKELY( scratch_txnpage_idx!=ULONG_MAX ) ) {
     fd_txncache_txnpage_t * txnpage = &tc->txnpages[ scratch_txnpage_idx ];
     memcpy( txnpage, tc->scratch_txnpage, sizeof(*txnpage) );
   }
   blockcache->shmem->pages_cnt = scratch_pages_cnt;
-  memcpy( blockcache->pages, tc->scratch_pages, tc->shmem->txnpages_per_blockhash_max*sizeof(blockcache->pages[0]) );
+  memcpy( blockcache->pages, tc->scratch_pages, tc->shmem->txnpages_per_blockhash_max*idx_sz );
   memcpy( blockcache->heads, tc->scratch_heads, tc->shmem->bucket_cnt*sizeof(blockcache->heads[0]) );
 }
 
@@ -531,7 +540,7 @@ purge_stale( fd_txncache_t * tc ) {
   fd_txncache_blockcache_shmem_t * root_shmem = root_slist_ele_peek_head( tc->shmem->root_ll, tc->blockcache_shmem_pool );
   FD_TEST( root_shmem );
   blockcache_t * root = &tc->blockcache_pool[ blockcache_pool_idx( tc->blockcache_shmem_pool, root_shmem ) ];
-  ushort free_before = tc->shmem->txnpages_free_cnt;
+  ulong free_before = tc->shmem->txnpages_free_cnt;
   /* One might think that an optimization here is to stop the descent on
      the latest rooted blockcache.  There could be no pruned minority
      forks from that point on.  As a result, there could be no stale
@@ -539,7 +548,7 @@ purge_stale( fd_txncache_t * tc ) {
      Unfortunately, frontier eviction means that any blockcache in the
      fork tree can have stale transactions. */
   purge_stale_on_fork( tc, root );
-  FD_LOG_WARNING(( "purge_stale: txnpages_free %hu -> %hu", free_before, tc->shmem->txnpages_free_cnt ));
+  FD_LOG_WARNING(( "purge_stale: txnpages_free %lu -> %lu", free_before, tc->shmem->txnpages_free_cnt ));
 }
 
 void
@@ -561,10 +570,20 @@ fd_txncache_insert( fd_txncache_t *       tc,
       /* Because of sizing invariants when creating the structure, it is
          not typically possible to fill it, unless there are stale
          transactions from minority forks that were purged floating
-         around, in which case we can purge them here and try again. */
+         around, in which case we can purge them here and try again.
+         Under the write lock there are no concurrent allocators, so a
+         page still unavailable after the purge means the cache is
+         undersized for the caller's usage. */
       fd_rwlock_unread( tc->shmem->lock );
       fd_rwlock_write( tc->shmem->lock );
-      if( FD_LIKELY( !fd_txncache_ensure_txnpage( tc, blockcache ) ) ) purge_stale( tc );
+      if( FD_LIKELY( !fd_txncache_ensure_txnpage( tc, blockcache ) ) ) {
+        purge_stale( tc );
+        if( FD_UNLIKELY( !fd_txncache_ensure_txnpage( tc, blockcache ) ) )
+          FD_LOG_ERR(( "txncache full after purging stale entries: blockcache holds %lu of %lu txnpages, pool has %lu of %lu free (active_slots_max=%lu txn_per_slot_max=%lu)",
+                       blockcache->shmem->pages_cnt, tc->shmem->txnpages_per_blockhash_max,
+                       tc->shmem->txnpages_free_cnt, tc->shmem->max_txnpages,
+                       tc->shmem->active_slots_max,  tc->shmem->txn_per_slot_max ));
+      }
       fd_rwlock_unwrite( tc->shmem->lock );
       fd_rwlock_read( tc->shmem->lock );
       continue;

--- a/src/flamenco/runtime/fd_txncache.h
+++ b/src/flamenco/runtime/fd_txncache.h
@@ -242,8 +242,9 @@ fd_txncache_advance_root( fd_txncache_t *       tc,
    Insertion cannot fail, as it is assumed the caller is respecting the
    invariants of the structure.  If there is no space internally to
    insert another transaction, stale entries from removed forks are
-   purged and the insert retries, spinning forever if the caller has
-   exceeded the sizing bounds and no stale entries exist.
+   purged and the insert retries.  If the purge frees nothing the
+   caller has exceeded the sizing bounds, which logs an error and
+   exits.
 
    This is a cheap, high performance, concurrent operation and can occur
    at the same time as queries and arbitrary other insertions. */

--- a/src/flamenco/runtime/fd_txncache_private.h
+++ b/src/flamenco/runtime/fd_txncache_private.h
@@ -18,6 +18,11 @@
    [149, 300). */
 #define FD_TXNCACHE_MAX_BLOCKHASH_DISTANCE (151UL)
 
+/* The global txn index (page*FD_TXNCACHE_TXNS_PER_PAGE+txn) is a uint
+   with UINT_MAX as the null link, which bounds the txnpage pool. */
+
+#define FD_TXNCACHE_MAX_TXNPAGES (UINT_MAX/FD_TXNCACHE_TXNS_PER_PAGE)
+
 struct __attribute__((packed)) fd_txncache_single_txn {
   uint  blockcache_next; /* Pointer to the next element in the blockcache hash chain containing this entry from the pool. */
   uint  generation;      /* The generation of the fork when this transaction was inserted.  Used to
@@ -68,7 +73,7 @@ struct fd_txncache_blockcache_shmem {
                             insert into the cache ourselves, we do just always use a key_offset of zero, so this is
                             only nonzero when constructed form a peer snapshot. */
 
-  ushort pages_cnt;      /* The number of txnpages currently in use to store the transactions in this blockcache. */
+  ulong pages_cnt;       /* The number of txnpages currently in use to store the transactions in this blockcache. */
 
   struct {
     ulong next;
@@ -129,11 +134,13 @@ struct __attribute__((aligned(FD_TXNCACHE_SHMEM_ALIGN))) fd_txncache_shmem_priva
   ulong  active_slots_max;
   ulong  bucket_cnt;      /* Hash buckets per blockcache.  Decoupled from txn_per_slot_max (load
                              factor 8) to reduce the heads arrays' memory footprint. */
-  ushort txnpages_per_blockhash_max;
-  ushort max_txnpages;
+  ulong  txnpages_per_blockhash_max;
+  ulong  max_txnpages;
+  ulong  txnpage_idx_sz;  /* Element size of every txnpage index array (blockcache->pages,
+                             txnpages_free, scratch_pages), see fd_txncache_txnpage_idx_sz. */
 
-  uint blockcache_generation; /* Incremented for every blockcache. */
-  ushort txnpages_free_cnt; /* The number of pages in the txnpages that are not currently in use. */
+  uint  blockcache_generation; /* Incremented for every blockcache. */
+  ulong txnpages_free_cnt; /* The number of pages in the txnpages that are not currently in use. */
 
   ulong root_cnt;
   root_slist_t root_ll[1]; /* A singly linked list of the forks that are roots of fork chains.  The tail is the
@@ -146,19 +153,51 @@ struct __attribute__((aligned(FD_TXNCACHE_SHMEM_ALIGN))) fd_txncache_shmem_priva
 
 FD_PROTOTYPES_BEGIN
 
-FD_FN_CONST ushort
-fd_txncache_max_txnpages_per_blockhash( ulong max_active_slots,
-                                        ulong max_txn_per_slot,
-                                        int   larger_max_cost_per_block );
+/* fd_txncache_max_txnpages{,_per_blockhash} return the txnpage pool
+   size and the per blockcache page cap for the given parameters.  The
+   result is not bounded; callers compare against
+   FD_TXNCACHE_MAX_TXNPAGES. */
 
-FD_FN_CONST ushort
+FD_FN_CONST ulong
+fd_txncache_max_txnpages_per_blockhash( ulong max_active_slots,
+                                        ulong max_txn_per_slot );
+
+FD_FN_CONST ulong
 fd_txncache_max_txnpages( ulong max_active_slots,
-                          ulong max_txn_per_slot,
-                          int   larger_max_cost_per_block );
+                          ulong max_txn_per_slot );
 
 FD_FN_CONST static inline ulong
 fd_txncache_bucket_cnt( ulong max_txn_per_slot ) {
   return fd_ulong_max( 1UL, (max_txn_per_slot+7UL)/8UL );
+}
+
+/* Txnpage indices are stored as ushort, which covers production
+   parameters, and widen to uint only when the pool exceeds the ushort
+   range (development.bench sizing), keeping the production footprint
+   unchanged.  The all-ones value of the width is the null index and
+   all-ones minus one is the allocation-in-progress flag, so memset 0xFF
+   nulls an array of either width.  ld/st access an index array of the
+   given element size. */
+
+FD_FN_CONST static inline ulong
+fd_txncache_txnpage_idx_sz( ulong max_txnpages ) {
+  return max_txnpages>USHORT_MAX-2UL ? sizeof(uint) : sizeof(ushort);
+}
+
+static inline ulong
+fd_txncache_txnpage_idx_ld( ulong        idx_sz,
+                            void const * idx,
+                            ulong        i ) {
+  return idx_sz==sizeof(uint) ? (ulong)((uint const *)idx)[ i ] : (ulong)((ushort const *)idx)[ i ];
+}
+
+static inline void
+fd_txncache_txnpage_idx_st( ulong  idx_sz,
+                            void * idx,
+                            ulong  i,
+                            ulong  val ) {
+  if( idx_sz==sizeof(uint) ) ((uint *)idx)[ i ] = (uint)val;
+  else                       ((ushort *)idx)[ i ] = (ushort)val;
 }
 
 FD_PROTOTYPES_END

--- a/src/flamenco/runtime/fd_txncache_shmem.c
+++ b/src/flamenco/runtime/fd_txncache_shmem.c
@@ -28,10 +28,9 @@
 #define SLIST_IMPL_STYLE 2
 #include "../../util/tmpl/fd_slist.c"
 
-FD_FN_CONST ushort
+FD_FN_CONST ulong
 fd_txncache_max_txnpages( ulong max_active_slots,
-                          ulong max_txn_per_slot,
-                          int   larger_max_cost_per_block ) {
+                          ulong max_txn_per_slot ) {
   /* The pool must hold the worst case set of simultaneously live
      transactions.  Entries stay live until their inserting fork's
      blockcache is removed, and rooted forks are retained for
@@ -55,25 +54,15 @@ fd_txncache_max_txnpages( ulong max_active_slots,
      transaction count bound (one blockcache's tail is already counted
      by the ceiling division). */
 
-  ulong result;
-  if( FD_UNLIKELY( larger_max_cost_per_block ) ) {
-    /* Raised block cost limits invalidate the 1x live bound.  Fall
-       back to every active slot simultaneously full. */
-    result = max_active_slots-1UL+max_active_slots*(1UL+(max_txn_per_slot-1UL)/FD_TXNCACHE_TXNS_PER_PAGE);
-  } else {
-    ulong snapshot_budget = FD_TXNCACHE_MAX_SLOT_DELTAS*max_txn_per_slot;
-    ulong live_budget     = (max_active_slots-1UL)*((max_txn_per_slot+1UL)/2UL);
-    result = max_active_slots-1UL
-           + 1UL+(snapshot_budget+live_budget-1UL)/FD_TXNCACHE_TXNS_PER_PAGE;
-  }
-  if( FD_UNLIKELY( result>USHORT_MAX-2UL ) ) return 0; /* MAX is the invalid flag, MAX-1 is the xbusy flag. */
-  return (ushort)result;
+  ulong snapshot_budget = FD_TXNCACHE_MAX_SLOT_DELTAS*max_txn_per_slot;
+  ulong live_budget     = (max_active_slots-1UL)*((max_txn_per_slot+1UL)/2UL);
+  return max_active_slots-1UL
+       + 1UL+(snapshot_budget+live_budget-1UL)/FD_TXNCACHE_TXNS_PER_PAGE;
 }
 
-FD_FN_CONST ushort
+FD_FN_CONST ulong
 fd_txncache_max_txnpages_per_blockhash( ulong max_active_slots,
-                                        ulong max_txn_per_slot,
-                                        int   larger_max_cost_per_block ) {
+                                        ulong max_txn_per_slot ) {
   /* The maximum number of transaction pages we might need to store all
      the transactions that could be seen in a blockhash.
 
@@ -81,13 +70,9 @@ fd_txncache_max_txnpages_per_blockhash( ulong max_active_slots,
      the same blockhash, but a blockhash can never hold more pages than
      exist in the pool. */
 
-  ulong max_txnpages = fd_txncache_max_txnpages( max_active_slots, max_txn_per_slot, larger_max_cost_per_block );
-  if( FD_UNLIKELY( !max_txnpages ) ) return 0;
-
+  ulong max_txnpages = fd_txncache_max_txnpages( max_active_slots, max_txn_per_slot );
   ulong result = 1UL+(max_txn_per_slot*max_active_slots)/FD_TXNCACHE_TXNS_PER_PAGE;
-  result = fd_ulong_min( result, max_txnpages );
-  if( FD_UNLIKELY( result>USHORT_MAX-2UL ) ) return 0; /* MAX is the invalid flag, MAX-1 is the xbusy flag. */
-  return (ushort)result;
+  return fd_ulong_min( result, max_txnpages );
 }
 
 FD_FN_CONST ulong
@@ -95,10 +80,9 @@ fd_txncache_shmem_align( void ) {
   return FD_TXNCACHE_SHMEM_ALIGN;
 }
 
-FD_FN_CONST ulong
+ulong
 fd_txncache_shmem_footprint( ulong max_live_slots,
-                             ulong max_txn_per_slot,
-                             int   larger_max_cost_per_block ) {
+                             ulong max_txn_per_slot ) {
   if( FD_UNLIKELY( max_live_slots<1UL ) ) return 0UL;
   if( FD_UNLIKELY( max_txn_per_slot<1UL ) ) return 0UL;
 
@@ -106,30 +90,29 @@ fd_txncache_shmem_footprint( ulong max_live_slots,
   ulong blockhash_map_chains = fd_ulong_pow2_up( 2UL*max_active_slots );
   ulong bucket_cnt = fd_txncache_bucket_cnt( max_txn_per_slot );
 
-  /* To save memory, txnpages are referenced as ushort which is enough
-     to support mainnet parameters without overflow. */
-  ushort _max_txnpages = fd_txncache_max_txnpages( max_active_slots, max_txn_per_slot, larger_max_cost_per_block );
-  if( FD_UNLIKELY( !_max_txnpages ) ) return 0UL;
-
-  ulong _max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, larger_max_cost_per_block );
-  if( FD_UNLIKELY( !_max_txnpages_per_blockhash ) ) return 0UL;
+  ulong _max_txnpages               = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot );
+  ulong _max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot );
+  if( FD_UNLIKELY( _max_txnpages>FD_TXNCACHE_MAX_TXNPAGES ) )
+    FD_LOG_ERR(( "txncache needs %lu txnpages but at most %lu are addressable (max_live_slots=%lu max_txn_per_slot=%lu)",
+                 _max_txnpages, FD_TXNCACHE_MAX_TXNPAGES, max_live_slots, max_txn_per_slot ));
+  ulong _txnpage_idx_sz = fd_txncache_txnpage_idx_sz( _max_txnpages );
 
   ulong _descends_footprint = descends_set_footprint( max_active_slots );
   if( FD_UNLIKELY( !_descends_footprint ) ) return 0UL;
 
   ulong l;
   l = FD_LAYOUT_INIT;
-  l = FD_LAYOUT_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,        sizeof(fd_txncache_shmem_t)                                 );
-  l = FD_LAYOUT_APPEND( l, blockhash_map_align(),          blockhash_map_footprint( blockhash_map_chains )             );
-  l = FD_LAYOUT_APPEND( l, blockcache_pool_align(),        blockcache_pool_footprint( max_active_slots )               );
-  l = FD_LAYOUT_APPEND( l, alignof(ushort),                max_active_slots*_max_txnpages_per_blockhash*sizeof(ushort) ); /* blockcache->pages */
-  l = FD_LAYOUT_APPEND( l, alignof(uint),                  max_active_slots*bucket_cnt*sizeof(uint)                    ); /* blockcache->heads */
-  l = FD_LAYOUT_APPEND( l, descends_set_align(),           max_active_slots*_descends_footprint                        ); /* blockcache->descends */
-  l = FD_LAYOUT_APPEND( l, alignof(ushort),                _max_txnpages*sizeof(ushort)                                ); /* txnpages_free */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_txnpage_t), _max_txnpages*sizeof(fd_txncache_txnpage_t)                 ); /* txnpages */
-  l = FD_LAYOUT_APPEND( l, alignof(ushort),                _max_txnpages_per_blockhash*sizeof(ushort)                  ); /* scratchpad txnpage pointer array for purge stale */
-  l = FD_LAYOUT_APPEND( l, alignof(uint),                  bucket_cnt*sizeof(uint)                                     ); /* scratchpad heads for purge stale */
-  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_txnpage_t), sizeof(fd_txncache_txnpage_t)                               ); /* scratchpad txnpage for purge stale */
+  l = FD_LAYOUT_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,        sizeof(fd_txncache_shmem_t)                                   );
+  l = FD_LAYOUT_APPEND( l, blockhash_map_align(),          blockhash_map_footprint( blockhash_map_chains )               );
+  l = FD_LAYOUT_APPEND( l, blockcache_pool_align(),        blockcache_pool_footprint( max_active_slots )                 );
+  l = FD_LAYOUT_APPEND( l, _txnpage_idx_sz,                max_active_slots*_max_txnpages_per_blockhash*_txnpage_idx_sz ); /* blockcache->pages */
+  l = FD_LAYOUT_APPEND( l, alignof(uint),                  max_active_slots*bucket_cnt*sizeof(uint)                      ); /* blockcache->heads */
+  l = FD_LAYOUT_APPEND( l, descends_set_align(),           max_active_slots*_descends_footprint                          ); /* blockcache->descends */
+  l = FD_LAYOUT_APPEND( l, _txnpage_idx_sz,                _max_txnpages*_txnpage_idx_sz                                 ); /* txnpages_free */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_txnpage_t), _max_txnpages*sizeof(fd_txncache_txnpage_t)                   ); /* txnpages */
+  l = FD_LAYOUT_APPEND( l, _txnpage_idx_sz,                _max_txnpages_per_blockhash*_txnpage_idx_sz                   ); /* scratchpad txnpage pointer array for purge stale */
+  l = FD_LAYOUT_APPEND( l, alignof(uint),                  bucket_cnt*sizeof(uint)                                       ); /* scratchpad heads for purge stale */
+  l = FD_LAYOUT_APPEND( l, alignof(fd_txncache_txnpage_t), sizeof(fd_txncache_txnpage_t)                                 ); /* scratchpad txnpage for purge stale */
   return FD_LAYOUT_FINI( l, FD_TXNCACHE_SHMEM_ALIGN );
 }
 
@@ -137,7 +120,6 @@ void *
 fd_txncache_shmem_new( void * shmem,
                        ulong  max_live_slots,
                        ulong  max_txn_per_slot,
-                       int    larger_max_cost_per_block,
                        ulong  seed ) {
   if( FD_UNLIKELY( !shmem ) ) {
     FD_LOG_WARNING(( "NULL shmem" ));
@@ -156,27 +138,28 @@ fd_txncache_shmem_new( void * shmem,
   ulong blockhash_map_chains = fd_ulong_pow2_up( 2UL*max_active_slots );
   ulong bucket_cnt = fd_txncache_bucket_cnt( max_txn_per_slot );
 
-  ushort _max_txnpages               = fd_txncache_max_txnpages( max_active_slots, max_txn_per_slot, larger_max_cost_per_block );
-  ushort _max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, larger_max_cost_per_block );
-
-  if( FD_UNLIKELY( !_max_txnpages ) ) return NULL;
-  if( FD_UNLIKELY( !_max_txnpages_per_blockhash ) ) return NULL;
+  ulong _max_txnpages               = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot );
+  ulong _max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot );
+  if( FD_UNLIKELY( _max_txnpages>FD_TXNCACHE_MAX_TXNPAGES ) )
+    FD_LOG_ERR(( "txncache needs %lu txnpages but at most %lu are addressable (max_live_slots=%lu max_txn_per_slot=%lu)",
+                 _max_txnpages, FD_TXNCACHE_MAX_TXNPAGES, max_live_slots, max_txn_per_slot ));
+  ulong _txnpage_idx_sz = fd_txncache_txnpage_idx_sz( _max_txnpages );
 
   ulong _descends_footprint = descends_set_footprint( max_active_slots );
   if( FD_UNLIKELY( !_descends_footprint ) ) return NULL;
 
   FD_SCRATCH_ALLOC_INIT( l, shmem );
-  fd_txncache_shmem_t * tc    = FD_SCRATCH_ALLOC_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,         sizeof(fd_txncache_shmem_t)                                 );
-  void * _blockhash_map       = FD_SCRATCH_ALLOC_APPEND( l, blockhash_map_align(),           blockhash_map_footprint( blockhash_map_chains )             );
-  void * _blockcache_pool     = FD_SCRATCH_ALLOC_APPEND( l, blockcache_pool_align(),         blockcache_pool_footprint( max_active_slots )               );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 max_active_slots*_max_txnpages_per_blockhash*sizeof(ushort) );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   max_active_slots*bucket_cnt*sizeof(uint)                    );
-  void * _blockcache_descends = FD_SCRATCH_ALLOC_APPEND( l, descends_set_align(),            max_active_slots*_descends_footprint                        );
-  void * _txnpages_free       = FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 _max_txnpages*sizeof(ushort)                                );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  _max_txnpages*sizeof(fd_txncache_txnpage_t)                 );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(ushort),                 _max_txnpages_per_blockhash*sizeof(ushort)                  );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   bucket_cnt*sizeof(uint)                                     );
-                                FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  sizeof(fd_txncache_txnpage_t)                               );
+  fd_txncache_shmem_t * tc    = FD_SCRATCH_ALLOC_APPEND( l, FD_TXNCACHE_SHMEM_ALIGN,         sizeof(fd_txncache_shmem_t)                                   );
+  void * _blockhash_map       = FD_SCRATCH_ALLOC_APPEND( l, blockhash_map_align(),           blockhash_map_footprint( blockhash_map_chains )               );
+  void * _blockcache_pool     = FD_SCRATCH_ALLOC_APPEND( l, blockcache_pool_align(),         blockcache_pool_footprint( max_active_slots )                 );
+                                FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 max_active_slots*_max_txnpages_per_blockhash*_txnpage_idx_sz );
+                                FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   max_active_slots*bucket_cnt*sizeof(uint)                      );
+  void * _blockcache_descends = FD_SCRATCH_ALLOC_APPEND( l, descends_set_align(),            max_active_slots*_descends_footprint                          );
+  void * _txnpages_free       = FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 _max_txnpages*_txnpage_idx_sz                                 );
+                                FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  _max_txnpages*sizeof(fd_txncache_txnpage_t)                   );
+                                FD_SCRATCH_ALLOC_APPEND( l, _txnpage_idx_sz,                 _max_txnpages_per_blockhash*_txnpage_idx_sz                   );
+                                FD_SCRATCH_ALLOC_APPEND( l, alignof(uint),                   bucket_cnt*sizeof(uint)                                       );
+                                FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_txncache_txnpage_t),  sizeof(fd_txncache_txnpage_t)                                 );
 
   fd_txncache_blockcache_shmem_t * blockcache_pool = blockcache_pool_join( blockcache_pool_new( _blockcache_pool, max_active_slots ) );
   FD_TEST( blockcache_pool );
@@ -200,11 +183,11 @@ fd_txncache_shmem_new( void * shmem,
   tc->bucket_cnt                 = bucket_cnt;
   tc->txnpages_per_blockhash_max = _max_txnpages_per_blockhash;
   tc->max_txnpages               = _max_txnpages;
+  tc->txnpage_idx_sz             = _txnpage_idx_sz;
 
   tc->blockcache_generation = 0U;
   tc->txnpages_free_cnt = _max_txnpages;
-  ushort * txnpages_free = (ushort *)_txnpages_free;
-  for( ushort i=0; i<_max_txnpages; i++ ) txnpages_free[ i ] = i;
+  for( ulong i=0UL; i<_max_txnpages; i++ ) fd_txncache_txnpage_idx_st( _txnpage_idx_sz, _txnpages_free, i, i );
 
   tc->seed = seed;
 

--- a/src/flamenco/runtime/fd_txncache_shmem.h
+++ b/src/flamenco/runtime/fd_txncache_shmem.h
@@ -23,23 +23,25 @@ FD_PROTOTYPES_BEGIN
 FD_FN_CONST ulong
 fd_txncache_shmem_align( void );
 
-/* larger_max_cost_per_block indicates the validator is running with
-   development.bench.larger_max_cost_per_block, which raises the block
-   cost limit and invalidates the tightened txnpage pool bound (which
-   assumes at most FD_MAX_TXN_PER_SLOT committable transactions per
-   slot).  When set, the pool is sized for every active slot
-   simultaneously full at max_txn_per_slot instead. */
+/* The txnpage pool is sized for the worst case set of simultaneously
+   live transactions: a full snapshot load (151 slot deltas at
+   max_txn_per_slot entries, which counts each transaction twice) plus
+   every other active fork full at max_txn_per_slot/2.  Callers pass
+   2*config->limits.max_txn_per_slot, so a raised [development.bench]
+   block cost limit sizes the pool up through that value.
 
-FD_FN_CONST ulong
+   footprint and new return 0 / NULL for zero max_live_slots or
+   max_txn_per_slot, and log an error and exit if the parameters need a
+   txnpage pool larger than the structure can address. */
+
+ulong
 fd_txncache_shmem_footprint( ulong max_live_slots,
-                             ulong max_txn_per_slot,
-                             int   larger_max_cost_per_block );
+                             ulong max_txn_per_slot );
 
 void *
 fd_txncache_shmem_new( void * shmem,
                        ulong  max_live_slots,
                        ulong  max_txn_per_slot,
-                       int    larger_max_cost_per_block,
                        ulong  seed );
 
 fd_txncache_shmem_t *

--- a/src/flamenco/runtime/fuzz_txncache_fork_graph.c
+++ b/src/flamenco/runtime/fuzz_txncache_fork_graph.c
@@ -126,7 +126,7 @@ fuzz_bounded( fuzz_cursor_t * cur,
 
 static fd_txncache_t *
 setup( ulong max_live_slots, ulong max_txn_per_slot ) {
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( fuzz_shmem, max_live_slots, max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( fuzz_shmem, max_live_slots, max_txn_per_slot, 0UL ) );
   FD_TEST( shtc );
 
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( fuzz_ljoin, shtc ) );
@@ -1141,7 +1141,7 @@ LLVMFuzzerInitialize( int *    argc,
   fd_log_level_logfile_set( 4 );
   atexit( fd_halt );
 
-  fuzz_shmem_fp = fd_txncache_shmem_footprint( FUZZ_MAX_LIVE_SLOTS, FUZZ_MAX_TXN_PER_SLOT, 0 );
+  fuzz_shmem_fp = fd_txncache_shmem_footprint( FUZZ_MAX_LIVE_SLOTS, FUZZ_MAX_TXN_PER_SLOT );
   fuzz_ljoin_fp = fd_txncache_footprint( FUZZ_MAX_LIVE_SLOTS );
   FD_TEST( fuzz_shmem_fp );
   FD_TEST( fuzz_ljoin_fp );

--- a/src/flamenco/runtime/test_txncache.c
+++ b/src/flamenco/runtime/test_txncache.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE /* MAP_ANONYMOUS */
 #include "fd_txncache.h"
 
 #include "../../disco/pack/fd_pack.h"
@@ -5,6 +6,8 @@
 #include "../../util/fd_util.h"
 #include "fd_txncache_shmem.h"
 #include "fd_txncache_private.h"
+
+#include <sys/mman.h>
 
 FD_STATIC_ASSERT( FD_TXNCACHE_ALIGN==128UL, unit_test );
 
@@ -28,8 +31,81 @@ test_page_sizing( void ) {
   ulong const max_active_slots = 2199UL;
   ulong const max_txn_per_slot = 196078UL;
 
-  FD_TEST( fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot, 0 )==32118UL );
-  FD_TEST( fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, 0 )==32118UL );
+  FD_TEST( fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot )==32118UL );
+  FD_TEST( fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot )==32118UL );
+  FD_TEST( fd_txncache_txnpage_idx_sz( 32118UL )==sizeof(ushort) );
+  FD_TEST( fd_txncache_shmem_footprint( 2048UL, max_txn_per_slot )==8251646848UL ); /* production, ushort page indices */
+
+  /* development.bench.max_cost_per_block = 540M: 2*529,411 txns per
+     slot.  The pool exceeds the ushort range, so page indices widen to
+     uint. */
+  ulong const bench_txn_per_slot = 1058822UL;
+  FD_TEST( fd_txncache_max_txnpages              ( max_active_slots, bench_txn_per_slot )==163762UL );
+  FD_TEST( fd_txncache_max_txnpages_per_blockhash( max_active_slots, bench_txn_per_slot )==163762UL );
+  FD_TEST( fd_txncache_txnpage_idx_sz( 163762UL )==sizeof(uint) );
+  FD_TEST( 163762UL<=FD_TXNCACHE_MAX_TXNPAGES );
+  FD_TEST( fd_txncache_shmem_footprint( 2048UL, bench_txn_per_slot )==42854135168UL );
+
+  FD_TEST( fd_txncache_txnpage_idx_sz( USHORT_MAX-2UL )==sizeof(ushort) );
+  FD_TEST( fd_txncache_txnpage_idx_sz( USHORT_MAX-1UL )==sizeof(uint)   );
+}
+
+static void
+test_bench_sizing( ulong max_live_slots,
+                   ulong expected_idx_sz ) {
+  FD_LOG_NOTICE(( "TEST BENCH SIZING (max_live_slots=%lu)", max_live_slots ));
+
+  /* The pool is tens of GiB at bench sizes but only the pages touched
+     by the inserts below are ever faulted in, so back it with a lazily
+     committed anonymous mapping rather than locked shmem. */
+
+  ulong const max_txn_per_slot = 1058822UL;
+  ulong footprint_shmem = fd_txncache_shmem_footprint( max_live_slots, max_txn_per_slot );
+  ulong footprint_local = fd_txncache_footprint( max_live_slots );
+  FD_TEST( footprint_shmem );
+
+  ulong   sz  = fd_ulong_align_up( footprint_shmem, FD_TXNCACHE_ALIGN )+footprint_local;
+  uchar * mem = mmap( NULL, sz, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0 );
+  FD_TEST( mem!=MAP_FAILED );
+  FD_TEST( fd_ulong_is_aligned( (ulong)mem, FD_TXNCACHE_SHMEM_ALIGN ) );
+
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( mem, max_live_slots, max_txn_per_slot, 0UL ) );
+  FD_TEST( shtc );
+  fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( mem+fd_ulong_align_up( footprint_shmem, FD_TXNCACHE_ALIGN ), shtc ) );
+  FD_TEST( tc );
+
+  ulong const max_active_slots = FD_TXNCACHE_MAX_BLOCKHASH_DISTANCE+max_live_slots;
+  FD_TEST( shtc->max_txnpages==fd_txncache_max_txnpages( max_active_slots, max_txn_per_slot ) );
+  FD_TEST( shtc->txnpage_idx_sz==expected_idx_sz );
+  FD_TEST( shtc->txnpages_free_cnt==shtc->max_txnpages );
+
+  /* Root -> a -> b.  Inserts on b under a's blockhash land in a's
+     blockcache and span three pages; cancelling a returns them. */
+
+  fd_txncache_fork_id_t root = fd_txncache_attach_child( tc, NULL_FORK );
+  fd_txncache_finalize_fork( tc, root, 0UL, BLOCKHASH(1UL) );
+  fd_txncache_fork_id_t a = fd_txncache_attach_child( tc, root );
+  fd_txncache_finalize_fork( tc, a, 0UL, BLOCKHASH(2UL) );
+  fd_txncache_fork_id_t b = fd_txncache_attach_child( tc, a );
+
+  ulong const txn_cnt = 2UL*FD_TXNCACHE_TXNS_PER_PAGE+1UL;
+  for( ulong i=0UL; i<txn_cnt; i++ ) fd_txncache_insert( tc, b, BLOCKHASH(2UL), TXNHASH(i) );
+  FD_TEST( shtc->txnpages_free_cnt==shtc->max_txnpages-3UL );
+  for( ulong i=0UL; i<txn_cnt; i++ ) FD_TEST(  fd_txncache_query( tc, b, BLOCKHASH(2UL), TXNHASH(i)         ) );
+  for( ulong i=0UL; i<64UL;     i++ ) FD_TEST( !fd_txncache_query( tc, b, BLOCKHASH(2UL), TXNHASH(txn_cnt+i) ) );
+
+  fd_txncache_cancel_fork( tc, a );
+  FD_TEST( shtc->txnpages_free_cnt==shtc->max_txnpages );
+
+  fd_txncache_fork_id_t c = fd_txncache_attach_child( tc, root );
+  fd_txncache_insert( tc, c, BLOCKHASH(1UL), TXNHASH(7UL) );
+  FD_TEST(  fd_txncache_query( tc, c, BLOCKHASH(1UL), TXNHASH(7UL) ) );
+  FD_TEST( !fd_txncache_query( tc, c, BLOCKHASH(1UL), TXNHASH(8UL) ) );
+
+  fd_txncache_reset( tc );
+  FD_TEST( shtc->txnpages_free_cnt==shtc->max_txnpages );
+
+  FD_TEST( !munmap( mem, sz ) );
 }
 
 void
@@ -37,7 +113,7 @@ test0( uchar * scratch0,
        uchar * scratch1 ) {
   FD_LOG_NOTICE(( "TEST 0" ));
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
@@ -64,18 +140,18 @@ void
 test_new_join( uchar * scratch0 ) {
   FD_LOG_NOTICE(( "TEST NEW" ));
 
-  FD_TEST( fd_txncache_shmem_new( NULL, 1UL, 1UL, 0, 0UL )==NULL );          /* null shmem         */
-  FD_TEST( fd_txncache_shmem_new( (void *)0x1UL, 1UL, 1UL, 0, 0UL )==NULL ); /* misaligned shmem   */
-  FD_TEST( fd_txncache_shmem_new( scratch0, 0UL, 1UL, 0, 0UL )==NULL );  /* 0 max_live_slots */
-  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 0UL, 0, 0UL )==NULL );  /* 0 max_txn_per_slot */
+  FD_TEST( fd_txncache_shmem_new( NULL, 1UL, 1UL, 0UL )==NULL );          /* null shmem         */
+  FD_TEST( fd_txncache_shmem_new( (void *)0x1UL, 1UL, 1UL, 0UL )==NULL ); /* misaligned shmem   */
+  FD_TEST( fd_txncache_shmem_new( scratch0, 0UL, 1UL, 0UL )==NULL );  /* 0 max_live_slots */
+  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 0UL, 0UL )==NULL );  /* 0 max_txn_per_slot */
 
-  FD_TEST( fd_txncache_shmem_new( scratch0, 1UL, 1UL, 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 2UL, 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 2UL, 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 4096UL, fd_ulong_pow2_up( FD_MAX_TXN_PER_SLOT ), 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 512UL, fd_ulong_pow2_up( FD_MAX_TXN_PER_SLOT ), 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 512UL, 1UL, 0, 0UL ) );
-  FD_TEST( fd_txncache_shmem_new( scratch0, 1UL, 1UL, 0, 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 1UL, 1UL, 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 2UL, 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 2UL, 2UL, 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 4096UL, fd_ulong_pow2_up( FD_MAX_TXN_PER_SLOT ), 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 512UL, fd_ulong_pow2_up( FD_MAX_TXN_PER_SLOT ), 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 512UL, 1UL, 0UL ) );
+  FD_TEST( fd_txncache_shmem_new( scratch0, 1UL, 1UL, 0UL ) );
 
   FD_LOG_NOTICE(( "TEST JOIN" ));
 
@@ -92,7 +168,7 @@ test_scratch( uchar * scratch0,
   ulong const max_live_slots   = 4UL;
   ulong const max_txn_per_slot = FD_PACK_MAX_TXNCACHE_TXN_PER_SLOT;
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, max_live_slots, max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, max_live_slots, max_txn_per_slot, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
@@ -102,7 +178,7 @@ test_scratch( uchar * scratch0,
   FD_TEST( scratch );
   FD_TEST( sz );
 
-  ulong footprint = fd_txncache_shmem_footprint( max_live_slots, max_txn_per_slot, 0 );
+  ulong footprint = fd_txncache_shmem_footprint( max_live_slots, max_txn_per_slot );
   FD_TEST( scratch>=scratch0 );
   FD_TEST( scratch+sz<=scratch0+footprint );
 
@@ -138,7 +214,7 @@ test_advance_root( uchar * scratch0,
                    uchar * scratch1 ) {
   FD_LOG_NOTICE(( "TEST ADVANCE ROOT" ));
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
@@ -182,14 +258,14 @@ test_purge_stale( uchar * scratch0,
      returns the rest to the pool: only the valid_pre_purge txns survive
      the purge, so ceil(valid_pre_purge/txns_per_page)==1. */
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, max_txn_per_slot, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
 
   ulong const max_active_slots = FD_TXNCACHE_MAX_BLOCKHASH_DISTANCE+4UL;
-  ulong const pages            = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, 0 );
-  ulong const max_txnpages     = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot, 0 );
+  ulong const pages            = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot );
+  ulong const max_txnpages     = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot );
 
   /* The intention of this test is to hit the per-blockhash page limit,
      not global exhaustion.  The test case should be kept relatively
@@ -316,10 +392,10 @@ test_purge_stale_global( uchar * scratch0,
   ulong const max_txn_per_slot = FD_TXNCACHE_TXNS_PER_PAGE;
   ulong const max_active_slots = FD_TXNCACHE_MAX_BLOCKHASH_DISTANCE+max_live_slots;
 
-  ulong const max_txnpages               = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot, 0 );
-  ulong const max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot, 0 );
+  ulong const max_txnpages               = fd_txncache_max_txnpages              ( max_active_slots, max_txn_per_slot );
+  ulong const max_txnpages_per_blockhash = fd_txncache_max_txnpages_per_blockhash( max_active_slots, max_txn_per_slot );
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, max_live_slots, max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, max_live_slots, max_txn_per_slot, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
@@ -453,7 +529,7 @@ test_advance_past_minority_then_purge( uchar * scratch0,
      repointed from loser_b to winner) and winner->sibling_id (must
      have been reset from loser_a to none). */
 
-  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0, 0UL ) );
+  fd_txncache_shmem_t * shtc = fd_txncache_shmem_join( fd_txncache_shmem_new( scratch0, 4UL, 4UL, 0UL ) );
   FD_TEST( shtc );
   fd_txncache_t * tc = fd_txncache_join( fd_txncache_new( scratch1, shtc ) );
   FD_TEST( tc );
@@ -464,8 +540,8 @@ test_advance_past_minority_then_purge( uchar * scratch0,
   fd_txncache_fork_id_t prev = root;
 
   ulong const max_active_slots = FD_TXNCACHE_MAX_BLOCKHASH_DISTANCE+4UL;
-  ulong const pages            = fd_txncache_max_txnpages_per_blockhash( max_active_slots, 4UL, 0 );
-  ulong const max_txnpages     = fd_txncache_max_txnpages              ( max_active_slots, 4UL, 0 );
+  ulong const pages            = fd_txncache_max_txnpages_per_blockhash( max_active_slots, 4UL );
+  ulong const max_txnpages     = fd_txncache_max_txnpages              ( max_active_slots, 4UL );
 
   FD_TEST( pages<max_txnpages );
   FD_TEST( pages<=64UL );
@@ -562,7 +638,7 @@ main( int     argc,
   test_bucket_cnt();
   test_page_sizing();
 
-  ulong max_footprint_shmem = fd_txncache_shmem_footprint( 4096UL, FD_MAX_TXN_PER_SLOT, 0 );
+  ulong max_footprint_shmem = fd_txncache_shmem_footprint( 4096UL, FD_MAX_TXN_PER_SLOT );
   ulong max_footprint_local = fd_txncache_footprint( FD_MAX_TXN_PER_SLOT );
 
   ulong max_footprint = fd_ulong_align_up( max_footprint_shmem, 4096UL ) + max_footprint_local;
@@ -579,6 +655,8 @@ main( int     argc,
   test_purge_stale( scratch0, scratch1, 256UL, 2000000UL ); /* Several pages per blockhash. */
   test_purge_stale_global( scratch0, scratch1 );
   test_advance_past_minority_then_purge( scratch0, scratch1 );
+  test_bench_sizing( 4UL,   sizeof(ushort) ); /* 29,624 txnpages */
+  test_bench_sizing( 560UL, sizeof(uint)   ); /* 66,111 txnpages, just past the ushort range */
 
   FD_LOG_NOTICE(( "pass" ));
   fd_halt();

--- a/src/flamenco/runtime/tests/fd_shred_harness.c
+++ b/src/flamenco/runtime/tests/fd_shred_harness.c
@@ -214,8 +214,8 @@ fd_solfuzz_pb_shred_run( fd_solfuzz_runner_t * runner,
 
   fd_rng_t rng_mem[1];
   fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 0UL ) );
-  void * sched_mem = fd_spad_alloc( runner->spad, fd_sched_align(), fd_sched_footprint( SCHED_DEPTH, SCHED_BLOCK_CNT_MAX ) );
-  fd_sched_t * sched = fd_sched_join( fd_sched_new( sched_mem, rng, SCHED_DEPTH, SCHED_BLOCK_CNT_MAX, SCHED_EXEC_CNT, 0 ) );
+  void * sched_mem = fd_spad_alloc( runner->spad, fd_sched_align(), fd_sched_footprint( SCHED_DEPTH, SCHED_BLOCK_CNT_MAX, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT ) );
+  fd_sched_t * sched = fd_sched_join( fd_sched_new( sched_mem, rng, SCHED_DEPTH, SCHED_BLOCK_CNT_MAX, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT, SCHED_EXEC_CNT, 0 ) );
   FD_TEST( sched );
   fd_sched_set_bypass_poh_verify( sched, 1 ); /* skip PoH end_hash compare */
   fd_sched_set_bypass_alut_resolution( sched, 1 ); /* skip ALUT resolution (no accdb) */

--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -104,7 +104,7 @@ fd_svm_mini_wksp_data_max( fd_svm_mini_limits_t const * limits ) {
   ulong joiner_cnt  = fd_ulong_max( limits->accdb_joiner_cnt, 1UL );
 
   ulong pcache_sz         = fd_progcache_shmem_footprint( txn_max, limits->max_progcache_recs );
-  ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot, 0 );
+  ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot );
   ulong txncache_sz       = fd_txncache_footprint( txn_max );
   ulong banks_sz          = fd_banks_footprint( txn_max, limits->max_fork_width, limits->max_stake_accounts, limits->max_fallback_stake_accounts, limits->max_vote_accounts );
   ulong runtime_stack_sz  = fd_runtime_stack_footprint( limits->max_vote_accounts, limits->max_vote_accounts, limits->max_stake_accounts );
@@ -143,7 +143,7 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
   ulong const joiner_cnt  = fd_ulong_max( limits->accdb_joiner_cnt, 1UL );
 
   ulong pcache_sz        = fd_progcache_shmem_footprint( txn_max, limits->max_progcache_recs );
-  ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot, 0 );
+  ulong txncache_shmem_sz = fd_txncache_shmem_footprint( txn_max, limits->max_txn_per_slot );
   ulong txncache_sz       = fd_txncache_footprint( txn_max );
   ulong banks_sz         = fd_banks_footprint( txn_max, limits->max_fork_width,
                                                limits->max_stake_accounts, limits->max_fallback_stake_accounts,
@@ -174,7 +174,7 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
   fd_memset( mini, 0, sizeof(fd_svm_mini_t) );
   mini->wksp = wksp;
 
-  fd_txncache_shmem_t * shtxncache = fd_txncache_shmem_join( fd_txncache_shmem_new( txncache_shmem, txn_max, limits->max_txn_per_slot, 0, 0UL ) );
+  fd_txncache_shmem_t * shtxncache = fd_txncache_shmem_join( fd_txncache_shmem_new( txncache_shmem, txn_max, limits->max_txn_per_slot, 0UL ) );
   if( FD_UNLIKELY( !shtxncache ) ) FD_LOG_ERR(( "fd_txncache_shmem_new failed" ));
 
   /* Create accdb backed by memfd */


### PR DESCRIPTION
Replaces the two [development.bench] booleans with the limits themselves, max_cost_per_block and max_shreds_per_block (0 in production), and derives max transactions per slot from them once at config load.  Every structure that was sized by FD_MAX_TXN_PER_SLOT or FD_SHRED_BLK_MAX at compile time (sched, replay, forest, chainer, rotor, store, txncache, snapin, poh timing tables, gui) is now sized from those values, with the production footprints unchanged byte for byte.  The chain's live limits are floored by the bench values where they apply, and the old hardcoded bounds that aborted or rejected blocks past 98,039 transactions or 32,768 shreds compare against the runtime limits instead.