### PR TITLE
smallset: undefine SET_IDX_T after template inclusion

### DIFF
--- a/src/util/tmpl/fd_smallset.c
+++ b/src/util/tmpl/fd_smallset.c
@@ -259,6 +259,7 @@ FD_PROTOTYPES_END
 #undef SET_POP_LSB
 #undef SET_FIND_LSB
 #undef SET_POPCNT
+#undef SET_IDX_T
 #undef SET_MAX
 #undef SET_TYPE
 #undef SET_NAME


### PR DESCRIPTION
otherwise a user may use a stale SET_IDX_T instead of the default