### PR TITLE
vm: zero less heap

### DIFF
--- a/src/flamenco/runtime/tests/fd_svm_mini.c
+++ b/src/flamenco/runtime/tests/fd_svm_mini.c
@@ -237,6 +237,7 @@ fd_svm_mini_create( fd_wksp_t *                  wksp,
 
   FD_TEST( fd_sha256_join( fd_sha256_new( mini->sha256 ) ) );
 
+  fd_memset( vm_mem, 0, fd_vm_footprint() );
   mini->vm = fd_vm_join( fd_vm_new( vm_mem ) );
   FD_TEST( mini->vm );
 

--- a/src/flamenco/vm/fd_vm.c
+++ b/src/flamenco/vm/fd_vm.c
@@ -471,6 +471,15 @@ fd_vm_footprint( void ) {
   return FD_VM_FOOTPRINT;
 }
 
+/* FD_VM_CONTROL_FOOTPRINT is the fixed size head region */
+
+#define FD_VM_CONTROL_FOOTPRINT (offsetof( fd_vm_t, shadow ))
+
+FD_STATIC_ASSERT( offsetof( fd_vm_t, stack )==FD_VM_CONTROL_FOOTPRINT+sizeof(((fd_vm_t *)NULL)->shadow), fd_vm_layout );
+FD_STATIC_ASSERT( offsetof( fd_vm_t, heap )==offsetof( fd_vm_t, stack )+FD_VM_STACK_MAX, fd_vm_layout );
+FD_STATIC_ASSERT( sizeof  ( fd_vm_t       )==offsetof( fd_vm_t, heap )+FD_VM_HEAP_MAX, fd_vm_layout );
+FD_STATIC_ASSERT( sizeof  ( fd_vm_t       )==FD_VM_FOOTPRINT,                          fd_vm_layout );
+
 void *
 fd_vm_new( void * shmem ) {
 
@@ -485,7 +494,7 @@ fd_vm_new( void * shmem ) {
   }
 
   fd_vm_t * vm = (fd_vm_t *)shmem;
-  fd_memset( vm, 0, fd_vm_footprint() );
+  fd_memset( vm, 0, FD_VM_CONTROL_FOOTPRINT ); /* partially zero, excludes shadow/stack/heap */
 
   FD_COMPILER_MFENCE();
   FD_VOLATILE( vm->magic ) = FD_VM_MAGIC;
@@ -652,8 +661,11 @@ fd_vm_init(
   /* Unpack input and rodata */
   fd_vm_mem_cfg( vm );
 
+  /* Zero the memory the program can observe */
+  fd_memset( vm->stack, 0, FD_VM_STACK_MAX );
+  fd_memset( vm->heap,  0, heap_max        );
+
   /* Initialize registers */
-  /* FIXME: Zero out shadow, stack and heap here? */
   fd_memset( vm->reg, 0, FD_VM_REG_MAX * sizeof(ulong) );
   vm->reg[1]  = FD_VM_MEM_MAP_INPUT_REGION_START;
   vm->reg[2]  = r2_initial_value;

--- a/src/flamenco/vm/fd_vm.h
+++ b/src/flamenco/vm/fd_vm.h
@@ -204,14 +204,6 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
   ulong                     reg   [ FD_VM_REG_MAX         ]; /* registers, indexed [0,FD_VM_REG_CNT).  Note that FD_VM_REG_MAX>FD_VM_REG_CNT.
                                                                 As such, malformed instructions, which can have src/dst reg index in
                                                                 [0,FD_VM_REG_MAX), cannot access info outside reg.  Aligned 8. */
-  fd_vm_shadow_t            shadow[ FD_VM_STACK_FRAME_MAX ]; /* shadow stack, indexed [0,frame_cnt), if frame_cnt>0, 0/frame_cnt-1 is
-                                                                bottom/top.  Aligned 16. */
-  uchar                     stack [ FD_VM_STACK_MAX       ]; /* stack, indexed [0,FD_VM_STACK_MAX).  Divided into FD_VM_STACK_FRAME_MAX
-                                                                frames.  Each frame has a FD_VM_STACK_GUARD_SZ region followed by a
-                                                                FD_VM_STACK_FRAME_SZ region.  reg[10] gives the offset of the start of the
-                                                                current stack frame.  Aligned 16. */
-  uchar                     heap  [ FD_VM_HEAP_MAX        ]; /* syscall heap, [0,heap_sz) used, [heap_sz,heap_max) free.  Aligned 8. */
-
   fd_sha256_t * sha; /* Pre-joined SHA instance. This should be re-initialised before every use. */
 
   ulong magic;    /* ==FD_VM_MAGIC */
@@ -234,6 +226,21 @@ struct __attribute__((aligned(FD_VM_HOST_REGION_ALIGN))) fd_vm {
   ulong sbpf_version;     /* SBPF version, SIMD-0161 */
 
   int dump_syscall_to_pb; /* If true, syscalls will be dumped to the specified output directory */
+
+  /* fd_vm_new zero-initializes up to this point only */
+
+  /* shadow stack, indexed [0,frame_cnt), if frame_cnt>0, 0/frame_cnt-1 is
+     bottom/top.  Lazily initialized. */
+  fd_vm_shadow_t shadow[ FD_VM_STACK_FRAME_MAX ] __attribute__((aligned(16)));
+
+  /* stack, indexed [0,FD_VM_STACK_MAX).  Divided into FD_VM_STACK_FRAME_MAX
+     frames.  Each frame has a FD_VM_STACK_GUARD_SZ region followed by a
+     FD_VM_STACK_FRAME_SZ region.  reg[10] gives the offset of the start of the
+     current stack frame. */
+  uchar stack[ FD_VM_STACK_MAX ] __attribute__((aligned(FD_VM_HOST_REGION_ALIGN)));
+
+  /* syscall heap, [0,heap_sz) used, [heap_sz,heap_max) free. */
+  uchar heap[ FD_VM_HEAP_MAX ] __attribute__((aligned(FD_VM_HOST_REGION_ALIGN)));
 };
 
 /* FIXME: MOVE ABOVE INTO PRIVATE WHEN CONSTRUCTORS READY */


### PR DESCRIPTION
Reduces per-execution memset from 512 KiB to 256 KiB.

- shadow stack does not need zeroing
- user stack and heap only need zeroing as per compute budget
  limits
