### PR TITLE
disco: compact transaction storage

### DIFF
--- a/src/choreo/tower/fd_tower.c
+++ b/src/choreo/tower/fd_tower.c
@@ -1371,7 +1371,7 @@ fd_tower_to_vote_txn( fd_tower_t const *    tower,
     ix_accs[1] = 1; /* vote authority */
     program_id = 3; /* vote program */
   }
-  vote_txn->payload_sz = fd_txn_add_instr( txn_meta_out, txn_out, program_id, ix_accs, 2, vote_ix_buf, vote_ix_sz );
+  vote_txn->payload_sz = (ushort)fd_txn_add_instr( txn_meta_out, txn_out, program_id, ix_accs, 2, vote_ix_buf, vote_ix_sz );
 }
 
 int

--- a/src/disco/fd_txn_p.h
+++ b/src/disco/fd_txn_p.h
@@ -5,7 +5,17 @@
 
 struct __attribute__((aligned(64))) fd_txn_p {
   uchar payload[FD_TPU_MTU];
-  ulong payload_sz;
+
+  /* Keep metadata within 40 bytes so fd_txn_p_t fits in 4992 bytes. */
+
+  /* Size of payload in bytes, at most FD_TPU_MTU. */
+  ushort payload_sz;
+
+  /* Source ipv4 address and tpu pipeline for this transaction. TPU is
+     one of FD_TXN_M_TPU_SOURCE_* */
+  uchar source_tpu;
+  uint  source_ipv4;
+
   union {
    struct {
      uint non_execution_cus;
@@ -38,10 +48,6 @@ struct __attribute__((aligned(64))) fd_txn_p {
     uint pack_alloc;
   };
 
-  /* Source ipv4 address and tpu pipeline for this transaction. TPU is one of FD_TXN_M_TPU_SOURCE_* */
-  uchar source_tpu;
-  uint  source_ipv4;
-
   /* Populated by pack, execle.  A combination of the bitfields
      FD_TXN_P_FLAGS_* defined above.  The execle sets the high byte with
      the transaction result code. */
@@ -56,6 +62,9 @@ struct __attribute__((aligned(64))) fd_txn_p {
 };
 
 typedef struct fd_txn_p fd_txn_p_t;
+
+FD_STATIC_ASSERT( FD_TPU_MTU<=USHORT_MAX, fd_txn_p_payload_sz );
+FD_STATIC_ASSERT( sizeof(fd_txn_p_t)==4992UL, fd_txn_p_layout );
 
 #define TXN(txn_p) ((fd_txn_t *)( (txn_p)->_ ))
 

--- a/src/disco/pack/fd_pack_tile.c
+++ b/src/disco/pack/fd_pack_tile.c
@@ -1042,7 +1042,7 @@ during_frag( fd_pack_ctx_t * ctx,
     fd_memcpy( ctx->cur_spot->alt_accts,     fd_txn_m_alut( txnm ),    addr_table_sz );
     ctx->cur_spot->txnp->scheduler_arrival_time_nanos = fd_clock_tile_now( ctx->clock );
     ctx->cur_spot->txnp->first_seen_nanos = txnm->first_seen_nanos;
-    ctx->cur_spot->txnp->payload_sz  = payload_sz;
+    ctx->cur_spot->txnp->payload_sz  = (ushort)payload_sz;
     ctx->cur_spot->txnp->source_ipv4 = source_ipv4;
     ctx->cur_spot->txnp->source_tpu  = source_tpu;
 

--- a/src/disco/pack/test_pack.c
+++ b/src/disco/pack/test_pack.c
@@ -203,7 +203,7 @@ make_transaction1( fd_txn_p_t * txnp,
     }
   }
 
-  txnp->payload_sz = (ulong)(p-p_base);
+  txnp->payload_sz = (ushort)(p-p_base);
   uint flags;
   fd_ulong_store_if( !!priority_fees, priority_fees, (rewards_per_cu * compute + 999999UL)/1000000UL );
   fd_ulong_store_if( !!pack_cost_estimate, pack_cost_estimate, fd_pack_compute_cost( TXN( txnp ), txnp->payload, &flags, NULL, NULL, NULL, NULL, NULL ) );
@@ -226,7 +226,7 @@ make_vote_transaction1( fd_txn_p_t * txnp,
                         ulong        i ) {
   uchar * p = txnp->payload;
   fd_memcpy( p, sample_vote, sample_vote_sz );
-  txnp->payload_sz = sample_vote_sz;
+  txnp->payload_sz = (ushort)sample_vote_sz;
 
   /* Make signature and the two writable accounts unique */
   p[ 0x01+(i%8) ] = (uchar)(p[ 0x01+(i%8) ] + 1UL + (i/8));
@@ -327,7 +327,7 @@ make_nonce_transaction1( fd_txn_p_t * txnp,
   *(ptrs[1]) = 3; fd_memcpy( ptrs[1]+1, &rewards_per_cu, sizeof(ulong) );
   *(ptrs[2]) = 4; fd_memcpy( ptrs[2]+1, &loaded_data_sz, sizeof(uint)  );
 
-  txnp->payload_sz = (ulong)(p-p_base);
+  txnp->payload_sz = (ushort)(p-p_base);
 }
 
 static void
@@ -751,7 +751,7 @@ performance_test2( void ) {
       for( ulong i=0UL; i<1024UL; i++ ) {
         fd_txn_e_t * slot      = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn       = (fd_txn_t *)txn_scratch[ i ];
-        slot->txnp->payload_sz = payload_sz[ i ];
+        slot->txnp->payload_sz = (ushort)payload_sz[ i ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ i ], payload_sz[ i ]                                                );
         fd_memcpy( TXN(slot->txnp),     txn,                  fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
         ulong _deleted;
@@ -837,7 +837,7 @@ void performance_test( int extra_bench ) {
         memcpy( payload_scratch[j&1]+1UL, &j, sizeof(ulong) );
         fd_txn_e_t * slot       = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn        = (fd_txn_t*) txn_scratch[ j&1 ];
-        slot->txnp->payload_sz  = payload_sz[ j&1 ];
+        slot->txnp->payload_sz  = (ushort)payload_sz[ j&1 ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ j&1 ], payload_sz[ j&1 ]                                              );
         fd_memcpy( TXN(slot->txnp),     txn,                    fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
         fd_pack_insert_txn_cancel( pack, slot );
@@ -849,7 +849,7 @@ void performance_test( int extra_bench ) {
         memcpy( payload_scratch[j&1]+1UL, &j, sizeof(ulong) );
         fd_txn_e_t * slot       = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn        = (fd_txn_t*) txn_scratch[ j&1 ];
-        slot->txnp->payload_sz  = payload_sz[ j&1 ];
+        slot->txnp->payload_sz  = (ushort)payload_sz[ j&1 ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ j&1 ], payload_sz[ j&1 ]                                              );
         fd_memcpy( TXN(slot->txnp),     txn,                    fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
 
@@ -895,7 +895,7 @@ void performance_test( int extra_bench ) {
         memcpy( payload_scratch[j&1]+1UL, &j, sizeof(ulong) );
         fd_txn_e_t * slot       = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn        = (fd_txn_t*) txn_scratch[ j&1 ];
-        slot->txnp->payload_sz  = payload_sz[ j&1 ];
+        slot->txnp->payload_sz  = (ushort)payload_sz[ j&1 ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ j&1 ], payload_sz[ j&1 ]                                              );
         fd_memcpy( TXN(slot->txnp),     txn,                    fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
 
@@ -924,7 +924,7 @@ void performance_test( int extra_bench ) {
         memcpy( payload_scratch[j&1]+1UL, &j, sizeof(ulong) );
         fd_txn_e_t * slot       = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn        = (fd_txn_t*) txn_scratch[ j&1 ];
-        slot->txnp->payload_sz  = payload_sz[ j&1 ];
+        slot->txnp->payload_sz  = (ushort)payload_sz[ j&1 ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ j&1 ], payload_sz[ j&1 ]                                              );
         fd_memcpy( TXN(slot->txnp),     txn,                    fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
 
@@ -1002,7 +1002,7 @@ void performance_end_block( void ) {
         }
         fd_txn_e_t * slot      = fd_pack_insert_txn_init( pack );
         fd_txn_t *   txn       = (fd_txn_t*) txn_scratch[ 0UL ];
-        slot->txnp->payload_sz = payload_sz[ 0UL ];
+        slot->txnp->payload_sz = (ushort)payload_sz[ 0UL ];
         fd_memcpy( slot->txnp->payload, payload_scratch[ 0UL ], payload_sz[ 0UL ]                                              );
         fd_memcpy( TXN(slot->txnp),     txn,                    fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
 

--- a/src/discof/replay/fd_sched.c
+++ b/src/discof/replay/fd_sched.c
@@ -2682,7 +2682,7 @@ fd_sched_parse_txn( fd_sched_t * sched, fd_sched_block_t * block, fd_sched_alut_
   sched->metrics->txn_parsed_cnt++;
   sched->txn_pool_free_cnt--;
   fd_txn_p_t * txn_p = sched->txn_pool + txn_idx;
-  txn_p->payload_sz  = pay_sz;
+  txn_p->payload_sz  = (ushort)pay_sz;
 
   txn_p->start_shred_idx = (ushort)fd_uint_min( shred_split( sched, block, block->fec_buf_boff+block->fec_buf_soff ), USHORT_MAX ); /* monitoring-only ushorts; saturate under bench shred counts */
   txn_p->start_shred_idx = fd_ushort_if( txn_p->start_shred_idx>0U, (ushort)(txn_p->start_shred_idx-1U), txn_p->start_shred_idx );

--- a/src/discof/replay/test_sched.c
+++ b/src/discof/replay/test_sched.c
@@ -13,13 +13,12 @@
 
 static void
 test_sched_footprint( void ) {
-  /* Retain the per-block saving from compact shred lengths under the
-     default scheduler sizing.  Production limits must reproduce the
-     footprint from before the limits became runtime values. */
-  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1121549696UL );
+  /* Retain the savings from compact shred lengths and 4992-byte
+     transactions under the default scheduler sizing. */
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1117355392UL );
   /* Only the shred length array scales with the shred limit. */
-  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, 4UL*FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1121549696UL+2048UL*3UL*FD_SHRED_BLK_MAX*sizeof(ushort) );
-  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, 5UL*FD_MAX_TXN_PER_SLOT )==1121549696UL );
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, 4UL*FD_SHRED_BLK_MAX, FD_MAX_TXN_PER_SLOT )==1117355392UL+2048UL*3UL*FD_SHRED_BLK_MAX*sizeof(ushort) );
+  FD_TEST( fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, 5UL*FD_MAX_TXN_PER_SLOT )==1117355392UL );
   FD_TEST( !fd_sched_footprint( 65536UL, 2048UL, 0UL, FD_MAX_TXN_PER_SLOT ) );
   FD_TEST( !fd_sched_footprint( 65536UL, 2048UL, FD_SHRED_BLK_MAX, 0UL ) );
 }

--- a/src/flamenco/runtime/program/test_create_account_allow_prefund.c
+++ b/src/flamenco/runtime/program/test_create_account_allow_prefund.c
@@ -169,7 +169,7 @@ build_txn( test_env_t *        env,
   memcpy( p, owner->key, 32 ); p += 32;
 
   ulong payload_sz = (ulong)(p - start);
-  env->txn_p->payload_sz = payload_sz;
+  env->txn_p->payload_sz = (ushort)payload_sz;
   FD_TEST( fd_txn_parse( env->txn_p->payload, payload_sz, TXN(env->txn_p), NULL ) > 0 );
 
   env->txn_in->txn              = env->txn_p;

--- a/src/flamenco/runtime/program/test_vote_program.c
+++ b/src/flamenco/runtime/program/test_vote_program.c
@@ -109,7 +109,7 @@ enable_mainnet_features( test_env_t * env ) {
 static void
 exec_txn_hex( test_env_t * env, char const * hex, int expect_ok, int expect_err ) {
   ulong txn_sz = strlen( hex ) / 2;
-  env->txn_p->payload_sz = txn_sz;
+  env->txn_p->payload_sz = (ushort)txn_sz;
   fd_hex_decode( env->txn_p->payload, hex, txn_sz );
   FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
   env->txn_in->txn              = env->txn_p;
@@ -264,7 +264,7 @@ setup_account_initialize_txn( test_env_t * env ) {
 
   /* decode and parse txn */
   ulong txn_sz = strlen(hex) / 2;
-  env->txn_p->payload_sz = txn_sz;
+  env->txn_p->payload_sz = (ushort)txn_sz;
   fd_hex_decode( env->txn_p->payload, hex, txn_sz );
   FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
 
@@ -329,7 +329,7 @@ setup_account_initialize_v2_txn( test_env_t * env ) {
 
   /* decode and parse txn */
   ulong txn_sz = strlen(hex) / 2;
-  env->txn_p->payload_sz = txn_sz;
+  env->txn_p->payload_sz = (ushort)txn_sz;
   fd_hex_decode( env->txn_p->payload, hex, txn_sz );
   FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
 
@@ -385,7 +385,7 @@ setup_update_commission_collector_txn( test_env_t * env ) {
 
   /* decode and parse txn */
   ulong txn_sz = strlen(hex) / 2;
-  env->txn_p->payload_sz = txn_sz;
+  env->txn_p->payload_sz = (ushort)txn_sz;
   fd_hex_decode( env->txn_p->payload, hex, txn_sz );
   FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
 
@@ -534,7 +534,7 @@ test_update_validator_identity_collector_sync( fd_svm_mini_t * mini, int feature
     strcat( hex, "01" ); strcat( hex, "02" ); strcat( hex, "02" );
     strcat( hex, "0100" ); strcat( hex, "04" ); strcat( hex, "04000000" );
     ulong txn_sz = strlen(hex) / 2;
-    env->txn_p->payload_sz = txn_sz;
+    env->txn_p->payload_sz = (ushort)txn_sz;
     fd_hex_decode( env->txn_p->payload, hex, txn_sz );
     FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
     env->txn_in->txn = env->txn_p;
@@ -610,7 +610,7 @@ test_update_commission_collector( fd_svm_mini_t * mini ) {
     strcat( hex, "01" ); strcat( hex, "03" ); strcat( hex, "03" );                                            \
     strcat( hex, (instr_accts) ); strcat( hex, "08" ); strcat( hex, (data_hex) );                             \
     ulong txn_sz = strlen(hex) / 2;                                                                           \
-    env->txn_p->payload_sz = txn_sz;                                                                          \
+    env->txn_p->payload_sz = (ushort)txn_sz;                                                                  \
     fd_hex_decode( env->txn_p->payload, hex, txn_sz );                                                        \
     FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );                          \
     env->txn_in->txn = env->txn_p;                                                                            \
@@ -682,7 +682,7 @@ test_update_commission_collector( fd_svm_mini_t * mini ) {
     strcat( hex, "01" ); strcat( hex, "03" ); strcat( hex, "02" );
     strcat( hex, "0102" ); strcat( hex, "08" ); strcat( hex, "1100000000000000" );
     ulong txn_sz = strlen(hex) / 2;
-    env->txn_p->payload_sz = txn_sz;
+    env->txn_p->payload_sz = (ushort)txn_sz;
     fd_hex_decode( env->txn_p->payload, hex, txn_sz );
     FD_TEST( fd_txn_parse( env->txn_p->payload, txn_sz, TXN(env->txn_p), NULL )>0 );
     env->txn_in->txn = env->txn_p;

--- a/src/flamenco/runtime/tests/fd_block_harness.c
+++ b/src/flamenco/runtime/tests/fd_block_harness.c
@@ -388,7 +388,7 @@ fd_solfuzz_pb_block_ctx_create( fd_solfuzz_runner_t *                runner,
     if( FD_UNLIKELY( msg_sz==ULONG_MAX ) ) {
       return NULL;
     }
-    txn->payload_sz = msg_sz;
+    txn->payload_sz = (ushort)msg_sz;
 
     // Reject any transactions that cannot be parsed
     if( FD_UNLIKELY( !fd_txn_parse( txn->payload, msg_sz, TXN( txn ), NULL ) ) ) {

--- a/src/flamenco/runtime/tests/fd_bundle_harness.c
+++ b/src/flamenco/runtime/tests/fd_bundle_harness.c
@@ -98,7 +98,7 @@ fd_solfuzz_pb_bundle_ctx_create( fd_solfuzz_runner_t *                 runner,
     ulong msg_sz = fd_solfuzz_pb_txn_serialize( txns[i].payload, &test_ctx->txns[i] );
     if( FD_UNLIKELY( msg_sz==ULONG_MAX ) ) return NULL;
     if( FD_UNLIKELY( !fd_txn_parse( txns[i].payload, msg_sz, TXN( &txns[i] ), NULL ) ) ) return NULL;
-    txns[i].payload_sz = msg_sz;
+    txns[i].payload_sz = (ushort)msg_sz;
   }
 
   *out_txn_cnt = txn_cnt;

--- a/src/flamenco/runtime/tests/fd_cost_harness.c
+++ b/src/flamenco/runtime/tests/fd_cost_harness.c
@@ -24,7 +24,7 @@ fd_solfuzz_pb_cost_run( fd_solfuzz_runner_t * runner,
   ulong txn_sz = fd_solfuzz_pb_txn_serialize( txn_p->payload, &input->tx );
   if( FD_UNLIKELY( txn_sz==ULONG_MAX ) ) return 0UL;
 
-  txn_p->payload_sz = txn_sz;
+  txn_p->payload_sz = (ushort)txn_sz;
   if( FD_UNLIKELY( !fd_txn_parse( txn_p->payload, txn_p->payload_sz, TXN( txn_p ), NULL ) ) ) {
     return 0UL;
   }

--- a/src/flamenco/runtime/tests/fd_instr_harness.c
+++ b/src/flamenco/runtime/tests/fd_instr_harness.c
@@ -81,7 +81,7 @@ fd_solfuzz_pb_instr_ctx_create( fd_solfuzz_runner_t *                runner,
 
     ulong payload_sz = fd_ulong_min( test_ctx->data->size, sizeof(txn->payload) );
     memcpy( txn->payload, test_ctx->data->bytes, payload_sz );
-    txn->payload_sz = payload_sz;
+    txn->payload_sz = (ushort)payload_sz;
   }
   txn_descriptor->transaction_version = FD_TXN_VLEGACY;
   txn_descriptor->acct_addr_cnt       = (ushort)test_ctx->accounts_count;

--- a/src/flamenco/runtime/tests/fd_txn_harness.c
+++ b/src/flamenco/runtime/tests/fd_txn_harness.c
@@ -125,7 +125,7 @@ fd_solfuzz_pb_txn_ctx_create( fd_solfuzz_runner_t *              runner,
     return NULL;
   }
 
-  txn->payload_sz = msg_sz;
+  txn->payload_sz = (ushort)msg_sz;
 
   return txn;
 }

--- a/src/flamenco/runtime/tests/test_accounts_resize_delta.c
+++ b/src/flamenco/runtime/tests/test_accounts_resize_delta.c
@@ -211,7 +211,7 @@ execute_txn( test_env_t *     env,
   ulong sz = txn_serialize( txn_p.payload, num_signers, signatures, num_signers,
                             0UL, num_readonly_unsigned, account_keys_cnt, account_keys,
                             &blockhash, instrs, instr_cnt );
-  txn_p.payload_sz = sz;
+  txn_p.payload_sz = (ushort)sz;
   FD_TEST( fd_txn_parse( txn_p.payload, sz, TXN( &txn_p ), NULL ) );
 
   env->txn_in.txn              = &txn_p;

--- a/src/flamenco/runtime/tests/test_cost_model.c
+++ b/src/flamenco/runtime/tests/test_cost_model.c
@@ -104,7 +104,7 @@ txn_serialize( fd_txn_p_t *     out,
   ushort addr_table_cnt = 0;
   FD_CHECKED_ADD_CU16_TO_TXN_DATA( txn_raw_begin, &txn_raw_cur_ptr, addr_table_cnt );
 
-  out->payload_sz = (ulong)(txn_raw_cur_ptr - txn_raw_begin);
+  out->payload_sz = (ushort)(txn_raw_cur_ptr - txn_raw_begin);
 }
 
 

--- a/src/flamenco/runtime/tests/test_fee_calculator.c
+++ b/src/flamenco/runtime/tests/test_fee_calculator.c
@@ -84,7 +84,7 @@ txn_serialize( fd_txn_p_t *     out,
   ushort addr_table_cnt = 0;
   FD_CHECKED_ADD_CU16_TO_TXN_DATA( txn_raw_begin, &txn_raw_cur_ptr, addr_table_cnt );
 
-  out->payload_sz = (ulong)(txn_raw_cur_ptr - txn_raw_begin);
+  out->payload_sz = (ushort)(txn_raw_cur_ptr - txn_raw_begin);
 }
 
 static void


### PR DESCRIPTION
shrink `fd_txn_p_t.payload_sz` to `ushort` and group the source fields beside it. This reduces metadata from 48 to 40 bytes and removes one 64-byte cache line from both transaction types.

| Storage | Before | After | Saving |
| --- | ---: | ---: | ---: |
| Compact transaction (`fd_txn_p_t`) | 5,056 B | 4,992 B | 64 B |
| Expanded transaction (`fd_txn_e_t`) | 7,104 B | 7,040 B | 64 B |
| Default replay scheduler footprint | 1,121,549,696 B | 1,117,355,392 B | **4 MiB** |
