### PR TITLE
always build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,5 @@ include $(wildcard $(addprefix config/extra/with-,$(addsuffix -pre.mk,$(EXTRAS))
 include config/machine/$(MACHINE).mk
 include $(addprefix config/extra/with-,$(addsuffix .mk,$(EXTRAS)))
 include config/extra/with-blst.mk
+include config/extra/with-zstd.mk
 include config/everything.mk

--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,5 @@ all:
 include $(wildcard $(addprefix config/extra/with-,$(addsuffix -pre.mk,$(EXTRAS))))
 include config/machine/$(MACHINE).mk
 include $(addprefix config/extra/with-,$(addsuffix .mk,$(EXTRAS)))
+include config/extra/with-blst.mk
 include config/everything.mk

--- a/config/cross/macos-arm-clang_x_linux-x86.mk
+++ b/config/cross/macos-arm-clang_x_linux-x86.mk
@@ -30,7 +30,3 @@ LDFLAGS+=--ld-path=$(shell brew --prefix lld)/bin/ld.lld
 
 CPPFLAGS+=-isystem ./opt/cross/$(CROSS)/usr/local/include
 LDFLAGS+=-L./opt/cross/$(CROSS)/usr/local/lib
-
-FD_HAS_ZSTD:=1
-CFLAGS+=-DFD_HAS_ZSTD=1
-LDFLAGS+=-lzstd

--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -29,7 +29,6 @@ endif
 endif
 
 include config/extra/with-s2nbignum.mk
-include config/extra/with-blst.mk
 include config/extra/with-zstd.mk
 include config/extra/with-lz4.mk
 

--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -29,7 +29,6 @@ endif
 endif
 
 include config/extra/with-s2nbignum.mk
-include config/extra/with-zstd.mk
 include config/extra/with-lz4.mk
 
 ifneq ($(CROSS),1)

--- a/config/extra/with-arm.mk
+++ b/config/extra/with-arm.mk
@@ -29,7 +29,6 @@ endif
 endif
 
 include config/extra/with-s2nbignum.mk
-include config/extra/with-lz4.mk
 
 ifneq ($(CROSS),1)
 include config/extra/with-openssl.mk

--- a/config/extra/with-blst.mk
+++ b/config/extra/with-blst.mk
@@ -3,7 +3,5 @@
 # links agave_validator (which statically bundles its own blst crate
 # copy) together with fd_ballet, and a trailing archive preserves the
 # agave-copy-wins member selection the opt/ path had.
-FD_HAS_BLST:=1
-CFLAGS+=-DFD_HAS_BLST=1
 BLST_LIBS=$(OBJDIR)/lib/libfd_blst.a
 VENDOR_LINK_LIBS+=fd_blst

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -17,6 +17,5 @@ FD_ARCH_SUPPORTS_SANDBOX:=1
 
 ifndef FD_NODEPS
 include config/extra/with-s2nbignum.mk
-include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk
 endif

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -17,7 +17,6 @@ FD_ARCH_SUPPORTS_SANDBOX:=1
 
 ifndef FD_NODEPS
 include config/extra/with-s2nbignum.mk
-include config/extra/with-blst.mk
 include config/extra/with-zstd.mk
 include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk

--- a/config/extra/with-x86-64.mk
+++ b/config/extra/with-x86-64.mk
@@ -17,7 +17,6 @@ FD_ARCH_SUPPORTS_SANDBOX:=1
 
 ifndef FD_NODEPS
 include config/extra/with-s2nbignum.mk
-include config/extra/with-zstd.mk
 include config/extra/with-lz4.mk
 include config/extra/with-openssl.mk
 endif

--- a/config/extra/with-zstd.mk
+++ b/config/extra/with-zstd.mk
@@ -1,7 +1,5 @@
 # Vendored in-tree (src/third_party/zstd), standalone trailing
 # archive (some targets, e.g. test_libc_zstd, link without fd_ballet
 # and resolve ZSTD_* from LDFLAGS).
-FD_HAS_ZSTD:=1
-CFLAGS+=-DFD_HAS_ZSTD=1
 CPPFLAGS:=-isystem src/third_party/zstd/lib $(CPPFLAGS)
 VENDOR_LINK_LIBS+=fd_zstd

--- a/src/.clangd
+++ b/src/.clangd
@@ -6,7 +6,6 @@ CompileFlags:
   - -DFD_HAS_ATOMIC=1
   - -DFD_HAS_DOUBLE=1
   - -DFD_HAS_INT128=1
-  - -DFD_HAS_ZSTD=1
   - -DFD_HAS_SSE=1
   - -DFD_USING_CLANG=1
 Completion:

--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -19,11 +19,9 @@ $(call add-objs,commands/gossip_dump,fd_firedancer_dev)
 $(call add-objs,commands/reasm,fd_firedancer_dev)
 $(call add-objs,commands/forktest/forktest commands/forktest/fd_forktest_tile,fd_firedancer_dev)
 
-# ifdef FD_HAS_BLST -- will be a required dependency soon
 ifdef FD_HAS_S2NBIGNUM
 $(call make-bin,firedancer-dev,main,fd_firedancer_dev fd_firedancer fddev_shared fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 endif
-# endif
 
 $(call make-integration-test,test_firedancer_dev,tests/test_firedancer_dev,fd_firedancer_dev fd_firedancer fddev_shared fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 $(call run-integration-test,test_firedancer_dev)

--- a/src/app/firedancer-dev/Local.mk
+++ b/src/app/firedancer-dev/Local.mk
@@ -2,7 +2,6 @@ ifdef FD_HAS_HOSTED
 ifdef FD_HAS_LINUX
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
-ifdef FD_HAS_ZSTD
 
 .PHONY: firedancer-dev
 
@@ -25,9 +24,6 @@ endif
 
 $(call make-integration-test,test_firedancer_dev,tests/test_firedancer_dev,fd_firedancer_dev fd_firedancer fddev_shared fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 $(call run-integration-test,test_firedancer_dev)
-else
-$(warning firedancer-dev build disabled due to lack of zstd)
-endif
 endif
 endif
 endif

--- a/src/app/firedancer/Local.mk
+++ b/src/app/firedancer/Local.mk
@@ -2,7 +2,6 @@ ifdef FD_HAS_HOSTED
 ifdef FD_HAS_THREADS
 ifdef FD_HAS_ALLOCA
 ifdef FD_HAS_DOUBLE
-ifdef FD_HAS_ZSTD
 
 $(OBJDIR)/obj/app/firedancer/config.o: src/app/firedancer/config/default.toml
 $(OBJDIR)/obj/app/firedancer/config.o: src/app/firedancer/config/testnet.toml
@@ -32,9 +31,6 @@ ifdef FD_HAS_S2NBIGNUM
 $(call make-bin,firedancer,main,fd_firedancer fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 endif
 
-else
-$(warning firedancer build disabled due to lack of zstd)
-endif
 endif
 endif
 endif

--- a/src/app/firedancer/Local.mk
+++ b/src/app/firedancer/Local.mk
@@ -28,11 +28,9 @@ $(call add-objs,commands/get_identity,fd_firedancer)
 $(call add-objs,commands/adminctl_client,fd_firedancer)
 $(call add-objs,commands/monitor_gossip/monitor_gossip commands/monitor_gossip/gossip_diag,fd_firedancer)
 
-# ifdef FD_HAS_BLST -- will be a required dependency soon
 ifdef FD_HAS_S2NBIGNUM
 $(call make-bin,firedancer,main,fd_firedancer fdctl_shared fdctl_platform fd_discof fd_disco fd_choreo fd_flamenco fd_quic fd_tls fd_reedsol fd_waltz fd_tango fd_ballet fd_util,$(OPENSSL_LIBS))
 endif
-# endif
 
 else
 $(warning firedancer build disabled due to lack of zstd)

--- a/src/ballet/bls/Local.mk
+++ b/src/ballet/bls/Local.mk
@@ -1,13 +1,4 @@
-ifdef FD_HAS_BLST
-
 $(call add-hdrs,fd_bls12_381.h fd_bls.h)
 $(call add-objs,fd_bls12_381 fd_bls,fd_ballet)
 $(call make-unit-test,test_bls12_381,test_bls12_381,fd_ballet fd_util,$(BLST_LIBS))
-
 $(call run-unit-test,test_bls12_381)
-
-else
-
-$(warning bls12_381 disabled due to lack of libblst)
-
-endif

--- a/src/ballet/zstd/Local.mk
+++ b/src/ballet/zstd/Local.mk
@@ -1,4 +1,3 @@
-ifdef FD_HAS_ZSTD
 $(call add-hdrs,fd_zstd.h)
 $(call add-objs,fd_zstd,fd_util)
 $(call make-unit-test,test_zstd,test_zstd,fd_util)
@@ -6,5 +5,4 @@ $(call run-unit-test,test_zstd)
 ifdef FD_HAS_HOSTED
 $(call make-bin,fd_zstd_pack,fd_zstd_pack,fd_util)
 $(call make-bin,fd_gzip_pack,fd_gzip_pack,fd_zlib fd_util)
-endif
 endif

--- a/src/ballet/zstd/fd_zstd.c
+++ b/src/ballet/zstd/fd_zstd.c
@@ -2,10 +2,6 @@
 #include "fd_zstd_private.h"
 #include "../../util/fd_util.h"
 
-#if !FD_HAS_ZSTD
-#error "fd_zstd requires libzstd"
-#endif
-
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #include <errno.h>

--- a/src/ballet/zstd/fd_zstd.h
+++ b/src/ballet/zstd/fd_zstd.h
@@ -46,8 +46,6 @@
    frame.  The Solana protocol does not properly bound max decompressed
    frame size, so using streaming mode is safer for now. */
 
-#if FD_HAS_ZSTD
-
 #include "../fd_ballet_base.h"
 
 /* FD_ZSTD_MAX_HDR_SZ is the amount of bytes required to fit any
@@ -157,7 +155,5 @@ fd_zstd_dstream_read( fd_zstd_dstream_t *     dstream,
 /* TODO: Migrate compression logic from fd_snapshot_create. to fd_zstd.h */
 
 FD_PROTOTYPES_END
-
-#endif /* FD_HAS_ZSTD */
 
 #endif /* HEADER_fd_src_ballet_zstd_fd_zstd_h */

--- a/src/ballet/zstd/test_zstd.c
+++ b/src/ballet/zstd/test_zstd.c
@@ -4,10 +4,6 @@
 #include <stdalign.h>
 #include <stddef.h>
 
-#if !FD_HAS_ZSTD
-#error "fd_compress requires Zstandard"
-#endif
-
 /* mem must be aligned */
 
 FD_STATIC_ASSERT( alignof ( fd_zstd_dstream_t      )==FD_ZSTD_DSTREAM_ALIGN, layout );

--- a/src/disco/gui/fd_gui_peers.c
+++ b/src/disco/gui/fd_gui_peers.c
@@ -41,14 +41,10 @@ fd_gui_peers_footprint( ulong max_ws_conn_cnt ) {
   l = FD_LAYOUT_APPEND( l, fd_gui_peers_node_sock_map_align(),      fd_gui_peers_node_sock_map_footprint     ( sock_chain_cnt )             );
   l = FD_LAYOUT_APPEND( l, alignof(fd_gui_peers_ws_conn_t),         max_ws_conn_cnt*sizeof(fd_gui_peers_ws_conn_t)                          );
 
-#if FD_HAS_ZSTD
   l = FD_LAYOUT_APPEND( l, 16UL,                                    FD_GUI_GEOIP_BIN_MAX+fd_ulong_align_up( ZSTD_estimateDStreamSize( 1<<FD_GUI_GEOIP_ZSTD_WINDOW_LOG ), 16UL ) );
-#endif
 
   return FD_LAYOUT_FINI( l, fd_gui_peers_align() );
 }
-
-#if FD_HAS_ZSTD
 
 /* load_geoip decompresses the dbip database image into image (a
    single streaming decompress; the image is the on-disk format, see
@@ -127,8 +123,6 @@ load_geoip( ZSTD_DCtx *      dctx,
   ip_db->seg_city    = seg_city;
 }
 
-#endif
-
 void *
 fd_gui_peers_new( void *             shmem,
                   fd_http_server_t * http,
@@ -160,7 +154,6 @@ fd_gui_peers_new( void *             shmem,
   void * _pubkey_map       = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_node_pubkey_map_align(),    fd_gui_peers_node_pubkey_map_footprint   ( pubkey_chain_cnt )           );
   void * _sock_map         = FD_SCRATCH_ALLOC_APPEND( l, fd_gui_peers_node_sock_map_align(),      fd_gui_peers_node_sock_map_footprint     ( sock_chain_cnt )             );
   ctx->client_viewports    = FD_SCRATCH_ALLOC_APPEND( l, alignof(fd_gui_peers_ws_conn_t),         max_ws_conn_cnt*sizeof(fd_gui_peers_ws_conn_t)                          );
-#if FD_HAS_ZSTD
   /* DCtx scratch is only needed during load_geoip below; it lives
      past the image so the image gets the full FD_GUI_GEOIP_BIN_MAX
      the generator enforces. */
@@ -168,7 +161,6 @@ fd_gui_peers_new( void *             shmem,
   ctx->dbip_image          = FD_SCRATCH_ALLOC_APPEND( l, 16UL,                                    FD_GUI_GEOIP_BIN_MAX+fd_ulong_align_up( zstd_ctx_sz, 16UL )             );
   ZSTD_DCtx * zstd_dctx = ZSTD_initStaticDStream( ctx->dbip_image+FD_GUI_GEOIP_BIN_MAX, zstd_ctx_sz );
   FD_TEST( zstd_dctx );
-#endif
 
     for( ulong i = 0UL; i<max_ws_conn_cnt; i++ ) ctx->client_viewports[ i ].connected = 0;
 
@@ -206,11 +198,7 @@ fd_gui_peers_new( void *             shmem,
     ctx->node_pubkey_map = fd_gui_peers_node_pubkey_map_join( fd_gui_peers_node_pubkey_map_new( _pubkey_map, pubkey_chain_cnt, seed ) );
     ctx->node_sock_map   = fd_gui_peers_node_sock_map_join  ( fd_gui_peers_node_sock_map_new  ( _sock_map,   sock_chain_cnt,   seed ) );
 
-#if FD_HAS_ZSTD
     load_geoip( zstd_dctx, ctx->dbip_image, FD_GUI_GEOIP_BIN_MAX, dbip_f, dbip_f_sz, &ctx->dbip );
-#else
-    ctx->dbip.seg_cnt = 0UL;
-#endif
 
     ctx->wfs_peers_cnt = 0UL;
     ctx->wfs_peers_valid = 0;
@@ -541,8 +529,6 @@ fd_gui_peers_handle_gossip_message( fd_gui_peers_ctx_t *       peers,
   fd_ptr_if( is_rx, (fd_gui_peers_metric_rate_t *)&peer->row.gossvf_rx_sum, (fd_gui_peers_metric_rate_t *)&peer->row.gossip_tx_sum )->cur += payload_sz;
 }
 
-#if FD_HAS_ZSTD
-
 /* geoip_lookup finds the segment covering ip_addr (network byte
    order) by binary search over the sorted disjoint segment starts.
    Returns the segment index, or ULONG_MAX if the database is empty. */
@@ -564,8 +550,6 @@ geoip_lookup( fd_gui_ip_db_t const * ip_db,
   }
   return lo;
 }
-
-#endif /* FD_HAS_ZSTD */
 
 #define SORT_NAME wfs_peer_sort
 #define SORT_KEY_T fd_gui_wfs_peer_t
@@ -696,16 +680,11 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
           peer->row.wallclock_nanos  = FD_MILLI_TO_NANOSEC( update->wallclock );
           peer->row.update_time_nanos = now;
           /* fetch and set country code */
-#if FD_HAS_ZSTD
           uint ip4 = peer->row.contact_info.sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_GOSSIP ].is_ipv6 ? 0 : peer->row.contact_info.sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_GOSSIP ].ip4;
           ulong dbip_seg = geoip_lookup( &peers->dbip, ip4 );
 
           peer->row.country_code_idx = dbip_seg!=ULONG_MAX ? peers->dbip.seg_country[ dbip_seg ] : UCHAR_MAX;
           peer->row.city_name_idx    = dbip_seg!=ULONG_MAX ? peers->dbip.seg_city   [ dbip_seg ] : UINT_MAX;
-#else
-          peer->row.country_code_idx = UCHAR_MAX;
-          peer->row.city_name_idx = UINT_MAX;
-#endif
 
           fd_gui_peers_live_table_idx_insert        ( peers->live_table,    update->contact_info->idx, peers->contact_info_table );
           fd_gui_peers_node_sock_map_idx_insert     ( peers->node_sock_map, update->contact_info->idx, peers->contact_info_table );
@@ -774,16 +753,11 @@ fd_gui_peers_handle_gossip_update( fd_gui_peers_ctx_t *               peers,
           peer->row.contact_info      = *update->contact_info->value;
 
           /* fetch and set country code */
-#if FD_HAS_ZSTD
           uint ip4 = peer->row.contact_info.sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_GOSSIP ].is_ipv6 ? 0 : peer->row.contact_info.sockets[ FD_GOSSIP_CONTACT_INFO_SOCKET_GOSSIP ].ip4;
           ulong dbip_seg = geoip_lookup( &peers->dbip, ip4 );
 
           peer->row.country_code_idx = dbip_seg!=ULONG_MAX ? peers->dbip.seg_country[ dbip_seg ] : UCHAR_MAX;
           peer->row.city_name_idx    = dbip_seg!=ULONG_MAX ? peers->dbip.seg_city   [ dbip_seg ] : UINT_MAX;
-#else
-          peer->row.country_code_idx = UCHAR_MAX;
-          peer->row.city_name_idx = UINT_MAX;
-#endif
 
           peer->row.valid = 1;
 

--- a/src/disco/gui/fd_gui_peers.h
+++ b/src/disco/gui/fd_gui_peers.h
@@ -26,12 +26,10 @@
 #include "../topo/fd_topo.h"
 #include "../../util/fd_hash32.h"
 
-#if FD_HAS_ZSTD
 #define FD_GUI_GEOIP_ZSTD_COMPRESSION_LEVEL 19
 #define FD_GUI_GEOIP_ZSTD_WINDOW_LOG 23
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
-#endif
 
 #include <math.h>
 

--- a/src/disco/gui/fd_gui_tile.c
+++ b/src/disco/gui/fd_gui_tile.c
@@ -664,11 +664,7 @@ gui_http_request( fd_http_server_request_t const * request ) {
     return (fd_http_server_response_t){
       .status            = 200,
       .upgrade_websocket = 1,
-#ifdef FD_HAS_ZSTD
       .compress_websocket = request->headers.compress_websocket,
-#else
-      .compress_websocket = 0,
-#endif
     };
   } else if( FD_LIKELY( !strcmp( request->path, "/favicon.svg" ) ) ) {
     return (fd_http_server_response_t){

--- a/src/disco/node_info/fd_node_info.h
+++ b/src/disco/node_info/fd_node_info.h
@@ -14,8 +14,6 @@
 #include "../../util/log/fd_log.h"
 #include "../../flamenco/fd_flamenco_base.h"
 
-FD_STATIC_ASSERT( FD_HAS_ATOMIC, fd_node_info requires atomics );
-
 #include <stdatomic.h>
 
 #define FD_NODE_INFO_MAGIC (0xf17eda2c4e490000UL) /* firedancer ni ver 0 */
@@ -66,8 +64,6 @@ fd_node_info_box_join( void * shni ) {
   return ni;
 }
 
-#if FD_HAS_ATOMIC
-
 /* fd_node_info_read does an atomic read of a shared fd_node_info_t. */
 
 static inline fd_node_info_t *
@@ -104,8 +100,6 @@ static inline void
 fd_node_info_write_end( fd_node_info_box_t * dst ) {
   atomic_fetch_add_explicit( &dst->seq_lock, 1U, memory_order_release );
 }
-
-#endif /* FD_HAS_ATOMIC */
 
 FD_PROTOTYPES_END
 

--- a/src/disco/topo/Local.mk
+++ b/src/disco/topo/Local.mk
@@ -8,8 +8,6 @@ $(call make-unit-test,test_dns_resolve,test_dns_resolve,fd_disco fd_ballet fd_ta
 $(call run-unit-test,test_topob)
 endif
 endif
-ifdef FD_HAS_DOUBLE
 $(call add-hdrs,fd_wksp_mon.h)
 $(call add-objs,fd_wksp_mon,fd_disco)
-endif
 endif

--- a/src/discof/backtest/Local.mk
+++ b/src/discof/backtest/Local.mk
@@ -4,10 +4,8 @@ $(call add-objs,fd_backtest_src_pcap,fd_discof)
 
 $(call add-objs,fd_backtest_tile,fd_discof)
 
-ifdef FD_HAS_ZSTD
 $(call add-objs,fd_libc_zstd,fd_discof)
 $(call make-unit-test,test_libc_zstd,test_libc_zstd,fd_discof fd_util)
 $(call run-unit-test,test_libc_zstd)
-endif
 
 endif

--- a/src/discof/backtest/fd_backtest_src.c
+++ b/src/discof/backtest/fd_backtest_src.c
@@ -5,10 +5,8 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include "../../util/net/fd_pcapng_private.h"
-#if FD_HAS_ZSTD
 #include <zstd.h>
 #include "fd_libc_zstd.h"
-#endif
 
 extern fd_backt_src_t *
 fd_backt_src_pcap_create( fd_backtest_src_opts_t const * opts,
@@ -47,10 +45,6 @@ detect_src_type( char const * path ) {
     return FD_BACKT_SRC_FMT_PCAPNG;
   }
 
-# if !FD_HAS_ZSTD
-  FD_LOG_WARNING(( "ledger auto detect: unsupported file type" ));
-  return FD_BACKT_SRC_INVAL;
-# else
   if( magic != ZSTD_MAGICNUMBER ) {
     FD_LOG_WARNING(( "ledger auto detect failed: file type of \"%s\" is not recognized", path ));
     return FD_BACKT_SRC_INVAL;
@@ -90,7 +84,6 @@ detect_src_type( char const * path ) {
     FD_LOG_WARNING(( "ledger auto detect failed: compressed content of \"%s\" is not recognized (magic number %08x)", path, fd_uint_bswap( magic ) ));
     return FD_BACKT_SRC_INVAL;
   }
-# endif
 }
 
 ulong

--- a/src/discof/backtest/fd_backtest_src_pcap.c
+++ b/src/discof/backtest/fd_backtest_src_pcap.c
@@ -13,11 +13,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if FD_HAS_ZSTD
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 #define FD_BACKT_ZSTD_WINDOW_SZ (1UL<<21UL)
-#endif
 
 extern fd_backt_src_vt_t const fd_backt_src_pcap_vt;
 
@@ -91,9 +89,7 @@ struct fd_backt_src_pcap {
   msgq_t *      msgq;
   msg_treap_t * treap;
 
-#if FD_HAS_ZSTD
   ZSTD_DStream * zstd;
-#endif
 };
 
 typedef struct fd_backt_src_pcap fd_backt_src_pcap_t;
@@ -246,7 +242,6 @@ static int
 fd_backt_src_pcap_rewind( fd_backt_src_pcap_t * src ) {
   fd_backt_src_pcap_fini_iter( src );
 
-#if FD_HAS_ZSTD
   if( FD_UNLIKELY( src->zstd ) ) {
     if( FD_UNLIKELY( fseek( src->file, 0L, SEEK_SET ) ) ) {
       FD_LOG_WARNING(( "fseek failed (%i-%s)", errno, fd_io_strerror( errno ) ));
@@ -254,7 +249,6 @@ fd_backt_src_pcap_rewind( fd_backt_src_pcap_t * src ) {
     }
     ZSTD_initDStream( src->zstd );
   }
-#endif
 
   if( src->format==FD_BACKT_SRC_FMT_PCAP ) {
     if( FD_UNLIKELY( fseek( src->file, 0L, SEEK_SET ) ) ) {
@@ -318,7 +312,6 @@ fd_backt_src_pcap_create( fd_backtest_src_opts_t const * opts,
     return NULL;
   }
 
-#if FD_HAS_ZSTD
   ZSTD_DStream * zstd = NULL;
   if( flags & FD_BACKT_SRC_FLAG_ZSTD ) {
     zstd = ZSTD_createDStream();
@@ -332,7 +325,6 @@ fd_backt_src_pcap_create( fd_backtest_src_opts_t const * opts,
     }
     file = zstd_file;
   }
-#endif
 
   fd_backt_src_pcap_t * src = calloc( 1UL, sizeof(fd_backt_src_pcap_t) );
   if( FD_UNLIKELY( !src ) ) FD_LOG_ERR(( "out of memory" ));
@@ -341,9 +333,7 @@ fd_backt_src_pcap_create( fd_backtest_src_opts_t const * opts,
     .src = {{ .vt = &fd_backt_src_pcap_vt }},
     .file = file,
     .format = format,
-#if FD_HAS_ZSTD
     .zstd = zstd,
-#endif
   };
 
   if( format==FD_BACKT_SRC_FMT_PCAP ) {
@@ -389,9 +379,7 @@ fd_backt_src_pcap_destroy( fd_backt_src_t * this ) {
 
   if( src->file ) fclose( src->file );
 
-#if FD_HAS_ZSTD
   if( src->zstd ) ZSTD_freeDStream( src->zstd );
-#endif
 
   free( src );
 }

--- a/src/discof/backtest/fd_libc_zstd.h
+++ b/src/discof/backtest/fd_libc_zstd.h
@@ -4,8 +4,6 @@
 /* fd_libc_zstd.h provides APIs for retro-fitting libc FILE-based apps
    with Zstandard compression support. */
 
-#if FD_HAS_ZSTD
-
 #include "../../util/fd_util_base.h"
 #include <stdio.h>
 #include <zstd.h>
@@ -45,7 +43,5 @@ FILE *
 fd_zstd_wstream_open( FILE * file,
                       int    level,
                       ulong  buf_sz );
-
-#endif /* FD_HAS_ZSTD */
 
 #endif /* HEADER_fd_src_discof_backtest_fd_libc_zstd_h */

--- a/src/discof/replay/Local.mk
+++ b/src/discof/replay/Local.mk
@@ -3,13 +3,15 @@ $(call add-objs,fd_rdisp,fd_discof)
 $(call make-unit-test,test_rdisp,test_rdisp,fd_discof fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_rdisp)
 $(call add-objs,fd_sched,fd_discof)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_sched,test_sched,fd_discof fd_choreo fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_sched)
-ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_sched_rdisp,fuzz_sched_rdisp,fd_discof fd_choreo fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 endif
 
+ifdef FD_HAS_HOSTED
 $(call add-objs,fd_replay_tile,fd_discof)
 $(call make-unit-test,test_replay_tile,test_replay_tile,fd_discof fd_choreo fd_disco fd_flamenco fd_vinyl fd_tango fd_ballet fd_util)
 $(call add-hdrs,fd_vote_tracker.h)
 $(call add-objs,fd_vote_tracker,fd_discof)
+endif

--- a/src/discof/replay/Local.mk
+++ b/src/discof/replay/Local.mk
@@ -9,11 +9,7 @@ ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_sched_rdisp,fuzz_sched_rdisp,fd_discof fd_choreo fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 endif
 
-ifdef FD_HAS_ZSTD # required to load snapshot
 $(call add-objs,fd_replay_tile,fd_discof)
 $(call make-unit-test,test_replay_tile,test_replay_tile,fd_discof fd_choreo fd_disco fd_flamenco fd_vinyl fd_tango fd_ballet fd_util)
 $(call add-hdrs,fd_vote_tracker.h)
 $(call add-objs,fd_vote_tracker,fd_discof)
-else
-$(warning "zstd not installed, skipping replay")
-endif

--- a/src/discof/restore/Local.mk
+++ b/src/discof/restore/Local.mk
@@ -4,23 +4,19 @@ $(call add-objs,fd_snapct_tile,fd_discof)
 $(call make-unit-test,test_snapct_tile,test_snapct_tile,fd_discof fd_disco fd_waltz fd_flamenco fd_ballet fd_tango fd_util,$(OPENSSL_LIBS))
 $(call run-unit-test,test_snapct_tile)
 $(call add-objs,fd_snapld_tile,fd_discof)
-ifdef FD_HAS_ZSTD
 $(call add-objs,fd_snapdc_tile,fd_discof)
 $(call make-unit-test,test_snapdc_tile,test_snapdc_tile,fd_discof fd_disco fd_waltz fd_flamenco fd_ballet fd_tango fd_util,$(OPENSSL_LIBS))
 $(call run-unit-test,test_snapdc_tile)
-endif # FD_HAS_ZSTD
 $(call add-objs,fd_snapin_tile,fd_discof)
 $(call make-unit-test,test_snapin_tile,test_snapin_tile,fd_discof fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_snapin_tile)
 $(call add-objs,fd_snapwr_tile,fd_discof)
 $(call make-unit-test,test_snapwr_tile,test_snapwr_tile,fd_discof fd_disco fd_flamenco fd_ballet fd_tango fd_util)
 $(call run-unit-test,test_snapwr_tile)
-ifdef FD_HAS_ZSTD
 $(call add-objs,utils/fd_zstd_frame,fd_discof)
 $(call make-unit-test,test_zstd_frame,utils/test_zstd_frame,fd_discof fd_ballet fd_util)
 $(call run-unit-test,test_zstd_frame)
 $(call make-fuzz-test,fuzz_zstd_frame,utils/fuzz_zstd_frame,fd_discof fd_ballet fd_util)
-endif # FD_HAS_ZSTD
 $(call add-objs,utils/fd_ssparse,fd_discof)
 $(call add-objs,utils/fd_ssmanifest_parser,fd_discof)
 $(call add-objs,utils/fd_ssload,fd_discof)

--- a/src/discof/restore/utils/fd_zstd_frame.c
+++ b/src/discof/restore/utils/fd_zstd_frame.c
@@ -3,10 +3,6 @@
 #include "../../../util/bits/fd_bits.h"
 #include "../../../util/log/fd_log.h"
 
-#if !FD_HAS_ZSTD
-#error "fd_zstd_frame requires Zstandard"
-#endif
-
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 

--- a/src/discof/rpc/fd_rpc_tile.c
+++ b/src/discof/rpc/fd_rpc_tile.c
@@ -33,10 +33,8 @@
 #include <sys/socket.h>
 #include <string.h>
 
-#if FD_HAS_ZSTD
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
-#endif
 
 #include "../../util/archive/fd_tar.h"
 #include "../../third_party/bzip2/bzlib.h"
@@ -377,10 +375,8 @@ struct fd_rpc_tile {
   fd_epoch_schedule_t      epoch_schedule;
   int                      has_epoch_schedule;
 
-# if FD_HAS_ZSTD
   ZSTD_CCtx * zstd_cctx;
   uchar compress_buf[ ZSTD_COMPRESSBOUND( FD_RUNTIME_ACC_SZ_MAX ) ];
-# endif
 
   /* Redirect to snapshot server */
   int    snapshot_server_enabled;
@@ -559,9 +555,7 @@ scratch_footprint( fd_topo_tile_t const * tile ) {
   l = FD_LAYOUT_APPEND( l, alignof(ulong),                    http_params.max_ws_connection_cnt*sizeof(ulong)                    );
   l = FD_LAYOUT_APPEND( l, alignof(uchar),                    fd_rpc_genesis_tar_max_sz( tile->rpc.genesis_max_message_size )    );
   l = FD_LAYOUT_APPEND( l, alignof(uchar),                    fd_rpc_genesis_tar_bz_max_sz( tile->rpc.genesis_max_message_size ) );
-# if FD_HAS_ZSTD
   l = FD_LAYOUT_APPEND( l, 16UL, ZSTD_estimateCCtxSize( FD_RPC_ZSTD_LEVEL ) );
-# endif
   return FD_LAYOUT_FINI( l, scratch_align() );
 }
 
@@ -1481,7 +1475,6 @@ fd_rpc_encode_account_data( fd_rpc_tile_t *             ctx,
     return 0;
   }
 
-# if FD_HAS_ZSTD
   if( is_zstd ) {
     ulong zstd_res = ZSTD_compressCCtx( ctx->zstd_cctx, ctx->compress_buf, sizeof(ctx->compress_buf), out, snip_sz, FD_RPC_ZSTD_LEVEL );
     if( ZSTD_isError( zstd_res ) ) {
@@ -1492,13 +1485,6 @@ fd_rpc_encode_account_data( fd_rpc_tile_t *             ctx,
     out    = ctx->compress_buf;
     out_sz = (ulong)zstd_res;
   }
-# else
-  if( is_zstd ) {
-    fd_http_server_unstage( ctx->http );
-    *err_response = PRINTF_JSON( ctx, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32065,\"message\":\"Firedancer Error: zstandard is disabled\"},\"id\":%s}\n", id_cstr );
-    return 0;
-  }
-# endif
 
   FD_BASE58_ENCODE_32_BYTES( acct_owner, owner_b58 );
   fd_http_server_printf( ctx->http,
@@ -2886,10 +2872,8 @@ unprivileged_init( fd_topo_t const *      topo,
   void * _ws_sub_slot    = FD_SCRATCH_ALLOC_APPEND( l, alignof(ulong),                    http_params.max_ws_connection_cnt*sizeof(ulong)                    );
   void * _genesis_tar    = FD_SCRATCH_ALLOC_APPEND( l, alignof(uchar),                    fd_rpc_genesis_tar_max_sz( tile->rpc.genesis_max_message_size )    );
   void * _genesis_tar_bz = FD_SCRATCH_ALLOC_APPEND( l, alignof(uchar),                    fd_rpc_genesis_tar_bz_max_sz( tile->rpc.genesis_max_message_size ) );
-# if FD_HAS_ZSTD
   ulong  zstd_wksp_sz = ZSTD_estimateCCtxSize( FD_RPC_ZSTD_LEVEL );
   void * _zstd_wksp   = FD_SCRATCH_ALLOC_APPEND( l, 16UL,                     zstd_wksp_sz                                           );
-# endif
 
   fd_alloc_t * alloc = fd_alloc_join( fd_alloc_new( _alloc, 1UL ), 1UL );
   FD_TEST( alloc );
@@ -2907,10 +2891,8 @@ unprivileged_init( fd_topo_t const *      topo,
   ctx->bz2_alloc = fd_alloc_join( fd_alloc_new( _bz2_alloc, 1UL ), 1UL );
   FD_TEST( ctx->bz2_alloc );
 
-# if FD_HAS_ZSTD
   ctx->zstd_cctx = ZSTD_initStaticCCtx( _zstd_wksp, zstd_wksp_sz );
   FD_CHECK_ERR( ctx->zstd_cctx, "ZSTD_initStaticCCtx failed" );
-# endif
 
   fd_clock_tile_init( ctx->clock );
   ctx->in_cnt          = tile->in_cnt;

--- a/src/discoh/guih/fd_guih_tile.c
+++ b/src/discoh/guih/fd_guih_tile.c
@@ -320,11 +320,7 @@ gui_http_request( fd_http_server_request_t const * request ) {
     return (fd_http_server_response_t){
       .status            = 200,
       .upgrade_websocket = 1,
-#ifdef FD_HAS_ZSTD
       .compress_websocket = request->headers.compress_websocket,
-#else
-      .compress_websocket = 0,
-#endif
     };
   } else if( FD_LIKELY( !strcmp( request->path, "/favicon.svg" ) ) ) {
     return (fd_http_server_response_t){

--- a/src/flamenco/accdb/Local.mk
+++ b/src/flamenco/accdb/Local.mk
@@ -1,10 +1,8 @@
-ifdef FD_HAS_ATOMIC
-ifdef FD_HAS_ALLOCA
-
 $(call add-hdrs,fd_accdb.h fd_accdb_base.h fd_accdb_cache.h fd_accdb_shmem.h)
 $(call add-objs,fd_accdb fd_accdb_cache fd_accdb_shmem,fd_flamenco)
 $(call add-objs,fd_accdb_tile,fd_disco) # TODO: MOVE TO DISCOF
 
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_accdb,test_accdb,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_accdb)
 
@@ -15,10 +13,8 @@ $(call make-unit-test,bench_accdb,bench_accdb,fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,bench_accdb_hotread,bench_accdb_hotread,fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,bench_accdb_txn,bench_accdb_txn,fd_flamenco fd_ballet fd_util)
 $(call make-unit-test,bench_accdb_cleanup,bench_accdb_cleanup,fd_flamenco fd_ballet fd_util)
+endif # FD_HAS_HOSTED
 
 ifdef FD_HAS_RACESAN
 $(call make-unit-test,test_accdb_racesan,test_accdb_racesan,fd_flamenco fd_ballet fd_util)
-endif
-
-endif
 endif

--- a/src/flamenco/genesis/Local.mk
+++ b/src/flamenco/genesis/Local.mk
@@ -1,7 +1,5 @@
-ifdef FD_HAS_DOUBLE
 $(call add-hdrs,fd_genesis_create.h)
 $(call add-objs,fd_genesis_create,fd_flamenco)
-endif
 
 $(call add-hdrs,fd_genesis_parse.h)
 $(call add-objs,fd_genesis_parse,fd_flamenco)

--- a/src/flamenco/progcache/Local.mk
+++ b/src/flamenco/progcache/Local.mk
@@ -18,7 +18,7 @@ $(call add-objs,fd_progcache_clock,fd_flamenco)
 $(call add-objs,fd_progcache_rec,fd_flamenco)
 $(call add-objs,fd_progcache_reclaim,fd_flamenco)
 
-ifdef FD_HAS_ATOMIC
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_progcache,test_progcache,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_progcache)
 ifdef FD_HAS_RACESAN

--- a/src/flamenco/rewards/Local.mk
+++ b/src/flamenco/rewards/Local.mk
@@ -6,9 +6,8 @@ $(call add-objs,fd_stake_rewards,fd_flamenco)
 $(call add-hdrs,fd_rewards.h)
 $(call add-objs,fd_rewards,fd_flamenco)
 
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_inflation_rate,test_inflation_rate,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_inflation_rate)
-
-ifdef FD_HAS_HOSTED
 $(call make-fuzz-test,fuzz_stake_rewards_forks,fuzz_stake_rewards_forks,fd_flamenco fd_ballet fd_util)
 endif

--- a/src/flamenco/runtime/Local.mk
+++ b/src/flamenco/runtime/Local.mk
@@ -13,7 +13,7 @@ $(call add-objs,fd_executor,fd_flamenco)
 
 $(call add-hdrs,fd_hashes.h)
 $(call add-objs,fd_hashes,fd_flamenco)
-ifdef FD_HAS_ATOMIC
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_hashes,test_hashes,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_hashes)
 endif
@@ -23,14 +23,16 @@ $(call add-objs,fd_pubkey_utils,fd_flamenco)
 
 $(call add-hdrs,fd_slot_params.h)
 $(call add-objs,fd_slot_params,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_slot_params,test_slot_params,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_slot_params)
+endif
 
-ifdef FD_HAS_ATOMIC
 $(call add-hdrs,fd_txncache_shmem.h fd_txncache.h)
 $(call add-objs,fd_txncache_shmem fd_txncache,fd_flamenco)
 $(call add-hdrs,fd_cost_tracker.h)
 $(call add-objs,fd_cost_tracker,fd_flamenco)
+ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_cost_tracker,test_cost_tracker,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_cost_tracker)
 endif
@@ -43,35 +45,28 @@ $(call add-objs,fd_borrowed_account,fd_flamenco)
 $(call make-unit-test,test_borrowed_account,test_borrowed_account,fd_flamenco fd_util)
 $(call run-unit-test,test_borrowed_account)
 
-ifdef FD_HAS_ATOMIC
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_bundle_exec,test_bundle_exec,fd_flamenco_test fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_bundle_exec)
 
 $(call make-unit-test,test_programdata_delayvis,test_programdata_delayvis,fd_flamenco_test fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_programdata_delayvis)
-endif
 $(call make-unit-test,test_runtime_alut,test_runtime_alut,fd_flamenco_test fd_flamenco fd_tango fd_ballet fd_util fd_disco)
 $(call run-unit-test,test_runtime_alut)
 endif
 
-ifdef FD_HAS_ATOMIC
 $(call add-hdrs,fd_bank.h)
 $(call add-objs,fd_bank,fd_flamenco)
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_bank,test_bank,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_bank)
 endif
-endif
 
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_txncache,test_txncache,fd_flamenco fd_ballet fd_util)
-ifdef FD_HAS_ATOMIC
 $(call make-fuzz-test,fuzz_txncache_fork_graph,fuzz_txncache_fork_graph,fd_flamenco fd_ballet fd_util)
 endif
-endif
 
-ifdef FD_HAS_ATOMIC
 $(call add-hdrs,fd_runtime.h fd_runtime_err.h fd_runtime_const.h fd_runtime_stack.h fd_runtime_helpers.h)
 $(call add-objs,fd_runtime,fd_flamenco)
 ifdef FD_HAS_HOSTED
@@ -96,17 +91,13 @@ $(call run-unit-test,test_cost_model)
 $(call make-unit-test,test_feature_activation,tests/test_feature_activation,fd_flamenco_test fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_feature_activation)
 endif
-endif
 
 $(call add-hdrs,fd_system_ids.h)
 $(call add-objs,fd_system_ids,fd_flamenco)
 $(call make-unit-test,test_system_ids,test_system_ids,fd_flamenco fd_util fd_ballet)
 $(call run-unit-test,test_system_ids)
 
-ifdef FD_HAS_ATOMIC
-
 ifdef FD_HAS_HOSTED
 # TODO: Flakes
 # $(call run-unit-test,test_txncache)
-endif
 endif

--- a/src/flamenco/runtime/sysvar/Local.mk
+++ b/src/flamenco/runtime/sysvar/Local.mk
@@ -24,9 +24,7 @@ $(call add-objs,fd_sysvar_recent_hashes,fd_flamenco)
 
 $(call add-hdrs,fd_sysvar_rent.h)
 $(call add-objs,fd_sysvar_rent,fd_flamenco)
-ifdef FD_HAS_DOUBLE
 $(call add-objs,fd_sysvar_rent1,fd_flamenco)
-endif
 
 $(call add-hdrs,fd_sysvar_slot_hashes.h)
 $(call add-objs,fd_sysvar_slot_hashes,fd_flamenco)

--- a/src/flamenco/stakes/Local.mk
+++ b/src/flamenco/stakes/Local.mk
@@ -1,8 +1,6 @@
 $(call add-hdrs,fd_stake_types.h)
-ifdef FD_HAS_DOUBLE
 $(call add-hdrs,fd_stakes.h)
 $(call add-objs,fd_stakes,fd_flamenco)
-endif
 
 $(call add-hdrs,fd_vote_stakes.h)
 $(call add-objs,fd_vote_stakes,fd_flamenco)

--- a/src/flamenco/stakes/fd_stake_types.h
+++ b/src/flamenco/stakes/fd_stake_types.h
@@ -26,9 +26,7 @@ struct __attribute__((packed)) fd_delegation {
   ulong       activation_epoch;
   ulong       deactivation_epoch;
   union {
-#   if FD_HAS_DOUBLE
     double    warmup_cooldown_rate;
-#   endif
     ulong     warmup_cooldown_rate_bits;
   };
 };

--- a/src/flamenco/stakes/fd_stakes.h
+++ b/src/flamenco/stakes/fd_stakes.h
@@ -18,7 +18,6 @@ stake_activating_and_deactivating( fd_delegation_t const *    self,
                                    fd_stake_history_t const * stake_history,
                                    ulong *                    new_rate_activation_epoch );
 
-#if FD_HAS_DOUBLE
 /* Caller must ensure cluster_portion is nonzero. */
 
 static inline ulong
@@ -32,7 +31,6 @@ fd_stake_calculate_change_allowance_float( ulong   current_epoch,
   double newly_changed_cluster_stake = (double)cluster_effective * warmup_cooldown_rate;
   return fd_rust_cast_double_to_ulong( weight * newly_changed_cluster_stake );
 }
-#endif /* FD_HAS_DOUBLE */
 
 ulong
 fd_stake_calculate_activation_allowance( ulong                            current_epoch,

--- a/src/flamenco/stakes/test_vote_stakes.c
+++ b/src/flamenco/stakes/test_vote_stakes.c
@@ -205,13 +205,8 @@ main( int argc, char ** argv ) {
   fd_vote_stakes_snap_insert_t_3( vote_stakes, root, &invalid_vote, &node_a, 300UL, 0U, invalid_bls );
   fd_vote_stakes_snap_insert_t_3( vote_stakes, root, &valid_vote,   &node_b, 100UL, 0U, valid_bls[0] );
   fd_vote_stakes_finalize( vote_stakes, 2UL );
-#if FD_HAS_BLST
   FD_TEST( epoch_rank( vote_stakes, root, FD_VOTE_STAKES_ITER_T_3, &invalid_vote )==FD_VOTE_STAKES_ALPENGLOW_RANK_NULL );
   FD_TEST( epoch_rank( vote_stakes, root, FD_VOTE_STAKES_ITER_T_3, &valid_vote   )==0U );
-#else
-  FD_TEST( epoch_rank( vote_stakes, root, FD_VOTE_STAKES_ITER_T_3, &invalid_vote )==0U );
-  FD_TEST( epoch_rank( vote_stakes, root, FD_VOTE_STAKES_ITER_T_3, &valid_vote   )==1U );
-#endif
   fd_vote_stakes_purge_fork( vote_stakes, root );
 
   fd_vote_stakes_reset( vote_stakes );

--- a/src/flamenco/types/fd_cast.h
+++ b/src/flamenco/types/fd_cast.h
@@ -12,8 +12,6 @@
 
 FD_PROTOTYPES_BEGIN
 
-#if FD_HAS_DOUBLE
-
 /* Cast a double to unsigned long with identical behaviour to Rust's
    saturating "as" case.
    Saturate to 0 if the value is negative or NaN.
@@ -97,8 +95,6 @@ fd_rust_cast_double_to_int( double f ) {
   if( FD_UNLIKELY( f<=-2147483648. ) ) return INT_MIN;  /* -2^31 */
   return (int)f;
 }
-
-#endif /* FD_HAS_DOUBLE */
 
 /* Single precision sources, same semantics. */
 

--- a/src/flamenco/vm/Local.mk
+++ b/src/flamenco/vm/Local.mk
@@ -5,10 +5,8 @@ $(call add-objs,fd_vm fd_vm_interp fd_vm_disasm fd_vm_trace,fd_flamenco)
 $(call add-hdrs,test_vm_util.h)
 $(call add-objs,test_vm_util,fd_flamenco)
 
-ifdef FD_HAS_BLST
 $(call make-unit-test,test_vm_interp,test_vm_interp,fd_flamenco fd_ballet fd_util fd_disco,$(BLST_LIBS))
 $(call run-unit-test,test_vm_interp)
-endif
 endif
 
 ifdef FD_HAS_HOSTED
@@ -16,10 +14,8 @@ $(call make-unit-test,test_vm_base,test_vm_base,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_vm_base)
 endif
 
-ifdef FD_HAS_BLST
 $(call make-unit-test,test_vm_instr,test_vm_instr,fd_flamenco fd_ballet fd_util,$(BLST_LIBS))
 $(call run-unit-test,test_vm_instr)
-endif
 
 ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_pointer_chase,test_pointer_chase,fd_util)

--- a/src/flamenco/vm/Local.mk
+++ b/src/flamenco/vm/Local.mk
@@ -1,23 +1,19 @@
-ifdef FD_HAS_HOSTED
 $(call add-hdrs,fd_vm_base.h fd_vm.h fd_vm_private.h) # FIXME: PRIVATE TEMPORARILY HERE DUE TO SOME MESSINESS IN FD_VM_SYSCALL.H
 $(call add-objs,fd_vm fd_vm_interp fd_vm_disasm fd_vm_trace,fd_flamenco)
 
+ifdef FD_HAS_HOSTED
 $(call add-hdrs,test_vm_util.h)
 $(call add-objs,test_vm_util,fd_flamenco)
 
 $(call make-unit-test,test_vm_interp,test_vm_interp,fd_flamenco fd_ballet fd_util fd_disco,$(BLST_LIBS))
 $(call run-unit-test,test_vm_interp)
-endif
 
-ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_vm_base,test_vm_base,fd_flamenco fd_ballet fd_util)
 $(call run-unit-test,test_vm_base)
-endif
 
 $(call make-unit-test,test_vm_instr,test_vm_instr,fd_flamenco fd_ballet fd_util,$(BLST_LIBS))
 $(call run-unit-test,test_vm_instr)
 
-ifdef FD_HAS_HOSTED
 $(call make-unit-test,test_pointer_chase,test_pointer_chase,fd_util)
 $(call run-unit-test,test_pointer_chase)
 endif

--- a/src/flamenco/vm/syscall/Local.mk
+++ b/src/flamenco/vm/syscall/Local.mk
@@ -8,7 +8,6 @@ $(call run-unit-test,test_vm_syscall_cpi)
 $(call make-unit-test,test_vm_syscall_hash,test_vm_syscall_hash,fd_flamenco fd_util fd_ballet)
 $(call run-unit-test,test_vm_syscall_hash)
 
-ifdef FD_HAS_BLST
 $(call make-unit-test,test_vm_syscalls,test_vm_syscalls,fd_flamenco fd_util fd_ballet)
 $(call run-unit-test,test_vm_syscalls)
 $(call make-unit-test,test_vm_syscall_curve,test_vm_syscall_curve,fd_flamenco fd_util fd_ballet)
@@ -17,5 +16,4 @@ $(call make-unit-test,test_cpi_shared_data_addr,test_cpi_shared_data_addr,fd_fla
 $(call run-unit-test,test_cpi_shared_data_addr)
 $(call make-unit-test,test_cpi_semantics,test_cpi_semantics,fd_flamenco_test fd_flamenco fd_util fd_ballet)
 $(call run-unit-test,test_cpi_semantics)
-endif
 endif

--- a/src/flamenco/vm/syscall/fd_vm_syscall.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall.c
@@ -132,14 +132,10 @@ fd_vm_syscall_register_slot( fd_sbpf_syscalls_t *      syscalls,
 
 //REGISTER( "sol_remaining_compute_units",           fd_vm_syscall_sol_remaining_compute_units );
 
-#if FD_HAS_BLST
   if( enable_bls12_381_syscall ) {
     REGISTER( "sol_curve_decompress",                fd_vm_syscall_sol_curve_decompress );
     REGISTER( "sol_curve_pairing_map",               fd_vm_syscall_sol_curve_pairing_map );
   }
-#else
-  (void)enable_bls12_381_syscall;
-#endif /* FD_HAS_BLST */
 
 # undef REGISTER
 

--- a/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
+++ b/src/flamenco/vm/syscall/fd_vm_syscall_curve.c
@@ -49,7 +49,6 @@ fd_vm_syscall_sol_curve_validate_point( /**/            void *  _vm,
     ret = (ulong)!fd_ristretto255_point_validate( point ); /* 0 if valid point, 1 if not */
     break;
 
-#if FD_HAS_BLST
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_BE:
   case FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G1_LE: {
 
@@ -67,7 +66,6 @@ fd_vm_syscall_sol_curve_validate_point( /**/            void *  _vm,
     point = FD_VM_MEM_HADDR_LD( vm, point_addr, FD_VM_ALIGN_RUST_POD_U8_ARRAY, FD_VM_SYSCALL_SOL_CURVE_BLS12_381_G2_POINT_SZ );
     ret = (ulong)!fd_bls12_381_g2_validate_syscall( point, big_endian ); /* 0 if valid point, 1 if not */
   } break;
-#endif
 
   default:
     /* https://github.com/anza-xyz/agave/blob/5b3390b99a6e7665439c623062c1a1dda2803524/programs/bpf_loader/src/syscalls/mod.rs#L919-L928 */
@@ -170,7 +168,6 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
     }
     break;
 
-#if FD_HAS_BLST
   /* BLS12-381 G1 */
   case BLS_G1_BE:
   case BLS_G1_LE:
@@ -226,7 +223,6 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
       goto invalid_error;
     }
     break;
-#endif
 
   default:
     goto invalid_error;
@@ -241,9 +237,7 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
   uchar const * inputL = FD_VM_MEM_HADDR_LD( vm, left_input_addr,  FD_VM_ALIGN_RUST_POD_U8_ARRAY, inputL_sz );
   uchar const * inputR = FD_VM_MEM_HADDR_LD( vm, right_input_addr, FD_VM_ALIGN_RUST_POD_U8_ARRAY, inputR_sz );
 
-#if FD_HAS_BLST
   int big_endian = ( curve_id & 0x80 ) ? 1 : 0;
-#endif
 
   switch( MATCH_ID_OP( curve_id, group_op ) ) {
 
@@ -343,7 +337,6 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
     break;
   }
 
-#if FD_HAS_BLST
   /* BLS12-381 G1 */
 
   /* https://github.com/anza-xyz/agave/blob/v4.0.0-alpha.0/syscalls/src/lib.rs#L1453 */
@@ -425,7 +418,6 @@ fd_vm_syscall_sol_curve_group_op( void *  _vm,
     }
     break;
   }
-#endif
 
   default:
     /* COV: this can never happen because of the previous switch */
@@ -642,8 +634,6 @@ fd_vm_syscall_sol_curve_multiscalar_mul( void *  _vm,
   return FD_VM_SUCCESS;
 }
 
-#if FD_HAS_BLST
-
 int
 fd_vm_syscall_sol_curve_decompress( /**/            void *  _vm,
                                     /**/            ulong   curve_id,
@@ -745,5 +735,3 @@ fd_vm_syscall_sol_curve_pairing_map( /**/            void *  _vm,
   *_ret = ret;
   return FD_VM_SUCCESS;
 }
-
-#endif

--- a/src/third_party/blst/Local.mk
+++ b/src/third_party/blst/Local.mk
@@ -1,14 +1,22 @@
-ifdef FD_HAS_BLST
-
 # Two-object build per upstream build.sh: server.c unity build +
 # assembly.S (#includes pre-generated per-arch .s bodies from elf/).
 # -fno-builtin: keep constant-time memory routines from becoming libc
 # calls.  x86: __BLST_PORTABLE__ assembles both ADX and portable paths
 # with runtime cpuid dispatch; -mno-avx per upstream (avoid SSE<->AVX
 # transition penalties).  arm: no variant dispatch; armv8 bodies only.
+# Other machines (noarch, power9, riscv) take the pure C path.  vect.h
+# forces 64-bit limbs whenever the compiler defines __x86_64__ or
+# __aarch64__, which no_asm.h (32-bit limbs only) cannot build, so
+# undefine them; blst includes only stddef.h so this is safe.
 BLST_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS))) -fno-builtin
+BLST_OBJS:=$(OBJDIR)/obj/third_party/blst/server.o
 ifdef FD_HAS_X86
 BLST_CFLAGS_NOWARN+=-D__BLST_PORTABLE__ -mno-avx
+BLST_OBJS+=$(OBJDIR)/obj/third_party/blst/assembly.o
+else ifdef FD_HAS_ARM
+BLST_OBJS+=$(OBJDIR)/obj/third_party/blst/assembly.o
+else
+BLST_CFLAGS_NOWARN+=-D__BLST_NO_ASM__ -U__x86_64__ -U__aarch64__
 endif
 
 $(OBJDIR)/obj/third_party/blst/server.o : src/third_party/blst/src/server.c $(OBJDIR)/.flags src/third_party/blst/Local.mk
@@ -26,8 +34,8 @@ ASM_DEPFILES+=$(OBJDIR)/obj/third_party/blst/assembly.d
 THIRDPARTY_DEPFILES+=$(OBJDIR)/obj/third_party/blst/server.d
 
 LIB_NAMES+=fd_blst
-LIB_OBJS_fd_blst+=$(OBJDIR)/obj/third_party/blst/server.o $(OBJDIR)/obj/third_party/blst/assembly.o
-$(OBJDIR)/lib/libfd_blst.a: $(OBJDIR)/obj/third_party/blst/server.o $(OBJDIR)/obj/third_party/blst/assembly.o
+LIB_OBJS_fd_blst+=$(BLST_OBJS)
+$(OBJDIR)/lib/libfd_blst.a: $(BLST_OBJS)
 $(OBJDIR)/lib/libfd_blst.a: $(OBJDIR)/lib/libfd_blst.a.mlist
 
 lib: $(OBJDIR)/lib/libfd_blst.a
@@ -36,6 +44,3 @@ lib: $(OBJDIR)/lib/libfd_blst.a
 # executables no prerequisite edge to it.  Order-only edge via
 # libfd_util.a (linked by every executable; excluded from its $^).
 $(OBJDIR)/lib/libfd_util.a: | $(OBJDIR)/lib/libfd_blst.a
-
-endif
-

--- a/src/third_party/blst/README.txt
+++ b/src/third_party/blst/README.txt
@@ -20,9 +20,14 @@ build.sh instead bakes -D__ADX__ from the build host's /proc/cpuinfo
 into the artifact; portable dispatch is safer for binaries deployed
 to heterogeneous CPUs at ~2x asm footprint.  On aarch64 assembly.S
 selects the armv8 bodies (build/elf/*-armv8.S); there is no variant
-dispatch.  -fno-builtin is required: without it the compiler
-pattern-matches blst's constant-time memory routines into libc
-memcpy/memset calls, silently breaking constant-time guarantees.
+dispatch.  Other machines (noarch, power9, riscv) build with
+-D__BLST_NO_ASM__ and without assembly.S, using the C fallback in
+src/no_asm.h.  no_asm.h only supports 32-bit limbs, but vect.h picks
+64-bit limbs when __x86_64__ or __aarch64__ is defined, so those
+macros are undefined on the command line.  -fno-builtin is required:
+without it the compiler pattern-matches blst's constant-time memory
+routines into libc memcpy/memset calls, silently breaking
+constant-time guarantees.
 
 For licensing information (Apache-2.0), see LICENSE in this
 directory and NOTICE in the root of this repo.

--- a/src/third_party/zstd/Local.mk
+++ b/src/third_party/zstd/Local.mk
@@ -1,5 +1,3 @@
-ifdef FD_HAS_ZSTD
-
 ZSTD_OBJS:=\
   common/debug \
   common/entropy_common \
@@ -26,6 +24,11 @@ ZSTD_OBJS:=\
   decompress/zstd_decompress_block
 
 ZSTD_CFLAGS_NOWARN:=$(filter-out -W%,$(filter-out -Werror,$(CPPFLAGS) $(CFLAGS))) -DZSTD_TRACE=0 -DDEBUGLEVEL=0 -DZSTD_LEGACY_SUPPORT=0 -DZSTD_ASAN_DONT_POISON_WORKSPACE=1 -DZSTD_MSAN_DONT_POISON_WORKSPACE=1
+# huf_decompress_amd64.S is the only asm; keep the C path for machines
+# without FD_HAS_X86 (noarch etc.) so it stays exercised.
+ifndef FD_HAS_X86
+ZSTD_CFLAGS_NOWARN+=-DZSTD_DISABLE_ASM
+endif
 
 $(OBJDIR)/obj/third_party/zstd/lib/%.o : src/third_party/zstd/lib/%.c $(OBJDIR)/.flags src/third_party/zstd/Local.mk
 	@echo -e "CC\t$(notdir $@)"
@@ -59,6 +62,3 @@ lib: $(OBJDIR)/lib/libfd_zstd.a
 # Global-LDFLAGS archive: order-only edge via libfd_util.a (see
 # third_party/blst/Local.mk for rationale).
 $(OBJDIR)/lib/libfd_util.a: | $(OBJDIR)/lib/libfd_zstd.a
-
-endif
-

--- a/src/util/bits/fd_float.h
+++ b/src/util/bits/fd_float.h
@@ -136,8 +136,6 @@ fd_fltbits_is_normal( ulong u ) {
          ( !fd_fltbits_is_nan   ( u ) );
 }
 
-#if FD_HAS_DOUBLE /* These are 64-bit / double precision counterparts to the above */
-
 FD_FN_CONST static inline ulong
 fd_dblbits( double f ) {
   union { ulong u[1]; double f[1]; } tmp;
@@ -197,8 +195,6 @@ fd_dblbits_is_normal( ulong u ) {
          ( !fd_dblbits_is_inf   ( u ) ) &
          ( !fd_dblbits_is_nan   ( u ) );
 }
-
-#endif
 
 FD_PROTOTYPES_END
 

--- a/src/util/clock/Local.mk
+++ b/src/util/clock/Local.mk
@@ -1,6 +1,6 @@
-ifdef FD_HAS_DOUBLE
 $(call add-hdrs,fd_clock.h)
 $(call add-objs,fd_clock,fd_util)
+ifdef FD_HAS_DOUBLE
 $(call make-unit-test,test_clock,test_clock,fd_util)
 $(call run-unit-test,test_clock)
 endif

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -196,13 +196,6 @@
 #define FD_HAS_LZ4 0
 #endif
 
-/* FD_HAS_ZSTD indicates that the target supports ZSTD compression.
-   Roughly, does "#include <zstd.h>" and the APIs therein work? */
-
-#ifndef FD_HAS_ZSTD
-#define FD_HAS_ZSTD 0
-#endif
-
 /* FD_HAS_COVERAGE indicates that the build target is built with coverage instrumentation. */
 
 #ifndef FD_HAS_COVERAGE

--- a/src/util/fd_util_base.h
+++ b/src/util/fd_util_base.h
@@ -815,8 +815,6 @@ fd_type_pun_const( void const * p ) {
 
 #define FD_VOLATILE(x) (*((volatile __typeof__((x)) *)&(x)))
 
-#if FD_HAS_ATOMIC
-
 /* FD_ATOMIC_FETCH_AND_{ADD,SUB,OR,AND,XOR}(p,v):
 
    FD_ATOMIC_FETCH_AND_ADD(p,v) does
@@ -864,8 +862,6 @@ fd_type_pun_const( void const * p ) {
    as a single atomic operation. */
 
 #define FD_ATOMIC_XCHG(p,v) __atomic_exchange_n( (p), (v), __ATOMIC_SEQ_CST )
-
-#endif /* FD_HAS_ATOMIC */
 
 /* FD_TL:  This indicates that the variable should be thread local.
 

--- a/src/waltz/http/fd_http_server.c
+++ b/src/waltz/http/fd_http_server.c
@@ -19,11 +19,9 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
-#if FD_HAS_ZSTD
 #define FD_HTTP_ZSTD_COMPRESSION_LEVEL 3
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
-#endif
 
 #define POOL_NAME       ws_conn_pool
 #define POOL_T          struct fd_http_server_ws_connection
@@ -123,9 +121,7 @@ fd_http_server_footprint( fd_http_server_params_t params ) {
   l = FD_LAYOUT_APPEND( l, 1UL,                                       params.max_ws_recv_frame_len*params.max_ws_connection_cnt                                          );
   l = FD_LAYOUT_APPEND( l, alignof( struct fd_http_server_ws_frame ), params.max_ws_send_frame_cnt*params.max_ws_connection_cnt*sizeof( struct fd_http_server_ws_frame ) );
   l = FD_LAYOUT_APPEND( l, 1UL,                                       params.outgoing_buffer_sz                                                                          );
-#if FD_HAS_ZSTD
   l = FD_LAYOUT_APPEND( l, 16UL,                                      ZSTD_estimateCCtxSize( FD_HTTP_ZSTD_COMPRESSION_LEVEL )                                            );
-#endif
   return FD_LAYOUT_FINI( l, fd_http_server_align() );
 }
 
@@ -165,9 +161,7 @@ fd_http_server_new( void *                     shmem,
   uchar * _ws_recv_bytes  = FD_SCRATCH_ALLOC_APPEND( l,  1UL,                                          params.max_ws_recv_frame_len*params.max_ws_connection_cnt                            );
   struct fd_http_server_ws_frame * _ws_send_frames = FD_SCRATCH_ALLOC_APPEND( l, alignof(struct fd_http_server_ws_frame), params.max_ws_send_frame_cnt*params.max_ws_connection_cnt*sizeof(struct fd_http_server_ws_frame) );
   http->oring             = FD_SCRATCH_ALLOC_APPEND( l,  1UL,                                          params.outgoing_buffer_sz                                                            );
-#if FD_HAS_ZSTD
   uchar * _zstd_ctx       = FD_SCRATCH_ALLOC_APPEND( l,  16UL,                                         ZSTD_estimateCCtxSize( FD_HTTP_ZSTD_COMPRESSION_LEVEL )                              );
-#endif
   http->oring_sz       = params.outgoing_buffer_sz;
   http->stage_err      = 0;
   http->stage_off      = 0UL;
@@ -187,13 +181,11 @@ fd_http_server_new( void *                     shmem,
   http->send_buffer_sz        = params.send_buffer_sz;
   http->compress_websocket    = params.compress_websocket;
 
-#if FD_HAS_ZSTD
   http->zstd_ctx = ZSTD_initStaticCCtx( _zstd_ctx, ZSTD_estimateCCtxSize( FD_HTTP_ZSTD_COMPRESSION_LEVEL ) );
   FD_TEST( http->zstd_ctx );
   ulong err = ZSTD_CCtx_setParameter( http->zstd_ctx, 100, FD_HTTP_ZSTD_COMPRESSION_LEVEL );
   if( FD_UNLIKELY( ZSTD_isError( err ) ) )
       FD_LOG_ERR(( "ZSTD_CCtx_setParameter failed (%s)", ZSTD_getErrorName( err ) ) );
-#endif
 
   http->conns = conn_pool_join( conn_pool_new( conn_pool, params.max_connection_cnt ) );
   conn_treap_join( conn_treap_new( http->conn_treap, params.max_connection_cnt ) );
@@ -729,14 +721,12 @@ parse_conn_http( fd_http_server_t * http,
     conn->request_bytes_len = conn->request_bytes_off+(ulong)result;
     conn->upgrade_websocket = 1;
 
-#if FD_HAS_ZSTD
     for( ulong i=0UL; i<num_headers; i++ ) {
       if( FD_LIKELY( headers[ i ].name_len==22UL && !strncasecmp( headers[ i ].name, "Sec-WebSocket-Protocol", 22UL ) &&
                      headers[ i ].value_len==13UL && !strncmp( headers[ i ].value, "compress-zstd", 13UL ) ) ) {
         compress_websocket = 1;
       }
     }
-#endif
 
     char const * sec_websocket_key = NULL;
     for( ulong i=0UL; i<num_headers; i++ ) {
@@ -1565,7 +1555,6 @@ fd_http_ws_compress_maybe( fd_http_server_t * http ) {
      disabled in the config */
   if( FD_LIKELY( !http->compress_websocket || http->stage_len <= 200 || http->stage_err ) ) return 0;
 
-#if FD_HAS_ZSTD
   ulong worst_case_compressed_sz = ZSTD_compressBound( http->stage_len );
   fd_http_server_reserve( http, worst_case_compressed_sz );
 
@@ -1582,9 +1571,6 @@ fd_http_ws_compress_maybe( fd_http_server_t * http ) {
   http->stage_comp_len = compressed_sz;
 
   return 1;
-#else
-  return 0;
-#endif
 }
 
 uchar *

--- a/src/waltz/http/fd_http_server_private.h
+++ b/src/waltz/http/fd_http_server_private.h
@@ -3,10 +3,8 @@
 
 #include "fd_http_server.h"
 
-#if FD_HAS_ZSTD
 #define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
-#endif
 
 #define FD_HTTP_SERVER_MAGIC (0xF17EDA2CE50A11D0) /* FIREDANCER HTTP V0 */
 
@@ -100,11 +98,9 @@ struct __attribute__((aligned(FD_HTTP_SERVER_ALIGN))) fd_http_server_private {
   ulong   oring_sz;
 
   int compress_websocket;
-#if FD_HAS_ZSTD
   uchar * zstd_scratch;
   ulong   zstd_scratch_sz;
   ZSTD_CCtx * zstd_ctx;
-#endif
 
   int   stage_err;
   ulong stage_off;

--- a/src/waltz/http/test_http_server.c
+++ b/src/waltz/http/test_http_server.c
@@ -186,12 +186,7 @@ test_oring( void ) {
 
   /* zstd cctx estimate assumes the single-threaded vendored build */
   uchar scratch[ 1633280 ] __attribute__((aligned(128UL)));
-#if FD_HAS_ZSTD
   FD_TEST( fd_http_server_footprint( params )==1633280 );
-#else
-  FD_TEST( fd_http_server_footprint( params )==329600 );
-  FD_TEST( fd_http_server_footprint( params )<=sizeof( scratch ) );
-#endif
   fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, NULL ) );
 
   http->stage_off = 6UL;
@@ -277,12 +272,7 @@ test_content_length_overflow_close( void ) {
 
   FD_LOG_NOTICE(( "footprint %lu", fd_http_server_footprint( params ) ));
   uchar scratch[ 1306624 ] __attribute__((aligned(128UL)));
-#if FD_HAS_ZSTD
   FD_TEST( fd_http_server_footprint( params )==sizeof( scratch ) );
-#else
-  FD_TEST( fd_http_server_footprint( params )==3072 );
-  FD_TEST( fd_http_server_footprint( params )<=sizeof( scratch ) );
-#endif
 
   fd_http_server_t * http = fd_http_server_join( fd_http_server_new( scratch, params, callbacks, &state ) );
   FD_TEST( http );


### PR DESCRIPTION
libzstd and blst are portable. The optional dependency wiring is silly.