### PR TITLE
events: pace whole messages, not per-poll byte slices

### DIFF
--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -797,6 +797,8 @@ tx( fd_event_client_t * client,
     int *               charge_busy ) {
   FD_TEST( client->state==FD_EVENT_CLIENT_STATE_CONNECTED );
 
+  long tokens = pace_refill( client, now );
+
   if( FD_UNLIKELY( client->event_stream && client->grpc_client->request_stream != NULL && client->grpc_client->request_stream!=client->event_stream ) ) return;
 
   if( FD_UNLIKELY( client->event_stream ) ) {
@@ -821,7 +823,7 @@ tx( fd_event_client_t * client,
     return;
   }
 
-  if( FD_UNLIKELY( pace_refill( client, now )<=0L ) ) return;
+  if( FD_UNLIKELY( tokens<=0L ) ) return;
 
   ulong msg_sz;
   uchar const * msg = fd_circq_cursor_advance( client->circq, &msg_sz );

--- a/src/disco/events/fd_event_client.c
+++ b/src/disco/events/fd_event_client.c
@@ -780,6 +780,17 @@ fd_event_client_grpc_ping_ack( void * app_ctx ) {
   FD_LOG_WARNING(( "Event gRPC ping ack" ));
 }
 
+static long
+pace_refill( fd_event_client_t * client,
+             long                now ) {
+  long ns_per_byte = (long)1e9/FD_EVENT_CLIENT_TX_RATE_BPS;
+  long dt          = fd_long_max( now-client->tx_tokens_ns, 0L );
+  long grant       = fd_long_min( dt/ns_per_byte, FD_EVENT_CLIENT_TX_BURST-client->tx_tokens );
+  client->tx_tokens   += grant;
+  client->tx_tokens_ns = client->tx_tokens==FD_EVENT_CLIENT_TX_BURST ? now : client->tx_tokens_ns+grant*ns_per_byte;
+  return client->tx_tokens;
+}
+
 static void
 tx( fd_event_client_t * client,
     long                now,
@@ -789,10 +800,7 @@ tx( fd_event_client_t * client,
   if( FD_UNLIKELY( client->event_stream && client->grpc_client->request_stream != NULL && client->grpc_client->request_stream!=client->event_stream ) ) return;
 
   if( FD_UNLIKELY( client->event_stream ) ) {
-    if( FD_UNLIKELY( fd_grpc_client_stream_send_is_blocked( client->grpc_client ) ) ) {
-      if( fd_grpc_client_tx_budget( client->grpc_client ) && fd_grpc_client_request_continue( client->grpc_client ) ) *charge_busy = 1;
-      return;
-    }
+    if( FD_UNLIKELY( fd_grpc_client_stream_send_is_blocked( client->grpc_client ) ) ) return;
   } else {
     if( FD_UNLIKELY( fd_grpc_client_request_is_blocked( client->grpc_client ) ) ) return;
   }
@@ -813,7 +821,7 @@ tx( fd_event_client_t * client,
     return;
   }
 
-  if( FD_UNLIKELY( !fd_grpc_client_tx_budget( client->grpc_client ) ) ) return;
+  if( FD_UNLIKELY( pace_refill( client, now )<=0L ) ) return;
 
   ulong msg_sz;
   uchar const * msg = fd_circq_cursor_advance( client->circq, &msg_sz );
@@ -833,6 +841,7 @@ tx( fd_event_client_t * client,
   int result = fd_grpc_client_stream_send_msg1( client->grpc_client, client->event_stream, msg, msg_sz );
   if( FD_UNLIKELY( !result ) ) return; /* Only reason for failure is too big message, so just skip it */
 
+  client->tx_tokens -= (long)msg_sz;
   client->metrics.events_sent++;
   client->last_stream_send_ns = now;
   *charge_busy = 1;
@@ -879,31 +888,12 @@ fd_event_client_next_deadline( fd_event_client_t const * client,
   if( FD_LIKELY( client->state==FD_EVENT_CLIENT_STATE_CONNECTED && client->event_stream ) ) {
     deadline = fd_long_min( deadline, fd_long_min( client->last_response_ns   +FD_EVENT_CLIENT_RESPONSE_TIMEOUT_NANOS,
                                                    client->last_stream_send_ns+FD_EVENT_CLIENT_HEARTBEAT_NANOS ) );
-    if( FD_UNLIKELY( client->tx_tokens<=0L && ( fd_circq_unsent_cnt( client->circq ) || fd_grpc_client_tx_pending( client->grpc_client ) || fd_grpc_client_tx_starved( client->grpc_client )==0UL ) ) ) {
+    if( FD_UNLIKELY( client->tx_tokens<=0L && fd_circq_unsent_cnt( client->circq ) ) ) {
       deadline = fd_long_min( deadline, client->tx_tokens_ns + (1L-client->tx_tokens)*(long)1e9/FD_EVENT_CLIENT_TX_RATE_BPS );
     }
     if( FD_UNLIKELY( client->stall_since ) ) deadline = fd_long_min( deadline, client->stall_since+FD_EVENT_CLIENT_CREDIT_STALL_NANOS );
   }
   return deadline;
-}
-
-static ulong
-pace_refill( fd_event_client_t * client,
-             long                now ) {
-  long ns_per_byte = (long)1e9/FD_EVENT_CLIENT_TX_RATE_BPS;
-  long dt          = fd_long_max( now-client->tx_tokens_ns, 0L );
-  long grant       = fd_long_min( dt/ns_per_byte, FD_EVENT_CLIENT_TX_BURST-client->tx_tokens );
-  client->tx_tokens   += grant;
-  client->tx_tokens_ns = client->tx_tokens==FD_EVENT_CLIENT_TX_BURST ? now : client->tx_tokens_ns+grant*ns_per_byte;
-  ulong budget = (ulong)fd_long_max( client->tx_tokens, 0L );
-  fd_grpc_client_set_tx_budget( client->grpc_client, budget );
-  return budget;
-}
-
-static void
-pace_debit( fd_event_client_t * client,
-            ulong               budget ) {
-  client->tx_tokens -= (long)( budget-fd_grpc_client_tx_budget( client->grpc_client ) );
 }
 
 static int
@@ -932,8 +922,6 @@ poll1( fd_event_client_t * client,
        long                now,
        int *               charge_busy ) {
   if( FD_UNLIKELY( !client->has_genesis_hash || !client->has_shred_version ) ) return;
-
-  ulong budget = pace_refill( client, now );
 
   if( FD_UNLIKELY( client->state==FD_EVENT_CLIENT_STATE_DISCONNECTED ) ) reconnect( client, now, charge_busy );
   if( FD_UNLIKELY( client->state==FD_EVENT_CLIENT_STATE_CONNECTING ) ) {
@@ -986,7 +974,6 @@ poll1( fd_event_client_t * client,
     if( FD_UNLIKELY( credit_stall_check( client, now ) ) ) return;
     tx( client, now, charge_busy );
   }
-  pace_debit( client, budget );
 }
 
 void

--- a/src/disco/events/test_event_client.c
+++ b/src/disco/events/test_event_client.c
@@ -465,6 +465,18 @@ FD_UNIT_TEST( credit_stall ) {
   long dl = fd_event_client_next_deadline( client, now );
   FD_TEST( dl<=now+FD_EVENT_CLIENT_CREDIT_STALL_NANOS );
 
+  /* The bucket keeps refilling while parked, so an expired pacing
+     deadline does not pin the tile awake. */
+  long const ns_per_byte = (long)1e9/FD_EVENT_CLIENT_TX_RATE_BPS;
+  b = fd_circq_push_back( circq, 1UL, 16UL ); FD_TEST( b ); memset( b, 0, 16UL );
+  client->tx_tokens = -1000L; client->tx_tokens_ns = now;
+  long t0 = now+2000L*ns_per_byte;
+  client->last_response_ns = t0; client->last_stream_send_ns = t0;
+  test_poll_tx( client, t0 );
+  FD_TEST( client->tx_tokens==1000L );
+  FD_TEST( fd_grpc_client_tx_starved( grpc )==rem ); /* still parked */
+  FD_TEST( fd_event_client_next_deadline( client, t0 )>t0 );
+
   /* A late grant makes progress: timer restarts from the new remainder. */
   long t1 = now+FD_EVENT_CLIENT_CREDIT_STALL_NANOS-(long)1e9;
   client->event_stream->s.tx_wnd = 50U;

--- a/src/disco/events/test_event_client.c
+++ b/src/disco/events/test_event_client.c
@@ -311,14 +311,12 @@ test_connected_client( fd_circq_t * circq,
   return client;
 }
 
-/* One poll's worth of sending without a socket: refill, tx, debit. */
+/* One poll's worth of sending without a socket. */
 static void
 test_poll_tx( fd_event_client_t * client,
               long                now ) {
-  ulong budget = pace_refill( client, now );
   int charge_busy = 0;
   tx( client, now, &charge_busy );
-  pace_debit( client, budget );
 }
 
 /* Drain frame_tx as if the socket had taken it; returns bytes drained. */
@@ -339,11 +337,12 @@ FD_UNIT_TEST( tx_pacing ) {
   fd_grpc_client_t * grpc = client->grpc_client;
 
   /* 2x burst worth of 1 KiB messages queued */
-  ulong const msg_sz  = 1024UL;
-  ulong const msg_cnt = 2UL*(ulong)FD_EVENT_CLIENT_TX_BURST/msg_sz;
+  ulong const msg_sz   = 1024UL;
+  ulong const msg_cnt  = 2UL*(ulong)FD_EVENT_CLIENT_TX_BURST/msg_sz;
+  ulong const frame_sz = msg_sz+sizeof(fd_grpc_hdr_t)+sizeof(fd_h2_frame_hdr_t);
   for( ulong i=0UL; i<msg_cnt; i++ ) { uchar * b = fd_circq_push_back( circq, 1UL, msg_sz ); FD_TEST( b ); memset( b, 0, msg_sz ); }
 
-  /* Same instant: sends until the bucket is empty, then stops. */
+  /* Same instant: whole messages go out until the bucket is empty. */
   long now = fd_log_wallclock();
   client->tx_tokens = FD_EVENT_CLIENT_TX_BURST; client->tx_tokens_ns = now;
   ulong sent = 0UL, wire = 0UL;
@@ -354,9 +353,9 @@ FD_UNIT_TEST( tx_pacing ) {
     if( client->metrics.events_sent==before ) break;
     sent++;
   }
-  FD_TEST( sent>0UL && sent<=(ulong)FD_EVENT_CLIENT_TX_BURST/msg_sz );
-  FD_TEST( wire<=(ulong)FD_EVENT_CLIENT_TX_BURST+sent*sizeof(fd_h2_frame_hdr_t) );
-  FD_TEST( client->tx_tokens<=0L || fd_grpc_client_tx_pending( grpc ) || grpc->request_tx_op->chunk_sz );
+  FD_TEST( sent>0UL && sent<=(ulong)FD_EVENT_CLIENT_TX_BURST/msg_sz+1UL );
+  FD_TEST( wire==sent*frame_sz ); /* one DATA frame per message, never sliced */
+  FD_TEST( client->tx_tokens<=0L && client->tx_tokens>-(long)msg_sz );
   client->last_response_ns = now;
   long dl = fd_event_client_next_deadline( client, now );
   FD_TEST( dl>now && dl<=now+(long)1e9 );
@@ -381,13 +380,13 @@ FD_UNIT_TEST( tx_pacing ) {
     if( !got ) break;
     wire2 += got;
   }
-  FD_TEST( wire2>0UL && wire2<=(ulong)FD_EVENT_CLIENT_TX_BURST+msg_cnt*sizeof(fd_h2_frame_hdr_t) );
+  FD_TEST( wire2>0UL && wire2<=((ulong)FD_EVENT_CLIENT_TX_BURST/msg_sz+1UL)*frame_sz );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 }
 
-/* A message larger than the burst leaves frame_tx in budget-sized slices
-   across polls; the parked remainder is not a credit stall. */
+/* A message larger than the burst still goes out whole; the bucket goes
+   negative and the next message waits for the refill. */
 FD_UNIT_TEST( tx_pacing_large_msg ) {
   static uchar circq_mem[ 4096UL+(2UL<<20) ] __attribute__((aligned(FD_CIRCQ_ALIGN)));
   fd_circq_t * circq = fd_circq_join( fd_circq_new( circq_mem, 2UL<<20 ) );
@@ -399,34 +398,34 @@ FD_UNIT_TEST( tx_pacing_large_msg ) {
 
   ulong const msg_sz = 3UL*(ulong)FD_EVENT_CLIENT_TX_BURST;
   uchar * b = fd_circq_push_back( circq, 1UL, msg_sz ); FD_TEST( b ); memset( b, 0, msg_sz );
+  b = fd_circq_push_back( circq, 1UL, 16UL ); FD_TEST( b ); memset( b, 0, 16UL );
 
   long now = fd_log_wallclock();
   client->tx_tokens = FD_EVENT_CLIENT_TX_BURST; client->tx_tokens_ns = now;
   test_poll_tx( client, now );
   ulong wire = test_drain( grpc );
   FD_TEST( client->metrics.events_sent==1UL );
-  FD_TEST( wire<=(ulong)FD_EVENT_CLIENT_TX_BURST+32UL*sizeof(fd_h2_frame_hdr_t) );
-  FD_TEST( grpc->request_tx_op->chunk_sz==msg_sz+sizeof(fd_grpc_hdr_t)-(ulong)FD_EVENT_CLIENT_TX_BURST );
-  FD_TEST( client->tx_tokens<=0L );
-  FD_TEST( !fd_grpc_client_tx_starved( grpc ) ); /* parked on budget, not on credit */
+  FD_TEST( wire>=msg_sz+sizeof(fd_grpc_hdr_t) );
+  FD_TEST( grpc->request_tx_op->chunk_sz==0UL );
+  FD_TEST( client->tx_tokens==-2L*FD_EVENT_CLIENT_TX_BURST );
+  FD_TEST( !fd_grpc_client_tx_starved( grpc ) );
   FD_TEST( !credit_stall_check( client, now ) );
   FD_TEST( !client->stall_since );
 
-  /* Same instant: nothing more goes out. */
+  /* Same instant: the small message waits. */
   test_poll_tx( client, now );
-  FD_TEST( !test_drain( grpc ) );
+  FD_TEST( client->metrics.events_sent==1UL && !test_drain( grpc ) );
+  client->last_response_ns = now;
+  long const ns_per_byte = (long)1e9/FD_EVENT_CLIENT_TX_RATE_BPS;
+  long dl = fd_event_client_next_deadline( client, now );
+  FD_TEST( dl==now+(2L*FD_EVENT_CLIENT_TX_BURST+1L)*ns_per_byte );
 
-  /* Each second releases another burst of the same message until done. */
-  ulong rem = grpc->request_tx_op->chunk_sz;
-  while( rem ) {
-    now += (long)1e9;
-    test_poll_tx( client, now );
-    ulong got = test_drain( grpc );
-    FD_TEST( got>0UL && got<=(ulong)FD_EVENT_CLIENT_TX_BURST+32UL*sizeof(fd_h2_frame_hdr_t) );
-    FD_TEST( grpc->request_tx_op->chunk_sz<rem );
-    rem = grpc->request_tx_op->chunk_sz;
-  }
+  /* At the deadline the bucket is back to one token: it goes out. */
+  test_poll_tx( client, dl-1L );
   FD_TEST( client->metrics.events_sent==1UL );
+  test_poll_tx( client, dl );
+  FD_TEST( client->metrics.events_sent==2UL );
+  FD_TEST( test_drain( grpc )==16UL+sizeof(fd_grpc_hdr_t)+sizeof(fd_h2_frame_hdr_t) );
 
   fd_rng_delete( fd_rng_leave( rng ) );
 }
@@ -441,8 +440,9 @@ FD_UNIT_TEST( credit_stall ) {
   fd_rng_t * rng = fd_rng_join( fd_rng_new( rng_mem, 0U, 1UL ) );
   fd_event_client_t * client = test_connected_client( circq, rng, 65536UL );
   fd_grpc_client_t * grpc = client->grpc_client;
-  client->sockfd = open( "/dev/null", O_RDONLY ); /* disconnect() closes it */
-  FD_TEST( client->sockfd>=0 );
+  int sv[2];
+  FD_TEST( 0==socketpair( AF_UNIX, SOCK_STREAM|SOCK_NONBLOCK, 0, sv ) );
+  client->sockfd = sv[0]; /* disconnect() closes it */
 
   ulong const msg_sz = 4096UL;
   uchar * b = fd_circq_push_back( circq, 1UL, msg_sz ); FD_TEST( b ); memset( b, 0, msg_sz );
@@ -468,8 +468,9 @@ FD_UNIT_TEST( credit_stall ) {
   /* A late grant makes progress: timer restarts from the new remainder. */
   long t1 = now+FD_EVENT_CLIENT_CREDIT_STALL_NANOS-(long)1e9;
   client->event_stream->s.tx_wnd = 50U;
-  fd_grpc_client_request_continue( grpc );
-  test_drain( grpc );
+  grpc->window_update_pending = 1;
+  int charge_busy = 0;
+  FD_TEST( 0==fd_grpc_client_rxtx_socket( grpc, client->sockfd, t1, &charge_busy ) );
   FD_TEST( fd_grpc_client_tx_starved( grpc )==rem-50UL );
   FD_TEST( !credit_stall_check( client, t1 ) );
   FD_TEST( client->stall_since==t1 );
@@ -484,6 +485,7 @@ FD_UNIT_TEST( credit_stall ) {
   FD_TEST( client->disconnected.reconnect_deadline>t2 );
   FD_TEST( client->sockfd==-1 );
 
+  close( sv[1] );
   fd_rng_delete( fd_rng_leave( rng ) );
 }
 

--- a/src/waltz/grpc/fd_grpc_client.c
+++ b/src/waltz/grpc/fd_grpc_client.c
@@ -11,6 +11,8 @@
 #include "../h2/fd_h2_rbuf_ossl.h"
 #endif
 
+static int
+fd_grpc_client_request_continue( fd_grpc_client_t * client );
 
 ulong
 fd_grpc_client_align( void ) {
@@ -88,7 +90,6 @@ fd_grpc_client_new( void *                             mem,
     .stream_bufs       = stream_buf_mem,
     .nanopb_tx         = nanopb_tx,
     .nanopb_tx_max     = buf_max,
-    .tx_budget         = ULONG_MAX,
     .frame_scratch     = frame_scratch,
     .frame_scratch_max = buf_max,
     .frame_rx_buf      = frame_rx_buf,
@@ -295,17 +296,6 @@ fd_grpc_client_tx_starved( fd_grpc_client_t const * client ) {
 }
 
 void
-fd_grpc_client_set_tx_budget( fd_grpc_client_t * client,
-                              ulong              budget ) {
-  client->tx_budget = budget;
-}
-
-ulong
-fd_grpc_client_tx_budget( fd_grpc_client_t const * client ) {
-  return client->tx_budget;
-}
-
-void
 fd_grpc_client_service_streams( fd_grpc_client_t * client,
                                 long               ts_nanos ) {
   ulong const meta_frame_max =
@@ -484,8 +474,7 @@ static int
 fd_grpc_client_request_continue1( fd_grpc_client_t * client ) {
   fd_grpc_h2_stream_t * stream    = client->request_stream;
   fd_h2_stream_t *      h2_stream = &stream->s;
-  ulong copied = fd_h2_tx_op_copy1( client->conn, h2_stream, client->frame_tx, client->request_tx_op, client->tx_budget );
-  if( client->tx_budget!=ULONG_MAX ) client->tx_budget -= copied;
+  fd_h2_tx_op_copy( client->conn, h2_stream, client->frame_tx, client->request_tx_op );
   if( FD_UNLIKELY( client->request_tx_op->chunk_sz ) ) return 0;
   client->request_stream = NULL;
   if( FD_UNLIKELY( h2_stream->state != FD_H2_STREAM_STATE_CLOSING_TX ) ) return 0;
@@ -495,7 +484,7 @@ fd_grpc_client_request_continue1( fd_grpc_client_t * client ) {
   return 1;
 }
 
-int
+static int
 fd_grpc_client_request_continue( fd_grpc_client_t * client ) {
   if( FD_UNLIKELY( client->conn->flags & (FD_H2_CONN_FLAGS_DEAD|FD_H2_CONN_FLAGS_SEND_GOAWAY) ) ) return 0;
   if( FD_UNLIKELY( !client->request_stream ) ) return 0;

--- a/src/waltz/grpc/fd_grpc_client.c
+++ b/src/waltz/grpc/fd_grpc_client.c
@@ -378,9 +378,9 @@ fd_grpc_client_rxtx_ossl( fd_grpc_client_t * client,
   }
   if( FD_UNLIKELY( conn->flags ) ) fd_h2_tx_control( conn, client->frame_tx, &fd_grpc_client_h2_callbacks );
   fd_h2_rx( conn, client->frame_rx, client->frame_tx, client->frame_scratch, client->frame_scratch_max, &fd_grpc_client_h2_callbacks );
-  if( FD_UNLIKELY( client->window_update_pending ) ) {
+  if( FD_UNLIKELY( client->window_update_pending || client->request_stream ) ) {
     client->window_update_pending = 0;
-    fd_grpc_client_request_continue( client );
+    fd_grpc_client_request_continue( client ); /* credit or TX ring space may have freed */
   }
   fd_grpc_client_service_streams( client, now );
   ulong write_sz = fd_h2_rbuf_ssl_write( client->frame_tx, ssl );
@@ -422,9 +422,9 @@ fd_grpc_client_rxtx_socket( fd_grpc_client_t * client,
 
   if( FD_UNLIKELY( conn->flags ) ) fd_h2_tx_control( conn, client->frame_tx, &fd_grpc_client_h2_callbacks );
   fd_h2_rx( conn, client->frame_rx, client->frame_tx, client->frame_scratch, client->frame_scratch_max, &fd_grpc_client_h2_callbacks );
-  if( FD_UNLIKELY( client->window_update_pending ) ) {
+  if( FD_UNLIKELY( client->window_update_pending || client->request_stream ) ) {
     client->window_update_pending = 0;
-    fd_grpc_client_request_continue( client );
+    fd_grpc_client_request_continue( client ); /* credit or TX ring space may have freed */
   }
   fd_grpc_client_service_streams( client, now );
 

--- a/src/waltz/grpc/fd_grpc_client.h
+++ b/src/waltz/grpc/fd_grpc_client.h
@@ -198,23 +198,6 @@ fd_grpc_client_tx_pending( fd_grpc_client_t const * client );
 FD_FN_PURE ulong
 fd_grpc_client_tx_starved( fd_grpc_client_t const * client );
 
-/* fd_grpc_client_set_tx_budget caps the request payload bytes that may
-   be copied into the TX frame buffer until the next call (pacing).
-   ULONG_MAX (the default) means unlimited.  fd_grpc_client_tx_budget
-   returns the remaining budget.  fd_grpc_client_request_continue
-   resumes a request send that was stopped by the budget or by flow
-   control; returns 1 if the request finished. */
-
-void
-fd_grpc_client_set_tx_budget( fd_grpc_client_t * client,
-                              ulong              budget );
-
-FD_FN_PURE ulong
-fd_grpc_client_tx_budget( fd_grpc_client_t const * client );
-
-int
-fd_grpc_client_request_continue( fd_grpc_client_t * client );
-
 /* fd_grpc_client_reset cancels all inflight requests and abandons the
    HTTP/2 client connection.  Config params are kept intact (e.g. host,
    port, version). */

--- a/src/waltz/grpc/fd_grpc_client_private.h
+++ b/src/waltz/grpc/fd_grpc_client_private.h
@@ -118,7 +118,6 @@ struct fd_grpc_client_private {
      Non-NULL until a gRPC request is fully written out. */
   fd_grpc_h2_stream_t * request_stream;
   fd_h2_tx_op_t         request_tx_op[1];
-  ulong                 tx_budget; /* request payload bytes still allowed into frame_tx, ULONG_MAX if unlimited */
 
   /* Stream pool */
   fd_grpc_h2_stream_t * stream_pool;

--- a/src/waltz/h2/fd_h2_tx.c
+++ b/src/waltz/h2/fd_h2_tx.c
@@ -2,21 +2,19 @@
 #include "fd_h2_conn.h"
 #include "fd_h2_stream.h"
 
-ulong
-fd_h2_tx_op_copy1( fd_h2_conn_t *   conn,
-                   fd_h2_stream_t * stream,
-                   fd_h2_rbuf_t *   rbuf_tx,
-                   fd_h2_tx_op_t *  tx_op,
-                   ulong            max_sz ) {
-  long quota = fd_long_min( fd_long_min( conn->tx_wnd, stream->tx_wnd ), (long)fd_ulong_min( max_sz, LONG_MAX ) );
-  if( FD_UNLIKELY( quota<=0L ) ) return 0UL;
+void
+fd_h2_tx_op_copy( fd_h2_conn_t *   conn,
+                  fd_h2_stream_t * stream,
+                  fd_h2_rbuf_t *   rbuf_tx,
+                  fd_h2_tx_op_t *  tx_op ) {
+  long quota = fd_long_min( conn->tx_wnd, stream->tx_wnd );
+  if( FD_UNLIKELY( quota<0L ) ) return;
 
-  if( FD_UNLIKELY( stream->state == FD_H2_STREAM_STATE_CLOSED ) ) return 0UL;
+  if( FD_UNLIKELY( stream->state == FD_H2_STREAM_STATE_CLOSED ) ) return;
   if( FD_UNLIKELY( stream->state != FD_H2_STREAM_STATE_OPEN &&
                    stream->state != FD_H2_STREAM_STATE_CLOSING_RX ) ) {
-    return 0UL;
+    return;
   }
-  ulong copied = 0UL;
 
   do {
     /* Calculate how much we can send in this frame */
@@ -46,7 +44,5 @@ fd_h2_tx_op_copy1( fd_h2_conn_t *   conn,
     conn->tx_wnd       -= (uint)payload_sz;
     stream->tx_wnd     -= (uint)payload_sz;
     quota              -= payload_sz;
-    copied             += (ulong)payload_sz;
   } while( quota );
-  return copied;
 }

--- a/src/waltz/h2/fd_h2_tx.h
+++ b/src/waltz/h2/fd_h2_tx.h
@@ -37,23 +37,13 @@ fd_h2_tx_op_init( fd_h2_tx_op_t * tx_op,
    possible.  Advances tx_op->chunk and reduces tx_op->chunk_sz.  Stops
    copying when one of the following limits is hit: {rbuf_tx is full,
    out of conn TX quota, out of stream TX quota, no more tx_op bytes
-   queued}.  fd_h2_tx_op_copy1 additionally stops after max_sz payload
-   bytes.  Returns the number of payload bytes copied. */
+   queued}. */
 
-ulong
-fd_h2_tx_op_copy1( fd_h2_conn_t *   conn,
-                   fd_h2_stream_t * stream,
-                   fd_h2_rbuf_t *   rbuf_tx,
-                   fd_h2_tx_op_t *  tx_op,
-                   ulong            max_sz );
-
-static inline ulong
+void
 fd_h2_tx_op_copy( fd_h2_conn_t *   conn,
                   fd_h2_stream_t * stream,
                   fd_h2_rbuf_t *   rbuf_tx,
-                  fd_h2_tx_op_t *  tx_op ) {
-  return fd_h2_tx_op_copy1( conn, stream, rbuf_tx, tx_op, ULONG_MAX );
-}
+                  fd_h2_tx_op_t *  tx_op );
 
 /* FIXME Add sendmsg-gather API here for streamlined transmit of
    multiple frames via sockets? */


### PR DESCRIPTION
The per-poll byte budget sliced each message into a DATA frame per poll, a few bytes each at the tile's poll rate.  Behind a backlog that frame flood stalls the edge within ~1 MB on every connection, and the 20 s credit-stall reconnect then repeats it forever.  Refill the bucket before taking a message, send it whole when the balance is positive and debit its size, letting the balance go one message negative.  Drop the gRPC/h2 budget plumbing.