### PR TITLE
bench: start the tps clock when load starts

### DIFF
--- a/src/app/shared_dev/commands/bench/fd_bencho.c
+++ b/src/app/shared_dev/commands/bench/fd_bencho.c
@@ -141,7 +141,7 @@ returnable_frag( fd_bencho_ctx_t *   ctx,
   ctx->last_txns  = txns;
   ctx->last_nanos = nanos;
   if( FD_UNLIKELY( !ctx->start_nanos ) ) {
-    if( FD_LIKELY( slot_txns ) ) { ctx->start_txns = txns; ctx->start_nanos = nanos; }
+    if( FD_LIKELY( slot_txns>1UL ) ) { ctx->start_txns = txns; ctx->start_nanos = nanos; }
     return 0;
   }
   ulong tps = (ulong)((double)slot_txns*1e9/(double)slot_ns);


### PR DESCRIPTION
The measurement window began at the first slot with any transactions, which is the first slot we vote in, several hundred milliseconds before the generators are sending and much longer than that when they sign ahead of time.  That idle span was averaged into the reported tps.