### PR TITLE
bench: spread sender connections across the quic tiles

### DIFF
--- a/src/app/shared_dev/commands/bench/fd_benchs.c
+++ b/src/app/shared_dev/commands/bench/fd_benchs.c
@@ -317,7 +317,8 @@ privileged_init( fd_topo_t const *      topo,
   int no_quic = ctx->no_quic = tile->benchs.no_quic;
   ushort port = 12000;
 
-  ctx->conn_cnt = tile->benchs.conn_cnt;
+  ulong quic_cnt = tile->benchs.conn_cnt; /* [layout] quic_tile_count */
+  ctx->conn_cnt = quic_cnt;
   if( !no_quic ) ctx->conn_cnt = 1;
   FD_TEST( ctx->conn_cnt <=sizeof(ctx->conn_fd)/sizeof(*ctx->conn_fd) );
   ctx->quic_ip   = tile->benchs.send_to_ip_addr;
@@ -338,8 +339,10 @@ privileged_init( fd_topo_t const *      topo,
 	    FD_LOG_ERR(( "Error setting transmit buffer size. Error: %d %s", errno, strerror( errno ) ));
     }
 
+    ulong  quic_idx   = (tile->kind_id*ctx->conn_cnt + i)%quic_cnt;
     ushort found_port = 0;
-    for( ulong j=0UL; j<10UL; j++ ) {
+    for( ; port<65535; port++ ) {
+      if( fd_disco_netmux_sig_hash( fd_disco_netmux_sig( ctx->quic_ip, port, 0U, 0UL, 42UL ) )%quic_cnt!=quic_idx ) continue;
       struct sockaddr_in addr = {
         .sin_family = AF_INET,
         .sin_port = fd_ushort_bswap( port ),
@@ -350,9 +353,9 @@ privileged_init( fd_topo_t const *      topo,
         break;
       }
       if( FD_UNLIKELY( EADDRINUSE!=errno ) ) FD_LOG_ERR(( "bind() failed (%i-%s)", errno, fd_io_strerror( errno ) ) );
-      port = (ushort)(port + ctx->conn_cnt); /* Make sure it round robins to the same tile index */
     }
     if( FD_UNLIKELY( !found_port ) ) FD_LOG_ERR(( "bind() failed to find a src port" ));
+    FD_LOG_INFO(( "src port %hu -> quic tile %lu", found_port, quic_idx ));
 
     struct sockaddr_in addr = {
       .sin_family = AF_INET,


### PR DESCRIPTION
Each quic tile keeps only the packets whose netmux hash, taken over the source address and port, selects it.  benchs stepped its source port by the connection count instead, which does not follow that hash: on this host every port it picked belonged to one tile, and the other received almost nothing.  Search for a port that hashes to the tile the socket is meant to feed.