### PR TITLE
runtime: base58 encode the program id only when it is logged

### DIFF
--- a/src/flamenco/runtime/fd_executor.c
+++ b/src/flamenco/runtime/fd_executor.c
@@ -1202,7 +1202,10 @@ fd_execute_instr( fd_runtime_t *      runtime,
     .txn_out      = txn_out,
     .bank         = bank,
   };
-  fd_base58_encode_32( txn_out->accounts.keys[ instr->program_id ].uc, NULL, ctx->program_id_base58 );
+
+  if( FD_UNLIKELY( !runtime->log.log_collector->disabled ) ) {
+    fd_base58_encode_32( txn_out->accounts.keys[ instr->program_id ].uc, NULL, ctx->program_id_base58 );
+  }
 
   /* Look up the native program. We check for precompiles within the lookup function as well.
      https://github.com/anza-xyz/agave/blob/v2.1.6/svm/src/message_processor.rs#L88 */


### PR DESCRIPTION
Every instruction encoded it, twice per transaction for the benchmark workload, and the only readers are log collector helpers that all return early when the collector is disabled.