### PR TITLE
execle: batch more microblocks into one rebate message

### DIFF
--- a/src/discof/execle/fd_execle_tile.c
+++ b/src/discof/execle/fd_execle_tile.c
@@ -19,7 +19,7 @@
 #include "generated/fd_execle_tile_seccomp.h"
 
 #define REBATE_BATCH_IDLE_LOOPS      (128UL)
-#define REBATE_BATCH_MAX_MICROBLOCKS (4UL)
+#define REBATE_BATCH_MAX_MICROBLOCKS (16UL)
 
 FD_STATIC_ASSERT( REBATE_BATCH_MAX_MICROBLOCKS*FD_PACK_REBATE_MAX_ENTRIES<=FD_PACK_REBATE_SUM_CAPACITY,
                   rebate_batch_fits_rebater );


### PR DESCRIPTION
At one transaction per microblock, four microblocks per rebate is a fragment for pack to handle every four transactions.  Sixteen is what the rebater's capacity allows.