### PR TITLE
topo: let tiles share a CPU in the affinity string

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -672,6 +672,13 @@ dynamic_port_range = "8900-9000"
     # not pinned and will float on the original core set that Firedancer
     # was started with.
     #
+    # A core preceded by an 's' like 's5' is shared.  The tile is homed
+    # at core 5, so its memory is placed on that core's NUMA node, but
+    # the kernel may schedule it on any shared core of that node.  A
+    # shared core is not claimed exclusively, so more than one tile may
+    # name it.  This is for tiles that are idle in your configuration
+    # and would otherwise hold a core a busy tile could use.
+    #
     # For example, if Firedancer has six tiles numbered 0..5, and the
     # affinity is specified as
     #

--- a/src/app/fdctl/topology.c
+++ b/src/app/fdctl/topology.c
@@ -123,15 +123,16 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
 
@@ -334,7 +335,7 @@ fd_topo_initialize( config_t * config ) {
 
     if( FD_LIKELY( strcmp( "", config->frankendancer.layout.agave_affinity ) ) ) {
       ushort agave_cpu[ FD_TILE_MAX ];
-      ulong agave_cpu_cnt = fd_topob_parse_affinity_cstr( config->frankendancer.layout.agave_affinity, agave_cpu, 0 );
+      ulong agave_cpu_cnt = fd_topob_parse_affinity_cstr( config->frankendancer.layout.agave_affinity, agave_cpu, 0, 0 );
 
       for( ulong i=0UL; i<agave_cpu_cnt; i++ ) {
         if( FD_UNLIKELY( agave_cpu[ i ]>=cpus->cpu_cnt ) )
@@ -358,7 +359,7 @@ fd_topo_initialize( config_t * config ) {
     }
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));

--- a/src/app/firedancer-dev/commands/forktest/forktest.c
+++ b/src/app/firedancer-dev/commands/forktest/forktest.c
@@ -201,15 +201,16 @@ forktest_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->firedancer.development.forktest.affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->firedancer.development.forktest.affinity, parsed_tile_to_cpu, 0, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [development.forktest.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
 
@@ -346,7 +347,7 @@ forktest_topo( config_t * config ) {
                        topo->tile_cnt, affinity_tile_cnt ));
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));

--- a/src/app/firedancer-dev/commands/repair.c
+++ b/src/app/firedancer-dev/commands/repair.c
@@ -286,14 +286,15 @@ repair_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0, 1 );
 
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
                   "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                   "in the system.",
-                  parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                  cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
 

--- a/src/app/firedancer-dev/commands/send_test/send_test.c
+++ b/src/app/firedancer-dev/commands/send_test/send_test.c
@@ -62,14 +62,15 @@ send_test_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( strcmp( config->layout.affinity, "auto" ) ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( strcmp( config->layout.affinity, "auto" ) ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 0, 1 );
 
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                     "in the system.",
-                    parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                    cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
 

--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -802,6 +802,13 @@ telemetry = true
     # not pinned and will float on the original core set that Firedancer
     # was started with.
     #
+    # A core preceded by an 's' like 's5' is shared.  The tile is homed
+    # at core 5, so its memory is placed on that core's NUMA node, but
+    # the kernel may schedule it on any shared core of that node.  A
+    # shared core is not claimed exclusively, so more than one tile may
+    # name it.  This is for tiles that are idle in your configuration
+    # and would otherwise hold a core a busy tile could use.
+    #
     # For example, if Firedancer has six tiles numbered 0..5, and the
     # affinity is specified as
     #

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -547,15 +547,16 @@ fd_topo_initialize( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 1 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( config->layout.affinity, parsed_tile_to_cpu, 1, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [layout.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
 
@@ -992,7 +993,7 @@ fd_topo_initialize( config_t * config ) {
                        topo->tile_cnt, affinity_tile_cnt ));
   } else {
     ushort blocklist_cores[ FD_TILE_MAX ];
-    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0 );
+    topo->blocklist_cores_cnt = fd_topob_parse_affinity_cstr( config->layout.blocklist_cores, blocklist_cores, 0, 0 );
     if( FD_UNLIKELY( topo->blocklist_cores_cnt>FD_TILE_MAX ) ) {
       FD_LOG_ERR(( "The CPU string in the configuration file under [layout.blocklist_cores] specifies more CPUs than Firedancer can use. "
                     "You should reduce the number of CPUs in the excluded cores string." ));

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -8,7 +8,7 @@
 #include <net/if.h>
 
 #define NAME_SZ                     (256UL)
-#define AFFINITY_SZ                 (256UL)
+#define AFFINITY_SZ                 (2048UL) /* FD_TOPO_MAX_TILES entries of "s1023," */
 #define CONFIGURE_STAGE_COUNT       ( 24UL)
 #define GOSSIP_TILE_ENTRYPOINTS_MAX ( 16UL)
 #define IP4_PORT_STR_MAX            ( 22UL)

--- a/src/app/shared/fd_config_json.c
+++ b/src/app/shared/fd_config_json.c
@@ -11,7 +11,7 @@
    or knowingly skipped) before the constant is bumped.  String keys of
    the user's own file are separately forced through the classification
    lists below. */
-FD_STATIC_ASSERT( sizeof(fd_config_t)==22974464UL, update_fd_config_to_json_for_the_layout_change );
+FD_STATIC_ASSERT( sizeof(fd_config_t)==22987008UL, update_fd_config_to_json_for_the_layout_change );
 
 #define REDACTED "[redacted]"
 

--- a/src/app/shared_dev/commands/bench/bench.c
+++ b/src/app/shared_dev/commands/bench/bench.c
@@ -77,15 +77,16 @@ add_bench_topo( fd_topo_t  * topo,
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_bench_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_bench_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [development.bench.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
   if( FD_LIKELY( !is_bench_auto_affinity ) ) {

--- a/src/app/shared_dev/commands/pktgen/pktgen.c
+++ b/src/app/shared_dev/commands/pktgen/pktgen.c
@@ -32,15 +32,16 @@ pktgen_topo( config_t * config ) {
 
   ulong affinity_tile_cnt = 0UL;
   ulong required_tile_cnt = 3UL+net_tile_cnt;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [development.pktgen.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
   if( FD_LIKELY( !is_auto_affinity ) ) {

--- a/src/app/shared_dev/commands/udpecho/udpecho.c
+++ b/src/app/shared_dev/commands/udpecho/udpecho.c
@@ -25,15 +25,16 @@ udpecho_topo( config_t * config ) {
   fd_topo_cpus_init( cpus );
 
   ulong affinity_tile_cnt = 0UL;
-  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0 );
+  if( FD_LIKELY( !is_auto_affinity ) ) affinity_tile_cnt = fd_topob_parse_affinity_cstr( affinity, parsed_tile_to_cpu, 0, 1 );
 
   ulong tile_to_cpu[ FD_TILE_MAX ] = {0};
   for( ulong i=0UL; i<affinity_tile_cnt; i++ ) {
-    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && parsed_tile_to_cpu[ i ]>=cpus->cpu_cnt ) )
+    ushort cpu_idx = (ushort)( parsed_tile_to_cpu[ i ] & ~FD_TOPOB_CPU_SHARED );
+    if( FD_UNLIKELY( parsed_tile_to_cpu[ i ]!=USHORT_MAX && cpu_idx>=cpus->cpu_cnt ) )
       FD_LOG_ERR(( "The CPU affinity string in the configuration file under [development.udpecho.affinity] specifies a CPU index of %hu, but the system "
                    "only has %lu CPUs. You should either change the CPU allocations in the affinity string, or increase the number of CPUs "
                    "in the system.",
-                   parsed_tile_to_cpu[ i ], cpus->cpu_cnt ));
+                   cpu_idx, cpus->cpu_cnt ));
     tile_to_cpu[ i ] = fd_ulong_if( parsed_tile_to_cpu[ i ]==USHORT_MAX, ULONG_MAX, (ulong)parsed_tile_to_cpu[ i ] );
   }
   if( FD_LIKELY( !is_auto_affinity ) ) {

--- a/src/disco/topo/fd_topob.c
+++ b/src/disco/topo/fd_topob.c
@@ -176,13 +176,13 @@ fd_topob_tile( fd_topo_t *    topo,
   tile->id                  = topo->tile_cnt;
   tile->kind_id             = kind_id;
   tile->is_agave            = is_agave;
-  tile->cpu_idx             = cpu_idx;
+  tile->cpu_idx             = fd_ulong_if( cpu_idx<ULONG_MAX, cpu_idx & ~FD_TOPOB_CPU_SHARED, ULONG_MAX );
   tile->in_cnt              = 0UL;
   tile->out_cnt             = 0UL;
   tile->event_link_id       = ULONG_MAX;
   tile->uses_obj_cnt        = 0UL;
   tile->is_waker_client     = is_waker_client;
-  tile->floats              = 0;
+  tile->floats              = cpu_idx<ULONG_MAX && !!(cpu_idx & FD_TOPOB_CPU_SHARED);
   tile->waker_client_idx    = ULONG_MAX;
   tile->waker_fseq_obj_id   = ULONG_MAX;
 
@@ -528,12 +528,13 @@ fd_topob_tile_priority_type( char const * name ) {
   return FD_TOPOB_PRIORITY_FLOATING;
 }
 
-FD_STATIC_ASSERT( FD_TILE_MAX<65535, update_tile_to_cpu_type );
+FD_STATIC_ASSERT( FD_TILE_MAX<FD_TOPOB_CPU_SHARED, update_tile_to_cpu_type );
 
 ulong
 fd_topob_parse_affinity_cstr( char const * cstr,
                               ushort *     tile_to_cpu,
-                              int          allow_repeats ) {
+                              int          allow_repeats,
+                              int          allow_shared ) {
   if( !cstr ) return 0UL;
   ulong cnt = 0UL;
 
@@ -571,8 +572,14 @@ fd_topob_parse_affinity_cstr( char const * cstr,
       continue;
     }
 
+    ulong shared = 0UL;
+    if( p[0]=='s' ) {
+      if( FD_UNLIKELY( !allow_shared ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (shared cpus not supported here)" ));
+      p++; shared = FD_TOPOB_CPU_SHARED;
+    }
+
     if( !fd_isdigit( (int)p[0] ) ) {
-      if( FD_UNLIKELY( p[0]!='\0' ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (range lo not a cpu)" ));
+      if( FD_UNLIKELY( shared || p[0]!='\0' ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (range lo not a cpu)" ));
       break;
     }
     ulong cpu0   = fd_cstr_to_ulong( p );
@@ -610,9 +617,10 @@ fd_topob_parse_affinity_cstr( char const * cstr,
 
     for( ulong cpu=cpu0; cpu<cpu1; cpu+=stride ) {
       if( FD_UNLIKELY( cnt>=FD_TILE_MAX ) ) FD_LOG_ERR(( "fd_topob: too many affinity entries" ));
-      if( FD_UNLIKELY( !allow_repeats && cpu_bv_test( cpu_assigned, cpu ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (repeated cpu)" ));
-      tile_to_cpu[ cnt++ ] = (ushort)cpu;
-      cpu_bv_insert( cpu_assigned, cpu );
+      if( FD_UNLIKELY( cpu>=FD_TILE_MAX ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (cpu index too large)" )); /* cpu_assigned holds FD_TILE_MAX */
+      if( FD_UNLIKELY( !allow_repeats && !shared && cpu_bv_test( cpu_assigned, cpu ) ) ) FD_LOG_ERR(( "fd_topob: malformed affinity string (repeated cpu)" ));
+      tile_to_cpu[ cnt++ ] = (ushort)(cpu | shared);
+      if( !shared ) cpu_bv_insert( cpu_assigned, cpu );
     }
   }
 
@@ -642,6 +650,8 @@ fd_topob_tile_live_phase( char const * name ) {
 static int
 fd_topob_cpu_overlap_allowed( fd_topo_tile_t const * a,
                               fd_topo_tile_t const * b ) {
+  if( a->floats && b->floats ) return 1;
+
   int a_phase = fd_topob_tile_live_phase( a->name );
   int b_phase = fd_topob_tile_live_phase( b->name );
 

--- a/src/disco/topo/fd_topob.h
+++ b/src/disco/topo/fd_topob.h
@@ -23,6 +23,12 @@
 #define FD_TOPOB_UNRELIABLE 0
 #define FD_TOPOB_RELIABLE 1
 
+/* Affinity entries prefixed with 's' ("s2", "s2-3") are shared, the
+   tile is homed at that CPU but floats over the shared CPUs on the
+   same NUMA node.  The bit is set in the parsed CPU index, and only
+   callers passing allow_shared accept it. */
+#define FD_TOPOB_CPU_SHARED (0x8000UL)
+
 /* Tile priority types used by fd_topob_auto_layout to classify tiles
    into scheduling categories. */
 #define FD_TOPOB_PRIORITY_FLOATING (1)
@@ -187,7 +193,8 @@ fd_topob_validate_cpu_overlaps( fd_topo_t const * topo );
 ulong
 fd_topob_parse_affinity_cstr( char const * cstr,
                               ushort *     tile_to_cpu,
-                              int          allow_repeats );
+                              int          allow_repeats,
+                              int          allow_shared );
 
 FD_PROTOTYPES_END
 

--- a/src/disco/topo/test_topob.c
+++ b/src/disco/topo/test_topob.c
@@ -574,6 +574,65 @@ FD_UNIT_TEST( test_cpu_overlap_banned ) {
            ( WIFSIGNALED( status ) && WTERMSIG( status )==SIGABRT ) );
 }
 
+FD_UNIT_TEST( test_cpu_overlap_shared ) {
+  static fd_topo_t _topo[1];
+  fd_topo_t * topo = _topo;
+  fd_memset( topo, 0, sizeof(*topo) );
+
+  add_test_tile( topo, "pack",  0UL, 9UL )->floats = 1;
+  add_test_tile( topo, "shred", 0UL, 9UL )->floats = 1;
+
+  fd_topob_validate_cpu_overlaps( topo );
+}
+
+/* ---- Affinity string parsing ------------------------------------------- */
+
+FD_UNIT_TEST( test_parse_affinity_shared ) {
+  ushort cpu[ FD_TILE_MAX ];
+
+  FD_TEST( fd_topob_parse_affinity_cstr( "0,s1,2-3,s4-6/2", cpu, 0, 1 )==6UL );
+  FD_TEST( cpu[ 0 ]==0                       );
+  FD_TEST( cpu[ 1 ]==(1|FD_TOPOB_CPU_SHARED) );
+  FD_TEST( cpu[ 2 ]==2                       );
+  FD_TEST( cpu[ 3 ]==3                       );
+  FD_TEST( cpu[ 4 ]==(4|FD_TOPOB_CPU_SHARED) );
+  FD_TEST( cpu[ 5 ]==(6|FD_TOPOB_CPU_SHARED) );
+
+  /* a shared entry does not claim the cpu, so it may repeat */
+  FD_TEST( fd_topob_parse_affinity_cstr( "s1,s1,f,s1", cpu, 0, 1 )==4UL );
+  FD_TEST( cpu[ 2 ]==USHORT_MAX );
+}
+
+/* A malformed affinity string is a FD_LOG_ERR, so parse it in a child. */
+static void
+parse_affinity_fails( char const * cstr,
+                      int          allow_shared ) {
+  pid_t pid = fork();
+  FD_TEST( pid>=0 );
+
+  if( pid==0 ) {
+    fd_log_level_logfile_set( 6 );
+
+    ushort cpu[ FD_TILE_MAX ];
+    fd_topob_parse_affinity_cstr( cstr, cpu, 0, allow_shared );
+    _exit( 0 );
+  }
+
+  int status = 0;
+  FD_TEST( waitpid( pid, &status, 0 )==pid );
+  FD_TEST( ( WIFEXITED( status ) && WEXITSTATUS( status )==1 ) ||
+           ( WIFSIGNALED( status ) && WTERMSIG( status )==SIGABRT ) );
+}
+
+FD_UNIT_TEST( test_parse_affinity_malformed ) {
+  parse_affinity_fails( "s",     1 ); /* shared prefix with no cpu */
+  parse_affinity_fails( "1,s",   1 );
+  parse_affinity_fails( "s1-",   1 );
+  parse_affinity_fails( "s1",    0 ); /* caller cannot handle shared */
+  parse_affinity_fails( "1,1",   1 ); /* a plain repeat is still banned */
+  parse_affinity_fails( "1024",  1 ); /* cpu index past the cpu_assigned bitset */
+}
+
 /* ======================================================================== */
 
 int


### PR DESCRIPTION
A hand written affinity names a CPU for every tile, so the two dozen tiles that are idle on a benchmark or single node cluster each hold a core a busy tile could have used.  An entry prefixed with 's' ("s2", "s2-3") homes the tile at that CPU but lets the kernel schedule it across the shared CPUs, which is what fd_topo_tile_t.floats already does for auto layout; nothing set it until now.  Shared entries do not claim a CPU exclusively, and two of them may overlap.

Affinity strings that name every CPU no longer fit in 256 bytes.