### PR TITLE
pack: copy the scheduled transaction with fd_memcpy_nt

### DIFF
--- a/src/disco/pack/fd_pack.c
+++ b/src/disco/pack/fd_pack.c
@@ -12,6 +12,15 @@
 
 #define FD_PACK_USE_NON_TEMPORAL_MEMCPY 1
 
+#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
+#include "../../util/simd/fd_nt_memcpy.h"
+#define pack_memcpy_out  fd_memcpy_nt_nofence
+#define pack_memcpy_fini() _mm_sfence()
+#else
+#define pack_memcpy_out  fd_memcpy
+#define pack_memcpy_fini()
+#endif
+
 /* Declare a bunch of helper structs used for pack-internal data
    structures. */
 typedef struct {
@@ -2081,45 +2090,8 @@ fd_pack_schedule_impl( fd_pack_t          * pack,
     FD_PACK_BITSET_OR( bitset_w_in_use,  cur->w_bitset  );
 
     fd_txn_p_t * out_txnp = out->txnp;
-    if(
-#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
-        FD_LIKELY( cur->txn->payload_sz>=1024UL )
-#else
-        0
-#endif
-      ) {
-#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
-      _mm512_stream_si512( (void*)(out_txnp->payload+   0UL), _mm512_load_epi64( cur->txn->payload+   0UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+  64UL), _mm512_load_epi64( cur->txn->payload+  64UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 128UL), _mm512_load_epi64( cur->txn->payload+ 128UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 192UL), _mm512_load_epi64( cur->txn->payload+ 192UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 256UL), _mm512_load_epi64( cur->txn->payload+ 256UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 320UL), _mm512_load_epi64( cur->txn->payload+ 320UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 384UL), _mm512_load_epi64( cur->txn->payload+ 384UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 448UL), _mm512_load_epi64( cur->txn->payload+ 448UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 512UL), _mm512_load_epi64( cur->txn->payload+ 512UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 576UL), _mm512_load_epi64( cur->txn->payload+ 576UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 640UL), _mm512_load_epi64( cur->txn->payload+ 640UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 704UL), _mm512_load_epi64( cur->txn->payload+ 704UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 768UL), _mm512_load_epi64( cur->txn->payload+ 768UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 832UL), _mm512_load_epi64( cur->txn->payload+ 832UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 896UL), _mm512_load_epi64( cur->txn->payload+ 896UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+ 960UL), _mm512_load_epi64( cur->txn->payload+ 960UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+1024UL), _mm512_load_epi64( cur->txn->payload+1024UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+1088UL), _mm512_load_epi64( cur->txn->payload+1088UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+1152UL), _mm512_load_epi64( cur->txn->payload+1152UL ) );
-      _mm512_stream_si512( (void*)(out_txnp->payload+1216UL), _mm512_load_epi64( cur->txn->payload+1216UL ) );
-
-      /* For V1 transactions, the payload can be up to 4096 bytes so we copy an additional 2816 bytes. */
-      if( FD_UNLIKELY( txn->transaction_version==FD_TXN_V1 ) ) {
-        for( ulong off=1280UL; off<FD_TPU_MTU; off+=64UL ) {
-          _mm512_stream_si512( (void*)(out_txnp->payload+off), _mm512_load_epi64( cur->txn->payload+off ) );
-        }
-      }
-#endif
-    } else {
-      fd_memcpy( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz );
-    }
+    if( FD_LIKELY( cur->txn->payload_sz>=1024UL ) ) pack_memcpy_out( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz );
+    else                                            fd_memcpy      ( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz );
 
     out_txnp->payload_sz                                = cur->txn->payload_sz;
     out_txnp->pack_cu.requested_exec_plus_acct_data_cus = cur->txn->pack_cu.requested_exec_plus_acct_data_cus;
@@ -2134,20 +2106,7 @@ fd_pack_schedule_impl( fd_pack_t          * pack,
 
     /* Copy the ALT accounts from the source fd_txn_e_t */
     ulong alt_acct_cnt = (ulong)txn->addr_table_adtl_cnt;
-#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
-    /* In order to use non-temporal copies, we have to copy a full cache
-       line (which fits two pubkeys) at a time.  If alt_acct_cnt is odd,
-       this copies one extra address, but it touches the same number of
-       cache lines, since both the source and destination are aligned
-       to 64 bytes. The max is even, so this can never read out of bounds. */
-    fd_acct_addr_t       * dst = out->alt_accts;
-    fd_acct_addr_t const * src = cur->txn_e->alt_accts;
-    for( ulong i=0UL; i<alt_acct_cnt; i+=2UL ) {
-      _mm512_stream_si512( (void*)(dst+i), _mm512_load_epi64( src+i ) );
-    }
-#else
-    fd_memcpy( out->alt_accts, cur->txn_e->alt_accts, alt_acct_cnt * sizeof(fd_acct_addr_t) );
-#endif
+    if( FD_UNLIKELY( alt_acct_cnt ) ) pack_memcpy_out( out->alt_accts, cur->txn_e->alt_accts, alt_acct_cnt*sizeof(fd_acct_addr_t) );
     out++;
 
     for( fd_txn_acct_iter_t iter=fd_txn_acct_iter_init( txn, FD_TXN_ACCT_CAT_WRITABLE );
@@ -2585,7 +2544,8 @@ fd_pack_try_schedule_bundle( fd_pack_t  * pack,
     fd_pack_ord_txn_t * cur = treap_rev_iter_ele( _cur, pool );
     fd_txn_t const    * txn = TXN(cur->txn);
     fd_txn_p_t        * out_txnp = out->txnp;
-    fd_memcpy( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz                                           );
+    if( FD_LIKELY( cur->txn->payload_sz>=1024UL ) ) pack_memcpy_out( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz );
+    else                                            fd_memcpy      ( out_txnp->payload, cur->txn->payload, cur->txn->payload_sz );
     fd_memcpy( TXN(out_txnp),     txn,               fd_txn_footprint( txn->instr_cnt, txn->addr_table_lookup_cnt ) );
     out_txnp->payload_sz                      = cur->txn->payload_sz;
     out_txnp->pack_cu.requested_exec_plus_acct_data_cus = cur->txn->pack_cu.requested_exec_plus_acct_data_cus;
@@ -2598,7 +2558,7 @@ fd_pack_try_schedule_bundle( fd_pack_t  * pack,
     out_txnp->flags                           = cur->txn->flags;
     /* Copy the ALT accounts from the source fd_txn_e_t */
     ulong alt_acct_cnt = (ulong)txn->addr_table_adtl_cnt;
-    fd_memcpy( out->alt_accts, cur->txn_e->alt_accts, alt_acct_cnt * sizeof(fd_acct_addr_t) );
+    if( FD_UNLIKELY( alt_acct_cnt ) ) pack_memcpy_out( out->alt_accts, cur->txn_e->alt_accts, alt_acct_cnt*sizeof(fd_acct_addr_t) );
     out++;
 
     pack->cumulative_block_cost += cur->compute_est;
@@ -2659,6 +2619,7 @@ fd_pack_try_schedule_bundle( fd_pack_t  * pack,
   if( FD_UNLIKELY( is_ib ) ) {
     pack->initializer_bundle_state = FD_PACK_IB_STATE_PENDING;
   }
+  pack_memcpy_fini();
   return retval;
 }
 
@@ -2689,6 +2650,15 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
   }
 
   ulong * use_by_bank_txn = pack->use_by_bank_txn[ bank_tile ];
+
+#if FD_HAS_X86
+  /* out is a cold dcache chunk.  Its payload is streamed, but the
+     metadata and TXN() lines are regular stores; start those reads for
+     ownership under the scheduling work. */
+  _mm_prefetch( (uchar *)out+FD_TPU_MTU,       _MM_HINT_ET0 );
+  _mm_prefetch( (uchar *)out+FD_TPU_MTU+ 64UL, _MM_HINT_ET0 );
+  _mm_prefetch( (uchar *)out+FD_TPU_MTU+128UL, _MM_HINT_ET0 );
+#endif
 
   ulong cu_limit    = total_cus - vote_cus;
   ulong txn_limit   = pack->lim->max_txn_per_microblock - vote_reserved_txns;
@@ -2753,10 +2723,7 @@ fd_pack_schedule_next_microblock( fd_pack_t *  pack,
   fd_histf_sample( pack->txn_per_microblock,  scheduled              );
   fd_histf_sample( pack->vote_per_microblock, status1.txns_scheduled );
 
-#if FD_HAS_AVX512 && FD_PACK_USE_NON_TEMPORAL_MEMCPY
-  _mm_sfence();
-#endif
-
+  pack_memcpy_fini();
   return scheduled;
 }
 

--- a/src/disco/pack/test_pack.c
+++ b/src/disco/pack/test_pack.c
@@ -1399,6 +1399,103 @@ test_reject_writes_to_sysvars( void ) {
 #undef N_ACCTS
 }
 
+/* The scheduled transaction is copied out of the pool with
+   non-temporal stores, which only move whole cache lines.  Cover a
+   payload past the V0 limit, sizes that are not a multiple of 64, and
+   an odd number of ALT accounts, on both scheduling paths. */
+
+static fd_txn_e_t copy_out_expected[ 3 ];
+
+static void
+make_wide_transaction( ulong        i,
+                       ulong        payload_sz,
+                       ulong        alt_cnt,
+                       char const * writes,
+                       char const * reads ) {
+  fd_txn_e_t * e = copy_out_expected + i;
+  fd_memset( e, 0, sizeof(fd_txn_e_t) );
+  make_transaction1( e->txnp, i, 500U, 500U, 11.0, writes, reads, NULL, NULL );
+  fd_txn_t * txn = TXN( e->txnp );
+  for( ulong b=e->txnp->payload_sz; b<payload_sz; b++ ) e->txnp->payload[ b ] = (uchar)(b*7UL+i);
+  e->txnp->payload_sz        = (ushort)payload_sz;
+  txn->transaction_version   = FD_TXN_V1;
+  txn->addr_table_lookup_cnt = (uchar)!!alt_cnt;
+  txn->addr_table_adtl_cnt   = (uchar)alt_cnt;
+  for( ulong a=0UL; a<alt_cnt; a++ ) fd_memset( e->alt_accts+a, (int)(16UL*i+a+1UL), sizeof(fd_acct_addr_t) );
+}
+
+static void
+fill_slot( fd_txn_e_t * slot,
+           ulong        i ) {
+  fd_txn_e_t const * e = copy_out_expected + i;
+  fd_memcpy( slot->txnp, e->txnp, sizeof(fd_txn_p_t) );
+  fd_memcpy( slot->alt_accts, e->alt_accts, (ulong)TXN( e->txnp )->addr_table_adtl_cnt*sizeof(fd_acct_addr_t) );
+}
+
+#define COPY_OUT_CANARY (0xa5)
+
+static void
+check_slot( fd_txn_e_t const * out,
+            ulong              i ) {
+  fd_txn_e_t const * e         = copy_out_expected + i;
+  ulong              payload_sz = e->txnp->payload_sz;
+  ulong              alt_cnt    = (ulong)TXN( e->txnp )->addr_table_adtl_cnt;
+
+  FD_TEST( out->txnp->payload_sz==payload_sz );
+  FD_TEST( !memcmp( out->txnp->payload, e->txnp->payload, payload_sz ) );
+  FD_TEST( !memcmp( out->alt_accts,     e->alt_accts,     alt_cnt*sizeof(fd_acct_addr_t) ) );
+
+  /* Nothing past the end of either may be written, or an
+     implementation that rounds up to a whole cache line passes the
+     comparisons above. */
+  for( ulong b=payload_sz; b<fd_ulong_min( payload_sz+64UL, FD_TPU_MTU ); b++ ) FD_TEST( out->txnp->payload[ b ]==COPY_OUT_CANARY );
+  for( ulong a=alt_cnt; a<fd_ulong_min( alt_cnt+2UL, FD_TXN_ACCT_ADDR_MAX ); a++ )
+    for( ulong b=0UL; b<sizeof(fd_acct_addr_t); b++ ) FD_TEST( out->alt_accts[ a ].b[ b ]==COPY_OUT_CANARY );
+}
+
+static void
+test_copy_out( void ) {
+  FD_LOG_NOTICE(( "TEST COPY OUT" ));
+
+  for( ulong payload_sz=1024UL; payload_sz<=FD_TPU_MTU; payload_sz+=311UL ) {
+    for( ulong alt_cnt=0UL; alt_cnt<4UL; alt_cnt++ ) {
+      ulong _deleted;
+
+      /* One transaction, copied by fd_pack_schedule_impl */
+      fd_pack_t * pack = init_all( 1024UL, 1UL, 8UL, &outcome );
+
+      make_wide_transaction( 0UL, payload_sz, alt_cnt, "A", "B" );
+      fd_txn_e_t * slot = fd_pack_insert_txn_init( pack );
+      fill_slot( slot, 0UL );
+      FD_TEST( fd_pack_insert_txn_fini( pack, slot, 0UL, &_deleted )>=0 );
+
+      fd_pack_microblock_complete( pack, 0UL );
+      fd_memset( outcome.results, COPY_OUT_CANARY, sizeof(fd_txn_e_t) );
+      FD_TEST( fd_pack_schedule_next_microblock( pack, 1000000UL, 0.0f, 0UL, FD_PACK_SCHEDULE_TXN, outcome.results )==1UL );
+      check_slot( outcome.results, 0UL );
+      fd_pack_delete( fd_pack_leave( pack ) );
+
+      /* A three transaction bundle, copied by fd_pack_try_schedule_bundle */
+      pack = init_all( 1024UL, 1UL, 8UL, &outcome );
+      fd_pack_set_initializer_bundles_ready( pack );
+
+      make_wide_transaction( 0UL, payload_sz, alt_cnt, "A", "B" );
+      make_wide_transaction( 1UL, payload_sz, alt_cnt, "C", "D" );
+      make_wide_transaction( 2UL, payload_sz, alt_cnt, "E", "F" );
+
+      fd_txn_e_t *        _bundle[ 3 ];
+      fd_txn_e_t * const * bundle = fd_pack_insert_bundle_init( pack, _bundle, 3UL );
+      for( ulong j=0UL; j<3UL; j++ ) fill_slot( bundle[ j ], j );
+      FD_TEST( fd_pack_insert_bundle_fini( pack, bundle, 3UL, 1000UL, 0, NULL, &_deleted )>=0 );
+
+      fd_memset( outcome.results, COPY_OUT_CANARY, 3UL*sizeof(fd_txn_e_t) );
+      FD_TEST( fd_pack_schedule_next_microblock( pack, FD_PACK_TEST_MAX_COST_PER_BLOCK, 0.0f, 0UL, FD_PACK_SCHEDULE_BUNDLE, outcome.results )==3UL );
+      for( ulong j=0UL; j<3UL; j++ ) check_slot( outcome.results+j, j );
+      fd_pack_delete( fd_pack_leave( pack ) );
+    }
+  }
+}
+
 static inline void
 test_reject( void ) {
   FD_LOG_NOTICE(( "TEST REJECT" ));
@@ -1727,6 +1824,7 @@ main( int     argc,
   test_limits();
   if( 0 ) test_vote_qos();
   test_reject_writes_to_sysvars();
+  test_copy_out();
   test_reject();
   test_reject_blocklist();
   test_duplicate_sig();

--- a/src/util/simd/fd_nt_memcpy.h
+++ b/src/util/simd/fd_nt_memcpy.h
@@ -68,12 +68,20 @@
    and is only included for completeness; the compiler may even replace
    a call to it with memcpy.
 
+   fd_memcpy_{nn,nt}_nofence are the same without the trailing fence,
+   for a caller issuing a run of non-temporal copies to disjoint
+   destinations.  The caller MUST execute _mm_sfence() itself after the
+   last copy and before anything that publishes the destinations.  One
+   fence for the run is much cheaper than one per copy, since each
+   fence drains the write combining buffers the copies just filled.
+
    WARNING: the writes to memory that this function issues may become
    visible to another core in a surprising order.  This is a normal part
    of the memcpy contract, but is especially true when using
-   non-temporal stores.  This function includes the appropriate fencing
-   so that stores issued by this function will become visible before any
-   stores following the function call.
+   non-temporal stores.  The fencing variants include the appropriate
+   fencing so that stores issued by the function will become visible
+   before any stores following the call; with the _nofence variants
+   that is the caller's job.
 
    WARNING: on many CPUs, a normal store following a non-temporal store
    to the same cache line causes a SEVERE performance degradation
@@ -85,7 +93,7 @@
 #include "../fd_util_base.h"
 #include <immintrin.h>
 
-#define FD_EMIT_TEMPORAL_MEMCPY( suffix, needs_sfence )                                               \
+#define FD_EMIT_TEMPORAL_MEMCPY( suffix, copy64, needs_sfence )                                       \
 FD_FN_UNUSED static void *                                                                            \
 fd_memcpy_##suffix( void       * FD_RESTRICT _d,                                                      \
                     void const * FD_RESTRICT _s,                                                      \
@@ -95,7 +103,7 @@ fd_memcpy_##suffix( void       * FD_RESTRICT _d,                                
   uchar const * FD_RESTRICT s   = (uchar const *)_s;                                                  \
   ulong align = fd_ulong_min( rem, fd_ulong_align_up( (ulong)d, 64UL ) - (ulong)d );                  \
   if( FD_UNLIKELY( align ) ) { memcpy( d, s, align ); rem -= align; d += align; s += align; }         \
-  for( ; rem>63UL; rem-=64UL, d += 64UL, s += 64UL ) copy64_##suffix( d, s );                         \
+  for( ; rem>63UL; rem-=64UL, d += 64UL, s += 64UL ) copy64( d, s );                                  \
   if( needs_sfence         ) _mm_sfence();                                                            \
   if( FD_UNLIKELY( rem   ) ) memcpy( d, s, rem );                                                     \
   return _d;                                                                                          \
@@ -155,10 +163,12 @@ fd_memcpy_##suffix( void       * FD_RESTRICT _d,                                
 #endif
 
 
-FD_EMIT_TEMPORAL_MEMCPY( nn, 1 )
-FD_EMIT_TEMPORAL_MEMCPY( nt, 1 )
-FD_EMIT_TEMPORAL_MEMCPY( tn, 0 )
-FD_EMIT_TEMPORAL_MEMCPY( tt, 0 )
+FD_EMIT_TEMPORAL_MEMCPY( nn,         copy64_nn, 1 )
+FD_EMIT_TEMPORAL_MEMCPY( nt,         copy64_nt, 1 )
+FD_EMIT_TEMPORAL_MEMCPY( tn,         copy64_tn, 0 )
+FD_EMIT_TEMPORAL_MEMCPY( tt,         copy64_tt, 0 )
+FD_EMIT_TEMPORAL_MEMCPY( nn_nofence, copy64_nn, 0 )
+FD_EMIT_TEMPORAL_MEMCPY( nt_nofence, copy64_nt, 0 )
 
 #undef copy64_nn
 #undef copy64_nt


### PR DESCRIPTION
The unrolled stream loop only covered the first 1280 bytes, with a second loop bolted on for V1 payloads, and the ALT copy rounded up to a whole cache line and read one address past the end.  fd_memcpy_nt does all of it, and its fence makes the trailing sfence in fd_pack_schedule_next_microblock redundant.  Prefetch the metadata and TXN() lines, which stay regular stores, before scheduling.