### PR TITLE
Benchmarks: Sweep accdb Cache Footprint and Min Reserved

### DIFF
--- a/src/flamenco/accdb/bench_accdb.c
+++ b/src/flamenco/accdb/bench_accdb.c
@@ -82,21 +82,27 @@ static uchar data_buf[ BENCH_MAX_DATA_SZ ];
 #define BENCH_CACHE_MIN_RESERVED (640UL)
 
 static fd_accdb_t *
-bench_setup( int * out_fd,
-             ulong max_accounts,
-             ulong max_live_slots,
-             ulong max_account_writes_per_slot,
-             ulong partition_cnt,
-             ulong partition_sz ) {
+bench_setup( int *   out_fd,
+             void ** out_shmem_mem,
+             void ** out_accdb_mem,
+             ulong   max_accounts,
+             ulong   max_live_slots,
+             ulong   max_account_writes_per_slot,
+             ulong   partition_cnt,
+             ulong   partition_sz,
+             ulong   cache_footprint ) {
   int fd = memfd_create( "accdb_bench", 0 );
   if( FD_UNLIKELY( fd<0 ) ) FD_LOG_ERR(( "memfd_create failed" ));
   *out_fd = fd;
 
-  ulong cache_fp = BENCH_CACHE_FOOTPRINT;
+  ulong cache_fp = cache_footprint;
   ulong shmem_fp = fd_accdb_shmem_footprint( max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, cache_fp, BENCH_CACHE_MIN_RESERVED, 1UL, 0UL );
   FD_TEST( shmem_fp );
+
   void * shmem_mem = aligned_alloc( fd_accdb_shmem_align(), shmem_fp );
   FD_TEST( shmem_mem );
+  *out_shmem_mem = shmem_mem;
+
   fd_accdb_shmem_t * shmem = fd_accdb_shmem_join(
       fd_accdb_shmem_new( shmem_mem, max_accounts, max_live_slots,
                           max_account_writes_per_slot, partition_cnt,
@@ -105,8 +111,11 @@ bench_setup( int * out_fd,
 
   ulong accdb_fp = fd_accdb_footprint( max_live_slots );
   FD_TEST( accdb_fp );
+
   void * accdb_mem = aligned_alloc( fd_accdb_align(), accdb_fp );
   FD_TEST( accdb_mem );
+  *out_accdb_mem = accdb_mem;
+
   fd_accdb_t * accdb = fd_accdb_join( fd_accdb_new( accdb_mem, shmem, fd, 0UL, NULL ) );
   FD_TEST( accdb );
   return accdb;
@@ -170,14 +179,19 @@ static void
 bench_write( ulong   account_cnt,
              fd_rng_t * rng ) {
   int fd;
+  void * shmem_mem;
+  void * accdb_mem;
   ulong partition_sz = 1UL<<30UL;
   ulong partition_cnt = 1024UL;
   fd_accdb_t * accdb = bench_setup( &fd,
+                                    &shmem_mem,
+                                    &accdb_mem,
                                     account_cnt + 1024UL,
                                     64UL,
                                     (uint)account_cnt + 1024U,
                                     partition_cnt,
-                                    partition_sz );
+                                    partition_sz,
+                                    BENCH_CACHE_FOOTPRINT);
 
   fd_accdb_fork_id_t root  = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork  = fd_accdb_attach_child( accdb, root );
@@ -206,6 +220,8 @@ bench_write( ulong   account_cnt,
                   (double)total_bytes / (double)(1UL<<20UL) / secs,
                   (double)dt / (double)account_cnt ));
 
+  free( accdb_mem );
+  free( shmem_mem );
   close( fd );
 }
 
@@ -217,14 +233,19 @@ static void
 bench_read( ulong   account_cnt,
             fd_rng_t * rng ) {
   int fd;
+  void * shmem_mem;
+  void * accdb_mem;
   ulong partition_sz = 1UL<<30UL;
   ulong partition_cnt = 1024UL;
   fd_accdb_t * accdb = bench_setup( &fd,
+                                    &shmem_mem,
+                                    &accdb_mem,
                                     account_cnt + 1024UL,
                                     64UL,
                                     (uint)account_cnt + 1024U,
                                     partition_cnt,
-                                    partition_sz );
+                                    partition_sz,
+                                    BENCH_CACHE_FOOTPRINT );
 
   fd_accdb_fork_id_t root  = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork  = fd_accdb_attach_child( accdb, root );
@@ -269,6 +290,8 @@ bench_read( ulong   account_cnt,
                   (double)total_bytes / (double)(1UL<<20UL) / secs,
                   (double)dt / (double)account_cnt ));
 
+  free( accdb_mem );
+  free( shmem_mem );
   close( fd );
 }
 
@@ -292,18 +315,24 @@ static void
 bench_replay( ulong   slot_cnt,
               ulong   writes_per_slot,
               ulong   reads_per_slot,
-              fd_rng_t * rng ) {
+              fd_rng_t * rng,
+              ulong   cache_footprint ) {
   int fd;
+  void * shmem_mem;
+  void * accdb_mem;
   ulong total_accounts = slot_cnt * writes_per_slot + 1024UL;
   ulong partition_sz  = 1UL<<30UL;
   ulong partition_cnt = 1024UL;
   ulong max_live      = 64UL;
   fd_accdb_t * accdb = bench_setup( &fd,
+                                    &shmem_mem,
+                                    &accdb_mem,
                                     total_accounts,
                                     max_live,
                                     writes_per_slot + 16UL,
                                     partition_cnt,
-                                    partition_sz );
+                                    partition_sz,
+                                    cache_footprint );
 
   fd_accdb_fork_id_t root = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
 
@@ -312,7 +341,7 @@ bench_replay( ulong   slot_cnt,
   /* We re-use a pool of pubkeys so that rooting has old versions to
      tombstone (realistic for hot accounts like token program,
      system program, fee payers, etc.). */
-  ulong pubkey_pool_sz = writes_per_slot * 4UL;
+  ulong pubkey_pool_sz = writes_per_slot * slot_cnt;
 
   ulong total_reads       = 0UL;
   ulong total_read_hits   = 0UL;
@@ -405,6 +434,8 @@ bench_replay( ulong   slot_cnt,
                   (double)m->disk_used_bytes / (double)(1UL<<20UL),
                   (double)m->disk_allocated_bytes / (double)(1UL<<20UL) ));
 
+  free( accdb_mem );
+  free( shmem_mem );
   close( fd );
 }
 
@@ -420,14 +451,19 @@ bench_mixed( ulong   base_cnt,
              uint    read_pct,
              fd_rng_t * rng ) {
   int fd;
+  void * shmem_mem;
+  void * accdb_mem;
   ulong partition_sz  = 1UL<<30UL;
   ulong partition_cnt = 1024UL;
   fd_accdb_t * accdb = bench_setup( &fd,
+                                    &shmem_mem,
+                                    &accdb_mem,
                                     base_cnt + op_cnt + 1024UL,
                                     64UL,
                                     (uint)(base_cnt + op_cnt) + 1024U,
                                     partition_cnt,
-                                    partition_sz );
+                                    partition_sz,
+                                    BENCH_CACHE_FOOTPRINT);
 
   fd_accdb_fork_id_t root = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork = fd_accdb_attach_child( accdb, root );
@@ -476,6 +512,8 @@ bench_mixed( ulong   base_cnt,
                   (double)dt / (double)op_cnt,
                   (uint)read_pct ));
 
+  free( accdb_mem );
+  free( shmem_mem );
   close( fd );
 }
 
@@ -492,7 +530,7 @@ main( int     argc,
   ulong reads_per_slot  = fd_env_strip_cmdline_ulong( &argc, &argv, "--reads-per-slot",  NULL,   4800UL  );
   ulong mixed_ops       = fd_env_strip_cmdline_ulong( &argc, &argv, "--mixed-ops",       NULL, 200000UL  );
   uint  read_pct        = fd_env_strip_cmdline_uint ( &argc, &argv, "--read-pct",        NULL,      80U  );
-  uint  seed            = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",            NULL,      42U  );
+  uint  seed             = fd_env_strip_cmdline_uint ( &argc, &argv, "--seed",            NULL,      42U  );
 
   FD_LOG_NOTICE(( "accdb benchmark (accounts=%lu slots=%lu wpslot=%lu "
                   "rpslot=%lu mixed_ops=%lu read_pct=%u seed=%u)",
@@ -510,10 +548,19 @@ main( int     argc,
   bench_read( account_cnt, rng );
 
   FD_LOG_NOTICE(( "--- replay simulation ---" ));
-  bench_replay( slot_cnt, writes_per_slot, reads_per_slot, rng );
+  bench_replay( slot_cnt, writes_per_slot, reads_per_slot, rng, BENCH_CACHE_FOOTPRINT);
 
   FD_LOG_NOTICE(( "--- mixed read/write (%u%% reads) ---", read_pct ));
   bench_mixed( account_cnt, mixed_ops, read_pct, rng );
+
+  FD_LOG_NOTICE(( "--- cache sweep ---" ));
+  ulong const cache_sweep_gib[] = { 7UL, 8UL, 10UL, 12UL, 16UL };
+  int length = sizeof( cache_sweep_gib ) / sizeof( cache_sweep_gib[0] );
+
+  for( int i = 0; i < length; i++ ) {
+    FD_LOG_NOTICE(( "--- cache sweep @ %lu GiB ---", cache_sweep_gib[i] ));
+    bench_replay( 1000, writes_per_slot, reads_per_slot, rng, cache_sweep_gib[i] << 30UL );
+  }
 
   fd_rng_delete( fd_rng_leave( rng ) );
 

--- a/src/flamenco/accdb/bench_accdb.c
+++ b/src/flamenco/accdb/bench_accdb.c
@@ -586,8 +586,8 @@ main( int     argc,
     FD_TEST( sweep_rng );
 
     FD_LOG_NOTICE(( "--- cache min reserved sweep @ %lu ---", min_reserved_sweep[i] ));
-    /* Using 10 Gi based on cache0footprint sweep and to support min_reserved = 800 */
-    bench_replay( 1000, writes_per_slot, reads_per_slot, sweep_rng, 10UL << 30, min_reserved_sweep[i] );
+    /* Using 10 GiB based on cache footprint sweep and to support min_reserved = 800 */
+    bench_replay( 1000, writes_per_slot, reads_per_slot, sweep_rng, 10UL << 30UL, min_reserved_sweep[i] );
 
     fd_rng_delete( fd_rng_leave ( sweep_rng ));
   }

--- a/src/flamenco/accdb/bench_accdb.c
+++ b/src/flamenco/accdb/bench_accdb.c
@@ -107,7 +107,7 @@ bench_setup( int *   out_fd,
   fd_accdb_shmem_t * shmem = fd_accdb_shmem_join(
       fd_accdb_shmem_new( shmem_mem, max_accounts, max_live_slots,
                           max_account_writes_per_slot, partition_cnt,
-                          partition_sz, cache_fp,  cache_min_reserved, 0, 42UL, 1UL, 0UL ) );
+                          partition_sz, cache_fp, cache_min_reserved, 0, 42UL, 1UL, 0UL ) );
   FD_TEST( shmem );
 
   ulong accdb_fp = fd_accdb_footprint( max_live_slots );
@@ -586,8 +586,8 @@ main( int     argc,
     FD_TEST( sweep_rng );
 
     FD_LOG_NOTICE(( "--- cache min reserved sweep @ %lu ---", min_reserved_sweep[i] ));
-    // Using 10 GiB instead of 16 based on results from the prior sweep but also to lighten computational load and meet the req for 800
-    bench_replay(1000, writes_per_slot, reads_per_slot, sweep_rng, 10UL << 30, min_reserved_sweep[i]);
+    /* Using 10 Gi based on cache0footprint sweep and to support min_reserved = 800 */
+    bench_replay( 1000, writes_per_slot, reads_per_slot, sweep_rng, 10UL << 30, min_reserved_sweep[i] );
 
     fd_rng_delete( fd_rng_leave ( sweep_rng ));
   }

--- a/src/flamenco/accdb/bench_accdb.c
+++ b/src/flamenco/accdb/bench_accdb.c
@@ -90,13 +90,14 @@ bench_setup( int *   out_fd,
              ulong   max_account_writes_per_slot,
              ulong   partition_cnt,
              ulong   partition_sz,
-             ulong   cache_footprint ) {
+             ulong   cache_footprint,
+             ulong   cache_min_reserved) {
   int fd = memfd_create( "accdb_bench", 0 );
   if( FD_UNLIKELY( fd<0 ) ) FD_LOG_ERR(( "memfd_create failed" ));
   *out_fd = fd;
 
   ulong cache_fp = cache_footprint;
-  ulong shmem_fp = fd_accdb_shmem_footprint( max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, cache_fp, BENCH_CACHE_MIN_RESERVED, 1UL, 0UL );
+  ulong shmem_fp = fd_accdb_shmem_footprint( max_accounts, max_live_slots, max_account_writes_per_slot, partition_cnt, cache_fp, cache_min_reserved, 1UL, 0UL );
   FD_TEST( shmem_fp );
 
   void * shmem_mem = aligned_alloc( fd_accdb_shmem_align(), shmem_fp );
@@ -106,7 +107,7 @@ bench_setup( int *   out_fd,
   fd_accdb_shmem_t * shmem = fd_accdb_shmem_join(
       fd_accdb_shmem_new( shmem_mem, max_accounts, max_live_slots,
                           max_account_writes_per_slot, partition_cnt,
-                          partition_sz, cache_fp, BENCH_CACHE_MIN_RESERVED, 0, 42UL, 1UL, 0UL ) );
+                          partition_sz, cache_fp,  cache_min_reserved, 0, 42UL, 1UL, 0UL ) );
   FD_TEST( shmem );
 
   ulong accdb_fp = fd_accdb_footprint( max_live_slots );
@@ -191,7 +192,8 @@ bench_write( ulong   account_cnt,
                                     (uint)account_cnt + 1024U,
                                     partition_cnt,
                                     partition_sz,
-                                    BENCH_CACHE_FOOTPRINT);
+                                    BENCH_CACHE_FOOTPRINT,
+                                    BENCH_CACHE_MIN_RESERVED);
 
   fd_accdb_fork_id_t root  = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork  = fd_accdb_attach_child( accdb, root );
@@ -245,7 +247,8 @@ bench_read( ulong   account_cnt,
                                     (uint)account_cnt + 1024U,
                                     partition_cnt,
                                     partition_sz,
-                                    BENCH_CACHE_FOOTPRINT );
+                                    BENCH_CACHE_FOOTPRINT,
+                                    BENCH_CACHE_MIN_RESERVED);
 
   fd_accdb_fork_id_t root  = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork  = fd_accdb_attach_child( accdb, root );
@@ -316,7 +319,8 @@ bench_replay( ulong   slot_cnt,
               ulong   writes_per_slot,
               ulong   reads_per_slot,
               fd_rng_t * rng,
-              ulong   cache_footprint ) {
+              ulong   cache_footprint,
+              ulong   cache_min_reserve ) {
   int fd;
   void * shmem_mem;
   void * accdb_mem;
@@ -332,7 +336,8 @@ bench_replay( ulong   slot_cnt,
                                     writes_per_slot + 16UL,
                                     partition_cnt,
                                     partition_sz,
-                                    cache_footprint );
+                                    cache_footprint,
+                                    cache_min_reserve );
 
   fd_accdb_fork_id_t root = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
 
@@ -463,7 +468,8 @@ bench_mixed( ulong   base_cnt,
                                     (uint)(base_cnt + op_cnt) + 1024U,
                                     partition_cnt,
                                     partition_sz,
-                                    BENCH_CACHE_FOOTPRINT);
+                                    BENCH_CACHE_FOOTPRINT,
+                                    BENCH_CACHE_MIN_RESERVED);
 
   fd_accdb_fork_id_t root = fd_accdb_attach_child( accdb, (fd_accdb_fork_id_t){ .val = USHORT_MAX } );
   fd_accdb_fork_id_t fork = fd_accdb_attach_child( accdb, root );
@@ -548,7 +554,7 @@ main( int     argc,
   bench_read( account_cnt, rng );
 
   FD_LOG_NOTICE(( "--- replay simulation ---" ));
-  bench_replay( slot_cnt, writes_per_slot, reads_per_slot, rng, BENCH_CACHE_FOOTPRINT);
+  bench_replay( slot_cnt, writes_per_slot, reads_per_slot, rng, BENCH_CACHE_FOOTPRINT, BENCH_CACHE_MIN_RESERVED);
 
   FD_LOG_NOTICE(( "--- mixed read/write (%u%% reads) ---", read_pct ));
   bench_mixed( account_cnt, mixed_ops, read_pct, rng );
@@ -558,8 +564,32 @@ main( int     argc,
   int length = sizeof( cache_sweep_gib ) / sizeof( cache_sweep_gib[0] );
 
   for( int i = 0; i < length; i++ ) {
+    fd_rng_t _sweep_rng[1];
+    fd_rng_t * sweep_rng = fd_rng_join ( fd_rng_new ( _sweep_rng, seed, 0UL ) );
+
+    FD_TEST( sweep_rng );
+
     FD_LOG_NOTICE(( "--- cache sweep @ %lu GiB ---", cache_sweep_gib[i] ));
-    bench_replay( 1000, writes_per_slot, reads_per_slot, rng, cache_sweep_gib[i] << 30UL );
+    bench_replay( 1000, writes_per_slot, reads_per_slot, sweep_rng, cache_sweep_gib[i] << 30U, BENCH_CACHE_MIN_RESERVED );
+
+    fd_rng_delete( fd_rng_leave ( sweep_rng ));
+  }
+
+  FD_LOG_NOTICE(( "--- cache min reserved sweep ---" ));
+  ulong const min_reserved_sweep[] = { 160UL, 320UL, 480UL, 640UL, 800UL };
+  length = sizeof( min_reserved_sweep ) / sizeof( min_reserved_sweep[0] );
+
+  for ( int i = 0; i < length; i++ ) {
+    fd_rng_t _sweep_rng[1];
+    fd_rng_t * sweep_rng = fd_rng_join( fd_rng_new ( _sweep_rng, seed, 0UL ));
+
+    FD_TEST( sweep_rng );
+
+    FD_LOG_NOTICE(( "--- cache min reserved sweep @ %lu ---", min_reserved_sweep[i] ));
+    // Using 10 GiB instead of 16 based on results from the prior sweep but also to lighten computational load and meet the req for 800
+    bench_replay(1000, writes_per_slot, reads_per_slot, sweep_rng, 10UL << 30, min_reserved_sweep[i]);
+
+    fd_rng_delete( fd_rng_leave ( sweep_rng ));
   }
 
   fd_rng_delete( fd_rng_leave( rng ) );


### PR DESCRIPTION
Added benchmarks to sweep:
- accdb cache footprint
- accdb min reserved

Used to investigate memory/performance tradeoffs in different cache configs.

Output of the Sweeps:
```
NOTICE  09-12 02:33:10.981122 0         bench_accdb.c(562): --- cache sweep ---
NOTICE  09-12 02:33:10.981156 0         bench_accdb.c(572): --- cache sweep @ 7 GiB ---
NOTICE  09-12 02:33:14.299312 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 3.311 s total
NOTICE  09-12 02:33:14.299349 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 2524603 reads/s, 396 ns/read
NOTICE  09-12 02:33:14.299356 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 923660 writes/s, 1083 ns/write
NOTICE  09-12 02:33:14.299359 0         bench_accdb.c(432):   root:    110159 ns/root, 0.110 s total (999 slots rooted)
NOTICE  09-12 02:33:14.299362 0         bench_accdb.c(435):   slot:    3310581 ns/slot (302 slots/s)
NOTICE  09-12 02:33:14.299364 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=149.47 MiB disk_alloc=1024.00 MiB
NOTICE  09-12 02:33:14.347193 0         bench_accdb.c(572): --- cache sweep @ 8 GiB ---
NOTICE  09-12 02:33:16.681598 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 2.181 s total
NOTICE  09-12 02:33:16.681635 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4081833 reads/s, 245 ns/read
NOTICE  09-12 02:33:16.681642 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1291957 writes/s, 774 ns/write
NOTICE  09-12 02:33:16.681645 0         bench_accdb.c(432):   root:    76315 ns/root, 0.076 s total (999 slots rooted)
NOTICE  09-12 02:33:16.681648 0         bench_accdb.c(435):   slot:    2181053 ns/slot (458 slots/s)
NOTICE  09-12 02:33:16.681650 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=29.00 MiB disk_alloc=1024.00 MiB
NOTICE  09-12 02:33:16.746601 0         bench_accdb.c(572): --- cache sweep @ 10 GiB ---
NOTICE  09-12 02:33:19.094274 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.899 s total
NOTICE  09-12 02:33:19.094312 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4356665 reads/s, 230 ns/read
NOTICE  09-12 02:33:19.094318 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1636319 writes/s, 611 ns/write
NOTICE  09-12 02:33:19.094322 0         bench_accdb.c(432):   root:    63618 ns/root, 0.064 s total (999 slots rooted)
NOTICE  09-12 02:33:19.094325 0         bench_accdb.c(435):   slot:    1898714 ns/slot (527 slots/s)
NOTICE  09-12 02:33:19.094327 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:19.154933 0         bench_accdb.c(572): --- cache sweep @ 12 GiB ---
NOTICE  09-12 02:33:21.725951 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.817 s total
NOTICE  09-12 02:33:21.725991 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4668007 reads/s, 214 ns/read
NOTICE  09-12 02:33:21.725998 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1660220 writes/s, 602 ns/write
NOTICE  09-12 02:33:21.726001 0         bench_accdb.c(432):   root:    66182 ns/root, 0.066 s total (999 slots rooted)
NOTICE  09-12 02:33:21.726011 0         bench_accdb.c(435):   slot:    1817229 ns/slot (550 slots/s)
NOTICE  09-12 02:33:21.726014 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:21.820239 0         bench_accdb.c(572): --- cache sweep @ 16 GiB ---
NOTICE  09-12 02:33:25.022690 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.856 s total
NOTICE  09-12 02:33:25.022744 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4492028 reads/s, 223 ns/read
NOTICE  09-12 02:33:25.022752 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1659998 writes/s, 602 ns/write
NOTICE  09-12 02:33:25.022755 0         bench_accdb.c(432):   root:    65002 ns/root, 0.065 s total (999 slots rooted)
NOTICE  09-12 02:33:25.022761 0         bench_accdb.c(435):   slot:    1856431 ns/slot (539 slots/s)
NOTICE  09-12 02:33:25.022764 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:25.185805 0         bench_accdb.c(578): --- cache min reserved sweep ---
NOTICE  09-12 02:33:25.185846 0         bench_accdb.c(588): --- cache min reserved sweep @ 160 ---
NOTICE  09-12 02:33:27.634844 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.860 s total
NOTICE  09-12 02:33:27.634885 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4495643 reads/s, 222 ns/read
NOTICE  09-12 02:33:27.634895 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1659976 writes/s, 602 ns/write
NOTICE  09-12 02:33:27.634898 0         bench_accdb.c(432):   root:    69689 ns/root, 0.070 s total (999 slots rooted)
NOTICE  09-12 02:33:27.634900 0         bench_accdb.c(435):   slot:    1860261 ns/slot (538 slots/s)
NOTICE  09-12 02:33:27.634903 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:27.710605 0         bench_accdb.c(588): --- cache min reserved sweep @ 320 ---
NOTICE  09-12 02:33:30.146173 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.846 s total
NOTICE  09-12 02:33:30.146220 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4508889 reads/s, 222 ns/read
NOTICE  09-12 02:33:30.146227 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1672347 writes/s, 598 ns/write
NOTICE  09-12 02:33:30.146230 0         bench_accdb.c(432):   root:    64144 ns/root, 0.064 s total (999 slots rooted)
NOTICE  09-12 02:33:30.146233 0         bench_accdb.c(435):   slot:    1846236 ns/slot (542 slots/s)
NOTICE  09-12 02:33:30.146235 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:30.222174 0         bench_accdb.c(588): --- cache min reserved sweep @ 480 ---
NOTICE  09-12 02:33:32.697378 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.887 s total
NOTICE  09-12 02:33:32.697416 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4422243 reads/s, 226 ns/read
NOTICE  09-12 02:33:32.697423 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1651198 writes/s, 606 ns/write
NOTICE  09-12 02:33:32.697426 0         bench_accdb.c(432):   root:    74471 ns/root, 0.074 s total (999 slots rooted)
NOTICE  09-12 02:33:32.697429 0         bench_accdb.c(435):   slot:    1886603 ns/slot (530 slots/s)
NOTICE  09-12 02:33:32.697431 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:32.772827 0         bench_accdb.c(588): --- cache min reserved sweep @ 640 ---
NOTICE  09-12 02:33:35.067687 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.849 s total
NOTICE  09-12 02:33:35.067731 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4524774 reads/s, 221 ns/read
NOTICE  09-12 02:33:35.067738 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1658440 writes/s, 603 ns/write
NOTICE  09-12 02:33:35.067749 0         bench_accdb.c(432):   root:    64649 ns/root, 0.065 s total (999 slots rooted)
NOTICE  09-12 02:33:35.067753 0         bench_accdb.c(435):   slot:    1849022 ns/slot (541 slots/s)
NOTICE  09-12 02:33:35.067756 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
NOTICE  09-12 02:33:35.133491 0         bench_accdb.c(588): --- cache min reserved sweep @ 800 ---
NOTICE  09-12 02:33:37.187148 0         bench_accdb.c(415): bench_replay: 1000 slots, 4800 reads/slot, 1200 writes/slot, 1.857 s total
NOTICE  09-12 02:33:37.187188 0         bench_accdb.c(421):   read:    4800000 queries (1765904 hits, 36.8% hit rate), 4508442 reads/s, 222 ns/read
NOTICE  09-12 02:33:37.187195 0         bench_accdb.c(427):   write:   1200000 writes, 158.01 MiB, 1651760 writes/s, 605 ns/write
NOTICE  09-12 02:33:37.187198 0         bench_accdb.c(432):   root:    66056 ns/root, 0.066 s total (999 slots rooted)
NOTICE  09-12 02:33:37.187201 0         bench_accdb.c(435):   slot:    1857197 ns/slot (538 slots/s)
NOTICE  09-12 02:33:37.187203 0         bench_accdb.c(440):   metrics: accounts_total=759245 disk_used=0.00 MiB disk_alloc=0.00 MiB
```
___
> [!NOTE]
> I think the hit rate is being calculated incorrectly but wasn't sure if you had any recommendations for correcting how it's calculated.